### PR TITLE
Run "Send to Claude" in the background like Save

### DIFF
--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -1,5 +1,9 @@
 import Foundation
 import Combine
+import OSLog
+
+private let postRecordingLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                      category: "PostRecordingCoordinator")
 
 /// Owns the "Name this recording" sheet lifecycle. The sheet pops the moment
 /// a recording is added (i.e. recording stopped) — NOT when transcription
@@ -26,6 +30,27 @@ final class PostRecordingCoordinator: ObservableObject {
     /// torn down, and so the in-flight handle survives the SwiftUI redraws
     /// that would otherwise re-create local `@State`.
     private var llmTasks: [UUID: Task<Void, Never>] = [:]
+
+    /// Background "Send to <LLM>" work, keyed per-recording. Owned here —
+    /// on the app-lifetime coordinator — rather than spawned as a bare
+    /// anonymous `Task.detached` from the sheet, so the call survives the
+    /// sheet being dismissed (the whole point of "fire and walk away") and
+    /// so `cancelAndDiscard` can cancel it before deleting the recording.
+    ///
+    /// Separate from `llmTasks` (the foreground / auto Suggest path) so a
+    /// manual Suggest and a background Send for the same recording don't
+    /// clobber each other's handle. Mirrors `RecordingSummarizer.inFlight`:
+    /// id-keyed, self-clearing on completion, re-send for the same id
+    /// cancels + replaces the prior one.
+    private var sendTasks: [UUID: Task<Void, Never>] = [:]
+
+    /// How long the background send will wait for an as-yet-unfinished
+    /// transcript before giving up. "Send to Claude" can now be pressed
+    /// before transcription finishes (fire and walk away), so when the
+    /// caller hands us an empty transcript we poll the store until the
+    /// recording lands in a terminal state. Generous bound: a long file
+    /// can still be transcribing minutes after the user walks away.
+    var transcriptWaitTimeout: TimeInterval = 600
 
     init(store: RecordingStore, transcription: TranscriptionService) {
         self.store = store
@@ -72,13 +97,134 @@ final class PostRecordingCoordinator: ObservableObject {
         llmTasks[recordingID] = nil
     }
 
+    // MARK: - Background "Send to <LLM>"
+
+    /// True while a background send is in flight for `recordingID`. Lets
+    /// the rename sheet (or any caller) reflect "still sending" state.
+    func isSending(_ recordingID: UUID) -> Bool {
+        sendTasks[recordingID] != nil
+    }
+
+    /// Fire the configured LLM action against `recordingID` in the
+    /// background and report the result through the activity banner.
+    ///
+    /// This is the shared implementation behind the rename sheet's
+    /// "Send to <LLM>" button and the right-click "Send to <LLM>…"
+    /// sheet. Both snapshot their prompt / transcript / summary and
+    /// dismiss BEFORE calling this, so the call genuinely runs in the
+    /// background — the user can close the sheet and walk away.
+    ///
+    /// `transcript` is whatever the caller had at click time. When the
+    /// user fires before transcription finishes it'll be empty; in that
+    /// case we wait for the recording to reach a terminal state and pull
+    /// the finished transcript out of the store ourselves, rather than
+    /// blocking the UI behind a disabled button. (The sheet used to gate
+    /// the button on `transcriptReady` for exactly this reason — now the
+    /// readiness wait lives here so "Send" is always pressable.)
+    ///
+    /// Idempotent per id: a second send for the same recording cancels and
+    /// replaces the first (no use case for two competing CLI calls writing
+    /// the same banner). The task clears its own handle on completion.
+    func sendToLLM(recordingID: UUID,
+                   tool: LLMTool,
+                   prompt: String,
+                   transcript: String,
+                   summary: String,
+                   executableOverride: String?) {
+        guard tool != .none else { return }
+        let toolName = tool.displayName
+
+        // Cancel + replace any prior send for this recording.
+        sendTasks[recordingID]?.cancel()
+
+        postStatus("Sending to \(toolName)…")
+
+        let timeout = transcriptWaitTimeout
+        let task = Task { @MainActor [weak self] in
+            defer {
+                if let self { self.sendTasks[recordingID] = nil }
+            }
+            guard let self else { return }
+            // Resolve the transcript: use the click-time snapshot if it
+            // already has text, otherwise wait for transcription to finish.
+            let resolved: String
+            if transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                guard let waited = await self.awaitTranscript(for: recordingID,
+                                                              timeout: timeout) else {
+                    if Task.isCancelled { return }
+                    self.postStatus("\(toolName): no transcript to send.", isError: true)
+                    return
+                }
+                resolved = waited
+            } else {
+                resolved = transcript
+            }
+            if Task.isCancelled { return }
+            do {
+                let output = try await LLMRunner.run(
+                    tool: tool,
+                    prompt: prompt,
+                    transcript: resolved,
+                    summary: summary,
+                    executablePathOverride: executableOverride,
+                    timeout: LLMRunner.defaultTimeout
+                )
+                let preview = output
+                    .replacingOccurrences(of: "\n", with: " ")
+                    .prefix(80)
+                self.postStatus("\(toolName): \(preview)")
+                postRecordingLog.log("send succeeded \(recordingID.uuidString.prefix(8), privacy: .public) -> \(output.count, privacy: .public) chars")
+            } catch LLMRunnerError.cancelled {
+                // User discarded the recording (or fired a replacement
+                // send) — no banner, the cancellation was deliberate.
+            } catch {
+                if Task.isCancelled { return }
+                self.postStatus("\(toolName) failed: \(error.localizedDescription)",
+                                isError: true)
+                postRecordingLog.error("send failed \(recordingID.uuidString.prefix(8), privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        sendTasks[recordingID] = task
+    }
+
+    /// Poll the store until `recordingID` has a non-empty transcript and
+    /// has left the in-progress states (`.pending` / `.running`), then
+    /// return the speaker-aware plain text. Returns nil if the recording
+    /// disappears, ends up with no text, or the wait times out / is
+    /// cancelled. The wait is cheap (a short sleep between checks) and
+    /// honours task cancellation so `cancelAndDiscard` unblocks it
+    /// immediately.
+    private func awaitTranscript(for recordingID: UUID,
+                                 timeout: TimeInterval) async -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if Task.isCancelled { return nil }
+            guard let rec = store.recordings.first(where: { $0.id == recordingID }) else {
+                return nil  // discarded out from under us
+            }
+            if rec.status != .pending && rec.status != .running {
+                let text = TranscriptFormatter.plainText(segments: rec.segments,
+                                                         fallback: rec.fullText)
+                return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? nil
+                    : text
+            }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        return nil
+    }
+
     /// The Cancel button in the rename sheet: throw away EVERYTHING related
     /// to this recording. The user's mental model is "I changed my mind" —
     /// transcription that's still running keeps burning CPU on a result they
     /// won't see, and the foreground/background LLM call keeps running
     /// against the user's CLI auth quota. So:
-    ///  1. cancel any in-flight LLM task (terminating the underlying CLI
-    ///     process via LLMRunner's task-cancellation handler)
+    ///  1. cancel any in-flight LLM task — both the foreground Suggest
+    ///     task AND the background Send task — terminating the underlying
+    ///     CLI process via LLMRunner's task-cancellation handler. (Without
+    ///     cancelling the Send task, Discard could delete the recording out
+    ///     from under an in-flight send, leaving a CLI call chewing on a
+    ///     transcript whose recording no longer exists.)
     ///  2. trip the transcription service's abort flag so whisper.cpp
     ///     unwinds within ~100ms instead of finishing
     ///  3. permanently delete the recording + its audio file
@@ -86,6 +232,9 @@ final class PostRecordingCoordinator: ObservableObject {
     func cancelAndDiscard() {
         guard let recording = pending else { pending = nil; return }
         if let task = llmTasks.removeValue(forKey: recording.id) {
+            task.cancel()
+        }
+        if let task = sendTasks.removeValue(forKey: recording.id) {
             task.cancel()
         }
         transcription.cancel(recordingID: recording.id)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -178,13 +178,17 @@ struct RenameRecordingSheet: View {
                 Spacer()
                 if llm.isConfigured && llm.postActionEnabled {
                     Button("Save") { save() }
+                    // Always enabled — pressing this saves, dismisses, and
+                    // runs the action in the BACKGROUND, exactly like Save.
+                    // It used to be `.disabled(!transcriptReady)`, which
+                    // forced the user to wait for transcription with the
+                    // sheet open before they could "fire and walk away".
+                    // The coordinator now waits for the transcript itself
+                    // when fired early, so the button never needs to gate.
                     Button("Send to \(llm.tool.displayName)") { saveAndSend() }
                         .keyboardShortcut(.defaultAction)
                         .buttonStyle(.borderedProminent)
-                        .disabled(!transcriptReady)
-                        .help(transcriptReady
-                              ? "Save the title and run your action in the background"
-                              : "Available once the transcript is ready")
+                        .help("Save the title and run your action in the background")
                 } else {
                     Button("Save") { save() }
                         .keyboardShortcut(.defaultAction)
@@ -398,8 +402,16 @@ struct RenameRecordingSheet: View {
     /// background. We never block the UI on the LLM here — that's the whole
     /// point of "Send": the user expects to get on with their day, and the
     /// activity banner reports success / failure when the CLI returns.
+    ///
+    /// The actual send is owned by `PostRecordingCoordinator` (an
+    /// app-lifetime object) rather than a bare `Task.detached` here, so
+    /// the call survives the sheet being torn down and `cancelAndDiscard`
+    /// can cancel it. We snapshot the prompt/transcript/summary first
+    /// (they're tied to this `liveRecording`) and hand them off; the
+    /// transcript snapshot may be empty if the user pressed Send before
+    /// transcription finished — the coordinator waits for it in that case.
     private func saveAndSend() {
-        let toolName = llm.tool.displayName
+        let recordingID = liveRecording.id
         let prompt = llm.postActionPrompt
         let transcriptSnapshot = transcript
         // Summary travels alongside the transcript so the LLM sees the
@@ -411,31 +423,12 @@ struct RenameRecordingSheet: View {
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let tool = llm.tool
         coordinator.dismiss(savingTitle: title)
-        coordinator.postStatus("Sending to \(toolName)…")
-        Task.detached(priority: .utility) {
-            do {
-                let output = try await LLMRunner.run(
-                    tool: tool,
-                    prompt: prompt,
-                    transcript: transcriptSnapshot,
-                    summary: summarySnapshot,
-                    executablePathOverride: executableOverride,
-                    timeout: LLMRunner.defaultTimeout
-                )
-                let preview = output
-                    .replacingOccurrences(of: "\n", with: " ")
-                    .prefix(80)
-                await MainActor.run {
-                    coordinator.postStatus("\(toolName): \(preview)")
-                }
-                print("LLMRunner: \(toolName) succeeded -> \(output.count) chars")
-            } catch {
-                await MainActor.run {
-                    coordinator.postStatus("\(toolName) failed: \(error.localizedDescription)",
-                                           isError: true)
-                }
-            }
-        }
+        coordinator.sendToLLM(recordingID: recordingID,
+                              tool: tool,
+                              prompt: prompt,
+                              transcript: transcriptSnapshot,
+                              summary: summarySnapshot,
+                              executableOverride: executableOverride)
     }
 
     private func fetchNameFromLLM(auto: Bool = false) async {

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -105,7 +105,7 @@ struct SendToLLMSheet: View {
     }
 
     private func send() {
-        let toolName = llm.tool.displayName
+        let recordingID = liveRecording.id
         let promptSnapshot = prompt
         let transcriptSnapshot = transcript
         // Include any Live-AI summary so the LLM sees the gist before the
@@ -117,29 +117,16 @@ struct SendToLLMSheet: View {
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let tool = llm.tool
         dismiss()
-        postRecording.postStatus("Sending to \(toolName)…")
-        Task.detached(priority: .utility) {
-            do {
-                let output = try await LLMRunner.run(
-                    tool: tool,
-                    prompt: promptSnapshot,
-                    transcript: transcriptSnapshot,
-                    summary: summarySnapshot,
-                    executablePathOverride: executableOverride,
-                    timeout: LLMRunner.defaultTimeout
-                )
-                let preview = output
-                    .replacingOccurrences(of: "\n", with: " ")
-                    .prefix(80)
-                await MainActor.run {
-                    postRecording.postStatus("\(toolName): \(preview)")
-                }
-            } catch {
-                await MainActor.run {
-                    postRecording.postStatus("\(toolName) failed: \(error.localizedDescription)",
-                                             isError: true)
-                }
-            }
-        }
+        // Hand off to the app-lifetime coordinator so the call is owned +
+        // cancellable rather than spawned as a fire-and-forget detached
+        // Task. The Send button here is already gated on a non-empty
+        // transcript, so the snapshot is populated and the coordinator
+        // runs it immediately (no transcript wait).
+        postRecording.sendToLLM(recordingID: recordingID,
+                                tool: tool,
+                                prompt: promptSnapshot,
+                                transcript: transcriptSnapshot,
+                                summary: summarySnapshot,
+                                executableOverride: executableOverride)
     }
 }

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+/// Tests for `PostRecordingCoordinator`'s background "Send to <LLM>"
+/// runner — the path the rename sheet's "Send to Claude" button and the
+/// right-click "Send to <LLM>…" sheet now delegate to.
+///
+/// Like `RecordingSummarizerTests`, end-to-end invocation uses a shell
+/// script masquerading as `claude` so the test runs without the real CLI
+/// installed.
+@MainActor
+final class PostRecordingCoordinatorSendTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var store: RecordingStore!
+    private var manager: ModelManager!
+    private var stub: StubWhisperEngine!
+    private var service: TranscriptionService!
+    private var coordinator: PostRecordingCoordinator!
+
+    private let diarSuite = "PostRecordingCoordinatorSendTests.diarization"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "PostRecordingCoordinatorSendTests")
+        try FileManager.default.createDirectory(at: tempRoot,
+                                                withIntermediateDirectories: true)
+        store = RecordingStore(rootDirectory: tempRoot)
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        stub = StubWhisperEngine()
+        service = TranscriptionService(
+            store: store,
+            modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: diarSuite)!),
+            engine: stub
+        )
+        coordinator = PostRecordingCoordinator(store: store, transcription: service)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        UserDefaults().removePersistentDomain(forName: diarSuite)
+        try await super.tearDown()
+    }
+
+    // MARK: - Background send runs + survives the caller
+
+    /// The send must run to completion on the coordinator even though the
+    /// caller (the sheet) returns immediately. We assert the banner ends
+    /// up carrying the scripted CLI output, and that `isSending` flips
+    /// true while in flight and clears afterward (id-keyed bookkeeping).
+    func test_send_runs_in_background_and_reports_via_banner() async throws {
+        let script = makeScript("""
+            #!/bin/sh
+            sleep 0.3
+            printf 'CLI ANSWER'
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        let rec = addCompletedRecording(text: "the transcript text")
+
+        XCTAssertFalse(coordinator.isSending(rec.id))
+        coordinator.sendToLLM(recordingID: rec.id,
+                              tool: .claude,
+                              prompt: "Summarize",
+                              transcript: "the transcript text",
+                              summary: "",
+                              executableOverride: script.path)
+        // Yield so the task body starts and registers itself.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertTrue(coordinator.isSending(rec.id),
+                      "isSending should be true while the CLI is running")
+
+        try await waitForBanner(containing: "CLI ANSWER", timeoutSeconds: 30)
+        XCTAssertFalse(coordinator.isSending(rec.id),
+                       "isSending should clear once the CLI returns")
+        XCTAssertEqual(coordinator.activityIsError, false)
+    }
+
+    /// A second send for the same recording id cancels + replaces the
+    /// first — no two competing CLI calls writing the same banner.
+    func test_second_send_for_same_id_replaces_the_first() async throws {
+        // First script blocks long enough that the replacement lands while
+        // it's still "running".
+        let slow = makeScript("""
+            #!/bin/sh
+            sleep 5
+            printf 'SLOW'
+            """)
+        let fast = makeScript("""
+            #!/bin/sh
+            printf 'FAST'
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: slow)
+            try? FileManager.default.removeItem(at: fast)
+        }
+
+        let rec = addCompletedRecording(text: "transcript")
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
+                              transcript: "transcript", summary: "",
+                              executableOverride: slow.path)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
+                              transcript: "transcript", summary: "",
+                              executableOverride: fast.path)
+
+        // The fast replacement wins; the slow one was cancelled (its
+        // .cancelled error is swallowed silently).
+        try await waitForBanner(containing: "FAST", timeoutSeconds: 30)
+        XCTAssertFalse(coordinator.activityStatus?.contains("SLOW") ?? false,
+                       "Replaced send must not surface its output")
+    }
+
+    // MARK: - Discard cancels an in-flight send
+
+    /// Discarding the recording (cancelAndDiscard) must cancel a pending
+    /// send so the CLI isn't left chewing on a transcript whose recording
+    /// has been deleted out from under it. After discard, `isSending`
+    /// clears and the recording is gone from the store.
+    func test_discard_cancels_in_flight_send() async throws {
+        let slow = makeScript("""
+            #!/bin/sh
+            sleep 10
+            printf 'SHOULD NOT LAND'
+            """)
+        defer { try? FileManager.default.removeItem(at: slow) }
+
+        // The recording must be `pending` in the coordinator for
+        // cancelAndDiscard to act on it.
+        let audioURL = store.freshAudioURL(suggestedName: "Discard")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(title: "Discard", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent,
+                            fullText: "transcript")
+        rec.status = .completed
+        store.add(rec)
+        coordinator.present(rec)
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
+                              transcript: "transcript", summary: "",
+                              executableOverride: slow.path)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(coordinator.isSending(rec.id))
+
+        coordinator.cancelAndDiscard()
+        // Cancellation propagates to the CLI (SIGTERM) — give it a beat.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertFalse(coordinator.isSending(rec.id),
+                       "Discard must cancel + clear the in-flight send")
+        XCTAssertNil(store.recordings.first(where: { $0.id == rec.id }),
+                     "Discard permanently deletes the recording")
+    }
+
+    // MARK: - Fired before the transcript is ready
+
+    /// "Send" can now be pressed before transcription finishes. With an
+    /// empty transcript snapshot the coordinator waits for the recording
+    /// to leave the in-progress states, then pulls the finished transcript
+    /// from the store and sends THAT — rather than no-op'ing on empty.
+    func test_send_waits_for_transcript_when_fired_early() async throws {
+        // Script echoes back enough of its argv that we can confirm the
+        // late-arriving transcript made it into the prompt.
+        let script = makeScript("""
+            #!/bin/sh
+            printf 'sent:%s' "$2"
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        // Recording starts in-progress with no text — mimics pressing
+        // Send while whisper is still running.
+        let audioURL = store.freshAudioURL(suggestedName: "Early")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(title: "Early", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent,
+                            fullText: "")
+        rec.status = .running
+        store.add(rec)
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "Do it",
+                              transcript: "",  // empty: fired early
+                              summary: "",
+                              executableOverride: script.path)
+        // It should still be in flight (waiting on the transcript), not
+        // bailed out.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertTrue(coordinator.isSending(rec.id),
+                      "Send should wait, not give up, on an empty transcript")
+
+        // Transcription finishes a moment later.
+        if var current = store.recordings.first(where: { $0.id == rec.id }) {
+            current.fullText = "finished transcript"
+            current.segments = [TranscriptSegment(start: 0, end: 1, text: "finished transcript")]
+            current.status = .completed
+            store.update(current)
+        }
+
+        try await waitForBanner(containing: "finished transcript", timeoutSeconds: 30)
+        XCTAssertFalse(coordinator.isSending(rec.id))
+    }
+
+    // MARK: - Helpers
+
+    /// Add a `.completed` recording with the given transcript text, with a
+    /// placeholder audio file so `RecordingStore.add` is happy.
+    private func addCompletedRecording(text: String) -> Recording {
+        let audioURL = store.freshAudioURL(suggestedName: "Send")
+        try? Data("not-audio".utf8).write(to: audioURL)
+        var rec = Recording(title: "Send", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent,
+                            fullText: text)
+        rec.status = .completed
+        store.add(rec)
+        return rec
+    }
+
+    private func waitForBanner(containing needle: String,
+                               timeoutSeconds: TimeInterval) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let status = coordinator.activityStatus, status.contains(needle) {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting for banner containing \"\(needle)\" (was: \(coordinator.activityStatus ?? "nil"))")
+    }
+
+    private func makeScript(_ body: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-send-test-\(UUID().uuidString).sh")
+        try? body.write(to: url, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: url.path
+        )
+        return url
+    }
+}


### PR DESCRIPTION
## What & why

In the post-record (rename) flow, pressing **Save** lets work continue in the background — the user can dismiss the sheet and walk away. **Send to Claude** did *not*:

1. The Send button in `RenameRecordingSheet.swift` was `.disabled(!transcriptReady)`, so it couldn't be pressed until transcription finished — defeating "fire and walk away". (Save is always enabled.)
2. `RenameRecordingSheet.saveAndSend()` spawned a bare anonymous `Task.detached` that no long-lived object owned/tracked — unlike the summary path, which is owned by the app-lifetime `RecordingSummarizer` (id-keyed `inFlight` map + write-back). The untracked send also meant `PostRecordingCoordinator.cancelAndDiscard()` couldn't cancel it — a footgun where Discard could delete a recording out from under an in-flight send. The same untracked send existed in `SendToLLMSheet.send()`.

This makes "Send to Claude" run in the background like Save, following the `RecordingSummarizer` pattern.

### Changes
- **`PostRecordingCoordinator`** gains an id-keyed background send runner:
  - `sendToLLM(recordingID:tool:prompt:transcript:summary:executableOverride:)` stores its `Task` in a `[UUID: Task<Void, Never>]` map (`sendTasks`), runs `LLMRunner.run(...)`, reports result/error through the existing activity banner (`postStatus`), and self-clears its handle on completion (`defer`). `isSending(_:)` exposes in-flight state.
  - If fired **before the transcript is ready** (empty snapshot), the runner polls the store for the finished transcript (`awaitTranscript`) instead of blocking the UI — so the button never needs to gate on readiness.
  - `cancelAndDiscard()` now also cancels the send task (Discard cancels a pending send), and a re-send for the same id cancels + replaces the prior one.
- **`RenameRecordingSheet.saveAndSend()`** and **`SendToLLMSheet.send()`** delegate to `sendToLLM(...)` instead of each spawning their own `Task.detached`.
- The rename sheet's **Send button drops `.disabled(!transcriptReady)`** so it can be fired and left to run.

### Why `PostRecordingCoordinator` (not `QuickActionsController`)?
`PostRecordingCoordinator` is the app-lifetime `@StateObject`/`ObservableObject` that **both** sheets already hold as an `@EnvironmentObject`, it already owns `postStatus` (the banner) and `cancelAndDiscard` (the footgun being fixed), and it already keeps a `[UUID: Task]` map. The callers snapshot prompt/transcript/summary and pass them in, so the runner needs **no** new dependency plumbing (no `LLMSettings`/`RecordingStore` injection). `QuickActionsController` would have required threading `LLMSettings` reads through and isn't held by these sheets.

## How it was tested
- `make project` + a `CODE_SIGNING_ALLOWED=NO` app build (`xcodebuild ... build`) — **BUILD SUCCEEDED**, changed files compiled clean (no errors/warnings).
- `build-for-testing` for the test target — **succeeded**.
- New `MilaTests/PostRecordingCoordinatorSendTests.swift` (mirrors `RecordingSummarizerTests`' script-as-`claude` stub via `executableOverride`): **4/4 pass** — background run reports via banner + `isSending` is id-keyed and clears; a second send for the same id replaces the first; Discard cancels an in-flight send (and deletes the recording); Send fired before the transcript is ready waits and then sends the finished transcript.
- Did not run the full `make test` suite (long-running; the focused new tests + full app/test-target compile cover the change).

## Checklist

- [x] Builds locally and the new tests pass (full `make test` not run — see above)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — behavior fix, not adding a new feature/changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)