### PR TITLE
Fix About panel credits area blending with the window background

### DIFF
--- a/Mila/Resources/Credits.html
+++ b/Mila/Resources/Credits.html
@@ -3,6 +3,13 @@
 <head>
 <meta charset="utf-8">
 <style>
+/* Adapt to the system About panel's appearance so this text area blends with
+   the surrounding window background instead of rendering as a darker/inset
+   light box. `color-scheme` makes WebKit give the document a transparent,
+   appearance-matching backdrop and adapt default colors; `background:
+   transparent` lets the panel's own windowBackgroundColor show through. */
+:root { color-scheme: light dark; }
+html, body { background: transparent; }
 body { font: 11px -apple-system, sans-serif; color: #222; margin: 0; padding: 6px 4px; }
 h2 { font-size: 11px; margin: 8px 0 2px 0; text-transform: uppercase; letter-spacing: 0.06em; color: #555; }
 p { margin: 0 0 6px 0; line-height: 1.4; }
@@ -10,6 +17,13 @@ ul { margin: 0 0 6px 0; padding-left: 14px; }
 li { margin: 1px 0; line-height: 1.4; }
 a { color: #0066cc; text-decoration: none; }
 .note { color: #777; font-size: 10px; }
+
+@media (prefers-color-scheme: dark) {
+  body { color: #ddd; }
+  h2 { color: #aaa; }
+  a { color: #6cb4ff; }
+  .note { color: #999; }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## What & why

The standard macOS About panel ("About Mila") loads the bundled `Credits.html` into a `WKWebView`-backed credits text area. `Credits.html` declared dark text (`#222`) on an implicit white `<body>` background with no `color-scheme`, so in **dark mode** WebKit rendered the credits as a light/white box sitting inside the dark About panel — a darker/inset "text box" that looked out of place. (In light mode the solid white body could also differ subtly from the panel's `windowBackgroundColor`.)

This makes the credits document adapt to the system appearance so it blends with the About panel's own window background in both light and dark mode, instead of drawing as a separate inset box.

Note: Mila does **not** have a custom About view — it uses the system `NSAboutPanel` (the default SwiftUI "About Mila" menu item). The panel auto-loads `Credits.html` from the bundle, so the credits HTML is the only place this is fixable in code without replacing the whole About window. The change is CSS-only and scoped to the credits text area.

Changes in `Mila/Resources/Credits.html`:
- declare `:root { color-scheme: light dark; }` so WebKit gives the document a transparent, appearance-matching backdrop and adapts its defaults
- set `html, body { background: transparent; }` so the panel's own `windowBackgroundColor` shows through (no inset box)
- add a `@media (prefers-color-scheme: dark)` override for text/link colors so the content stays legible against the dark panel

No hard-coded window color; relies on the system About panel's own background.

## How it was tested

- `make build` → `** BUILD SUCCEEDED **` (Debug, platform=macOS)
- CSS-only change to the bundled credits document; no code paths affected.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)