### PR TITLE
Single-block action items + consolidated copy buttons (RTL fix)

### DIFF
--- a/Mila/Views/AIOverviewSection.swift
+++ b/Mila/Views/AIOverviewSection.swift
@@ -34,6 +34,13 @@ struct AIOverviewSection: View {
     /// `summary` is nil but we still want feedback that work is
     /// happening).
     var isSummarizing: Bool = false
+    /// Whether the per-block "Copy summary" / "Copy action items"
+    /// header buttons are shown. The rename sheet keeps them (default
+    /// `true`); the detail view hides them — it consolidates copy into
+    /// two location-based buttons (Summary+Action-items up top, the
+    /// transcript copy in the transcript area). The block's native
+    /// right-click "Copy" stays in both places either way.
+    var showsBlockCopyButtons: Bool = true
 
     /// True iff there's at least one non-empty piece to show. Callers
     /// can use this to collapse their wrapper (avoiding an empty card
@@ -89,11 +96,13 @@ struct AIOverviewSection: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 8)
-                if !text.isEmpty {
+                if showsBlockCopyButtons, !text.isEmpty {
                     // One-click copy of the whole summary. The selectable
                     // text + context menu stay; a visible button just makes
                     // "grab the summary" obvious (matches the transcript's
-                    // Copy button).
+                    // Copy button). Hidden in the detail view (which copies
+                    // summary + action items from the header button) but
+                    // kept in the rename sheet.
                     Button {
                         AIOverviewSection.copyToPasteboard(text)
                     } label: {
@@ -146,32 +155,48 @@ struct AIOverviewSection: View {
 
     private func actionItemsView(alignment: Alignment,
                                  multiline: TextAlignment) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        // One combined bullet line per item, joined into a SINGLE Text so
+        // the whole list is drag-selectable / copyable at once (the old
+        // per-item Text views couldn't be selected together). Non-breaking
+        // space after the bullet keeps "•" glued to its line on wrap.
+        let combined = items.map { "•\u{00A0}\($0.text)" }.joined(separator: "\n")
+        return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Label("Action items", systemImage: "checklist")
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(.tint)
                 Spacer(minLength: 8)
-                // Each row is individually selectable + copyable, but they're
-                // separate Text views so you can't drag-select them all at
-                // once. This copies every item as a bulleted block in one
-                // click — the affordance users were missing for action items.
-                Button {
-                    AIOverviewSection.copyToPasteboard(Self.actionItemsText(items))
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                }
-                .buttonStyle(.borderless)
-                .help("Copy action items")
-                .accessibilityIdentifier("detail.actionItems.copy")
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                ForEach(items) { item in
-                    ActionItemRow(text: item.text,
-                                  alignment: alignment,
-                                  multiline: multiline)
+                if showsBlockCopyButtons {
+                    // Copies every item as a bulleted block in one click.
+                    // Hidden in the detail view (consolidated into the
+                    // header's summary + action-items copy button) but kept
+                    // in the rename sheet.
+                    Button {
+                        AIOverviewSection.copyToPasteboard(Self.actionItemsText(items))
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy action items")
+                    .accessibilityIdentifier("detail.actionItems.copy")
                 }
             }
+            // Single selectable block. Drive the block's layout direction
+            // from the section's RTL decision so the bullets land on the
+            // correct (right) side for Hebrew — the per-item HStack used to
+            // put the "•" on the left even in RTL.
+            Text(combined)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: alignment)
+                .multilineTextAlignment(multiline)
+                .textSelection(.enabled)
+                .environment(\.layoutDirection, sectionIsRTL ? .rightToLeft : .leftToRight)
+                .contextMenu {
+                    Button("Copy") {
+                        AIOverviewSection.copyToPasteboard(Self.actionItemsText(items))
+                    }
+                }
         }
     }
 
@@ -184,34 +209,5 @@ struct AIOverviewSection: View {
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(text, forType: .string)
-    }
-}
-
-/// Single bullet line for an action item — selectable text plus a
-/// right-click "Copy" affordance. Internal so both the detail view
-/// and the rename sheet share the exact row layout.
-private struct ActionItemRow: View {
-    let text: String
-    let alignment: Alignment
-    let multiline: TextAlignment
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("•").foregroundStyle(.secondary)
-            // Selectable so the user can drag-select the row's text;
-            // right-click surfaces a one-click "Copy" for the whole
-            // item (the most common ask — paste it into a TODO list).
-            Text(text)
-                .font(.callout)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: alignment)
-                .multilineTextAlignment(multiline)
-                .textSelection(.enabled)
-                .contextMenu {
-                    Button("Copy") {
-                        AIOverviewSection.copyToPasteboard(text)
-                    }
-                }
-        }
     }
 }

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -161,12 +161,12 @@ struct RecordingDetailView: View {
             .help("Share audio")
 
             Button {
-                copyTranscript()
+                copyOverview()
             } label: {
                 Image(systemName: "doc.on.doc")
             }
-            .disabled(recording.fullText.isEmpty)
-            .help("Copy transcript")
+            .disabled(!hasOverviewToCopy)
+            .help("Copy summary + action items")
 
             Button {
                 exportSRT()
@@ -261,35 +261,54 @@ struct RecordingDetailView: View {
                 description: Text("Click \(Image(systemName: "text.badge.checkmark")) Transcribe to start.")
             )
         } else {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 4) {
-                    // Show the speaker column whenever ANY segment has a
-                    // speaker label — that's how the user knows
-                    // diarization actually ran for this recording.
-                    // Dictation segments have nil speakers, so they
-                    // naturally hide the column; a meeting where
-                    // pyannote found only 1 speaker still shows
-                    // "Speaker A" so the user gets feedback that the
-                    // detection ran (vs. silently failing to detect).
-                    let hasSpeakers = recording.segments.contains { $0.speaker != nil }
-                    ForEach(recording.segments) { seg in
-                        SegmentRow(segment: seg,
-                                   isActive: currentTime >= seg.start && currentTime < seg.end,
-                                   showSpeaker: hasSpeakers,
-                                   language: recording.language,
-                                   onTap: { seek(to: seg.start) })
+            VStack(spacing: 0) {
+                // Transcript-area copy button, on the right just below the
+                // AI-overview banner's divider. Mirrors the consolidated
+                // copy model: this grabs the transcript; the header button
+                // grabs the summary + action items.
+                HStack {
+                    Spacer()
+                    Button {
+                        copyTranscript()
+                    } label: {
+                        Image(systemName: "doc.on.doc")
                     }
-                }
-                .padding()
-                .environment(\.layoutDirection, recording.language == "he" ? .rightToLeft : .leftToRight)
-            }
-            .contextMenu {
-                let other = RecordingLanguage.fromCode(recording.language).other
-                Button("Re-transcribe in \(other.flagEmoji) \(other.displayName)") {
-                    retranscribe(in: other)
-                }
-                Button("Copy transcript") { copyTranscript() }
+                    .buttonStyle(.borderless)
                     .disabled(recording.fullText.isEmpty)
+                    .help("Copy transcript")
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        // Show the speaker column whenever ANY segment has a
+                        // speaker label — that's how the user knows
+                        // diarization actually ran for this recording.
+                        // Dictation segments have nil speakers, so they
+                        // naturally hide the column; a meeting where
+                        // pyannote found only 1 speaker still shows
+                        // "Speaker A" so the user gets feedback that the
+                        // detection ran (vs. silently failing to detect).
+                        let hasSpeakers = recording.segments.contains { $0.speaker != nil }
+                        ForEach(recording.segments) { seg in
+                            SegmentRow(segment: seg,
+                                       isActive: currentTime >= seg.start && currentTime < seg.end,
+                                       showSpeaker: hasSpeakers,
+                                       language: recording.language,
+                                       onTap: { seek(to: seg.start) })
+                        }
+                    }
+                    .padding()
+                    .environment(\.layoutDirection, recording.language == "he" ? .rightToLeft : .leftToRight)
+                }
+                .contextMenu {
+                    let other = RecordingLanguage.fromCode(recording.language).other
+                    Button("Re-transcribe in \(other.flagEmoji) \(other.displayName)") {
+                        retranscribe(in: other)
+                    }
+                    Button("Copy transcript") { copyTranscript() }
+                        .disabled(recording.fullText.isEmpty)
+                }
             }
         }
     }
