### PR TITLE
Fix Zoom meeting detection: mic-capture instead of window titles

### DIFF
--- a/Mila/Audio/MeetingDetector.swift
+++ b/Mila/Audio/MeetingDetector.swift
@@ -1,69 +1,83 @@
 import AppKit
 import Combine
+import CoreAudio
 import CoreGraphics
+import OSLog
 
 /// Detects when the user joined a meeting in a supported app, so the
 /// app-level prompt coordinator can offer to start transcribing.
 ///
-/// Detection is a low-frequency poll (every 3 s) of the window list,
-/// not an event subscription, because none of the meeting apps publish
-/// a "user joined a meeting" notification. The polling cost is trivial
-/// — `CGWindowListCopyWindowInfo` is a single syscall returning a
-/// description dictionary, and we only inspect titles for processes
-/// matching a known bundle ID.
+/// **Primary signal — microphone capture (macOS 14.4+).** During *any*
+/// Zoom meeting the Zoom process is actively capturing the mic. The Core
+/// Audio per-process API (`kAudioProcessPropertyIsRunningInput`) reports
+/// that per bundle ID, with **no permission prompt** and crucially
+/// **independent of the window title** — so it fires for instant,
+/// scheduled, and join-by-link meetings alike, and it re-arms naturally
+/// (capture stops the moment you leave). This replaced a brittle window-
+/// title match (`title contains "zoom meeting"`) that silently failed for
+/// named/scheduled meetings and needed Screen Recording permission.
 ///
