### PR TITLE
fix: create PythonRuntime placeholder so local make build doesn't fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ bootstrap:
 	}
 
 project: bootstrap
+	@# PythonRuntime is a .gitignored folder reference (see project.yml). It is
+	@# only populated by `make bundle-diarization`. XcodeGen's `optional: true`
+	@# suppresses generation errors but still emits the copy-resources phase, so
+	@# xcodebuild fails on the missing path. Ensure an (empty) dir exists; the app
+	@# detects no bundled python and falls back to system python automatically.
+	@mkdir -p Mila/Resources/PythonRuntime
 	xcodegen generate
 
 open: project


### PR DESCRIPTION
## What & why

`make build`/`make run`/`make test` fail on a fresh clone with:

```
error: The file "PythonRuntime" couldn't be opened because there is no such file. (in target 'Mila')
```

`Mila/Resources/PythonRuntime` is a `.gitignored` folder reference (see `project.yml`) that is only populated by `make bundle-diarization`. XcodeGen's `optional: true` suppresses *generation-time* errors but still emits the copy-resources build phase, so `xcodebuild` fails on the missing path. CI never hits this because every workflow restores `PythonRuntime` from an `actions/cache` step before building — but a contributor who hasn't run the (heavy) `make bundle-diarization` can't even launch the app.

This adds a one-line `mkdir -p Mila/Resources/PythonRuntime` to the `project` target so the folder always exists before generation/build. An empty dir copies harmlessly, and `DiarizationBootstrap.bundledPythonPath` detects no bundled `python3.11` and falls back to system python — exactly the behavior the `project.yml` comment already documents.

## How it was tested

- `make build` — **passes** (previously failed at the `CpResource PythonRuntime` step).
- App launches and runs from the resulting `.app`.
- `make test` — the two failures observed locally are environmental and unrelated to this Makefile-only change: the `MilaUITests` runner times out "enabling automation mode" (needs local Automation permission), and `LLMRunnerTests.test_cursor_cli_returns_a_title...` is a real-CLI smoke test that runs only when `cursor-agent` is installed (auto-skips in CI). Neither touches resource bundling.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — build passes; remaining `make test` failures are pre-existing/environmental (UI automation + live `cursor-agent` CLI), not caused by this change
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — n/a, build-only change
