### PR TITLE
Meetings: prompt to STOP recording when a meeting ends

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -293,6 +293,7 @@ struct MilaApp: App {
                 .task { maybeRelocateBundle() }
                 .task { enqueueRecoveredRecordings() }
                 .task { startMeetingDetectionIfNeeded() }
+                .task { await simulateMeetingEndedIfRequested() }
                 .task { await wireLiveAIPipeline() }
                 .task { await injectFixtureWavIfRequested() }
                 .task { await runFinalizeRegressionIfRequested() }
@@ -397,6 +398,32 @@ struct MilaApp: App {
     private func startMeetingDetectionIfNeeded() {
         meetingPrompt.start()
         meetingPrompt.bindEnabledChanges()
+    }
+
+    /// CI/UI-test seam for the end-of-meeting STOP prompt. With
+    /// `--ui-test-simulate-meeting-ended` present we start a fake
+    /// recording (no AVAudioEngine / no real Zoom) and then fire the
+    /// detector's `meetingEnded` subject for Zoom, exercising the exact
+    /// production path: `MeetingPromptCoordinator.handleMeetingEnd` →
+    /// `showStopPanel`. The UI test then asserts the stop prompt
+    /// (`meetingStopPrompt.*`) appears. Mirrors the
+    /// `--ui-test-inject-fixture-wav=` injection style used elsewhere.
+    @MainActor
+    private func simulateMeetingEndedIfRequested() async {
+        guard CommandLine.arguments.contains("--ui-test-simulate-meeting-ended") else { return }
+        // Let `startMeetingDetectionIfNeeded` mount the coordinator's
+        // `meetingEnded` subscription before we fire the event.
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-fake-recording-\(UUID().uuidString).wav")
+        await actions.startFakeRecordingForTesting(outputURL: outputURL)
+        // Give the fake recording a moment to flip `actions.isRecording`.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        if let zoom = MeetingDetector.supportedApps.first {
+            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+                .log("simulate-meeting-ended: firing meetingEnded for \(zoom.displayName, privacy: .public)")
+            meetingDetector.meetingEnded.send(zoom)
+        }
     }
 
     /// Wire the Live AI pipeline. Observes `RecordingSession.state` and

--- a/Mila/Audio/MeetingDetector.swift
+++ b/Mila/Audio/MeetingDetector.swift
@@ -64,12 +64,40 @@ final class MeetingDetector: ObservableObject {
     /// meeting, so leaving and rejoining a call surfaces a fresh prompt.
     let meetingStarted = PassthroughSubject<App, Never>()
 
+    /// Fired exactly once when a previously-active meeting goes inactive —
+    /// the inverse of `meetingStarted`. Debounced (see
+    /// `endConfirmationPolls`) so a momentary mic drop by Zoom doesn't
+    /// masquerade as the meeting ending. The coordinator uses this to ask
+    /// whether to STOP an in-flight recording.
+    let meetingEnded = PassthroughSubject<App, Never>()
+
+    /// How many consecutive polls a previously-active meeting must read as
+    /// inactive before we treat it as genuinely ended. At a 3 s poll this
+    /// is ~6 s of sustained silence — long enough to ride out Zoom briefly
+    /// releasing the mic (mute/unmute, device switch) without a false
+    /// "meeting ended". Internal so tests can drive the transition with a
+    /// known threshold.
+    let endConfirmationPolls: Int
+
     private var pollTask: Task<Void, Never>?
     /// Canonical bundle IDs we've already prompted for in the current run
     /// of a meeting. Cleared (re-armed) when the meeting ends.
     private var firedFor: Set<String> = []
+    /// Canonical bundle IDs we've seen in a meeting AND not yet fired a
+    /// `meetingEnded` for. A bundle ID stays here from the first active
+    /// poll until the end transition is confirmed and emitted, so we emit
+    /// `meetingEnded` exactly once per meeting.
+    private var endArmed: Set<String> = []
+    /// Per-app count of consecutive polls observed inactive while still
+    /// `endArmed`. Reset to zero on any active poll; once it reaches
+    /// `endConfirmationPolls` we emit `meetingEnded` and disarm.
+    private var inactiveStreak: [String: Int] = [:]
     /// Logged once so we know which detection path is live in the field.
     private var loggedMode = false
+
+    init(endConfirmationPolls: Int = 2) {
+        self.endConfirmationPolls = max(1, endConfirmationPolls)
+    }
 
     func start() {
         guard pollTask == nil else { return }
@@ -91,13 +119,13 @@ final class MeetingDetector: ObservableObject {
         pollTask?.cancel()
         pollTask = nil
         firedFor.removeAll()
+        endArmed.removeAll()
+        inactiveStreak.removeAll()
     }
 
     /// Exposed for tests and one-shot manual triggers (e.g. a future
     /// "Test the meeting prompt" button in Settings).
     func pollOnce() {
-        var activeMeetings: Set<String> = []
-
         // Primary path: which bundle IDs are capturing the mic right now?
         // nil ⇒ the per-process audio API isn't available (older macOS).
         let capturing = bundleIDsCapturingMicInput()
@@ -106,6 +134,7 @@ final class MeetingDetector: ObservableObject {
             Self.log.notice("detection mode: \(capturing == nil ? "window-title (fallback)" : "mic-capture", privacy: .public)")
         }
 
+        var activeMeetings: Set<String> = []
         for app in Self.supportedApps {
             let inMeeting: Bool
             if let capturing {
@@ -115,24 +144,66 @@ final class MeetingDetector: ObservableObject {
             } else {
                 inMeeting = isRunning(app) && hasMeetingWindow(for: app)
             }
+            if inMeeting { activeMeetings.insert(app.bundleID) }
+        }
+        processActiveMeetings(activeMeetings)
+    }
 
-            if inMeeting {
-                activeMeetings.insert(app.bundleID)
-                if !firedFor.contains(app.bundleID) {
-                    firedFor.insert(app.bundleID)
-                    Self.log.notice("meeting detected: \(app.displayName, privacy: .public) → firing prompt")
-                    meetingStarted.send(app)
-                }
+    /// Test seam: drive the state machine directly with a set of "in a
+    /// meeting" bundle IDs, bypassing Core Audio. Lets unit tests exercise
+    /// the start/end transitions (and the end-debounce) deterministically
+    /// without a real Zoom or any audio hardware.
+    func simulatePollForTesting(activeBundleIDs: Set<String>) {
+        processActiveMeetings(activeBundleIDs)
+    }
+
+    /// The pure transition core shared by the live poll and the test seam:
+    /// given the set of bundle IDs currently in a meeting, fire
+    /// `meetingStarted` on the rising edge and `meetingEnded` on a
+    /// debounced falling edge.
+    private func processActiveMeetings(_ activeMeetings: Set<String>) {
+        for app in Self.supportedApps where activeMeetings.contains(app.bundleID) {
+            // A meeting is (still) live — arm the end-detector and
+            // clear any in-progress inactivity streak so a brief mic
+            // drop that already recovered doesn't count toward "ended".
+            endArmed.insert(app.bundleID)
+            inactiveStreak[app.bundleID] = 0
+            if !firedFor.contains(app.bundleID) {
+                firedFor.insert(app.bundleID)
+                Self.log.notice("meeting detected: \(app.displayName, privacy: .public) → firing prompt")
+                meetingStarted.send(app)
             }
         }
 
-        // Re-arm any app that left its meeting — leaving a call and
-        // joining a new one should produce a fresh prompt.
+        // Re-arm the START prompt for any app that left its meeting —
+        // leaving a call and joining a new one should produce a fresh
+        // prompt. This is immediate (no debounce): re-arming early is
+        // harmless because the next *start* still requires a fresh active
+        // poll.
         let ended = firedFor.subtracting(activeMeetings)
         if !ended.isEmpty {
             Self.log.notice("meeting ended, re-armed: \(ended, privacy: .public)")
         }
         firedFor = firedFor.intersection(activeMeetings)
+
+        // Drive the debounced active→inactive transition that powers the
+        // STOP prompt. Unlike the re-arm above, this only fires after the
+        // meeting has read inactive for `endConfirmationPolls` consecutive
+        // polls, so a momentary Zoom mic release doesn't look like the call
+        // ending.
+        for bundleID in endArmed where !activeMeetings.contains(bundleID) {
+            let streak = (inactiveStreak[bundleID] ?? 0) + 1
+            if streak >= endConfirmationPolls {
+                inactiveStreak[bundleID] = nil
+                endArmed.remove(bundleID)
+                if let app = Self.supportedApps.first(where: { $0.bundleID == bundleID }) {
+                    Self.log.notice("meeting ended (confirmed): \(app.displayName, privacy: .public) → firing stop prompt")
+                    meetingEnded.send(app)
+                }
+            } else {
+                inactiveStreak[bundleID] = streak
+            }
+        }
     }
 
     private func isRunning(_ app: App) -> Bool {

--- a/Mila/Views/MeetingPromptOverlay.swift
+++ b/Mila/Views/MeetingPromptOverlay.swift
@@ -22,7 +22,8 @@ final class MeetingPromptCoordinator: ObservableObject {
     private let detector: MeetingDetector
     private let settings: MeetingDetectionSettings
     private let actions: QuickActionsController
-    private var cancellable: AnyCancellable?
+    private var startCancellable: AnyCancellable?
+    private var endCancellable: AnyCancellable?
     private var window: NSPanel?
 
     init(detector: MeetingDetector,
@@ -33,11 +34,41 @@ final class MeetingPromptCoordinator: ObservableObject {
         self.actions = actions
     }
 
+    /// Pure decision for whether the *stop* prompt should appear when a
+    /// meeting goes inactive. Extracted so it's unit-testable without a
+    /// real Zoom: the inputs are exactly the three things that gate the
+    /// prompt. NOT gated on how the recording started — a manual record and
+    /// an auto-prompt record are treated identically.
+    ///
+    /// - Parameters:
+    ///   - detectionEnabled: the user's `MeetingDetectionSettings.enabled`
+    ///     toggle — the whole feature is off when this is false.
+    ///   - appSilenced: whether the user chose "don't show this for X" for
+    ///     the app whose meeting just ended.
+    ///   - isRecording: whether Mila is actively recording right now.
+    ///   - promptAlreadyShowing: whether a prompt panel is already up (we
+    ///     never stack a second one).
+    static func shouldShowStopPrompt(detectionEnabled: Bool,
+                                     appSilenced: Bool,
+                                     isRecording: Bool,
+                                     promptAlreadyShowing: Bool) -> Bool {
+        guard detectionEnabled else { return false }
+        guard !appSilenced else { return false }
+        guard isRecording else { return false }
+        guard !promptAlreadyShowing else { return false }
+        return true
+    }
+
     func start() {
-        cancellable = detector.meetingStarted
+        startCancellable = detector.meetingStarted
             .receive(on: DispatchQueue.main)
             .sink { [weak self] app in
                 self?.handleMeetingStart(app: app)
+            }
+        endCancellable = detector.meetingEnded
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] app in
+                self?.handleMeetingEnd(app: app)
             }
         if settings.enabled {
             detector.start()
@@ -45,8 +76,10 @@ final class MeetingPromptCoordinator: ObservableObject {
     }
 
     func stop() {
-        cancellable?.cancel()
-        cancellable = nil
+        startCancellable?.cancel()
+        startCancellable = nil
+        endCancellable?.cancel()
+        endCancellable = nil
         detector.stop()
         hidePanel()
     }
@@ -81,13 +114,28 @@ final class MeetingPromptCoordinator: ObservableObject {
         guard settings.enabled else { return }
         guard !settings.isDisabled(forBundleID: app.bundleID) else { return }
 
-        showPanel(for: app)
+        showStartPanel(for: app)
     }
 
-    private func showPanel(for app: MeetingDetector.App) {
+    /// The inverse of `handleMeetingStart`: a meeting we were tracking went
+    /// inactive. If Mila is recording (regardless of how that recording was
+    /// started) and the feature is enabled, offer to stop.
+    private func handleMeetingEnd(app: MeetingDetector.App) {
+        guard Self.shouldShowStopPrompt(
+            detectionEnabled: settings.enabled,
+            appSilenced: settings.isDisabled(forBundleID: app.bundleID),
+            isRecording: actions.isRecording,
+            promptAlreadyShowing: window != nil
+        ) else { return }
+
+        showStopPanel(for: app)
+    }
+
+    private func showStartPanel(for app: MeetingDetector.App) {
         let view = MeetingPromptView(
             app: app,
-            onStart: { [weak self] in
+            kind: .start,
+            onPrimary: { [weak self] in
                 self?.hidePanel()
                 Task { @MainActor [weak self] in
                     // Auto-prompt always captures system audio — the
@@ -111,7 +159,35 @@ final class MeetingPromptCoordinator: ObservableObject {
                 self?.hidePanel()
             }
         )
+        presentPanel(hosting: view)
+    }
 
+    /// Mirror of `showStartPanel` for the end-of-meeting case. The primary
+    /// action stops the active recording; "Keep recording" just dismisses.
+    private func showStopPanel(for app: MeetingDetector.App) {
+        let view = MeetingPromptView(
+            app: app,
+            kind: .stop,
+            onPrimary: { [weak self] in
+                self?.hidePanel()
+                Task { @MainActor [weak self] in
+                    await self?.actions.stopRecording()
+                }
+            },
+            onDismiss: { [weak self] in
+                // "Keep recording" or the auto-dismiss timeout — leave the
+                // recording running and just hide the panel.
+                self?.hidePanel()
+            },
+            onSilenceApp: { [weak self] in
+                self?.settings.disable(bundleID: app.bundleID)
+                self?.hidePanel()
+            }
+        )
+        presentPanel(hosting: view)
+    }
+
+    private func presentPanel(hosting view: MeetingPromptView) {
         let panel = NSPanel(
             contentRect: NSRect(origin: .zero, size: NSSize(width: 360, height: 168)),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -162,8 +238,17 @@ final class MeetingPromptCoordinator: ObservableObject {
 /// with the progress bar across the bottom acting as the countdown.
 /// Hovering pauses the bar (and freezes the auto-dismiss timer).
 private struct MeetingPromptView: View {
+    /// Which prompt this is — start a recording (meeting detected) or stop
+    /// one (meeting ended). Drives all the copy, the primary button style,
+    /// and the accessibility identifiers so a single view body serves both.
+    enum Kind {
+        case start
+        case stop
+    }
+
     let app: MeetingDetector.App
-    let onStart: () -> Void
+    let kind: Kind
+    let onPrimary: () -> Void
     let onDismiss: () -> Void
     let onSilenceApp: () -> Void
 
@@ -215,7 +300,44 @@ private struct MeetingPromptView: View {
         .onHover { hovering = $0 }
         .onReceive(timer) { _ in tick() }
         .onAppear { lastTick = Date() }
-        .accessibilityIdentifier("meetingPrompt.\(app.bundleID)")
+        .accessibilityIdentifier("\(identifierPrefix).\(app.bundleID)")
+    }
+
+    /// Accessibility-identifier prefix, distinct per kind so UI tests can
+    /// target the start prompt and the stop prompt independently.
+    private var identifierPrefix: String {
+        switch kind {
+        case .start: return "meetingPrompt"
+        case .stop:  return "meetingStopPrompt"
+        }
+    }
+
+    private var titleText: String {
+        switch kind {
+        case .start: return "\(app.displayName) meeting detected"
+        case .stop:  return "\(app.displayName) meeting ended"
+        }
+    }
+
+    private var subtitleText: String {
+        switch kind {
+        case .start: return "Want Mila to transcribe this call?"
+        case .stop:  return "Stop recording now?"
+        }
+    }
+
+    private var primaryButtonText: String {
+        switch kind {
+        case .start: return "Start transcribing"
+        case .stop:  return "Stop recording"
+        }
+    }
+
+    private var dismissButtonText: String {
+        switch kind {
+        case .start: return "Not now"
+        case .stop:  return "Keep recording"
+        }
     }
 
     /// Brighter card fill — `regularMaterial` skews dark on macOS in
@@ -244,7 +366,7 @@ private struct MeetingPromptView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(alignment: .firstTextBaseline) {
-                    Text("\(app.displayName) meeting detected")
+                    Text(titleText)
                         .font(.callout.weight(.semibold))
                     Spacer()
                     Button {
@@ -261,30 +383,30 @@ private struct MeetingPromptView: View {
                     }
                     .buttonStyle(.plain)
                     .help("More options")
-                    .accessibilityIdentifier("meetingPrompt.chevron")
+                    .accessibilityIdentifier("\(identifierPrefix).chevron")
                 }
 
-                Text("Want Mila to transcribe this call?")
+                Text(subtitleText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
-                    Button(action: triggerStart) {
-                        Text("Start transcribing")
+                    Button(action: triggerPrimary) {
+                        Text(primaryButtonText)
                             .font(.callout.weight(.medium))
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .accessibilityIdentifier("meetingPrompt.start")
+                    .accessibilityIdentifier("\(identifierPrefix).primary")
 
                     Button(action: triggerDismiss) {
-                        Text("Not now")
+                        Text(dismissButtonText)
                             .font(.callout)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .accessibilityIdentifier("meetingPrompt.dismiss")
+                    .accessibilityIdentifier("\(identifierPrefix).dismiss")
                 }
                 .padding(.top, 4)
             }
@@ -303,7 +425,7 @@ private struct MeetingPromptView: View {
                 .foregroundStyle(.primary)
             }
             .buttonStyle(.plain)
-            .accessibilityIdentifier("meetingPrompt.silence")
+            .accessibilityIdentifier("\(identifierPrefix).silence")
 
             Text("You can re-enable this in Settings → Meetings.")
                 .font(.caption2)
@@ -345,10 +467,10 @@ private struct MeetingPromptView: View {
         }
     }
 
-    private func triggerStart() {
+    private func triggerPrimary() {
         guard !dismissed else { return }
         dismissed = true
-        onStart()
+        onPrimary()
     }
 
     private func triggerDismiss() {

--- a/Mila/Views/MeetingPromptOverlay.swift
+++ b/Mila/Views/MeetingPromptOverlay.swift
@@ -24,7 +24,14 @@ final class MeetingPromptCoordinator: ObservableObject {
     private let actions: QuickActionsController
     private var startCancellable: AnyCancellable?
     private var endCancellable: AnyCancellable?
+    private var recordingStateCancellable: AnyCancellable?
     private var window: NSPanel?
+    /// True only while the currently-presented panel is the *stop* prompt.
+    /// Used to auto-dismiss that prompt if recording ends through any other
+    /// path (Record button, hotkey, sleep) during its countdown — a dead
+    /// "Stop recording" button is worse than no prompt. The start prompt is
+    /// untouched by this.
+    private var stopPromptShowing = false
 
     init(detector: MeetingDetector,
          settings: MeetingDetectionSettings,
@@ -59,6 +66,18 @@ final class MeetingPromptCoordinator: ObservableObject {
         return true
     }
 
+    /// Pure decision for whether a *showing* stop prompt should now
+    /// auto-dismiss. The stop prompt only makes sense while a recording is
+    /// live — its sole action is "stop recording." If recording ends through
+    /// any other path during the prompt's countdown (Record button, hotkey,
+    /// system sleep, etc.), the button becomes a dead no-op, so we tear the
+    /// prompt down. Only applies to the stop prompt; the start prompt is left
+    /// alone. Extracted so it's unit-testable without a real Zoom / panel.
+    static func shouldDismissStopPrompt(stopPromptShowing: Bool,
+                                        isRecording: Bool) -> Bool {
+        stopPromptShowing && !isRecording
+    }
+
     func start() {
         startCancellable = detector.meetingStarted
             .receive(on: DispatchQueue.main)
@@ -70,6 +89,15 @@ final class MeetingPromptCoordinator: ObservableObject {
             .sink { [weak self] app in
                 self?.handleMeetingEnd(app: app)
             }
+        // Auto-dismiss a showing stop prompt the moment recording leaves the
+        // active state through any path — `activeJob` is what backs
+        // `isRecording`, so observing it covers the Record button, hotkeys,
+        // and system-sleep stops alike.
+        recordingStateCancellable = actions.$activeJob
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.dismissStopPromptIfRecordingEnded()
+            }
         if settings.enabled {
             detector.start()
         }
@@ -80,6 +108,8 @@ final class MeetingPromptCoordinator: ObservableObject {
         startCancellable = nil
         endCancellable?.cancel()
         endCancellable = nil
+        recordingStateCancellable?.cancel()
+        recordingStateCancellable = nil
         detector.stop()
         hidePanel()
     }
@@ -129,6 +159,17 @@ final class MeetingPromptCoordinator: ObservableObject {
         ) else { return }
 
         showStopPanel(for: app)
+    }
+
+    /// Fires on every `actions.activeJob` change. If the stop prompt is up
+    /// and recording is no longer active, dismiss it — the "Stop recording"
+    /// button would otherwise be a dead no-op (recording already ended).
+    private func dismissStopPromptIfRecordingEnded() {
+        guard Self.shouldDismissStopPrompt(
+            stopPromptShowing: stopPromptShowing,
+            isRecording: actions.isRecording
+        ) else { return }
+        hidePanel()
     }
 
     private func showStartPanel(for app: MeetingDetector.App) {
@@ -184,6 +225,7 @@ final class MeetingPromptCoordinator: ObservableObject {
                 self?.hidePanel()
             }
         )
+        stopPromptShowing = true
         presentPanel(hosting: view)
     }
 
@@ -214,6 +256,7 @@ final class MeetingPromptCoordinator: ObservableObject {
     }
 
     private func hidePanel() {
+        stopPromptShowing = false
         guard let panel = window else { return }
         self.window = nil
         NSAnimationContext.runAnimationGroup({ ctx in

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -793,9 +793,9 @@ private struct MeetingsSettingsTab: View {
                 header
                 Toggle(isOn: $settings.enabled) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Offer to transcribe when a meeting starts")
+                        Text("Prompt when a meeting starts or ends")
                             .font(.body)
-                        Text("Mila shows a small prompt in the top-right when it sees you join a meeting in a supported app.")
+                        Text("Mila shows a small prompt in the top-right when it sees you join a meeting in a supported app — and, while it's recording, when that meeting ends, it offers to stop.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)

--- a/MilaTests/MeetingStopPromptTests.swift
+++ b/MilaTests/MeetingStopPromptTests.swift
@@ -75,6 +75,44 @@ final class MeetingStopPromptTests: XCTestCase {
         )
     }
 
+    // MARK: - Auto-dismiss when recording ends elsewhere
+
+    /// The bug this fixes: the stop prompt is up (≤10s countdown) and the
+    /// user stops recording through ANOTHER path (Record button, hotkey,
+    /// system sleep). The prompt must tear down rather than leave a dead
+    /// "Stop recording" button.
+    func test_stop_prompt_dismisses_when_recording_ends() {
+        XCTAssertTrue(
+            MeetingPromptCoordinator.shouldDismissStopPrompt(
+                stopPromptShowing: true,
+                isRecording: false
+            ),
+            "A showing stop prompt must auto-dismiss once recording is no longer active"
+        )
+    }
+
+    func test_stop_prompt_stays_while_recording_continues() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldDismissStopPrompt(
+                stopPromptShowing: true,
+                isRecording: true
+            ),
+            "While recording is still active the stop prompt's button is live — keep it up"
+        )
+    }
+
+    /// The start prompt (and the no-prompt case) never set `stopPromptShowing`,
+    /// so recording-state changes must not dismiss anything through this path.
+    func test_no_dismiss_when_stop_prompt_not_showing() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldDismissStopPrompt(
+                stopPromptShowing: false,
+                isRecording: false
+            ),
+            "With no stop prompt up (start prompt or nothing), recording-end must not dismiss"
+        )
+    }
+
     // MARK: - Detector transition (debounce)
 
     /// A single inactive poll must NOT fire `meetingEnded` — that's the

--- a/MilaTests/MeetingStopPromptTests.swift
+++ b/MilaTests/MeetingStopPromptTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+import Combine
+@testable import Mila
+
+/// Unit tests for the inverse of the "meeting detected → start recording?"
+/// prompt: when a meeting goes inactive while Mila is recording, offer to
+/// STOP. Two layers are covered:
+///
+///   1. The pure decision (`MeetingPromptCoordinator.shouldShowStopPrompt`)
+///      — the four gates that decide whether the stop prompt appears.
+///   2. The detector's debounced active→inactive transition that emits
+///      `meetingEnded` (so a momentary mic drop doesn't fire a false stop).
+@MainActor
+final class MeetingStopPromptTests: XCTestCase {
+
+    // MARK: - Decision logic
+
+    func test_recording_and_meeting_ended_triggers_stop_prompt() {
+        XCTAssertTrue(
+            MeetingPromptCoordinator.shouldShowStopPrompt(
+                detectionEnabled: true,
+                appSilenced: false,
+                isRecording: true,
+                promptAlreadyShowing: false
+            ),
+            "Recording + meeting ended + enabled should offer to stop"
+        )
+    }
+
+    func test_not_recording_does_not_trigger_stop_prompt() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldShowStopPrompt(
+                detectionEnabled: true,
+                appSilenced: false,
+                isRecording: false,
+                promptAlreadyShowing: false
+            ),
+            "No active recording → nothing to stop, so no prompt"
+        )
+    }
+
+    func test_feature_disabled_does_not_trigger_stop_prompt() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldShowStopPrompt(
+                detectionEnabled: false,
+                appSilenced: false,
+                isRecording: true,
+                promptAlreadyShowing: false
+            ),
+            "Meeting detection disabled in Settings gates the whole feature"
+        )
+    }
+
+    func test_app_silenced_does_not_trigger_stop_prompt() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldShowStopPrompt(
+                detectionEnabled: true,
+                appSilenced: true,
+                isRecording: true,
+                promptAlreadyShowing: false
+            ),
+            "A \"don't show for X\"-silenced app should not stop-prompt either"
+        )
+    }
+
+    func test_existing_prompt_blocks_a_second_stop_prompt() {
+        XCTAssertFalse(
+            MeetingPromptCoordinator.shouldShowStopPrompt(
+                detectionEnabled: true,
+                appSilenced: false,
+                isRecording: true,
+                promptAlreadyShowing: true
+            ),
+            "Never stack a second floating panel on top of an existing one"
+        )
+    }
+
+    // MARK: - Detector transition (debounce)
+
+    /// A single inactive poll must NOT fire `meetingEnded` — that's the
+    /// brief mic-drop case (mute/unmute, device switch) we deliberately
+    /// ride out. `endConfirmationPolls: 2` means two consecutive inactive
+    /// polls are required.
+    func test_brief_drop_does_not_fire_meeting_ended() {
+        let detector = MeetingDetector(endConfirmationPolls: 2)
+        var ended: [MeetingDetector.App] = []
+        let cancellable = detector.meetingEnded.sink { ended.append($0) }
+        defer { cancellable.cancel() }
+
+        let zoom = MeetingDetector.supportedApps[0]
+        detector.simulatePollForTesting(activeBundleIDs: [zoom.bundleID])  // active
+        detector.simulatePollForTesting(activeBundleIDs: [])               // 1 inactive
+        detector.simulatePollForTesting(activeBundleIDs: [zoom.bundleID])  // recovered
+
+        XCTAssertTrue(ended.isEmpty,
+                      "A single inactive poll before recovery must not fire meetingEnded")
+    }
+
+    /// Sustained inactivity (>= `endConfirmationPolls`) fires exactly once.
+    func test_sustained_inactivity_fires_meeting_ended_once() {
+        let detector = MeetingDetector(endConfirmationPolls: 2)
+        var ended: [MeetingDetector.App] = []
+        let cancellable = detector.meetingEnded.sink { ended.append($0) }
+        defer { cancellable.cancel() }
+
+        let zoom = MeetingDetector.supportedApps[0]
+        detector.simulatePollForTesting(activeBundleIDs: [zoom.bundleID])  // active
+        detector.simulatePollForTesting(activeBundleIDs: [])               // 1 inactive
+        detector.simulatePollForTesting(activeBundleIDs: [])               // 2 inactive → fire
+        detector.simulatePollForTesting(activeBundleIDs: [])               // still inactive, no re-fire
+
+        XCTAssertEqual(ended.map(\.bundleID), [zoom.bundleID],
+                       "Sustained inactivity should fire meetingEnded exactly once")
+    }
+
+    /// A meeting that never went active can't "end".
+    func test_never_active_never_fires_meeting_ended() {
+        let detector = MeetingDetector(endConfirmationPolls: 2)
+        var ended: [MeetingDetector.App] = []
+        let cancellable = detector.meetingEnded.sink { ended.append($0) }
+        defer { cancellable.cancel() }
+
+        detector.simulatePollForTesting(activeBundleIDs: [])
+        detector.simulatePollForTesting(activeBundleIDs: [])
+        detector.simulatePollForTesting(activeBundleIDs: [])
+
+        XCTAssertTrue(ended.isEmpty,
+                      "An app that was never in a meeting should never fire meetingEnded")
+    }
+
+    /// Leaving and rejoining produces a fresh `meetingEnded` the second
+    /// time too (the end-detector re-arms on each fresh active run).
+    func test_rejoin_then_end_fires_meeting_ended_again() {
+        let detector = MeetingDetector(endConfirmationPolls: 2)
+        var ended: [MeetingDetector.App] = []
+        let cancellable = detector.meetingEnded.sink { ended.append($0) }
+        defer { cancellable.cancel() }
+
+        let zoom = MeetingDetector.supportedApps[0]
+        // First meeting + end.
+        detector.simulatePollForTesting(activeBundleIDs: [zoom.bundleID])
+        detector.simulatePollForTesting(activeBundleIDs: [])
+        detector.simulatePollForTesting(activeBundleIDs: [])  // fire #1
+        // Second meeting + end.
+        detector.simulatePollForTesting(activeBundleIDs: [zoom.bundleID])
+        detector.simulatePollForTesting(activeBundleIDs: [])
+        detector.simulatePollForTesting(activeBundleIDs: [])  // fire #2
+
+        XCTAssertEqual(ended.count, 2,
+                       "Re-joining and ending a second meeting should fire meetingEnded again")
+    }
+}

--- a/MilaUITests/MeetingStopPromptUITests.swift
+++ b/MilaUITests/MeetingStopPromptUITests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+/// GUI automation for the end-of-meeting STOP prompt. Launches the app with
+/// `--ui-test-simulate-meeting-ended`, which starts a fake recording (no
+/// AVAudioEngine / no real Zoom) and then fires the detector's
+/// `meetingEnded` event for Zoom. We assert the floating stop prompt
+/// (`meetingStopPrompt.*`) appears with its primary "Stop recording" button.
+///
+/// This exercises the production presentation path
+/// (`MeetingPromptCoordinator.handleMeetingEnd` → `showStopPanel`); the only
+/// thing faked is the trigger, since a real Zoom call can't run on CI.
+final class MeetingStopPromptUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_stop_prompt_appears_when_meeting_ends_while_recording() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-test-simulate-meeting-ended"]
+        app.launch()
+
+        // The stop prompt is a borderless NSPanel hosting the SwiftUI card.
+        // Match the kind-specific accessibility identifier prefix.
+        let stopPrompt = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH 'meetingStopPrompt'"))
+            .firstMatch
+        XCTAssertTrue(stopPrompt.waitForExistence(timeout: 15),
+                      "Stop-recording prompt did not appear after the meeting ended while recording")
+
+        // The primary action button should read / identify as "Stop recording".
+        let stopButton = app.descendants(matching: .any)
+            .matching(identifier: "meetingStopPrompt.primary")
+            .firstMatch
+        XCTAssertTrue(stopButton.waitForExistence(timeout: 5),
+                      "Stop-recording prompt is missing its primary 'Stop recording' button")
+    }
+}


### PR DESCRIPTION
## What

Mila already detects when you join a Zoom meeting and **prompts to start** recording. This adds the inverse: when a tracked meeting goes **inactive while Mila is actively recording**, a floating prompt asks whether to **stop**:

> **Zoom meeting ended** — Stop recording now?  [Stop recording] [Keep recording]

It fires regardless of how the recording was started (auto-prompt or manual), and is gated on the same Settings → Meetings toggle as the start prompt.

## How

- **`MeetingDetector`** now emits a debounced `meetingEnded` subject on the active→inactive transition (the inverse of `meetingStarted`). To avoid false positives when Zoom momentarily drops the mic (mute/unmute, device switch), the falling edge requires `endConfirmationPolls` consecutive inactive polls (default **2** → ~6s at the 3s poll). The transition core is factored into `processActiveMeetings(_:)`, fed by either the real Core Audio poll or a `simulatePollForTesting(activeBundleIDs:)` test seam.
- **`MeetingPromptCoordinator`** subscribes to `meetingEnded` and presents the stop prompt. The overlay (`MeetingPromptView`) is generalized with a `Kind` (`.start` / `.stop`) that drives the copy, the primary button, and the accessibility identifiers (`meetingPrompt.*` vs `meetingStopPrompt.*`).
- The show/no-show decision is a **pure, injectable** `MeetingPromptCoordinator.shouldShowStopPrompt(detectionEnabled:appSilenced:isRecording:promptAlreadyShowing:)` — easy to unit-test without a real Zoom.
- Stopping routes through `QuickActionsController.stopRecording()`.
- Settings → Meetings copy updated to mention both directions.

## Tests

- **Unit** (`MilaTests/MeetingStopPromptTests.swift`):
  - decision logic — recording + meeting ended → prompt; not recording → none; feature disabled → none; app silenced → none; prompt already showing → none.
  - detector transition — a brief drop+recover does **not** fire; sustained inactivity fires exactly once; never-active never fires; rejoin-then-end fires again.
- **UI** (`MilaUITests/MeetingStopPromptUITests.swift`, optional): launches with `--ui-test-simulate-meeting-ended`, which starts a fake recording and fires `meetingEnded`, then asserts the `meetingStopPrompt.*` panel appears. Exercises the real presentation path; only the trigger is faked.

## Verification

- `xcodebuild ... build-for-testing` — **TEST BUILD SUCCEEDED** (app + both test targets compile).
- Ran `MilaTests/MeetingStopPromptTests` — **9/9 passed**.

## What a human should check

- **Real Zoom end-of-meeting behavior**: confirm leaving/ending an actual Zoom call while recording surfaces the stop prompt within a few seconds, and that ordinary mid-call mic mute/unmute does **not** trip it (the debounce should absorb it). The ~6s debounce window may want tuning against real Zoom mic-release timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)