### PR TITLE
Skip offline re-diarize when the live pass found ≤3 speakers

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -27,6 +27,23 @@ final class QuickActionsController: ObservableObject {
         case importingFile(URL)
     }
 
+    /// Upper bound on the number of distinct speakers the LIVE diarizer
+    /// found below which we skip the offline re-diarize pass entirely.
+    ///
+    /// The offline re-diarize (`TranscriptionService.rediarizeSegments`)
+    /// only exists to fix the online diarizer's tendency to OVER-segment —
+    /// it labels each utterance as it streams in and can never revise, so a
+    /// single narrator can end up split across 7 `SPEAKER_NN`. Global
+    /// clustering on the finished WAV collapses those back down.
+    ///
+    /// But over-segmentation only matters when MANY speakers were minted.
+    /// For a short conversation the live pass already pinned at ≤3 distinct
+    /// speakers, the labels are almost certainly correct, so re-running the
+    /// heavy pyannote subprocess is wasted work and delay — "when you're
+    /// done, you're just done." We re-diarize only when the live count
+    /// exceeds this threshold. See `shouldRediarize(liveSpeakerCount:)`.
+    static let maxLiveSpeakersToSkipRediarize = 3
+
     @Published private(set) var activeJob: ActiveJob = .none
     @Published private(set) var availableApps: [SCRunningApplication] = []
     @Published var isAppPickerShown = false
@@ -737,6 +754,20 @@ final class QuickActionsController: ObservableObject {
         finalizeTail(for: updated, liveTranscriptIsAuthoritative: liveTranscriptIsAuthoritative)
     }
 
+    /// Whether the offline re-diarize pass is worth running given how many
+    /// distinct speakers the LIVE diarizer already found. Re-diarization
+    /// only corrects OVER-segmentation, which only happens when many
+    /// speakers were minted; at or below `maxLiveSpeakersToSkipRediarize`
+    /// the live labels are almost certainly already right, so we skip the
+    /// heavy pyannote subprocess. `liveSpeakerCount == 0` (no labels at
+    /// all) also skips — there's nothing for the offline pass to clean up.
+    ///
+    /// Pure + `static` so the gate is unit-testable without a real
+    /// diarization subprocess (which CI can't spin up).
+    static func shouldRediarize(liveSpeakerCount: Int) -> Bool {
+        liveSpeakerCount > maxLiveSpeakersToSkipRediarize
+    }
+
     /// The HEAVY, live-singleton-free tail of finalization, run as a
     /// detached, id-keyed background task so the record button (freed in
     /// `stopRecording` once the live pipeline is drained) stays usable
