### PR TITLE
Live AI: guarantee a fresh per-recording Claude session (fix cross-recording bleed)

### DIFF
--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Combine
+import OSLog
+
+private let liveAILog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveAISession")
 
 /// Drives the LLM half of Live AI mode. Holds an action-item list, fires a
 /// debounced one-shot LLM call against the latest transcript on each tick,
@@ -143,6 +146,11 @@ final class LiveAISession: ObservableObject {
         sessionID = (llmSettings.tool == .claude) ? UUID() : nil
         sessionEstablished = false
         lastTranscriptSent = ""
+        // os_log (NOT print) so the session UUID lands in diagnostic reports.
+        // A fresh `start()` per recording is the invariant that prevents
+        // cross-recording `--resume` bleed; logging the new id makes a
+        // regression visible in `Mila-DiagnosticReport`.
+        liveAILog.log("start: fresh session=\(self.sessionID?.uuidString.prefix(8) ?? "none", privacy: .public) tool=\(self.llmSettings.tool.rawValue, privacy: .public)")
     }
 
     /// Wait until any in-flight (or coalesced-and-pending) LLM tick
@@ -186,6 +194,17 @@ final class LiveAISession: ObservableObject {
         coalesced = false
         latestTranscript = ""
         isThinking = false
+        // Clear the rolling AI output too. `cancel()` is both the leading
+        // half of `start()` AND the gated-hardware reset path
+        // (wireLiveAIPipeline calls it when Live AI is unavailable). In both
+        // cases the previous recording's summary / action items must NOT
+        // survive — otherwise `stopRecording` snapshots stale content onto a
+        // new recording. Previously cancel() left these intact, so the
+        // gated-branch comment claiming it "clears summary/actionItems" was a
+        // no-op. (start() also re-clears them; harmless redundancy.)
+        actionItems = []
+        summary = ""
+        lastError = nil
         pendingKickTask?.cancel()
         pendingKickTask = nil
         lastKickStartedAt = nil
@@ -371,6 +390,11 @@ TRANSCRIPT SO FAR:
         // session the model didn't actually produce.
         let kickSessionID = sessionID
         print("LiveAI[\(kickTag)]: tool=\(tool.rawValue) model=\(model.isEmpty ? "(default)" : model) session=\(llmSession) delta=\(useSession ? augmentedTranscript.count : 0)ch full=\(snapshot.count)ch items=\(actionItems.count) sending…")
+        // os_log mirror of the session decision so diagnostic reports capture
+        // it. A `.resume` on a recording's FIRST tick is the signature of the
+        // cross-recording bleed bug (the session wasn't freshly started); a
+        // healthy recording always opens with `.new`.
+        liveAILog.log("tick \(kickTag, privacy: .public): session=\(String(describing: llmSession), privacy: .public) established=\(self.sessionEstablished, privacy: .public)")
         inFlight = Task { @MainActor [weak self] in
             let llmStart = Date()
             do {

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -354,6 +354,15 @@ final class QuickActionsController: ObservableObject {
         }
         do {
             try await session.start(source: source, outputURL: url)
+            // Guarantee a fresh, isolated Live AI session for THIS recording
+            // (new Claude session UUID + cleared summary/action items) before
+            // any transcript can be fed. This is the single deterministic
+            // reset point — relying on the async `.recording` state observer
+            // (wireLiveAIPipeline) instead risked the transition being
+            // coalesced under load, leaving the previous recording's session
+            // live so its first tick `--resume`d the prior meeting →
+            // cross-recording summary/action-item bleed. See LiveAISession.start().
+            liveAISession?.start()
             activeJob = .recording(withSystemAudio: withSystemAudio)
             sleepGuard.preventIdleSleep(reason: "Mila is recording")
             startSilenceWatch(watching: source)
@@ -440,6 +449,9 @@ final class QuickActionsController: ObservableObject {
         do {
             let source: RecordingSource = includeMic ? .meeting : .systemAudio
             try await session.start(source: source, outputURL: url)
+            // Fresh, isolated per-recording Live AI session — see the matching
+            // call in startRecording() for the full rationale.
+            liveAISession?.start()
             activeJob = .recordingApp(processID: app?.processID, includeMic: includeMic)
             sleepGuard.preventIdleSleep(reason: "Mila is recording")
             startSilenceWatch(watching: source)

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1031,14 +1031,14 @@ struct MilaApp: App {
                     // the ArraySlice on some Swift-concurrency edge.
                     transcriber?.ingest(samples)
                 }
-                // Always reset Live AI session state at .recording —
-                // this clears stale `summary` / `actionItems` from a
-                // previous recording so the AI pane never shows
-                // last meeting's content if the user toggles Live AI
-                // on mid-recording. start() is cheap (no subprocess
-                // until the first feed) and only allocates a session
-                // UUID for Claude.
-                aiSession.start()
+                // NOTE: the Live AI session is reset deterministically at
+                // record-start in QuickActionsController (`liveAISession?.start()`),
+                // NOT here. Driving the reset off this async `.recording`
+                // observer risked the transition being coalesced under load,
+                // leaving the previous recording's session live so its first
+                // tick `--resume`d the prior meeting → cross-recording bleed.
+                // By the time this runs, the session has already been freshly
+                // started for this recording.
                 diarizer.reset()
                 diarizer.similarityThreshold = aiSettings.speakerSimilarityThreshold
                 // Detach the diarizer start so a quick stop-after-start
@@ -1157,9 +1157,9 @@ struct MilaApp: App {
                 }
                 // Note: don't cancel aiSession here — QuickActionsController
                 // still needs to read .summary and .actionItems out of
-                // it when assembling the saved Recording. The next
-                // .recording transition's `aiSession.start()` clears
-                // these.
+                // it when assembling the saved Recording. The NEXT
+                // recording clears these via `liveAISession?.start()` at
+                // record-start (in QuickActionsController).
                 sessionRef.onLiveSamples = nil
             }
         }


### PR DESCRIPTION
Fixes #29

## Problem

A new recording's Live AI summary / action items could contain a **previous recording's content** ("yesterday's summary"). The Live AI pipeline did not guarantee a fresh, isolated Claude session per recording, and a secondary reset path silently failed to clear state.

## Root causes

1. **Timing-dependent reset.** `LiveAISession.start()` (fresh `--session-id` UUID, `sessionEstablished = false`, cleared `summary`/`actionItems`) ran **only** from the async `.recording` handler in `wireLiveAIPipeline`, which consumes a Combine `AsyncPublisher`. Under load that can coalesce/drop a `.recording` transition (the `.idle` branch awaits), leaving the previous recording's session live → the new recording's first tick `--resume`s the prior meeting → blended summary + carried-over action items (re-emitted without timestamps → `[0s]`).
2. **`cancel()` didn't clear AI output.** The gated-hardware branch (`!isLiveAIAvailable`) calls `aiSession.cancel()` with a comment claiming it clears `summary`/`actionItems` — but it never did, so on low-end hardware the prior recording's output leaked directly.

## Changes

- **Deterministic per-recording reset:** `liveAISession?.start()` is now called synchronously at record-start in `QuickActionsController` (`startRecording` + `startAppRecording`), and the observer-driven `aiSession.start()` is removed. A fresh isolated Claude session is guaranteed before any transcript is fed.
- **`cancel()` now clears** `summary`/`actionItems`/`lastError`.
- **OSLog instrumentation** for the fresh-session UUID (`start()`) and the `.new`/`.resume` decision per tick. These were `print`-only and absent from `Mila-DiagnosticReport`; a `.resume` on a recording's *first* tick is the bleed signature and is now captured.

## Honest caveat

Exact reproduction was **not** captured (Live AI session decisions were `print`-only, so absent from the diagnostic report). The reported recording showed the `[0s]`-action-item signature consistent with carried-over conversation memory, but as recurring daily standups the summaries also overlap naturally. These changes (a) fix a confirmed latent bug (`cancel()`), (b) remove the confirmed timing fragility that *permits* the bleed, and (c) add the instrumentation needed to prove any recurrence definitively.

## Test plan

- [x] `make build` (Debug, macOS) — **BUILD SUCCEEDED**
- [ ] Record two back-to-back meetings; confirm the second's summary/action items contain no content from the first.
- [ ] Confirm diagnostic report now contains `LiveAISession` OSLog lines (`start: fresh session=…`, `tick …: session=new/resume`), and that each recording's first tick logs `session=new`.

## Follow-ups (not here)
- Scope `sessionEstablished`/`--resume` to an explicit recording identity (defense-in-depth).
- `--resume` accumulating a whole meeting's context also contributes to slow stop-time finalize — revisit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
