### PR TITLE
Release notes gate: require RELEASE_NOTES/v<version>.md so 'What's New' is never blank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,15 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
 - Run tests with `make test` or via Xcode.
 
 ## Release Process
+- **Release notes are REQUIRED, first.** Every release must add
+  `RELEASE_NOTES/v<MARKETING_VERSION>.md` (Markdown, user-facing). This file
+  becomes the Sparkle appcast `<description>` — i.e. the in-app "What's New"
+  popup users see on update. Without it that popup is blank ("a new version is
+  available" with no changelog). The signing pipeline runs
+  `scripts/check-release-notes.sh <version>` **before building** and FAILS the
+  release if the file is missing/empty/boilerplate, so this can't be skipped.
+  Do NOT rely on the `project.yml` changelog comment or the GitHub Release body —
+  neither feeds the appcast. See `RELEASE_NOTES/README.md`.
 - Version is bumped only in `project.yml` (`MARKETING_VERSION` +
   `CURRENT_PROJECT_VERSION`). `Info.plist` inherits both via
   `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)` — never hardcode

--- a/RELEASE_NOTES/README.md
+++ b/RELEASE_NOTES/README.md
@@ -1,0 +1,39 @@
+# Release notes
+
+One Markdown file per release, named `v<MARKETING_VERSION>.md` (e.g. `v1.8.14.md`).
+
+## Why this is required
+
+The signing/publish pipeline turns this file into the Sparkle appcast
+`<description>` for the release — which is **exactly what Mila's in-app
+"What's New" popup shows** when a user updates. If it's missing, the popup
+degrades to a bare *"a new version of Mila is available"* with no changelog.
+
+To make that impossible to forget, the release pipeline **fails fast — before
+the build** — when `RELEASE_NOTES/v<version>.md` is missing, empty, or still
+contains boilerplate. The check is [`scripts/check-release-notes.sh`](../scripts/check-release-notes.sh);
+run it locally any time: `scripts/check-release-notes.sh 1.8.14`.
+
+## Writing the notes
+
+- Audience is **end users**, not developers — describe what changed for *them*.
+- Markdown. A short bulleted list works best (it renders to `<ul><li>` in the
+  appcast); bold the lead of each bullet.
+- Cover only the user-visible changes in this version.
+
+Example (`v1.8.14.md`):
+
+```md
+- **Fixed a cross-recording mix-up in AI summaries** — a recording's summary
+  and action items could occasionally include content carried over from a
+  previous recording. Each recording now uses a fully isolated AI session.
+```
+
+## Where this fits in the release
+
+1. Write `RELEASE_NOTES/v<version>.md` (this step).
+2. Bump `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` in `project.yml`.
+3. Commit + push to `main`, tag `v<version>`, push the tag.
+4. Trigger the signing/notarize/publish job with `gitRef=v<version>`.
+
+See `CLAUDE.md` › Release Process.

--- a/RELEASE_NOTES/v1.8.14.md
+++ b/RELEASE_NOTES/v1.8.14.md
@@ -1,0 +1,1 @@
+- **Fixed a cross-recording mix-up in AI summaries** — a recording's summary and action items could occasionally include content carried over from a previous recording. Each recording now uses a fully isolated AI session, so its summary reflects only that conversation.

--- a/scripts/check-release-notes.sh
+++ b/scripts/check-release-notes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Release-notes gate.
+#
+# Asserts that RELEASE_NOTES/v<version>.md exists and contains real,
+# user-facing notes — NOT empty and NOT the auto-generated boilerplate.
+#
+# WHY THIS EXISTS: the signing/publish pipeline turns RELEASE_NOTES/v<version>.md
+# into the Sparkle appcast <description> for the release, which is exactly what
+# Mila's in-app "What's New" popup shows on update. When that file is missing,
+# the popup degrades to a bare "a new version is available" with no changelog.
+# The pipeline runs this check BEFORE the (long) build so a release can never
+# silently ship empty release notes.
+#
+# Usage:
+#   scripts/check-release-notes.sh <marketing-version>
+#   e.g. scripts/check-release-notes.sh 1.8.14
+#
+# Exits 0 when the notes are present and real; non-zero (with guidance) otherwise.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "usage: scripts/check-release-notes.sh <marketing-version>" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NOTES="$ROOT/RELEASE_NOTES/v${VERSION}.md"
+
+if [[ ! -f "$NOTES" ]]; then
+  cat >&2 <<EOF
+ERROR: missing release notes for v${VERSION}.
+
+  Create:  RELEASE_NOTES/v${VERSION}.md   (Markdown, user-facing)
+
+It becomes the Sparkle appcast <description> — the in-app "What's New" shown
+when users update. See RELEASE_NOTES/README.md.
+EOF
+  exit 1
+fi
+
+# Real content = everything that isn't blank, an HTML comment, or a heading.
+CONTENT="$(grep -vE '^[[:space:]]*(<!--.*-->|#|$)' "$NOTES" | tr -d '[:space:]' || true)"
+if [[ -z "$CONTENT" ]]; then
+  echo "ERROR: RELEASE_NOTES/v${VERSION}.md is empty / has no real notes." >&2
+  exit 1
+fi
+
+# Reject leftover stubs / the known auto-created GitHub Release boilerplate so a
+# half-filled template can't slip through.
+if grep -qiE 'Notarized; auto-updates via Sparkle|TODO|FIXME|REPLACE ?ME|<fill[ -]?in>|XXX' "$NOTES"; then
+  echo "ERROR: RELEASE_NOTES/v${VERSION}.md still contains boilerplate / TODO text." >&2
+  echo "       Write the actual user-facing changes for ${VERSION}." >&2
+  exit 1
+fi
+
+echo "OK: RELEASE_NOTES/v${VERSION}.md present with real notes."


### PR DESCRIPTION
## Why

v1.8.14's in-app **"What's New"** popup was blank — just "a new version is available." Sparkle's "What's New" is the appcast `<description>`, which the publish pipeline builds from release notes; nothing required them to exist, and the `project.yml` changelog *comment* never feeds the appcast. So the description silently came out empty.

## What this does

Makes real release notes a **required, version-controlled, enforced** input:

- **`RELEASE_NOTES/v<MARKETING_VERSION>.md`** (Markdown, user-facing) is now the single source for the appcast `<description>` / What's New.
- **`scripts/check-release-notes.sh <version>`** asserts the file exists and is real — not empty, not boilerplate/TODO. The signing pipeline runs it **before the build**, so a release **fails fast** instead of silently shipping blank notes. (Companion PR in the signing repo wires the gate + uses the file as the notes source.)
- **`RELEASE_NOTES/README.md`** documents the convention; **`CLAUDE.md`** makes it the required first release step.
- Backfills **`RELEASE_NOTES/v1.8.14.md`**.

## Verified

```
$ scripts/check-release-notes.sh 1.8.14   # OK (rc 0)
$ scripts/check-release-notes.sh 9.9.9     # missing  → rc 1
$ # boilerplate body                        → rc 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)