@@ -774,17 +805,28 @@ final class QuickActionsController: ObservableObject {
                 // labels. Skips gracefully — keeping the live speakers — if
                 // diarization isn't configured or the pass fails.
                 //
-                // Re-fetch before writing: the user may have renamed the
-                // recording (rename sheet) while this tail was running, so
-                // we update only the segments rather than clobbering the row.
-                if let rediarized = await self.transcription.rediarizeSegments(
-                    wavURL: self.store.audioURL(for: updated),
-                    segments: updated.segments) {
-                    updated.segments = rediarized
-                    if var current = self.store.recordings.first(where: { $0.id == id }) {
-                        current.segments = rediarized
-                        self.store.update(current)
-                        updated = current
+                // Only re-diarize when the live pass minted MORE than
+                // `maxLiveSpeakersToSkipRediarize` distinct speakers —
+                // that's the over-segmentation the offline pass fixes. A
+                // short conversation the live diarizer already pinned at
+                // ≤3 speakers is almost certainly correct, so we finalize
+                // with the live labels as-is and skip the heavy pyannote
+                // subprocess (saves seconds of post-record delay).
+                let liveSpeakerCount = Set(updated.segments.compactMap(\.speaker)).count
+                if Self.shouldRediarize(liveSpeakerCount: liveSpeakerCount) {
+                    // Re-fetch before writing: the user may have renamed the
+                    // recording (rename sheet) while this tail was running, so
+                    // we update only the segments rather than clobbering the row.
+                    if let rediarized = await self.transcription.rediarizeSegments(
+                        wavURL: self.store.audioURL(for: updated),
+                        segments: updated.segments,
+                        recordingID: id) {
+                        updated.segments = rediarized
+                        if var current = self.store.recordings.first(where: { $0.id == id }) {
+                            current.segments = rediarized
+                            self.store.update(current)
+                            updated = current
+                        }
                     }
                 }
                 // Write the SRT sidecar + trigger the summarizer ourselves (the

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -16,6 +16,15 @@ private let serviceLog = Logger(subsystem: "io.island.whisper.IslandWhisper", ca
 final class TranscriptionService: ObservableObject {
     @Published private(set) var activeRecordingID: UUID?
     @Published private(set) var pendingIDs: [UUID] = []
+
+    /// Set to a recording's id while the OFFLINE speaker re-diarize pass is
+    /// running for it (`rediarizeSegments`). This is NOT transcription —
+    /// the transcript text is already final by this point; the pyannote
+    /// subprocess is only re-clustering speaker labels. The UI uses this to
+    /// show an accurate "Identifying speakers…" status instead of falsely
+    /// implying the transcript is still being produced. `nil` when no
+    /// re-diarize is in flight.
+    @Published private(set) var diarizingRecordingID: UUID?
     @Published private(set) var progress: Double = 0
     @Published var lastError: String?
 
@@ -271,8 +280,15 @@ final class TranscriptionService: ObservableObject {
     /// diarization isn't configured, there are no segments, the offline pass
     /// yields no turns, or it throws. The whole pass runs off-main inside
     /// `SpeakerDiarizer.diarize`.
-    func rediarizeSegments(wavURL: URL, segments: [TranscriptSegment]) async -> [TranscriptSegment]? {
+    ///
+    /// Pass `recordingID` so the UI can show an accurate "Identifying
+    /// speakers…" status (via `diarizingRecordingID`) for exactly the
+    /// recording being re-diarized — the transcript text is already final
+    /// here, so calling this "Transcribing" would mislead.
+    func rediarizeSegments(wavURL: URL, segments: [TranscriptSegment], recordingID: UUID? = nil) async -> [TranscriptSegment]? {
         guard diarizationSettings.isConfigured, !segments.isEmpty else { return nil }
+        diarizingRecordingID = recordingID
+        defer { diarizingRecordingID = nil }
         do {
             let turns = try await SpeakerDiarizer.diarize(wavURL: wavURL,
                                                           pythonPath: diarizationSettings.pythonPath)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -77,13 +77,19 @@ struct RenameRecordingSheet: View {
             || summarizer.isSummarizing(liveRecording.id)
     }
 
-    /// "Transcribing…", "Done", "Failed", "Waiting in queue" — drives the
-    /// progress indicator inside the sheet.
+    /// "Transcribing…", "Identifying speakers…", "Done", "Failed",
+    /// "Waiting in queue" — drives the progress indicator inside the sheet.
     private var transcriptionLabel: String {
         let live = liveRecording
         if transcription.activeRecordingID == live.id {
             let pct = Int(transcription.progress * 100)
             return "Transcribing… \(pct)%"
+        }
+        // The offline re-diarize pass: the transcript text is already final
+        // (status is .completed), so "Transcribing" would be wrong — the
+        // pyannote subprocess is only re-clustering speaker labels.
+        if transcription.diarizingRecordingID == live.id {
+            return "Identifying speakers…"
         }
         switch live.status {
         case .pending:   return "Waiting to transcribe…"
@@ -384,13 +390,20 @@ struct RenameRecordingSheet: View {
 
     @ViewBuilder
     private var statusIcon: some View {
-        switch liveRecording.status {
-        case .completed:
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-        case .failed:
-            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
-        default:
+        // While the offline re-diarize is in flight the transcript is done
+        // but speaker labels aren't — show a spinner, not the green check,
+        // to match the "Identifying speakers…" label.
+        if transcription.diarizingRecordingID == liveRecording.id {
             ProgressView().controlSize(.small)
+        } else {
+            switch liveRecording.status {
+            case .completed:
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+            case .failed:
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
+            default:
+                ProgressView().controlSize(.small)
+            }
         }
     }
 

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -295,6 +295,29 @@ final class QuickActionsControllerTests: XCTestCase {
                        "the heavy finalize tail must run with the record button free")
     }
 
+    // MARK: - Re-diarize gate (skip when the live pass found few speakers)
+
+    /// The offline re-diarize only fixes the online diarizer's
+    /// over-segmentation, which only happens when MANY speakers were
+    /// minted. At or below the threshold the live labels are kept as-is
+    /// (no heavy pyannote subprocess). `0` (no labels) also skips.
+    func test_shouldRediarize_skips_at_or_below_threshold() {
+        XCTAssertEqual(QuickActionsController.maxLiveSpeakersToSkipRediarize, 3)
+        XCTAssertFalse(QuickActionsController.shouldRediarize(liveSpeakerCount: 0),
+                       "No live speaker labels at all — nothing to clean up, skip")
+        XCTAssertFalse(QuickActionsController.shouldRediarize(liveSpeakerCount: 1))
+        XCTAssertFalse(QuickActionsController.shouldRediarize(liveSpeakerCount: 2))
+        XCTAssertFalse(QuickActionsController.shouldRediarize(liveSpeakerCount: 3),
+                       "Exactly at the threshold must still skip")
+    }
+
+    /// Above the threshold the live pass over-segmented (e.g. one narrator
+    /// split into 7 speakers) — re-diarize to re-cluster globally.
+    func test_shouldRediarize_runs_above_threshold() {
+        XCTAssertTrue(QuickActionsController.shouldRediarize(liveSpeakerCount: 4))
+        XCTAssertTrue(QuickActionsController.shouldRediarize(liveSpeakerCount: 7))
+    }
+
     func test_user_bug_repro_second_recording_after_first_started_transcribing() async throws {
         let first = tempRoot.appendingPathComponent("recording-A.wav")
         let second = tempRoot.appendingPathComponent("recording-B.wav")


### PR DESCRIPTION
## What & why

At recording stop in VAD mode, `QuickActionsController.finalizeTail` runs an offline pyannote **re-diarization** pass (`TranscriptionService.rediarizeSegments`) that REPLACES the live speaker labels. Its only purpose is to fix the live diarizer's tendency to **over-segment** — it labels each utterance as it streams in and can never revise, so a single narrator can end up split into 7 `SPEAKER_NN`. Global clustering on the finished WAV collapses those back down.

But over-segmentation only matters when **many** speakers were minted. For a short conversation the live pass already pinned at **≤3 distinct speakers**, the labels are almost certainly already correct, so re-running the heavy pyannote subprocess is wasted work and post-record delay — "when you're done, you're just done."

This PR:

1. **Gates the re-diarize on a named threshold.** Before calling `rediarizeSegments`, `finalizeTail` now computes the distinct live speaker count (`Set(updated.segments.compactMap(\.speaker)).count`). It re-diarizes only when that count **exceeds** `QuickActionsController.maxLiveSpeakersToSkipRediarize` (= `3`); at or below the threshold (and `0` = no labels at all) it finalizes with the live labels as-is. The existing Phase A / Phase B finalize structure from the record-while-finalizing work is untouched — only the re-diarize call is gated. The decision is extracted into a pure `static func shouldRediarize(liveSpeakerCount:)` so it's unit-testable without a real diarization subprocess.

2. **Fixes a misleading status.** By the time the re-diarize runs the transcript text is already final (`status == .completed`), but the rename sheet showed a green "Transcript ready" check while the pyannote subprocess kept running silently. `TranscriptionService` now exposes `diarizingRecordingID` (set around `rediarizeSegments` via a new optional `recordingID:` arg), and `RenameRecordingSheet` shows **"Identifying speakers…"** with a spinner for that window — accurate, since it's speaker recognition, not transcription.

   Note on the "Transcribing" wording: every literal "Transcribing…" string in the views (`RenameRecordingSheet`, `RecordingDetailView`, the queue rows) is gated on the **transcription queue** (`transcription.activeRecordingID == recording.id`, or `status == .running`). During the offline re-diarize none of those apply (it's a separate `SpeakerDiarizer.diarize` subprocess, not the queue, and status is `.completed`), so there was no incorrect "Transcribing" string to remove — the misleading part was the premature "Transcript ready" while diarization continued. Those queue-driven labels were left untouched; only the genuinely-diarization case was corrected.

## How it was tested

- `make build` → `** BUILD SUCCEEDED **`.
- `build-for-testing` → `** TEST BUILD SUCCEEDED **`.
- Added two fast unit tests for the gate boundary (`test_shouldRediarize_skips_at_or_below_threshold`, `test_shouldRediarize_runs_above_threshold`) in `QuickActionsControllerTests`; ran them via `test-without-building` → 2 tests, 0 failures.

## Checklist

- [x] Builds locally (`make build`) and the new gate tests pass
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — N/A: changelog entries are release-keyed (e.g. "1.8.5 (date) — …") and this PR doesn't bump the version, so no entry was added. Fold into the next release's changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)