### PR TITLE
LLM integration: auto-summary toggle + configurable CLI timeout

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -8,7 +8,7 @@ enum LLMRunnerError: LocalizedError {
     case executableNotFound(String)
     case launchFailed(Error)
     case nonZeroExit(code: Int32, stderr: String)
-    case timedOut
+    case timedOut(seconds: Int)
     case emptyOutput
     case cancelled
 
@@ -23,8 +23,8 @@ enum LLMRunnerError: LocalizedError {
         case .nonZeroExit(let code, let stderr):
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             return "LLM CLI exited with status \(code). \(trimmed)"
-        case .timedOut:
-            return "LLM CLI did not respond within the timeout."
+        case .timedOut(let seconds):
+            return "LLM CLI did not respond within \(seconds)s. If it's running an agentic task (e.g. calendar lookup), raise the timeout in Settings → LLM."
         case .emptyOutput:
             return "LLM CLI returned no output. Check the prompt or your CLI's auth."
         case .cancelled:
@@ -259,7 +259,7 @@ enum LLMRunner {
         if runningGroup.wait(timeout: deadline) == .timedOut {
             process.terminate()
             _ = group.wait(timeout: .now() + 1)
-            throw LLMRunnerError.timedOut
+            throw LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up)))
         }
         group.wait()
 

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -136,6 +136,17 @@ final class LLMSettings: ObservableObject {
         didSet { defaults.set(postActionPrompt, forKey: Keys.actionPrompt) }
     }
 
+    /// Maximum wall-clock seconds Mila allows a post-recording LLM call to
+    /// run before killing the subprocess. Applies to title generation, the
+    /// auto-summary, and the Send-action button. Live AI's per-tick timeouts
+    /// are tuned separately and are not affected by this setting.
+    @Published var cliTimeout: TimeInterval {
+        didSet {
+            guard cliTimeout != oldValue else { return }
+            defaults.set(cliTimeout, forKey: Keys.cliTimeout)
+        }
+    }
+
     /// Master switch for the AUTOMATIC post-recording summary
     /// (`RecordingSummarizer`). When off, no summary is generated when a
     /// recording finishes, on launch backfill, or on re-transcription —
@@ -169,6 +180,7 @@ final class LLMSettings: ObservableObject {
         // have never seen this key, silently disabling summaries for
         // everyone on upgrade. Treat "key absent" as true.
         self.summaryEnabled = (defaults.object(forKey: Keys.summaryEnabled) as? Bool) ?? true
+        self.cliTimeout = (defaults.object(forKey: Keys.cliTimeout) as? Double) ?? 300
     }
 
     /// Default name prompt is deliberately *tool-free*. The previous default
@@ -202,5 +214,6 @@ final class LLMSettings: ObservableObject {
         static let actionEnabled = "llm.action.enabled"
         static let actionPrompt = "llm.action.prompt"
         static let summaryEnabled = "llm.summary.enabled"
+        static let cliTimeout = "llm.cli.timeout"
     }
 }

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -136,6 +136,20 @@ final class LLMSettings: ObservableObject {
         didSet { defaults.set(postActionPrompt, forKey: Keys.actionPrompt) }
     }
 
+    /// Master switch for the AUTOMATIC post-recording summary
+    /// (`RecordingSummarizer`). When off, no summary is generated when a
+    /// recording finishes, on launch backfill, or on re-transcription —
+    /// the app behaves as a transcript-only tool. The explicit
+    /// "Regenerate summary" affordance still works on demand; this only
+    /// governs the automatic path.
+    ///
+    /// Defaults to ON (see init) so existing users keep their summaries
+    /// unless they opt out. Surfaced in Settings → LLM next to the name /
+    /// action toggles, which is where users expect to find it.
+    @Published var summaryEnabled: Bool {
+        didSet { defaults.set(summaryEnabled, forKey: Keys.summaryEnabled) }
+    }
+
     /// Convenience the UI uses to decide whether to surface the rename /
     /// run-action buttons at all.
     var isConfigured: Bool { tool != .none }
