### PR TITLE
Make summary + action items copyable in one click; un-truncate detail buttons

### DIFF
--- a/Mila/Views/AIOverviewSection.swift
+++ b/Mila/Views/AIOverviewSection.swift
@@ -88,6 +88,21 @@ struct AIOverviewSection: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                Spacer(minLength: 8)
+                if !text.isEmpty {
+                    // One-click copy of the whole summary. The selectable
+                    // text + context menu stay; a visible button just makes
+                    // "grab the summary" obvious (matches the transcript's
+                    // Copy button).
+                    Button {
+                        AIOverviewSection.copyToPasteboard(text)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy summary")
+                    .accessibilityIdentifier("detail.summary.copy")
+                }
             }
             // Selectable + right-clickable so users can grab the summary
             // into another doc / chat. `textSelection(.enabled)` gives
@@ -132,9 +147,24 @@ struct AIOverviewSection: View {
     private func actionItemsView(alignment: Alignment,
                                  multiline: TextAlignment) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Label("Action items", systemImage: "checklist")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(.tint)
+            HStack(spacing: 6) {
+                Label("Action items", systemImage: "checklist")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.tint)
+                Spacer(minLength: 8)
+                // Each row is individually selectable + copyable, but they're
+                // separate Text views so you can't drag-select them all at
+                // once. This copies every item as a bulleted block in one
+                // click — the affordance users were missing for action items.
+                Button {
+                    AIOverviewSection.copyToPasteboard(Self.actionItemsText(items))
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .help("Copy action items")
+                .accessibilityIdentifier("detail.actionItems.copy")
+            }
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(items) { item in
                     ActionItemRow(text: item.text,
@@ -143,6 +173,11 @@ struct AIOverviewSection: View {
                 }
             }
         }
+    }
+
+    /// All action items as a bulleted plain-text block, for one-click copy.
+    fileprivate static func actionItemsText(_ items: [ActionItem]) -> String {
+        items.map { "• \($0.text)" }.joined(separator: "\n")
     }
 
     fileprivate static func copyToPasteboard(_ text: String) {

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -130,7 +130,11 @@ struct RecordingDetailView: View {
         let currentLang = RecordingLanguage.fromCode(recording.language)
         let busy = transcription.activeRecordingID == recording.id
                    || transcription.pendingIDs.contains(recording.id)
-        return HStack {
+        // Icon-only buttons with hover tooltips. Labeled buttons here
+        // competed with the title for header width and truncated ("Copy
+        // tra…"); icons keep all four actions visible at any window size.
+        // The Re-transcribe MENU keeps its full text labels in the dropdown.
+        return HStack(spacing: 10) {
             Menu {
                 Button {
                     transcription.enqueue(recording)
@@ -145,29 +149,32 @@ struct RecordingDetailView: View {
                           systemImage: "arrow.triangle.2.circlepath")
                 }
             } label: {
-                Label(recording.status == .completed ? "Re-transcribe" : "Transcribe",
-                      systemImage: "text.badge.checkmark")
+                Image(systemName: "text.badge.checkmark")
             }
+            .fixedSize()
             .disabled(busy)
+            .help(recording.status == .completed ? "Re-transcribe" : "Transcribe")
 
             ShareLink(item: store.audioURL(for: recording)) {
-                Label("Share audio", systemImage: "square.and.arrow.up")
+                Image(systemName: "square.and.arrow.up")
             }
+            .help("Share audio")
 
             Button {
                 copyTranscript()
             } label: {
-                Label("Copy transcript", systemImage: "doc.on.doc")
+                Image(systemName: "doc.on.doc")
             }
             .disabled(recording.fullText.isEmpty)
+            .help("Copy transcript")
 
             Button {
                 exportSRT()
             } label: {
-                Label("Export Subtitles", systemImage: "captions.bubble")
+                Image(systemName: "captions.bubble")
             }
             .disabled(recording.segments.isEmpty)
-            .help("Save subtitles (.srt) for the original video/audio")
+            .help("Export subtitles (.srt) for the original video/audio")
         }
     }
 


### PR DESCRIPTION
## What & why

Two reported gaps in the recording **detail view**:

1. **Action items weren't easily copyable.** Each item is a separate selectable `Text`, so — unlike the single summary `Text` — you couldn't drag-select them all at once, and the only affordance was a per-item right-click "Copy". Users could copy the summary but not "the action items."
   → Added a one-click **Copy action items** button to the Action-items header (copies every item as a `• …` block), plus a matching **Copy summary** button to the Summary header. The existing per-item selection + context menus are unchanged. Both `AIOverviewSection` call sites (detail view + post-record rename sheet) benefit.

2. **The detail header action buttons were truncating** ("Copy tra…"). The four labeled buttons (Re-transcribe / Share audio / Copy transcript / Export Subtitles) competed with the title for header width.
   → Switched them to **icon-only with hover tooltips** (`.help`), so all four stay visible at any window size and the row reads like a native toolbar. The Re-transcribe **menu keeps full text labels** in its dropdown.

## How it was tested

- `make build` → **BUILD SUCCEEDED**.
- Visual/UX change only; no logic touched (the copy helpers reuse the existing `copyToPasteboard`). No unit test added — it's presentation.

## Checklist

- [x] Builds locally (`make build`)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (n/a — UI polish)