### PR TITLE
Send to LLM: choose transcript vs. summary + action items

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -65,20 +65,44 @@ enum LLMRunner {
     /// transcript. Empty / whitespace-only `summary` is omitted entirely
     /// (we don't want "Summary: (empty)" confusing the model when Live AI
     /// wasn't configured for this recording).
+    ///
+    /// `actionItems`, when non-empty, renders an `Action items:` section
+    /// (one `- item` per line) between the summary and the transcript. Empty
+    /// items are dropped, and a fully-empty list omits the section entirely —
+    /// same collapse-empties philosophy as `summary`. Section order when all
+    /// three are present is: Summary, Action items, Full transcript.
     static func composedPrompt(_ userPrompt: String,
                                transcript: String,
-                               summary: String = "") -> String {
+                               summary: String = "",
+                               actionItems: [String] = []) -> String {
         let prompt = userPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let body = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         let gist = summary.trimmingCharacters(in: .whitespacesAndNewlines)
-        if body.isEmpty && gist.isEmpty { return prompt }
-        if gist.isEmpty {
-            return "\(prompt)\n\n---\nTranscript:\n\(body)"
+        let items = actionItems
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        // Build the non-empty sections in display order, then join. This
+        // keeps the prompt-only / transcript-only / summary-only shapes the
+        // old code produced while letting Action items slot in cleanly.
+        var sections: [String] = []
+        if !gist.isEmpty {
+            sections.append("Summary:\n\(gist)")
         }
-        if body.isEmpty {
-            return "\(prompt)\n\n---\nSummary:\n\(gist)"
+        if !items.isEmpty {
+            let rendered = items.map { "- \($0)" }.joined(separator: "\n")
+            sections.append("Action items:\n\(rendered)")
         }
-        return "\(prompt)\n\n---\nSummary:\n\(gist)\n\nFull transcript:\n\(body)"
+        if !body.isEmpty {
+            // Label the transcript "Transcript" when it stands alone, but
+            // "Full transcript" once a summary/action-items gist precedes it —
+            // the qualifier signals to the model that the gist above is the
+            // condensed version of what follows.
+            let label = (gist.isEmpty && items.isEmpty) ? "Transcript" : "Full transcript"
+            sections.append("\(label):\n\(body)")
+        }
+        if sections.isEmpty { return prompt }
+        return "\(prompt)\n\n---\n" + sections.joined(separator: "\n\n")
     }
 
     /// Run `tool` with `prompt` + `transcript`. Returns stdout, trimmed.
@@ -93,12 +117,17 @@ enum LLMRunner {
     /// configured) — the wire format collapses to the old transcript-only
     /// shape in that case.
     ///
+    /// `actionItems` (optional) renders an `Action items:` section between the
+    /// summary and the transcript. Used by the "Summary & action items" send
+    /// mode. Empty by default so existing callers keep the prior wire format.
+    ///
     /// `timeout` defaults to 5 minutes. Pass a smaller value for foreground
     /// callers that block UI (e.g. the Suggest button).
     static func run(tool: LLMTool,
                     prompt: String,
                     transcript: String,
                     summary: String = "",
+                    actionItems: [String] = [],
                     executablePathOverride: String?,
                     model: String? = nil,
                     session: LLMSession = .none,
@@ -107,7 +136,7 @@ enum LLMRunner {
 
         let executable = try resolveExecutable(tool: tool,
                                                override: executablePathOverride)
-        let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary)
+        let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary, actionItems: actionItems)
         let modelTag = (model?.isEmpty ?? true) ? "(default)" : (model ?? "")
         let sessionTag: String = {
             switch session {

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -96,6 +96,27 @@ enum LLMSession: Equatable {
     case resume(UUID)
 }
 
+/// What content the "Send to <LLM>" sheet ships alongside the prompt.
+///
+/// `.transcript` is the long-standing default — it sends the full transcript
+/// (with the Live-AI summary prepended when one exists). `.summaryAndActionItems`
+/// is the lighter alternative: it sends the rolling summary plus the recording's
+/// action items *instead of* the raw transcript, which is what most users want
+/// when they just need the takeaways rather than the verbatim text.
+enum LLMSendContent: String, CaseIterable, Identifiable, Codable {
+    case transcript
+    case summaryAndActionItems
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .transcript:           return "Transcript"
+        case .summaryAndActionItems: return "Summary & action items"
+        }
+    }
+}
+
 /// User-configurable prompts + tool selection for the LLM integration. The
 /// "name" prompt is sent right after a recording transcribes so the user can
 /// accept / reject a suggested title; the "action" prompt is what the user
@@ -136,6 +157,13 @@ final class LLMSettings: ObservableObject {
         didSet { defaults.set(postActionPrompt, forKey: Keys.actionPrompt) }
     }
 
+    /// Default for what the "Send to <LLM>" sheet ships: the full transcript
+    /// (current behaviour) or the summary + action items instead. Surfaced as
+    /// a global default in Settings and seeds the per-send picker in the sheet.
+    @Published var sendContent: LLMSendContent {
+        didSet { defaults.set(sendContent.rawValue, forKey: Keys.sendContent) }
+    }
+
     /// Convenience the UI uses to decide whether to surface the rename /
     /// run-action buttons at all.
     var isConfigured: Bool { tool != .none }
@@ -151,6 +179,8 @@ final class LLMSettings: ObservableObject {
         self.namePrompt = defaults.string(forKey: Keys.namePrompt) ?? Self.defaultNamePrompt
         self.postActionEnabled = defaults.bool(forKey: Keys.actionEnabled)
         self.postActionPrompt = defaults.string(forKey: Keys.actionPrompt) ?? Self.defaultActionPrompt
+        let rawSendContent = defaults.string(forKey: Keys.sendContent) ?? LLMSendContent.transcript.rawValue
+        self.sendContent = LLMSendContent(rawValue: rawSendContent) ?? .transcript
     }
 
     /// Default name prompt is deliberately *tool-free*. The previous default
@@ -183,5 +213,6 @@ final class LLMSettings: ObservableObject {
         static let namePrompt = "llm.name.prompt"
         static let actionEnabled = "llm.action.enabled"
         static let actionPrompt = "llm.action.prompt"
+        static let sendContent = "llm.sendContent"
     }
 }

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -137,6 +137,7 @@ final class PostRecordingCoordinator: ObservableObject {
                    prompt: String,
                    transcript: String,
                    summary: String,
+                   actionItems: [String] = [],
                    executableOverride: String?) {
         guard tool != .none else { return }
         let toolName = tool.displayName
@@ -154,8 +155,17 @@ final class PostRecordingCoordinator: ObservableObject {
             guard let self else { return }
             // Resolve the transcript: use the click-time snapshot if it
             // already has text, otherwise wait for transcription to finish.
+            //
+            // Exception: the "Summary & action items" send mode deliberately
+            // ships an EMPTY transcript (the summary + items carry the
+            // payload). In that case we must not stall waiting for — and then
+            // injecting — the transcript the caller chose to omit. Only wait
+            // when there's genuinely nothing to send yet.
+            let hasSummary = !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            let hasItems = actionItems.contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            let hasOtherPayload = hasSummary || hasItems
             let resolved: String
-            if transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !hasOtherPayload {
                 guard let waited = await self.awaitTranscript(for: recordingID,
                                                               timeout: timeout) else {
                     if Task.isCancelled { return }
@@ -173,6 +183,7 @@ final class PostRecordingCoordinator: ObservableObject {
                     prompt: prompt,
                     transcript: resolved,
                     summary: summary,
+                    actionItems: actionItems,
                     executablePathOverride: executableOverride,
                     timeout: LLMRunner.defaultTimeout
                 )

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -15,6 +15,10 @@ struct SendToLLMSheet: View {
 
     @State private var prompt: String = ""
 
+    /// What this send ships — seeded from the global default
+    /// (`llm.sendContent`) on appear, then editable per-send.
+    @State private var sendContent: LLMSendContent = .transcript
+
     /// Live recording from the store so an in-flight re-transcription
     /// updates the preview without the sheet needing to be reopened.
     private var liveRecording: Recording {
@@ -26,11 +30,54 @@ struct SendToLLMSheet: View {
                                       fallback: liveRecording.fullText)
     }
 
+    private var summary: String {
+        (liveRecording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var actionItemTexts: [String] {
+        (liveRecording.actionItems ?? [])
+            .map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// The actual transcript / summary / action-items triple that will be
+    /// sent, resolved from the per-send `sendContent` picker.
+    ///
+    /// In `.summaryAndActionItems` mode we ship the summary + action items and
+    /// drop the transcript — *unless* both are empty (e.g. the recording ran
+    /// without Live AI), in which case we fall back to sending the transcript
+    /// so the send is never empty. The `.transcript` default sends the
+    /// transcript and the summary (the long-standing behaviour), no items.
+    private var resolvedPayload: (transcript: String, summary: String, actionItems: [String]) {
+        switch sendContent {
+        case .transcript:
+            return (transcript, summary, [])
+        case .summaryAndActionItems:
+            if summary.isEmpty && actionItemTexts.isEmpty {
+                // Fallback: nothing to summarise — send the transcript so the
+                // send still carries content.
+                return (transcript, "", [])
+            }
+            return ("", summary, actionItemTexts)
+        }
+    }
+
+    /// True when the resolved payload has *something* to send. The Send button
+    /// gates on this rather than on the raw transcript, so summary-only sends
+    /// (transcript still in flight) are allowed.
+    private var hasContentToSend: Bool {
+        let p = resolvedPayload
+        return !p.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !p.summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !p.actionItems.isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             header
+            contentPicker
             promptEditor
-            transcriptPreview
+            contentPreview
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
@@ -38,29 +85,60 @@ struct SendToLLMSheet: View {
                 Button("Send to \(llm.tool.displayName)") { send() }
                     .keyboardShortcut(.defaultAction)
                     .buttonStyle(.borderedProminent)
-                    .disabled(transcript.isEmpty || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(!hasContentToSend || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
         .padding(20)
-        .frame(width: 560, height: 480)
+        .frame(width: 560, height: 540)
         .onAppear {
             // Seed with the saved action prompt; user can edit just for this
             // run without overwriting Settings.
             if prompt.isEmpty {
                 prompt = llm.postActionPrompt
             }
+            // Seed the per-send content choice from the global default.
+            sendContent = llm.sendContent
         }
         .accessibilityIdentifier("sendtollm.sheet")
     }
 
+    /// Header verb tracks what will actually be sent: "transcript" for the
+    /// default mode, "summary" once the summary+items mode resolves to a
+    /// non-empty summary/items payload, and back to "transcript" when that
+    /// mode falls back (no Live-AI content).
     private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Send transcript to \(llm.tool.displayName)")
+        let noun: String = {
+            switch sendContent {
+            case .transcript: return "transcript"
+            case .summaryAndActionItems:
+                return (summary.isEmpty && actionItemTexts.isEmpty) ? "transcript" : "summary"
+            }
+        }()
+        return VStack(alignment: .leading, spacing: 4) {
+            Text("Send \(noun) to \(llm.tool.displayName)")
                 .font(.title3.weight(.semibold))
             Text(liveRecording.title)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
+        }
+    }
+
+    private var contentPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Picker("Send", selection: $sendContent) {
+                Text("Transcript").tag(LLMSendContent.transcript)
+                Text("Summary & action items").tag(LLMSendContent.summaryAndActionItems)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityIdentifier("sendtollm.content.picker")
+            if sendContent == .summaryAndActionItems && summary.isEmpty && actionItemTexts.isEmpty {
+                Text("No summary or action items for this recording (Live AI was off) — the transcript will be sent instead.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
@@ -85,14 +163,32 @@ struct SendToLLMSheet: View {
         }
     }
 
-    private var transcriptPreview: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Transcript")
+    /// Preview reflects the *resolved* payload, not the raw transcript, so the
+    /// user sees exactly what the LLM will receive for the current mode.
+    private var contentPreview: some View {
+        let payload = resolvedPayload
+        let body: String = {
+            var parts: [String] = []
+            if !payload.summary.isEmpty {
+                parts.append("Summary:\n\(payload.summary)")
+            }
+            if !payload.actionItems.isEmpty {
+                parts.append("Action items:\n" + payload.actionItems.map { "- \($0)" }.joined(separator: "\n"))
+            }
+            if !payload.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let label = (payload.summary.isEmpty && payload.actionItems.isEmpty) ? "Transcript" : "Full transcript"
+                parts.append("\(label):\n\(payload.transcript)")
+            }
+            return parts.joined(separator: "\n\n")
+        }()
+        let isEmpty = body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("Preview")
                 .font(.callout.weight(.semibold))
             ScrollView {
-                Text(transcript.isEmpty ? "(no transcript yet — wait for it to finish, then try again)" : transcript)
+                Text(isEmpty ? "(nothing to send yet — wait for the recording to finish, then try again)" : body)
                     .font(.system(.callout))
-                    .foregroundStyle(transcript.isEmpty ? .secondary : .primary)
+                    .foregroundStyle(isEmpty ? .secondary : .primary)
                     .multilineTextAlignment(.leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .textSelection(.enabled)
@@ -101,32 +197,35 @@ struct SendToLLMSheet: View {
             .frame(maxHeight: 160)
             .background(Color.primary.opacity(0.04),
                         in: RoundedRectangle(cornerRadius: 6))
+            .accessibilityIdentifier("sendtollm.preview")
         }
     }
 
     private func send() {
         let recordingID = liveRecording.id
         let promptSnapshot = prompt
-        let transcriptSnapshot = transcript
-        // Include any Live-AI summary so the LLM sees the gist before the
-        // raw transcript. Empty when this recording ran without Live AI —
-        // LLMRunner.composedPrompt then collapses to the old transcript-only
-        // wire format.
-        let summarySnapshot = (liveRecording.summary ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Snapshot the payload resolved from the per-send content picker:
+        //  * .transcript          → transcript + summary (gist above raw text)
+        //  * .summaryAndActionItems → summary + action items, no transcript
+        //    (falls back to transcript when both are empty)
+        // LLMRunner.composedPrompt collapses any empty sections, so an
+        // empty summary / items just drops back to the old wire format.
+        let payload = resolvedPayload
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let tool = llm.tool
         dismiss()
         // Hand off to the app-lifetime coordinator so the call is owned +
         // cancellable rather than spawned as a fire-and-forget detached
         // Task. The Send button here is already gated on a non-empty
-        // transcript, so the snapshot is populated and the coordinator
-        // runs it immediately (no transcript wait).
+        // payload, so the coordinator runs it immediately (no transcript
+        // wait) — except for the summary/items mode, whose deliberately
+        // empty transcript the coordinator knows not to wait on.
         postRecording.sendToLLM(recordingID: recordingID,
                                 tool: tool,
                                 prompt: promptSnapshot,
-                                transcript: transcriptSnapshot,
-                                summary: summarySnapshot,
+                                transcript: payload.transcript,
+                                summary: payload.summary,
+                                actionItems: payload.actionItems,
                                 executableOverride: executableOverride)
     }
 }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -479,6 +479,8 @@ private struct LLMSettingsTab: View {
                 namePromptSection
                 Divider()
                 actionPromptSection
+                Divider()
+                sendContentSection
             }
             .padding(.vertical, 4)
         }
@@ -550,6 +552,21 @@ private struct LLMSettingsTab: View {
             ExamplesView(title: "Examples", items: LLMSettings.actionExamples) {
                 settings.postActionPrompt = $0
             }
+        }
+    }
+
+    private var sendContentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Send to LLM", selection: $settings.sendContent) {
+                ForEach(LLMSendContent.allCases) { content in
+                    Text(content.displayName).tag(content)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text("Transcript by default; or send the summary + action items instead.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -178,6 +178,90 @@ final class LLMRunnerTests: XCTestCase {
                        "Make a doc.\n\n---\nSummary:\nMigration is done.")
     }
 
+    // MARK: - Action items wire format
+
+    /// Summary + action items with NO transcript (the "Summary & action
+    /// items" send mode when Live AI was on). The wire format must include a
+    /// `Summary:` section and an `Action items:` section, and must NOT include
+    /// a `Full transcript:` / `Transcript:` section.
+    func test_composed_prompt_with_summary_and_action_items_no_transcript() {
+        let composed = LLMRunner.composedPrompt(
+            "Email the team.",
+            transcript: "",
+            summary: "We finalised the Q3 roadmap.",
+            actionItems: ["Uri opens the migration PR", "Dana reviews by Friday"])
+        XCTAssertEqual(composed, """
+            Email the team.
+
+            ---
+            Summary:
+            We finalised the Q3 roadmap.
+
+            Action items:
+            - Uri opens the migration PR
+            - Dana reviews by Friday
+            """)
+        XCTAssertFalse(composed.contains("Full transcript:"))
+        XCTAssertFalse(composed.contains("Transcript:"))
+    }
+
+    /// Action items format as `- ` bullet lines, one per item, with empty /
+    /// whitespace-only items dropped.
+    func test_composed_prompt_action_items_format_as_dash_lines() {
+        let composed = LLMRunner.composedPrompt(
+            "Do it.",
+            transcript: "",
+            summary: "Gist.",
+            actionItems: ["First", "   ", "Second"])
+        XCTAssertTrue(composed.contains("Action items:\n- First\n- Second"),
+                      "items not rendered as dash lines / empty not dropped: \(composed)")
+    }
+
+    /// All three sections present → order is Summary, Action items, Full
+    /// transcript.
+    func test_composed_prompt_orders_summary_then_items_then_transcript() {
+        let composed = LLMRunner.composedPrompt(
+            "Go.",
+            transcript: "Raw words.",
+            summary: "Gist.",
+            actionItems: ["Ship it"])
+        XCTAssertEqual(composed, """
+            Go.
+
+            ---
+            Summary:
+            Gist.
+
+            Action items:
+            - Ship it
+
+            Full transcript:
+            Raw words.
+            """)
+    }
+
+    /// Back-compat: transcript + summary, no action items, is byte-for-byte
+    /// identical to today's wire format.
+    func test_composed_prompt_transcript_and_summary_unchanged_without_items() {
+        let composed = LLMRunner.composedPrompt(
+            "Make a tweet from this.",
+            transcript: "Hello world.",
+            summary: "We discussed the new schema.",
+            actionItems: [])
+        XCTAssertEqual(composed,
+                       "Make a tweet from this.\n\n---\nSummary:\nWe discussed the new schema.\n\nFull transcript:\nHello world.")
+    }
+
+    /// Everything empty (no transcript, no summary, no items) → prompt only.
+    func test_composed_prompt_all_empty_is_prompt_only() {
+        let composed = LLMRunner.composedPrompt(
+            "Just answer.",
+            transcript: "   ",
+            summary: "",
+            actionItems: ["  "])
+        XCTAssertEqual(composed, "Just answer.")
+    }
+
     func test_timeout_fires_when_process_exceeds_limit() async {
         // Script ignores its args and sleeps 5s. Runner times out at 1s.
         // The contract verified here is "the timeout error fires" — wall

--- a/MilaTests/LLMSettingsTests.swift
+++ b/MilaTests/LLMSettingsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Mila
+
+/// Settings-model tests for `LLMSettings`. Isolated to a custom UserDefaults
+/// suite per the project convention so they don't pollute (or read from) the
+/// user's real `.standard` defaults.
+@MainActor
+final class LLMSettingsTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suite = "LLMSettingsTests"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        UserDefaults().removePersistentDomain(forName: suite)
+        defaults = UserDefaults(suiteName: suite)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suite)
+        try await super.tearDown()
+    }
+
+    /// Fresh install: the "Send to LLM" content choice defaults to the
+    /// transcript — preserving today's behaviour for users who don't touch
+    /// the new setting.
+    func test_send_content_defaults_to_transcript() {
+        let settings = LLMSettings(defaults: defaults)
+        XCTAssertEqual(settings.sendContent, .transcript)
+    }
+
+    func test_send_content_persists_across_instances() {
+        let first = LLMSettings(defaults: defaults)
+        first.sendContent = .summaryAndActionItems
+
+        let reloaded = LLMSettings(defaults: defaults)
+        XCTAssertEqual(reloaded.sendContent, .summaryAndActionItems)
+    }
+}


### PR DESCRIPTION
## What

Adds a configurable choice for **what content the "Send to \<LLM\>" sheet ships**:

- **Transcript** (default — unchanged behaviour: full transcript, with the Live-AI summary prepended above it when present)
- **Summary & action items** (sent *instead of* the transcript)

The choice is surfaced **both** as a global default in **Settings → LLM** and as a **per-send segmented picker** in the sheet (seeded from the default).

Action items were previously never sent to the LLM — this mode adds them.

## How

- **`LLMSettings`** — new `LLMSendContent` enum (`.transcript` / `.summaryAndActionItems`) and a persisted `@Published var sendContent` (namespaced key `llm.sendContent`, **default `.transcript`**, read in `init`).
- **`LLMRunner.composedPrompt`** — new `actionItems: [String] = []` param. Renders an `Action items:` section (one `- item` per line) when non-empty. Section order when present: **Summary → Action items → Full transcript**. Keeps the existing collapse-empties behaviour plus the prompt-only / transcript-only shapes. `run(...)` accepts + forwards `actionItems` (default `[]`), so all other callers (LiveAISession, RecordingSummarizer, name-gen, RenameRecordingSheet) are untouched.
- **`PostRecordingCoordinator.sendToLLM`** — new `actionItems: [String] = []` param, forwarded to `LLMRunner.run`. The "wait for the transcript to finish" safety net is now skipped when the summary/items payload is non-empty, so the deliberately-empty transcript in summary mode isn't waited on (or injected) behind the scenes.
- **`SendToLLMSheet`** — per-send `@State sendContent` seeded from `llm.sendContent`; segmented picker (`Transcript` / `Summary & action items`). The payload is resolved from the picker; the **preview**, the **header label**, and the **Send-button enablement** all track the *resolved* payload (gated on resolved-payload non-empty, not just the raw transcript). 
- **`SettingsView`** — a segmented `Picker` bound to `llm.sendContent` in the LLM section, with the help caption *"Transcript by default; or send the summary + action items instead."*

### Edge case: empty-summary fallback
In `.summaryAndActionItems` mode, if **both** the summary and the action items are empty (e.g. the recording ran with Live AI off), the sheet **falls back to sending the transcript** so the send is never empty. The sheet shows an inline caption explaining this, and the header noun flips back to "transcript" to reflect what's actually sent.

## Tests
- `MilaTests/LLMRunnerTests.swift`: summary + action items with no transcript → has `Summary:` + `Action items:`, no `Full transcript:`; transcript + summary, no items → byte-for-byte unchanged from today; all-empty → prompt only; action-items list formats as `- ` lines with empties dropped; full Summary → Action items → Full transcript ordering.
- `MilaTests/LLMSettingsTests.swift` (new): `sendContent` defaults to `.transcript` and persists across instances, isolated to a custom `UserDefaults` suite per the project convention.

## Verification
- `make project` + `build-for-testing`: **TEST BUILD SUCCEEDED**.
- Ran `MilaTests/LLMRunnerTests` + `MilaTests/LLMSettingsTests`: **20 passed, 0 failed**.

## Release
Targets a future release (post-1.8.13). Left as a **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)