-/// We rely on Screen Recording permission for cross-process window
-/// titles. Mila already requests this for `SystemAudioRecorder`, so the
-/// common case is "we have it." When the permission is missing we
-/// silently skip detection — the prompt simply never fires, which is
-/// better than nagging the user about another permission.
+/// **Fallback — window title (older macOS / API unavailable).** Where the
+/// per-process audio API isn't present we fall back to scanning Zoom's
+/// on-screen window titles via `CGWindowListCopyWindowInfo` (needs Screen
+/// Recording permission for titles; silently skipped without it).
+///
+/// Detection is a low-frequency poll (every 3 s), not an event
+/// subscription — neither the audio nor the window signal posts a "user
+/// joined a meeting" notification.
 @MainActor
 final class MeetingDetector: ObservableObject {
-    /// One supported app — bundle ID plus the window-title substrings
-    /// that indicate the user is *in a meeting* (as opposed to just
-    /// having the app open on the launcher screen).
+    private static let log = Logger(
+        subsystem: "io.island.whisper.IslandWhisper", category: "MeetingDetector")
+
+    /// One supported app. `bundleID` is the canonical ID used for the
+    /// prompt's snooze / silence keys and display; `captureBundlePrefixes`
+    /// are matched (by prefix) against the bundle IDs of processes that are
+    /// actively capturing the mic; `meetingTitleHints` is the window-title
+    /// fallback used only when the audio API is unavailable.
     struct App: Hashable {
         let bundleID: String
         let displayName: String
-        /// Substrings, lowercased, used against window titles. A match
-        /// means "this app is hosting a meeting right now."
+        /// Any running audio process whose bundle ID has one of these
+        /// prefixes AND is capturing mic input ⇒ this app is in a meeting.
+        /// A prefix (not exact) because Zoom may capture under a helper
+        /// bundle ID (`us.zoom.*`) rather than `us.zoom.xos`.
+        let captureBundlePrefixes: [String]
+        /// Lowercased window-title substrings, fallback path only.
         let meetingTitleHints: [String]
     }
 
-    /// The current list of supported meeting apps. Zoom is the only one
-    /// implemented now; adding Google Meet / Teams later is just an
-    /// entry in this array.
+    /// Supported meeting apps. Zoom is the only one implemented now;
+    /// adding Google Meet / Teams later is an entry here (they'd use the
+    /// same mic-capture signal, keyed on their own bundle IDs).
     static let supportedApps: [App] = [
         App(
             bundleID: "us.zoom.xos",
             displayName: "Zoom",
-            // Zoom's meeting window title is "Zoom Meeting" most of the
-            // time; the standalone launcher window is "Zoom Workplace"
-            // or "Zoom" without "Meeting" in it, so the substring is
-            // tight enough not to false-positive.
+            captureBundlePrefixes: ["us.zoom"],
             meetingTitleHints: ["zoom meeting"]
         )
     ]
 
-    /// Fired exactly once per meeting — the first time we detect that a
-    /// supported app has a meeting window. Re-armed when the meeting
-    /// window disappears, so leaving and rejoining a call surfaces a
-    /// second prompt.
+    /// Fired exactly once per meeting — the first poll that sees a
+    /// supported app in a meeting. Re-armed when that app stops being in a
+    /// meeting, so leaving and rejoining a call surfaces a fresh prompt.
     let meetingStarted = PassthroughSubject<App, Never>()
 
     private var pollTask: Task<Void, Never>?
-    /// Bundle IDs we've already prompted for in the current "session"
-    /// (a continuous run of the meeting window). Cleared when the
-    /// meeting window goes away.
+    /// Canonical bundle IDs we've already prompted for in the current run
+    /// of a meeting. Cleared (re-armed) when the meeting ends.
     private var firedFor: Set<String> = []
+    /// Logged once so we know which detection path is live in the field.
+    private var loggedMode = false
 
     func start() {
         guard pollTask == nil else { return }
+        Self.log.notice("starting meeting detector (poll every 3s)")
         pollTask = Task { @MainActor [weak self] in
-            // Initial small delay so the detector doesn't fire during
-            // app launch (when Zoom might already have a meeting open
-            // — the user just got home from work, that's fine, no need
-            // to nag them in the first second).
+            // Small initial delay so we don't fire during app launch (the
+            // user may already be in a meeting — no need to nag them in
+            // the first second).
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             while let self, !Task.isCancelled {
                 self.pollOnce()
@@ -73,6 +87,7 @@ final class MeetingDetector: ObservableObject {
     }
 
     func stop() {
+        Self.log.notice("stopping meeting detector")
         pollTask?.cancel()
         pollTask = nil
         firedFor.removeAll()
@@ -81,34 +96,114 @@ final class MeetingDetector: ObservableObject {
     /// Exposed for tests and one-shot manual triggers (e.g. a future
     /// "Test the meeting prompt" button in Settings).
     func pollOnce() {
-        let running = NSWorkspace.shared.runningApplications
         var activeMeetings: Set<String> = []
 
+        // Primary path: which bundle IDs are capturing the mic right now?
+        // nil ⇒ the per-process audio API isn't available (older macOS).
+        let capturing = bundleIDsCapturingMicInput()
+        if !loggedMode {
+            loggedMode = true
+            Self.log.notice("detection mode: \(capturing == nil ? "window-title (fallback)" : "mic-capture", privacy: .public)")
+        }
+
         for app in Self.supportedApps {
-            // First, is the app even running? Bail early — cheap check
-            // before pulling the window list.
-            guard running.contains(where: { $0.bundleIdentifier == app.bundleID }) else {
-                continue
+            let inMeeting: Bool
+            if let capturing {
+                inMeeting = app.captureBundlePrefixes.contains { prefix in
+                    capturing.contains { $0.hasPrefix(prefix) }
+                }
+            } else {
+                inMeeting = isRunning(app) && hasMeetingWindow(for: app)
             }
-            if hasMeetingWindow(for: app) {
+
+            if inMeeting {
                 activeMeetings.insert(app.bundleID)
                 if !firedFor.contains(app.bundleID) {
                     firedFor.insert(app.bundleID)
+                    Self.log.notice("meeting detected: \(app.displayName, privacy: .public) → firing prompt")
                     meetingStarted.send(app)
                 }
             }
         }
 
-        // Re-arm any app whose meeting window went away — leaving a
-        // call and joining a new one should produce a fresh prompt.
+        // Re-arm any app that left its meeting — leaving a call and
+        // joining a new one should produce a fresh prompt.
+        let ended = firedFor.subtracting(activeMeetings)
+        if !ended.isEmpty {
+            Self.log.notice("meeting ended, re-armed: \(ended, privacy: .public)")
+        }
         firedFor = firedFor.intersection(activeMeetings)
     }
 
+    private func isRunning(_ app: App) -> Bool {
+        NSWorkspace.shared.runningApplications
+            .contains { $0.bundleIdentifier == app.bundleID }
+    }
+
+    // MARK: - Primary signal: per-process mic capture (Core Audio)
+
+    /// Bundle IDs of processes currently capturing microphone input, via
+    /// the Core Audio per-process object API. Returns `nil` when that API
+    /// is unavailable (older macOS) so the caller falls back to window
+    /// titles. Reading capture *state* (not the audio samples) needs no
+    /// permission and triggers no TCC prompt.
+    private func bundleIDsCapturingMicInput() -> Set<String>? {
+        let system = AudioObjectID(kAudioObjectSystemObject)
+        var listAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        guard AudioObjectHasProperty(system, &listAddr) else { return nil }
+
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(system, &listAddr, 0, nil, &size) == noErr,
+              size > 0 else { return nil }
+        let count = Int(size) / MemoryLayout<AudioObjectID>.size
+        var processes = [AudioObjectID](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(system, &listAddr, 0, nil, &size, &processes) == noErr
+        else { return nil }
+
+        var capturing: Set<String> = []
+        for proc in processes where isRunningInput(proc) {
+            if let bundleID = processBundleID(proc) {
+                capturing.insert(bundleID)
+            }
+        }
+        return capturing
+    }
+
+    private func isRunningInput(_ object: AudioObjectID) -> Bool {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyIsRunningInput,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        guard AudioObjectHasProperty(object, &addr) else { return false }
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(object, &addr, 0, nil, &size, &value) == noErr
+        else { return false }
+        return value != 0
+    }
+
+    private func processBundleID(_ object: AudioObjectID) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyBundleID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        guard AudioObjectHasProperty(object, &addr) else { return nil }
+        var cfString: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        guard AudioObjectGetPropertyData(object, &addr, 0, nil, &size, &cfString) == noErr,
+              let cfString else { return nil }
+        return cfString.takeRetainedValue() as String
+    }
+
+    // MARK: - Fallback signal: window title (older macOS)
+
     /// True iff a window owned by an app with the given bundle ID has a
     /// title containing one of `app.meetingTitleHints`. Without Screen
-    /// Recording permission, window titles for other processes come
-    /// back nil — in that case we conservatively return false rather
-    /// than firing on every running supported app.
+    /// Recording permission, window titles for other processes come back
+    /// nil — in that case we conservatively return false.
     private func hasMeetingWindow(for app: App) -> Bool {
         let runningPIDs = NSWorkspace.shared.runningApplications
             .filter { $0.bundleIdentifier == app.bundleID }
@@ -116,20 +211,13 @@ final class MeetingDetector: ObservableObject {
         guard !runningPIDs.isEmpty else { return false }
 
         let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
-        guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
-            return false
-        }
+        guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]]
+        else { return false }
         for window in info {
             guard let pid = window[kCGWindowOwnerPID as String] as? Int32,
                   runningPIDs.contains(pid) else { continue }
             guard let title = window[kCGWindowName as String] as? String,
-                  !title.isEmpty else {
-                // No title (or empty title) most likely means we don't
-                // have Screen Recording permission for window titles —
-                // skip the window. (Zoom's meeting window always has a
-                // non-empty title when permission is granted.)
-                continue
-            }
+                  !title.isEmpty else { continue }
             let lower = title.lowercased()
             if app.meetingTitleHints.contains(where: { lower.contains($0) }) {
                 return true

--- a/Mila/Models/MeetingDetectionSettings.swift
+++ b/Mila/Models/MeetingDetectionSettings.swift
@@ -4,8 +4,8 @@ import Combine
 /// User-facing toggle + per-app silencing for the meeting auto-prompt.
 ///
 /// The prompt asks "Start transcribing?" when a meeting app (Zoom for
-/// now — Google Meet / Teams are easy to add later) becomes the active
-/// meeting host. Two pieces of state are persisted:
+/// now — Google Meet / Teams are easy to add later) is detected in a live
+/// meeting. Two pieces of state are persisted:
 ///
 ///   * `enabled` — global on/off. ON by default; the toggle lives in
 ///     Settings → Meetings.
@@ -13,15 +13,14 @@ import Combine
 ///     about, via the prompt's overflow chevron. Stored as a comma-
 ///     separated string in UserDefaults so it survives launches without
 ///     a custom Codable property list.
+///
+/// There used to be a 60-minute per-app *snooze* on dismiss — a workaround
+/// for the old window-title detector that couldn't tell one meeting from
+/// the next. `MeetingDetector` now re-arms reliably when a meeting ends
+/// (mic capture stops), so "Not now" simply declines the current meeting
+/// and the next one prompts again; no app-wide snooze is needed.
 @MainActor
 final class MeetingDetectionSettings: ObservableObject {
-    /// How long we suppress the prompt for a bundle ID after the user
-    /// dismisses it ("Not now" or auto-dismiss). Matches the user's
-    /// "at least 60 minutes" floor: we can't reliably tell a same vs
-    /// different meeting from window titles alone, so we snooze the
-    /// app and re-arm on the next poll past this deadline.
-    static let snoozeDuration: TimeInterval = 60 * 60
-
     @Published var enabled: Bool {
         didSet { defaults.set(enabled, forKey: Keys.enabled) }
     }
@@ -31,19 +30,11 @@ final class MeetingDetectionSettings: ObservableObject {
             defaults.set(joined, forKey: Keys.disabledBundleIDs)
         }
     }
-    /// `bundleID` -> wall-clock expiry (`timeIntervalSince1970`). Stored
-    /// as `[String: Double]` because that's natively plist-codable.
-    @Published private(set) var snoozedUntil: [String: Double] {
-        didSet { defaults.set(snoozedUntil, forKey: Keys.snoozedUntil) }
-    }
 
     private let defaults: UserDefaults
-    private let now: () -> Date
 
-    init(defaults: UserDefaults = .standard,
-         now: @escaping () -> Date = Date.init) {
+    init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.now = now
         // ON by default — first launch should surface the feature so
         // users discover it. The toggle in Settings flips it.
         if defaults.object(forKey: Keys.enabled) == nil {
@@ -54,35 +45,10 @@ final class MeetingDetectionSettings: ObservableObject {
         self.disabledBundleIDs = Set(
             raw.split(separator: ",").map(String.init).filter { !$0.isEmpty }
         )
-        let stored = defaults.dictionary(forKey: Keys.snoozedUntil) as? [String: Double] ?? [:]
-        let cutoff = now().timeIntervalSince1970
-        self.snoozedUntil = stored.filter { $0.value > cutoff }
     }
 
     func isDisabled(forBundleID bundleID: String) -> Bool {
         disabledBundleIDs.contains(bundleID)
-    }
-
-    /// True iff a fresh dismiss has happened recently enough that we
-    /// shouldn't re-prompt for this app yet.
-    func isSnoozed(forBundleID bundleID: String) -> Bool {
-        guard let expiry = snoozedUntil[bundleID] else { return false }
-        return expiry > now().timeIntervalSince1970
-    }
-
-    /// Suppress the prompt for `bundleID` for `Self.snoozeDuration`.
-    /// Called when the user dismisses the prompt (explicit "Not now"
-    /// or auto-dismiss timeout). Replaces any earlier snooze for the
-    /// same app — a fresh dismiss restarts the clock.
-    func snooze(bundleID: String) {
-        guard !bundleID.isEmpty else { return }
-        var copy = snoozedUntil
-        copy[bundleID] = now().addingTimeInterval(Self.snoozeDuration).timeIntervalSince1970
-        // Garbage-collect any other expired entries while we're here so
-        // the dict doesn't grow over time.
-        let cutoff = now().timeIntervalSince1970
-        copy = copy.filter { $0.value > cutoff }
-        snoozedUntil = copy
     }
 
     /// Permanently silence the prompt for `bundleID`. Used by the
@@ -106,6 +72,5 @@ final class MeetingDetectionSettings: ObservableObject {
     private enum Keys {
         static let enabled = "meetingDetection.enabled"
         static let disabledBundleIDs = "meetingDetection.disabledBundleIDs"
-        static let snoozedUntil = "meetingDetection.snoozedUntil"
     }
 }

--- a/Mila/Views/MeetingPromptOverlay.swift
+++ b/Mila/Views/MeetingPromptOverlay.swift
@@ -80,7 +80,6 @@ final class MeetingPromptCoordinator: ObservableObject {
         guard !actions.isRecording else { return }
         guard settings.enabled else { return }
         guard !settings.isDisabled(forBundleID: app.bundleID) else { return }
-        guard !settings.isSnoozed(forBundleID: app.bundleID) else { return }
 
         showPanel(for: app)
     }
@@ -100,14 +99,11 @@ final class MeetingPromptCoordinator: ObservableObject {
                 }
             },
             onDismiss: { [weak self] in
-                // Suppress re-prompts for this app for the snooze
-                // window. The existing `firedFor` re-arm logic in
-                // MeetingDetector covers "same window stays open";
-                // the snooze covers "window briefly went away and
-                // came back" and "user joined another meeting in
-                // the same app within an hour" — both cases where
-                // the original "Not now" intent still applies.
-                self?.settings.snooze(bundleID: app.bundleID)
+                // "Not now" or the auto-dismiss timeout — just hide. We no
+                // longer snooze: the detector re-arms when the meeting ends
+                // (mic capture stops), so the *next* meeting prompts again,
+                // while its `firedFor` prevents re-prompting within the
+                // current meeting. "Don't show for X" stops prompts entirely.
                 self?.hidePanel()
             },
             onSilenceApp: { [weak self] in

--- a/MilaTests/MeetingDetectionSettingsTests.swift
+++ b/MilaTests/MeetingDetectionSettingsTests.swift
@@ -11,49 +11,37 @@ final class MeetingDetectionSettingsTests: XCTestCase {
         return d
     }
 
-    func test_snooze_marks_bundle_id_as_snoozed_until_expiry() {
-        var clock = Date()
-        let s = MeetingDetectionSettings(defaults: freshDefaults(), now: { clock })
-
-        XCTAssertFalse(s.isSnoozed(forBundleID: "us.zoom.xos"))
-        s.snooze(bundleID: "us.zoom.xos")
-        XCTAssertTrue(s.isSnoozed(forBundleID: "us.zoom.xos"))
-
-        clock = clock.addingTimeInterval(MeetingDetectionSettings.snoozeDuration - 1)
-        XCTAssertTrue(s.isSnoozed(forBundleID: "us.zoom.xos"),
-                      "Still inside snooze window")
-
-        clock = clock.addingTimeInterval(2)
-        XCTAssertFalse(s.isSnoozed(forBundleID: "us.zoom.xos"),
-                       "Past snooze deadline — re-arm allowed")
-    }
-
-    func test_snooze_persists_across_re_init_until_expiry() {
-        let defaults = freshDefaults()
-        var clock = Date()
-
-        do {
-            let s = MeetingDetectionSettings(defaults: defaults, now: { clock })
-            s.snooze(bundleID: "us.zoom.xos")
-        }
-
-        // Reload with the same defaults — snooze should still apply.
-        clock = clock.addingTimeInterval(30 * 60)
-        let reloaded = MeetingDetectionSettings(defaults: defaults, now: { clock })
-        XCTAssertTrue(reloaded.isSnoozed(forBundleID: "us.zoom.xos"))
-
-        // Past expiry — re-init drops the stale entry.
-        clock = clock.addingTimeInterval(60 * 60)
-        let afterExpiry = MeetingDetectionSettings(defaults: defaults, now: { clock })
-        XCTAssertFalse(afterExpiry.isSnoozed(forBundleID: "us.zoom.xos"))
-        XCTAssertTrue(afterExpiry.snoozedUntil.isEmpty,
-                      "Expired entries should be GC'd on init")
-    }
-
-    func test_snooze_empty_bundle_id_is_noop() {
+    func test_enabled_defaults_on_for_first_launch() {
         let s = MeetingDetectionSettings(defaults: freshDefaults())
-        s.snooze(bundleID: "")
-        XCTAssertTrue(s.snoozedUntil.isEmpty)
-        XCTAssertFalse(s.isSnoozed(forBundleID: ""))
+        XCTAssertTrue(s.enabled, "Detection should default ON so users discover it")
+    }
+
+    func test_disable_then_reenable_bundle_id() {
+        let s = MeetingDetectionSettings(defaults: freshDefaults())
+        XCTAssertFalse(s.isDisabled(forBundleID: "us.zoom.xos"))
+
+        s.disable(bundleID: "us.zoom.xos")
+        XCTAssertTrue(s.isDisabled(forBundleID: "us.zoom.xos"))
+
+        s.reenable(bundleID: "us.zoom.xos")
+        XCTAssertFalse(s.isDisabled(forBundleID: "us.zoom.xos"))
+    }
+
+    func test_disabled_bundle_ids_persist_across_re_init() {
+        let defaults = freshDefaults()
+        do {
+            let s = MeetingDetectionSettings(defaults: defaults)
+            s.disable(bundleID: "us.zoom.xos")
+        }
+        let reloaded = MeetingDetectionSettings(defaults: defaults)
+        XCTAssertTrue(reloaded.isDisabled(forBundleID: "us.zoom.xos"),
+                      "Silenced apps should survive a relaunch")
+    }
+
+    func test_disable_empty_bundle_id_is_noop() {
+        let s = MeetingDetectionSettings(defaults: freshDefaults())
+        s.disable(bundleID: "")
+        XCTAssertFalse(s.isDisabled(forBundleID: ""))
+        XCTAssertTrue(s.disabledBundleIDs.isEmpty)
     }
 }


### PR DESCRIPTION
The meeting auto-prompt missed meetings and "stopped working" for users. Diagnosed by instrumenting Zoom live (process list, window titles, and Core Audio per-process capture state). Two root causes:

## 1. Fragile detection (window title)
Detection scanned Zoom's window title for the substring `"Zoom Meeting"`, which needs **Screen Recording permission** and breaks whenever Zoom changes/localises the title.

Replaced with the durable signal the pro tools (Recall.ai, etc.) effectively use: **per-process microphone capture** via the Core Audio process API (`kAudioProcessPropertyIsRunningInput`). Any `us.zoom.*` process actively capturing the mic ⇒ in a meeting.
- Title-independent (instant / scheduled / join-by-link all work)
- **No permission prompt** to read capture state
- Re-arms naturally — capture stops when you leave, so the next meeting prompts again
- Verified live: `us.zoom.xos` reads `IsRunningInput=1` in a meeting, `0` idle

Window-title detection is kept as a **fallback** for macOS without the API (runtime-gated via `AudioObjectHasProperty`).

## 2. Over-snoozing
Any dismiss — including the **10-second auto-dismiss** — silenced Zoom for **60 minutes**. So ignoring one prompt made detection look broken for the next meeting (this, not the detector, is what suppressed the second popup in testing). That snooze was a workaround for the old detector not being able to tell meetings apart; the new detector re-arms reliably, so it's **removed entirely**. "Not now" / auto-dismiss now just hide — the next meeting prompts again; "Don't show for X" still stops prompts.

## Also
- `.notice` logging in `MeetingDetector` so detection is diagnosable via `log show` (`detection mode: mic-capture`, `meeting detected: Zoom → firing prompt`, `meeting ended, re-armed`).
- Snooze unit tests replaced with disable/re-enable tests.

Verified: app build ✓, test build ✓, detector fired + re-armed across back-to-back meetings live ✓, "Not now → rejoin → prompts again" ✓.

Generated with Claude Code