@@ -343,6 +362,36 @@ struct RecordingDetailView: View {
                                                  fallback: recording.fullText)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    /// Whether there's any AI overview content (summary or action items)
+    /// to copy. Gates the header's "Copy summary + action items" button.
+    private var hasOverviewToCopy: Bool {
+        let hasSummary = recording.summary?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let hasItems = !(recording.actionItems ?? []).isEmpty
+        return hasSummary || hasItems
+    }
+
+    /// Copy the AI overview (summary + action items) as plain text: the
+    /// summary first, then — separated by a blank line — the action items
+    /// as `•\u{00A0}…` lines. Only the parts that actually exist are
+    /// included, so a summary-only or items-only recording copies cleanly.
+    private func copyOverview() {
+        var parts: [String] = []
+        if let summary = recording.summary?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !summary.isEmpty {
+            parts.append(summary)
+        }
+        let items = recording.actionItems ?? []
+        if !items.isEmpty {
+            parts.append(items.map { "•\u{00A0}\($0.text)" }.joined(separator: "\n"))
+        }
+        guard !parts.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(parts.joined(separator: "\n\n"), forType: .string)
     }
 }
 
@@ -422,7 +471,12 @@ private struct AIOverviewBanner: View {
             items: items,
             recordingLanguage: recordingLanguage,
             onRegenerateSummary: onRegenerateSummary,
-            isSummarizing: isSummarizing
+            isSummarizing: isSummarizing,
+            // The detail view consolidates copy into two location-based
+            // buttons (Summary+Action-items up top, transcript in the
+            // transcript area), so the per-block header copy buttons are
+            // hidden here. The block's native right-click "Copy" stays.
+            showsBlockCopyButtons: false
         )
         if section.hasContent {
             VStack(spacing: 0) {


### PR DESCRIPTION
## What & why

Reworks the recording detail view's AI-overview copy affordances and fixes an RTL bug in the action-items list.

**Change 1 — Action items become one selectable text block (RTL fix).** In `AIOverviewSection.actionItemsView`, the `ForEach(items) { ActionItemRow(...) }` (and the now-unused `ActionItemRow` struct) is replaced with a single `Text` containing all items as `•\u{00A0}…` bulleted lines joined with newlines, so the whole list is drag-selectable/copyable at once. The block's layout direction is driven from the existing `sectionIsRTL` (`.environment(\.layoutDirection, ...)`) so bullets render on the correct (right) side for Hebrew — previously the per-item HStack put the `•` on the left even in RTL. A right-click "Copy" (copies all items) stays. This is the shared component, so the fix applies to both the detail view and the post-record rename sheet.

**Change 2 — Consolidate visible copy buttons (two total, by location).**
- New `showsBlockCopyButtons: Bool = true` on `AIOverviewSection` gates the per-block Summary / Action-items header copy buttons. Default `true` keeps the rename sheet unchanged; the detail view's `AIOverviewBanner` passes `showsBlockCopyButtons: false`, so it shows no per-block buttons.
- The detail header's icon-only `doc.on.doc` button is repurposed to copy **Summary + Action items** (combined string: summary, blank line, then action items as `•\u{00A0}…` lines — only the parts that exist), via a new `copyOverview()` helper. Tooltip "Copy summary + action items"; disabled when there's no summary and no action items.
- A new icon-only **Copy transcript** button (`doc.on.doc`, "Copy transcript") is added at the top-right of the transcript area, just below the AI-overview divider; it calls the existing `copyTranscript()` and is disabled when `recording.fullText` is empty. The transcript context-menu "Copy transcript" stays.

Net result in the detail view: exactly two visible copy buttons (Summary+Action-items up top, transcript in the transcript area) plus native right-click copy on each block.

## How it was tested

- `make build` -> `** BUILD SUCCEEDED **` (fresh clone, recurse-submodules).
- RTL: verified by reasoning about the SwiftUI layout (no live UI/data in this environment). The combined `Text` sets `\.layoutDirection` to `.rightToLeft` when `sectionIsRTL` is true, which mirrors the bullet/line ordering so `•` sits on the right edge for Hebrew items; `multilineTextAlignment`/`frame(alignment:)` already trail for RTL. Could not run the app to visually confirm pixel placement.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)