### PR TITLE
Fix #19: delete .srt sidecar on permanent delete (no more orphaned files)

### DIFF
--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -121,6 +121,15 @@ struct Recording: Identifiable, Codable, Hashable {
         (audioFileName as NSString).deletingPathExtension + ".summary.txt"
     }
 
+    /// File name (relative to recordings directory) of the sidecar `.srt`
+    /// subtitle file auto-written after transcription (see
+    /// `TranscriptExporter.writeSRT(for:in:)`). Same derive-from-audio
+    /// convention as the other sidecars so deleting a recording can clean
+    /// up `Foo.srt` alongside `Foo.wav`/`Foo.txt`/`Foo.summary.txt`.
+    var subtitleFileName: String {
+        (audioFileName as NSString).deletingPathExtension + ".srt"
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -276,6 +276,13 @@ final class RecordingStore: ObservableObject {
         recordingsDirectory.appendingPathComponent(recording.summaryFileName)
     }
 
+    /// Path of the per-recording `.srt` subtitle sidecar auto-written after
+    /// transcription. May be absent (recording still pending, or it had no
+    /// segments) — callers should treat absence as "nothing to remove".
+    func subtitleURL(for recording: Recording) -> URL {
+        recordingsDirectory.appendingPathComponent(recording.subtitleFileName)
+    }
+
     func freshAudioURL(suggestedName: String? = nil) -> URL {
         let stamp = ISO8601DateFormatter().string(from: Date())
             .replacingOccurrences(of: ":", with: "-")
@@ -389,12 +396,16 @@ final class RecordingStore: ObservableObject {
         persist()
     }
 
-    /// Remove the metadata + audio file from disk.
+    /// Remove the metadata + every on-disk file for a recording: the audio
+    /// plus all sidecars (`.txt` transcript, `.summary.txt`, `.srt`
+    /// subtitles). Missing files are ignored — each is best-effort so one
+    /// absent sidecar doesn't strand the others.
     func permanentlyDelete(_ recording: Recording) {
         recordings.removeAll { $0.id == recording.id }
         try? fileManager.removeItem(at: audioURL(for: recording))
         try? fileManager.removeItem(at: transcriptURL(for: recording))
         try? fileManager.removeItem(at: summaryURL(for: recording))
+        try? fileManager.removeItem(at: subtitleURL(for: recording))
         persist()
     }
 

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -332,6 +332,28 @@ final class RecordingStoreTests: XCTestCase {
                        "permanentlyDelete must remove the summary sidecar too")
     }
 
+    func test_permanently_delete_removes_subtitle_sidecar() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "S", source: .microphone, audioFileName: "s.wav")
+        store.add(rec)
+        // The .srt sidecar is written post-transcription by TranscriptExporter,
+        // not by add() — simulate it landing next to the audio.
+        let srt = store.subtitleURL(for: rec)
+        try "1\n00:00:00,000 --> 00:00:01,000\nhi\n".write(to: srt, atomically: true, encoding: .utf8)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: srt.path))
+
+        store.permanentlyDelete(rec)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: srt.path),
+                       "permanentlyDelete must remove the .srt subtitle sidecar too")
+    }
+
+    func test_subtitle_filename_derived_from_audio_filename() {
+        let rec = Recording(title: "X",
+                            source: .microphone,
+                            audioFileName: "Voice Memo 2024-01-01.m4a")
+        XCTAssertEqual(rec.subtitleFileName, "Voice Memo 2024-01-01.srt")
+    }
+
     func test_summary_filename_derived_from_audio_filename() {
         let rec = Recording(title: "X",
                             source: .microphone,


### PR DESCRIPTION
## Problem

Fixes #19. Permanently deleting a transcription left an orphaned `.srt` subtitle file on disk.

Every transcription auto-writes four files into the Recordings folder:
- the audio (`.wav`/`.m4a`)
- `.txt` transcript sidecar
- `.summary.txt` sidecar
- `.srt` subtitle sidecar — `TranscriptExporter.writeSRT(for:in:)`, called from `TranscriptionService` and `QuickActionsController` after every transcription

`RecordingStore.permanentlyDelete(_:)` removed the first three but **not** the `.srt`, so a `Recording <timestamp>.srt` was orphaned for every deleted recording.

> Note: deleting from "All Transcriptions" is a *soft* delete (moves to **Recently Deleted**), where files intentionally remain until the recording is purged — that's the trash/restore feature working as designed. The genuine leak is in the permanent-delete path, which is what this PR fixes.

## Fix

- Add `Recording.subtitleFileName` and `RecordingStore.subtitleURL(for:)`, mirroring the existing transcript/summary sidecar helpers.
- Remove the `.srt` in `permanentlyDelete` alongside the other sidecars.

## Tests

- `test_permanently_delete_removes_subtitle_sidecar` — writes a `.srt` next to the audio, permanently deletes, asserts it's gone.
- `test_subtitle_filename_derived_from_audio_filename` — covers the `.m4a` → `.srt` base-name derivation.

`make build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)