### PR TITLE
docs: add System requirements section for end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,32 @@ running through `whisper.cpp` (GPU via Metal).
 - Per-segment timestamps, click to seek, copy/share transcript, RTL rendering
   for Hebrew.
 
-## Requirements
+## System requirements
 
-- macOS 14 (Sonoma) or newer.
+To **run** Mila:
+
+- **macOS 14 (Sonoma) or later.**
+- **Apple Silicon (M-series) strongly recommended.** Transcription runs on the
+  Metal GPU (`whisper.cpp`) and speaker diarization on MPS/CPU (pyannote). Intel
+  Macs fall back to CPU and are much slower.
+- **Disk:** ~4.6 GB for the two default Whisper models, downloaded on first
+  launch (ivrit.ai `large-v3` ~3.0 GB + OpenAI `large-v3-turbo` ~1.6 GB). Add
+  ~1 GB more if you enable speaker diarization (bundled Python runtime plus a
+  torch download on first enable).
+- **Memory (approximate):** 16 GB unified memory recommended. 8 GB is workable
+  for plain transcription but tight with diarization. Rough working set: Hebrew
+  `large-v3` ~3.5–4 GB, English `large-v3-turbo` ~1.5–2 GB, speaker diarization
+  adds ~1–2 GB. (RAM figures are approximate guidance, not a hard spec.)
+- **Live (real-time) mode** — running transcription and diarization concurrently
+  in real time is the heaviest path. It's **automatically disabled on MacBook
+  Air–class chips** (they can't keep up in real time) and recommended on M-series
+  Pro/Max, or M2 and newer. Recording plus after-the-fact transcription still
+  works on Air.
+
+To **build** Mila:
+
 - Xcode 15.3 or newer (Command Line Tools alone are not enough).
 - Homebrew (used to install [`xcodegen`](https://github.com/yonaskolb/XcodeGen)).
-- ~4.6 GB of disk for both default ggml models.
 
 ## Build & run
 


### PR DESCRIPTION
## What & why

Adds a **System requirements** section to the README aimed at *end users
running* Mila, distinct from the existing *build* prerequisites.

The previous "Requirements" section mixed runtime and build needs. This splits
it into **To run** and **To build**:

- **To run** now documents: macOS 14 (Sonoma) or later; Apple Silicon strongly
  recommended (Metal GPU for transcription, MPS/CPU for diarization; Intel falls
  back to slow CPU); disk (~4.6 GB for the two default models, +~1 GB with
  diarization); approximate memory guidance (16 GB recommended, 8 GB workable
  but tight); and that Live/real-time mode is automatically disabled on MacBook
  Air–class chips (recommended on M-series Pro/Max or M2+).
- **To build** keeps the Xcode + Homebrew/xcodegen prerequisites.

RAM figures are phrased as approximate guidance, not a hard spec. The
MacBook Air live-mode gating matches `SystemCapabilities.isLiveAIRecommended`.

## How it was tested

Docs-only change — no code touched. Verified the rendered Markdown structure
and that the live-mode claim matches the gating in
`Mila/Models/SystemCapabilities.swift`.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — n/a, docs-only
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, documentation update only