@@ -151,6 +165,10 @@ final class LLMSettings: ObservableObject {
         self.namePrompt = defaults.string(forKey: Keys.namePrompt) ?? Self.defaultNamePrompt
         self.postActionEnabled = defaults.bool(forKey: Keys.actionEnabled)
         self.postActionPrompt = defaults.string(forKey: Keys.actionPrompt) ?? Self.defaultActionPrompt
+        // Default-on: a bare `defaults.bool` would read false for users who
+        // have never seen this key, silently disabling summaries for
+        // everyone on upgrade. Treat "key absent" as true.
+        self.summaryEnabled = (defaults.object(forKey: Keys.summaryEnabled) as? Bool) ?? true
     }
 
     /// Default name prompt is deliberately *tool-free*. The previous default
@@ -183,5 +201,6 @@ final class LLMSettings: ObservableObject {
         static let namePrompt = "llm.name.prompt"
         static let actionEnabled = "llm.action.enabled"
         static let actionPrompt = "llm.action.prompt"
+        static let summaryEnabled = "llm.summary.enabled"
     }
 }

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -137,7 +137,8 @@ final class PostRecordingCoordinator: ObservableObject {
                    prompt: String,
                    transcript: String,
                    summary: String,
-                   executableOverride: String?) {
+                   executableOverride: String?,
+                   cliTimeout: TimeInterval = LLMRunner.defaultTimeout) {
         guard tool != .none else { return }
         let toolName = tool.displayName
 
@@ -174,7 +175,7 @@ final class PostRecordingCoordinator: ObservableObject {
                     transcript: resolved,
                     summary: summary,
                     executablePathOverride: executableOverride,
-                    timeout: LLMRunner.defaultTimeout
+                    timeout: cliTimeout
                 )
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -57,13 +57,9 @@ final class RecordingSummarizer: ObservableObject {
     /// gets an automatic backfill sweep the moment the toggle flips.
     private var cancellables: Set<AnyCancellable> = []
 
-    /// Timeout for the one-shot summary call. Comfortably larger than
-    /// the live-session per-tick budget because cold-starting `claude`
-    /// can take 30–60s on the first invocation after a sleep / fresh
-    /// boot. Foreground UI isn't blocked — the recording is already
-    /// saved with `.completed` status before we get here — so the
-    /// generous bound is fine.
-    var timeoutSeconds: TimeInterval = 300
+    /// Timeout for the one-shot summary call. Reads from `LLMSettings.cliTimeout`
+    /// so it follows the user's preference set in Settings → LLM.
+    var timeoutSeconds: TimeInterval { llmSettings.cliTimeout }
 
     init(store: RecordingStore,
          llmSettings: LLMSettings,

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -111,6 +111,7 @@ final class RecordingSummarizer: ObservableObject {
     /// Public so callers + tests can ask the same question we ask
     /// internally without re-deriving the predicate.
     func shouldSummarize(_ recording: Recording) -> Bool {
+        guard llmSettings.summaryEnabled else { return false }
         guard llmSettings.isConfigured else { return false }
         let transcript = recording.fullText
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -174,6 +175,10 @@ final class RecordingSummarizer: ObservableObject {
     /// Idempotent: re-runs are safe — recordings already in flight are
     /// skipped by `runSummary`'s own dedup check.
     func backfillIfNeeded() {
+        guard llmSettings.summaryEnabled else {
+            summarizerLog.log("backfill: skipped — auto-summary disabled")
+            return
+        }
         guard llmSettings.isConfigured else {
             summarizerLog.log("backfill: skipped — LLM not configured")
             return
@@ -334,6 +339,10 @@ final class RecordingSummarizer: ObservableObject {
     /// "skipped <id>: <reason>" shape backfill uses.
     private func logSkip(_ recording: Recording, force: Bool) {
         let id = recording.id
+        if !llmSettings.summaryEnabled {
+            summarizerLog.log("skipped \(self.shortID(id), privacy: .public): auto-summary disabled")
+            return
+        }
         if !llmSettings.isConfigured {
             summarizerLog.log("skipped \(self.shortID(id), privacy: .public): LLM not configured")
             return

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -385,8 +385,14 @@ struct MilaApp: App {
         // summary referring to the previous transcript; we force-
         // regenerate so the user doesn't end up with a stale summary
         // that disagrees with what the segments now say.
-        svc.onTranscriptionCompleted = { [weak summarizer] rec, wasRetranscription in
+        svc.onTranscriptionCompleted = { [weak summarizer, weak llm] rec, wasRetranscription in
             if wasRetranscription {
+                // `regenerate` bypasses the "already has a summary" gate by
+                // design (it's also the manual on-demand path), so it does
+                // NOT consult `summaryEnabled` itself. Guard the AUTOMATIC
+                // re-transcription trigger here so a transcript-only user
+                // doesn't get a summary regenerated behind their back.
+                guard llm?.summaryEnabled ?? true else { return }
                 summarizer?.regenerate(rec)
             } else {
                 summarizer?.summarizeIfNeeded(rec)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -441,7 +441,8 @@ struct RenameRecordingSheet: View {
                               prompt: prompt,
                               transcript: transcriptSnapshot,
                               summary: summarySnapshot,
-                              executableOverride: executableOverride)
+                              executableOverride: executableOverride,
+                              cliTimeout: llm.cliTimeout)
     }
 
     private func fetchNameFromLLM(auto: Bool = false) async {
@@ -450,15 +451,12 @@ struct RenameRecordingSheet: View {
         if auto { didAutoSuggest = true }
         defer { isFetchingName = false }
         do {
-            // Foreground suggest gets a tighter timeout (90s) so a hung CLI
-            // doesn't pin the sheet for 5 minutes. Background "Send" uses
-            // the full 5-min default.
             let suggestion = try await LLMRunner.run(
                 tool: llm.tool,
                 prompt: llm.namePrompt,
                 transcript: transcript,
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
-                timeout: 90
+                timeout: llm.cliTimeout
             )
             let cleaned = suggestion
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -127,6 +127,7 @@ struct SendToLLMSheet: View {
                                 prompt: promptSnapshot,
                                 transcript: transcriptSnapshot,
                                 summary: summarySnapshot,
-                                executableOverride: executableOverride)
+                                executableOverride: executableOverride,
+                                cliTimeout: llm.cliTimeout)
     }
 }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -478,6 +478,8 @@ private struct LLMSettingsTab: View {
                 Divider()
                 summarySection
                 Divider()
+                timeoutSection
+                Divider()
                 namePromptSection
                 Divider()
                 actionPromptSection
@@ -525,6 +527,29 @@ private struct LLMSettingsTab: View {
                 .toggleStyle(.switch)
                 .accessibilityIdentifier("llm.summary.enabled.toggle")
             Text("When on, Mila runs a one-shot LLM pass after every recording finishes and stores the result as the recording's AI Overview. Turn this off to keep Mila transcript-only. Existing summaries are kept, and any recording that still has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var timeoutSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("CLI timeout").frame(width: 100, alignment: .leading)
+                Stepper(value: $settings.cliTimeout, in: 30...900, step: 30) {
+                    EmptyView()
+                }
+                Text("\(Int(settings.cliTimeout))s")
+                    .monospacedDigit()
+                    .frame(width: 44, alignment: .trailing)
+                Button("Reset") { settings.cliTimeout = 300 }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+            .font(.callout)
+            Text("Maximum time Mila waits for a CLI response before giving up. Applies to title generation, auto-summary, and the Send-action button. Raise this if your prompt uses agentic tools (e.g. calendar lookup) that need extra time to complete.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -476,6 +476,8 @@ private struct LLMSettingsTab: View {
                 header
                 toolPicker
                 Divider()
+                summarySection
+                Divider()
                 namePromptSection
                 Divider()
                 actionPromptSection
@@ -511,6 +513,18 @@ private struct LLMSettingsTab: View {
             }
             .font(.callout)
             Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("Automatically summarize recordings", isOn: $settings.summaryEnabled)
+                .toggleStyle(.switch)
+                .accessibilityIdentifier("llm.summary.enabled.toggle")
+            Text("When on, Mila runs a one-shot LLM pass after every recording finishes and stores the result as the recording's AI Overview. Turn this off to keep Mila transcript-only. Existing summaries are kept, and any recording that still has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -75,6 +75,27 @@ final class RecordingSummarizerTests: XCTestCase {
         XCTAssertTrue(summarizer.shouldSummarize(rec))
     }
 
+    /// The auto-summary master switch. When the user turns off
+    /// "Automatically summarize recordings" the post-recording summary
+    /// must NOT fire, even with the LLM configured and a transcript ready.
+    func test_should_summarize_false_when_auto_summary_disabled() {
+        llm.tool = .claude
+        llm.summaryEnabled = false
+        let rec = Recording(title: "T", source: .microphone, audioFileName: "t.wav",
+                            fullText: "the transcript")
+        XCTAssertFalse(summarizer.shouldSummarize(rec),
+                       "Disabling auto-summary must gate shouldSummarize")
+    }
+
+    /// Default-on: existing users (and fresh installs) keep getting
+    /// summaries unless they explicitly opt out. A bare `defaults.bool`
+    /// would default to false and silently disable the feature for
+    /// everyone, so the property must default to true.
+    func test_summary_enabled_defaults_true() {
+        XCTAssertTrue(llm.summaryEnabled,
+                      "Auto-summary must default to on to preserve existing behaviour")
+    }
+
     func test_should_summarize_treats_whitespace_summary_as_empty() {
         llm.tool = .claude
         var rec = Recording(title: "T", source: .microphone, audioFileName: "t.wav",
@@ -256,6 +277,75 @@ final class RecordingSummarizerTests: XCTestCase {
         let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
         XCTAssertEqual(updated.summary, "live_summary_from_recording",
                        "Late-arriving CLI output must not overwrite a summary that already exists")
+    }
+
+    /// End-to-end: with auto-summary disabled, a freshly transcribed
+    /// recording must be left untouched — the CLI is never invoked and no
+    /// summary lands. The script would write "SHOULD NOT RUN" if reached.
+    func test_summarize_skips_when_auto_summary_disabled() async throws {
+        let script = makeScript("""
+            #!/bin/sh
+            printf 'SHOULD NOT RUN'
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        llm.tool = .claude
+        llm.executablePath = script.path
+        llm.summaryEnabled = false
+
+        let audioURL = store.freshAudioURL(suggestedName: "Off")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Off",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "transcript text"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        // Give a doomed CLI call time to land if the gate failed.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertNil(updated.summary,
+                     "No summary should be written while auto-summary is disabled")
+    }
+
+    /// The explicit "Regenerate summary" affordance is a deliberate user
+    /// action and must work even when AUTOMATIC summaries are turned off —
+    /// the toggle governs the post-recording auto path, not on-demand use.
+    func test_regenerate_works_even_when_auto_summary_disabled() async throws {
+        let script = makeScript("""
+            #!/bin/sh
+            printf 'ON DEMAND'
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        llm.tool = .claude
+        llm.executablePath = script.path
+        llm.summaryEnabled = false
+
+        let audioURL = store.freshAudioURL(suggestedName: "Manual")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "Manual",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "transcript text"
+        )
+        // Mirrors the real UI path: the "Regenerate summary" action is only
+        // reachable on a recording that already has a summary (e.g. made
+        // before the user disabled auto-summary). Regenerate must still
+        // refresh it on demand despite the master switch being off.
+        rec.summary = "stale summary from before auto-summary was disabled"
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        try await waitForSummary(recordingID: rec.id,
+                                 timeoutSeconds: 120,
+                                 expected: "ON DEMAND")
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "ON DEMAND")
     }
 
     // MARK: - Force / regenerate path

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ distribution via the App Store you'd:
 
 Newest first. Dates are release dates.
 
-- **Unreleased** — Added an "Automatically summarize recordings" toggle (Settings → LLM, on by default) so Mila can run transcript-only: turn it off and no AI Overview is generated after a recording, on launch backfill, or on re-transcription.
+- **Unreleased** — Added an "Automatically summarize recordings" toggle (Settings → LLM, on by default) so Mila can run transcript-only: turn it off and no AI Overview is generated after a recording, on launch backfill, or on re-transcription. Added a configurable CLI timeout (default 300s, Settings → LLM) that applies to title generation, auto-summary, and the Send-action button; improved the timeout error message to name the elapsed seconds and point to the setting.
 - **1.8.5** (2026-06-09) — Independent mic / app-audio capture toggles, AAC (`.m4a`) recordings, and a configurable recording-storage cap.
 - **1.8.4** (2026-06-09) — Fixed speaker diarization silently breaking in notarized builds (the bundled Python couldn't load torch's dylibs).
 - **1.8.3** (2026-06-08) — Mic-capture diagnostics, automatic language detection, and a post-recording sheet fix.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ distribution via the App Store you'd:
 
 Newest first. Dates are release dates.
 
+- **Unreleased** — Added an "Automatically summarize recordings" toggle (Settings → LLM, on by default) so Mila can run transcript-only: turn it off and no AI Overview is generated after a recording, on launch backfill, or on re-transcription.
 - **1.8.5** (2026-06-09) — Independent mic / app-audio capture toggles, AAC (`.m4a`) recordings, and a configurable recording-storage cap.
 - **1.8.4** (2026-06-09) — Fixed speaker diarization silently breaking in notarized builds (the bundled Python couldn't load torch's dylibs).
 - **1.8.3** (2026-06-08) — Mic-capture diagnostics, automatic language detection, and a post-recording sheet fix.


### PR DESCRIPTION
## What & why

Two related improvements to the post-recording LLM integration:

### 1. Automatically summarize recordings toggle

Previously, `RecordingSummarizer` fired whenever an LLM CLI was configured, with no way to turn it off short of unsetting the CLI entirely. This PR adds a dedicated **Automatically summarize recordings** toggle (Settings → LLM, on by default) that gates only the automatic summary paths, leaving name generation and post-actions unaffected.

### 2. Configurable CLI timeout

All three post-recording `claude -p` call sites had hardcoded timeouts (title: 90 s, summary + Send: 300 s). When a title prompt uses agentic tools (e.g. calendar lookup), the subprocess routinely hits the 90 s cap and the user sees a generic error with no guidance.

This PR replaces the hardcoded timeouts with a single user-controlled **CLI timeout** stepper (Settings → LLM, default 300 s, range 30-900 s) and improves the error message to name the elapsed seconds and point to the setting.

Root-cause identified from a real session: `claude` spent the full 90 s running `find /` looking for the `gws` binary (not on Mila'''s minimal PATH), then was SIGKILLed (exit 137).

## Changes

**`LLMSettings`**
- New `summaryEnabled: Bool` (default on) — gates automatic summary paths
- New `cliTimeout: TimeInterval` (default 300 s, persisted as `llm.cli.timeout`)

**`RecordingSummarizer`**
- `shouldSummarize` predicate respects `summaryEnabled`
- `timeoutSeconds` is now a computed property reading `llmSettings.cliTimeout` (was a stored 300 s constant)

**`MilaApp`** - auto re-transcription hook respects `summaryEnabled`

**`LLMRunner`** - `timedOut` now carries elapsed seconds; error message names them and links to Settings → LLM

**`PostRecordingCoordinator`** - `sendToLLM` gains a `cliTimeout` parameter (default = `LLMRunner.defaultTimeout` for back-compat)

**`RenameRecordingSheet`** - hardcoded `timeout: 90` replaced with `llm.cliTimeout`; Send path updated

**`SendToLLMSheet`** - passes `cliTimeout: llm.cliTimeout`

**`SettingsView` (LLM tab)**
- New **Automatically summarize recordings** toggle (between tool picker and name prompt)
- New **CLI timeout** stepper (30-900 s, step 30, Reset button) with caption

**`README.md`** - Unreleased changelog updated for both features

Live AI'''s per-tick and cold-start timeouts are excluded - they are tuned separately.

## How it was tested

- `make build` - clean build
- `make test` - all unit tests that can pass do pass
- Pre-existing failures (5 total, unrelated to this PR):
  - 3 UI tests have a timing fragility (screenshot before window renders)
  - 2 `LLMRunnerTests` E2E tests require real CLI installs
  - `test_timeout_fires_when_process_exceeds_limit` **passes** confirming `timedOut(seconds:)` is backward-compatible
  - `PostRecordingCoordinatorSendTests` and `RecordingSummarizerBackfillTests` pass in isolation

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog