### PR TITLE
Align Home Mic / App-audio toggle labels

### DIFF
--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -128,6 +128,11 @@ struct HomeView: View {
                     Image(systemName: "mic.fill")
                         .font(.callout)
                         .foregroundStyle(.tint)
+                        // Fixed-width icon column so both rows' labels line up.
+                        // mic.fill and speaker.wave.2.fill have different
+                        // intrinsic widths, which otherwise pushes "App audio"
+                        // right of "Microphone" (and the glyphs don't align).
+                        .frame(width: 22)
                     Text("Microphone")
                         .font(.callout)
                 }
@@ -140,6 +145,7 @@ struct HomeView: View {
                     Image(systemName: "speaker.wave.2.fill")
                         .font(.callout)
                         .foregroundStyle(.tint)
+                        .frame(width: 22)  // see Microphone icon above
                     Text("App audio")
                         .font(.callout)
                 }


### PR DESCRIPTION
The two source toggles below the Record button (`HomeView.sourceToggles`) used bare icons — `mic.fill` and `speaker.wave.2.fill` — which have different intrinsic widths. So "App audio" started right of "Microphone", and the icons themselves didn't line up.

Fix: put each icon in a fixed-width (22 pt) column (`.frame(width: 22)`) so both rows' icons sit in a uniform column and both labels share the same left edge.

Verified with a local build + screenshot — the "Microphone" and "App audio" labels now align.

Generated with Claude Code