### PR TITLE
Add Settings → LLM test panel + persistent Extra CLI args (#32)

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -33,6 +33,31 @@ enum LLMRunnerError: LocalizedError {
     }
 }
 
+/// Everything the Settings → LLM test panel needs to explain a run to the
+/// user. Produced by `LLMRunner.diagnose`. Unlike `LLMRunner.run`, nothing is
+/// thrown away on failure: the user sees the exact command, the exit code, and
+/// both streams so they can self-diagnose (or re-run `command` in a terminal).
+struct LLMTestResult: Equatable {
+    /// The exact, shell-quoted command line that was launched (or would have
+    /// been, if we got far enough to build it). Empty when no tool/executable
+    /// was resolved.
+    var command: String = ""
+    /// True only when the CLI launched and exited 0.
+    var succeeded: Bool = false
+    /// Process exit code, or nil when the CLI never launched (setup error).
+    var exitCode: Int32? = nil
+    var stdout: String = ""
+    var stderr: String = ""
+    var durationSeconds: TimeInterval = 0
+    /// Set when something prevented the CLI from even running — no tool
+    /// selected, executable not on PATH, launch failure.
+    var setupError: String? = nil
+    var timedOut: Bool = false
+
+    /// Whether anything actually ran. False for pure setup failures.
+    var didLaunch: Bool { exitCode != nil }
+}
+
 /// Spawns the configured `claude` or `cursor-agent` binary with the user's
 /// prompt + transcript and returns whatever the CLI prints to stdout.
 ///
@@ -93,6 +118,11 @@ enum LLMRunner {
     /// configured) — the wire format collapses to the old transcript-only
     /// shape in that case.
     ///
+    /// `extraArgs` are appended verbatim after the tool's standard arguments
+    /// — the user's persisted "Extra CLI args" from Settings → LLM (e.g.
+    /// `--model …`, a permission flag). Empty for callers that manage their
+    /// own args (Live AI pins its own model).
+    ///
     /// `timeout` defaults to 5 minutes. Pass a smaller value for foreground
     /// callers that block UI (e.g. the Suggest button).
     static func run(tool: LLMTool,
@@ -102,6 +132,7 @@ enum LLMRunner {
                     executablePathOverride: String?,
                     model: String? = nil,
                     session: LLMSession = .none,
+                    extraArgs: [String] = [],
                     timeout: TimeInterval = LLMRunner.defaultTimeout) async throws -> String {
         guard tool != .none else { throw LLMRunnerError.toolDisabled }
 
@@ -139,12 +170,25 @@ enum LLMRunner {
                 }()
                 DispatchQueue.global(qos: .userInitiated).async {
                     do {
-                        let result = try runProcess(executable: executable,
-                                                    arguments: tool.arguments(prompt: fullPrompt, model: model, session: session),
-                                                    timeout: timeout,
-                                                    handle: handle,
-                                                    sandboxKey: sandboxKey)
-                        continuation.resume(returning: result)
+                        let outcome = try executeProcess(executable: executable,
+                                                         arguments: tool.arguments(prompt: fullPrompt, model: model, session: session) + extraArgs,
+                                                         timeout: timeout,
+                                                         handle: handle,
+                                                         sandboxKey: sandboxKey)
+                        // The Swift Task that drove us was cancelled mid-flight
+                        // — `handle` SIGTERM'd the process, so the user-visible
+                        // truth is "we cancelled it", not "the CLI crashed".
+                        if outcome.cancelled {
+                            continuation.resume(throwing: LLMRunnerError.cancelled)
+                        } else if outcome.timedOut {
+                            continuation.resume(throwing: LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up))))
+                        } else if outcome.exitCode != 0 {
+                            continuation.resume(throwing: LLMRunnerError.nonZeroExit(
+                                code: outcome.exitCode,
+                                stderr: outcome.stderr.isEmpty ? outcome.stdout : outcome.stderr))
+                        } else {
+                            continuation.resume(returning: outcome.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+                        }
                     } catch {
                         continuation.resume(throwing: error)
                     }
@@ -155,11 +199,143 @@ enum LLMRunner {
         }
     }
 
-    private static func runProcess(executable: URL,
-                                   arguments: [String],
-                                   timeout: TimeInterval,
-                                   handle: ProcessHandle,
-                                   sandboxKey: String? = nil) throws -> String {
+    /// Run the configured CLI like `run` does, but never throw — capture the
+    /// exact command line, exit code, stdout, and stderr and hand them all
+    /// back so the Settings → LLM test panel can show the user precisely what
+    /// happened. This is the "why isn't my LLM working?" debugging path: the
+    /// returned `command` is copy-pasteable into a terminal so the user can
+    /// reproduce the run themselves.
+    ///
+    /// `extraArgs` are appended verbatim after the tool's standard arguments
+    /// — the user types them in the test panel (e.g. `--model claude-sonnet-4-6`,
+    /// `--debug`) so they can probe param changes without us hardcoding a
+    /// model picker. Setup problems (no tool selected, executable not found)
+    /// come back in `setupError` rather than as an exception.
+    static func diagnose(tool: LLMTool,
+                         prompt: String,
+                         transcript: String,
+                         summary: String = "",
+                         extraArgs: [String] = [],
+                         executablePathOverride: String?,
+                         model: String? = nil,
+                         timeout: TimeInterval = 120) async -> LLMTestResult {
+        guard tool != .none else {
+            return LLMTestResult(setupError: LLMRunnerError.toolDisabled.errorDescription ?? "No LLM configured.")
+        }
+        let executable: URL
+        do {
+            executable = try resolveExecutable(tool: tool, override: executablePathOverride)
+        } catch {
+            let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+            return LLMTestResult(setupError: msg)
+        }
+        let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary)
+        let args = tool.arguments(prompt: fullPrompt, model: model) + extraArgs
+        let command = ([executable.path] + args).map(shellQuote).joined(separator: " ")
+        let start = Date()
+        let handle = ProcessHandle()
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let elapsed: () -> TimeInterval = { Date().timeIntervalSince(start) }
+                do {
+                    let outcome = try executeProcess(executable: executable,
+                                                     arguments: args,
+                                                     timeout: timeout,
+                                                     handle: handle,
+                                                     sandboxKey: nil)
+                    continuation.resume(returning: LLMTestResult(
+                        command: command,
+                        succeeded: !outcome.timedOut && outcome.exitCode == 0,
+                        exitCode: outcome.exitCode,
+                        stdout: outcome.stdout,
+                        stderr: outcome.stderr,
+                        durationSeconds: elapsed(),
+                        timedOut: outcome.timedOut))
+                } catch {
+                    // Only `launchFailed` reaches here now.
+                    let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+                    continuation.resume(returning: LLMTestResult(
+                        command: command,
+                        durationSeconds: elapsed(),
+                        setupError: msg))
+                }
+            }
+        }
+    }
+
+    /// Split a free-text "extra arguments" string into an argv array, honoring
+    /// single quotes, double quotes, and backslash escapes the way a POSIX
+    /// shell would — so a user can paste `--model "claude sonnet"` and get two
+    /// tokens, not three. Deliberately small: it covers the quoting users
+    /// actually type, not the full shell grammar.
+    static func tokenizeArguments(_ input: String) -> [String] {
+        var args: [String] = []
+        var current = ""
+        var hasToken = false
+        var inSingle = false
+        var inDouble = false
+        let chars = Array(input)
+        var i = 0
+        while i < chars.count {
+            let c = chars[i]
+            if inSingle {
+                if c == "'" { inSingle = false } else { current.append(c) }
+            } else if inDouble {
+                if c == "\"" {
+                    inDouble = false
+                } else if c == "\\", i + 1 < chars.count, chars[i + 1] == "\"" || chars[i + 1] == "\\" {
+                    i += 1
+                    current.append(chars[i])
+                } else {
+                    current.append(c)
+                }
+            } else if c == "'" {
+                inSingle = true; hasToken = true
+            } else if c == "\"" {
+                inDouble = true; hasToken = true
+            } else if c == "\\", i + 1 < chars.count {
+                i += 1
+                current.append(chars[i]); hasToken = true
+            } else if c == " " || c == "\t" || c == "\n" {
+                if hasToken { args.append(current); current = ""; hasToken = false }
+            } else {
+                current.append(c); hasToken = true
+            }
+            i += 1
+        }
+        if hasToken { args.append(current) }
+        return args
+    }
+
+    /// Quote a single argv token for display so the rendered `command` can be
+    /// pasted back into a shell and run as-is. Tokens made only of "safe"
+    /// characters are left bare; everything else is single-quoted with any
+    /// embedded single quotes escaped the classic `'\''` way.
+    static func shellQuote(_ s: String) -> String {
+        if s.isEmpty { return "''" }
+        let safe = CharacterSet(charactersIn:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./=:,@+")
+        if s.unicodeScalars.allSatisfy({ safe.contains($0) }) { return s }
+        return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Raw result of a single CLI invocation, before any success/failure
+    /// interpretation. `run` maps this onto its throwing contract; `diagnose`
+    /// surfaces every field verbatim so the Settings test panel can show the
+    /// user exactly what happened (exit code, stdout, stderr) even on failure.
+    struct ProcessOutcome {
+        let stdout: String
+        let stderr: String
+        let exitCode: Int32
+        let timedOut: Bool
+        let cancelled: Bool
+    }
+
+    private static func executeProcess(executable: URL,
+                                       arguments: [String],
+                                       timeout: TimeInterval,
+                                       handle: ProcessHandle,
+                                       sandboxKey: String? = nil) throws -> ProcessOutcome {
         let process = Process()
         process.executableURL = executable
         process.arguments = arguments
@@ -256,29 +432,26 @@ enum LLMRunner {
             runningGroup.leave()
         }
         let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
-        if runningGroup.wait(timeout: deadline) == .timedOut {
+        let timedOut = runningGroup.wait(timeout: deadline) == .timedOut
+        if timedOut {
             process.terminate()
             _ = group.wait(timeout: .now() + 1)
-            throw LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up)))
-        }
-        group.wait()
-
-        // The Swift Task that drove us was cancelled mid-flight — `handle`
-        // has SIGTERM'd the process so it likely exited with a non-zero
-        // status, but the user-visible truth is "we cancelled it", not
-        // "the CLI crashed".
-        if handle.wasTerminated {
-            throw LLMRunnerError.cancelled
+        } else {
+            group.wait()
         }
 
         let stdout = String(data: outData, encoding: .utf8) ?? ""
         let stderr = String(data: errData, encoding: .utf8) ?? ""
 
-        guard process.terminationStatus == 0 else {
-            throw LLMRunnerError.nonZeroExit(code: process.terminationStatus,
-                                             stderr: stderr.isEmpty ? stdout : stderr)
-        }
-        return stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ProcessOutcome(stdout: stdout,
+                              stderr: stderr,
+                              // After a timeout the process was terminated, so
+                              // its status is meaningless — report the standard
+                              // SIGTERM-ish code so callers don't treat it as a
+                              // clean exit.
+                              exitCode: timedOut ? -1 : process.terminationStatus,
+                              timedOut: timedOut,
+                              cancelled: handle.wasTerminated)
     }
 
     /// Create a brand-new empty directory inside the system temp area. The

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -233,33 +233,40 @@ enum LLMRunner {
         let args = tool.arguments(prompt: fullPrompt, model: model) + extraArgs
         let command = ([executable.path] + args).map(shellQuote).joined(separator: " ")
         let start = Date()
+        // Bridge Task cancellation to the child process, same as `run` — if
+        // the test is cancelled (Settings closed, a newer run started), SIGTERM
+        // the CLI instead of leaving it alive until the timeout.
         let handle = ProcessHandle()
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let elapsed: () -> TimeInterval = { Date().timeIntervalSince(start) }
-                do {
-                    let outcome = try executeProcess(executable: executable,
-                                                     arguments: args,
-                                                     timeout: timeout,
-                                                     handle: handle,
-                                                     sandboxKey: nil)
-                    continuation.resume(returning: LLMTestResult(
-                        command: command,
-                        succeeded: !outcome.timedOut && outcome.exitCode == 0,
-                        exitCode: outcome.exitCode,
-                        stdout: outcome.stdout,
-                        stderr: outcome.stderr,
-                        durationSeconds: elapsed(),
-                        timedOut: outcome.timedOut))
-                } catch {
-                    // Only `launchFailed` reaches here now.
-                    let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
-                    continuation.resume(returning: LLMTestResult(
-                        command: command,
-                        durationSeconds: elapsed(),
-                        setupError: msg))
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let elapsed: () -> TimeInterval = { Date().timeIntervalSince(start) }
+                    do {
+                        let outcome = try executeProcess(executable: executable,
+                                                         arguments: args,
+                                                         timeout: timeout,
+                                                         handle: handle,
+                                                         sandboxKey: nil)
+                        continuation.resume(returning: LLMTestResult(
+                            command: command,
+                            succeeded: !outcome.timedOut && outcome.exitCode == 0,
+                            exitCode: outcome.exitCode,
+                            stdout: outcome.stdout,
+                            stderr: outcome.stderr,
+                            durationSeconds: elapsed(),
+                            timedOut: outcome.timedOut))
+                    } catch {
+                        // Only `launchFailed` reaches here now.
+                        let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+                        continuation.resume(returning: LLMTestResult(
+                            command: command,
+                            durationSeconds: elapsed(),
+                            setupError: msg))
+                    }
                 }
             }
+        } onCancel: {
+            handle.terminate()
         }
     }
 
@@ -434,11 +441,18 @@ enum LLMRunner {
         let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
         let timedOut = runningGroup.wait(timeout: deadline) == .timedOut
         if timedOut {
+            // SIGTERM first; if the CLI ignores it, hard-kill after a short
+            // grace period so we don't read half-drained pipes or remove the
+            // sandbox out from under a still-running child.
             process.terminate()
-            _ = group.wait(timeout: .now() + 1)
-        } else {
-            group.wait()
+            if runningGroup.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                runningGroup.wait()
+            }
         }
+        // Drain the pipe readers once the process is known to be gone (either it
+        // exited on its own or we killed it above).
+        group.wait()
 
         let stdout = String(data: outData, encoding: .utf8) ?? ""
         let stderr = String(data: errData, encoding: .utf8) ?? ""

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -161,9 +161,90 @@ final class LLMSettings: ObservableObject {
         didSet { defaults.set(summaryEnabled, forKey: Keys.summaryEnabled) }
     }
 
+    /// Free-text extra CLI arguments appended to EVERY post-recording
+    /// invocation (title suggestion, auto-summary, Send-action) as well as the
+    /// test panel run — lets the user pin a model or pass debug/permission
+    /// flags without us baking in a picker. Tokenized shell-style before being
+    /// passed to the CLI (see `extraArgsTokens`). Live AI is excluded: it pins
+    /// its own model and would clash with a user-supplied `--model`.
+    @Published var extraArgs: String {
+        didSet {
+            guard extraArgs != oldValue else { return }
+            defaults.set(extraArgs, forKey: Keys.extraArgs)
+        }
+    }
+
+    /// `extraArgs` parsed into an argv array, ready to hand to `LLMRunner`.
+    var extraArgsTokens: [String] { LLMRunner.tokenizeArguments(extraArgs) }
+
     /// Convenience the UI uses to decide whether to surface the rename /
     /// run-action buttons at all.
     var isConfigured: Bool { tool != .none }
+
+    // MARK: - Test / diagnostics
+    //
+    // Backing state for the Settings → LLM "Test" panel. The transcript /
+    // result here are an ephemeral scratch area for answering "why isn't my
+    // LLM working?" — they're not persisted (the extra-args the test uses ARE
+    // persisted; see `extraArgs` above). Kept on the app-lifetime settings
+    // object (not view @State) so the result survives tab switches while the
+    // Settings window is open.
+
+    /// Which configured prompt the test runs.
+    enum TestPromptKind: String, CaseIterable, Identifiable {
+        case name
+        case action
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .name:   return "Name suggestion"
+            case .action: return "Action"
+            }
+        }
+    }
+
+    @Published var testPromptKind: TestPromptKind = .name
+    /// Editable transcript fed to the test run; prefilled with a short sample
+    /// meeting so the button works on a fresh install with one click.
+    @Published var testTranscript: String = LLMSettings.sampleTranscript
+    @Published private(set) var isTesting = false
+    @Published private(set) var lastTestResult: LLMTestResult?
+
+    /// The prompt the test will actually send, given the current selection.
+    var testPrompt: String {
+        testPromptKind == .name ? namePrompt : postActionPrompt
+    }
+
+    /// Run the configured prompt against the sample transcript and stash the
+    /// full result (command + streams + exit code) for the UI to render.
+    func runTest() async {
+        isTesting = true
+        defer { isTesting = false }
+        let result = await LLMRunner.diagnose(
+            tool: tool,
+            prompt: testPrompt,
+            transcript: testTranscript,
+            extraArgs: extraArgsTokens,
+            executablePathOverride: executablePath.isEmpty ? nil : executablePath,
+            // Use the same timeout real runs use so the test faithfully
+            // reproduces production behaviour — including letting the user
+            // confirm that raising the timeout fixes a slow agentic run.
+            timeout: cliTimeout)
+        lastTestResult = result
+    }
+
+    /// Sample meeting transcript used by the test panel. Deliberately short,
+    /// concrete, and decision-laden so both "suggest a title" and "summarize"
+    /// prompts have something real to chew on.
+    static let sampleTranscript = """
+        Alex: Thanks for joining. The goal today is to lock the Q3 launch date for the mobile app.
+        Priya: Engineering is on track — the remaining blocker is the offline-sync bug, which I expect closed by Wednesday.
+        Sam: Marketing needs two weeks of lead time once we have a firm date for the press push.
+        Alex: Then let's target August 19th for launch, with a go/no-go check the Friday before.
+        Priya: Works for me. I'll send the updated timeline today.
+        Sam: I'll draft the announcement and share it for review by next Monday.
+        Alex: Great — action items: Priya closes the sync bug and sends the timeline, Sam drafts the announcement. Let's reconvene Friday.
+        """
 
     private let defaults: UserDefaults
 
@@ -181,6 +262,7 @@ final class LLMSettings: ObservableObject {
         // everyone on upgrade. Treat "key absent" as true.
         self.summaryEnabled = (defaults.object(forKey: Keys.summaryEnabled) as? Bool) ?? true
         self.cliTimeout = (defaults.object(forKey: Keys.cliTimeout) as? Double) ?? 300
+        self.extraArgs = defaults.string(forKey: Keys.extraArgs) ?? ""
     }
 
     /// Default name prompt is deliberately *tool-free*. The previous default
@@ -215,5 +297,6 @@ final class LLMSettings: ObservableObject {
         static let actionPrompt = "llm.action.prompt"
         static let summaryEnabled = "llm.summary.enabled"
         static let cliTimeout = "llm.cli.timeout"
+        static let extraArgs = "llm.extraArgs"
     }
 }

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -218,7 +218,13 @@ final class LLMSettings: ObservableObject {
     /// Run the configured prompt against the sample transcript and stash the
     /// full result (command + streams + exit code) for the UI to render.
     func runTest() async {
+        // A fast double-tap can enqueue two `Task { await runTest() }` calls
+        // before the button re-renders disabled — bail on the second so we
+        // don't spawn duplicate subprocesses or let a late finisher overwrite
+        // a newer result.
+        guard !isTesting else { return }
         isTesting = true
+        lastTestResult = nil
         defer { isTesting = false }
         let result = await LLMRunner.diagnose(
             tool: tool,

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -138,6 +138,7 @@ final class PostRecordingCoordinator: ObservableObject {
                    transcript: String,
                    summary: String,
                    executableOverride: String?,
+                   extraArgs: [String] = [],
                    cliTimeout: TimeInterval = LLMRunner.defaultTimeout) {
         guard tool != .none else { return }
         let toolName = tool.displayName
@@ -175,6 +176,7 @@ final class PostRecordingCoordinator: ObservableObject {
                     transcript: resolved,
                     summary: summary,
                     executablePathOverride: executableOverride,
+                    extraArgs: extraArgs,
                     timeout: cliTimeout
                 )
                 let preview = output

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -257,6 +257,7 @@ final class RecordingSummarizer: ObservableObject {
             ? nil
             : llmSettings.executablePath
         let model = liveAISettings.model
+        let extraArgs = llmSettings.extraArgsTokens
         let promptLanguageName: String = {
             switch liveAISettings.outputLanguage {
             case .auto:
@@ -298,6 +299,7 @@ final class RecordingSummarizer: ObservableObject {
                     transcript: transcript,
                     executablePathOverride: executableOverride,
                     model: model.isEmpty ? nil : model,
+                    extraArgs: extraArgs,
                     timeout: timeout
                 )
                 let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -442,6 +442,7 @@ struct RenameRecordingSheet: View {
                               transcript: transcriptSnapshot,
                               summary: summarySnapshot,
                               executableOverride: executableOverride,
+                              extraArgs: llm.extraArgsTokens,
                               cliTimeout: llm.cliTimeout)
     }
 
@@ -456,6 +457,7 @@ struct RenameRecordingSheet: View {
                 prompt: llm.namePrompt,
                 transcript: transcript,
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
+                extraArgs: llm.extraArgsTokens,
                 timeout: llm.cliTimeout
             )
             let cleaned = suggestion

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -128,6 +128,7 @@ struct SendToLLMSheet: View {
                                 transcript: transcriptSnapshot,
                                 summary: summarySnapshot,
                                 executableOverride: executableOverride,
+                                extraArgs: llm.extraArgsTokens,
                                 cliTimeout: llm.cliTimeout)
     }
 }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -483,6 +483,8 @@ private struct LLMSettingsTab: View {
                 namePromptSection
                 Divider()
                 actionPromptSection
+                Divider()
+                testSection
             }
             .padding(.vertical, 4)
         }
@@ -515,6 +517,18 @@ private struct LLMSettingsTab: View {
             }
             .font(.callout)
             Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Text("Extra CLI args").frame(width: 130, alignment: .leading)
+                TextField("(none) e.g. --model claude-sonnet-4-6", text: $settings.extraArgs)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.callout, design: .monospaced))
+            }
+            .font(.callout)
+            Text("Appended to every run (name suggestion, auto-summary, Send action, and the test below). Shell-style quoting is supported; for most CLIs a flag here overrides an earlier one. Live AI manages its own model and is unaffected.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -590,6 +604,164 @@ private struct LLMSettingsTab: View {
                 settings.postActionPrompt = $0
             }
         }
+    }
+
+    // MARK: Test panel
+
+    private var testSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Test")
+                .font(.title3.weight(.semibold))
+            Text("Run the configured prompt against a sample transcript to see exactly what Mila sends and what your CLI returns. Use this to debug a tool that isn't working — the command shown below is the literal one Mila runs, so you can copy it into a terminal yourself.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Picker("Prompt to test", selection: $settings.testPromptKind) {
+                ForEach(LLMSettings.TestPromptKind.allCases) { kind in
+                    Text(kind.label).tag(kind)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Text("Sample transcript")
+                .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            TextEditor(text: $settings.testTranscript)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minHeight: 90, maxHeight: 150)
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
+
+            Text("The test uses your configured Extra CLI args (above), so it reproduces exactly what a real run does.")
+                .font(.caption).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 10) {
+                Button {
+                    Task { await settings.runTest() }
+                } label: {
+                    if settings.isTesting {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small)
+                            Text("Running…")
+                        }
+                    } else {
+                        Text("Run test")
+                    }
+                }
+                .disabled(settings.tool == .none || settings.isTesting)
+
+                if settings.tool == .none {
+                    Text("Select a tool above first.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+
+            if let result = settings.lastTestResult {
+                LLMTestResultView(result: result)
+            }
+        }
+    }
+}
+
+/// Renders the outcome of a Settings → LLM test run: the exact command (with a
+/// Copy button), a status line, and the captured stdout/stderr. Designed so a
+/// user who can't get their CLI working can read or copy everything they need
+/// to self-diagnose.
+private struct LLMTestResultView: View {
+    let result: LLMTestResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            statusLine
+
+            if !result.command.isEmpty {
+                labeledBlock("Command", text: result.command, copyable: true)
+            }
+            if let error = result.setupError {
+                labeledBlock("Problem", text: error, copyable: false)
+            }
+            if result.didLaunch {
+                if !result.stdout.isEmpty {
+                    labeledBlock("Output (stdout)", text: result.stdout, copyable: true)
+                }
+                if !trimmed(result.stderr).isEmpty {
+                    labeledBlock("Diagnostics (stderr)", text: result.stderr, copyable: true)
+                }
+                if result.stdout.isEmpty && trimmed(result.stderr).isEmpty {
+                    Text("The CLI produced no output.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var statusLine: some View {
+        HStack(spacing: 8) {
+            icon
+            Text(statusText)
+                .font(.callout.weight(.medium))
+            Spacer()
+            if result.durationSeconds > 0 {
+                Text(String(format: "%.1fs", result.durationSeconds))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        if result.succeeded {
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+        } else {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+        }
+    }
+
+    private var statusText: String {
+        if result.succeeded { return "Success" }
+        if result.timedOut { return "Timed out — the CLI didn't respond in time" }
+        if let error = result.setupError, !result.didLaunch { return error }
+        if let code = result.exitCode { return "CLI exited with status \(code)" }
+        return "Failed"
+    }
+
+    private func labeledBlock(_ label: String, text: String, copyable: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if copyable {
+                    Button {
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.setString(text, forType: .string)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy to clipboard")
+                }
+            }
+            ScrollView {
+                Text(text)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+            .frame(maxHeight: 160)
+            .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private func trimmed(_ s: String) -> String {
+        s.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -249,6 +249,134 @@ final class LLMRunnerTests: XCTestCase {
                           "claude reply looks like prose, not a title: \(result)")
     }
 
+    // MARK: - Argument tokenizer / shell quoting
+
+    func test_tokenize_simple_space_separated() {
+        XCTAssertEqual(LLMRunner.tokenizeArguments("--model sonnet --debug"),
+                       ["--model", "sonnet", "--debug"])
+    }
+
+    func test_tokenize_empty_is_no_args() {
+        XCTAssertEqual(LLMRunner.tokenizeArguments("   "), [])
+    }
+
+    func test_tokenize_double_quotes_keep_spaces_together() {
+        XCTAssertEqual(LLMRunner.tokenizeArguments("--model \"claude sonnet 4\""),
+                       ["--model", "claude sonnet 4"])
+    }
+
+    func test_tokenize_single_quotes_keep_spaces_together() {
+        XCTAssertEqual(LLMRunner.tokenizeArguments("--name 'Big Meeting'"),
+                       ["--name", "Big Meeting"])
+    }
+
+    func test_tokenize_backslash_escapes_space() {
+        XCTAssertEqual(LLMRunner.tokenizeArguments("a\\ b c"),
+                       ["a b", "c"])
+    }
+
+    func test_shellQuote_leaves_safe_tokens_bare() {
+        XCTAssertEqual(LLMRunner.shellQuote("--model"), "--model")
+        XCTAssertEqual(LLMRunner.shellQuote("claude-sonnet-4-6"), "claude-sonnet-4-6")
+    }
+
+    func test_shellQuote_wraps_tokens_with_spaces() {
+        XCTAssertEqual(LLMRunner.shellQuote("hello world"), "'hello world'")
+    }
+
+    func test_shellQuote_escapes_embedded_single_quote() {
+        XCTAssertEqual(LLMRunner.shellQuote("it's"), "'it'\\''s'")
+    }
+
+    func test_shellQuote_empty_is_quoted() {
+        XCTAssertEqual(LLMRunner.shellQuote(""), "''")
+    }
+
+    // MARK: - diagnose() — non-throwing test path
+
+    func test_diagnose_reports_setup_error_when_tool_disabled() async {
+        let result = await LLMRunner.diagnose(tool: .none,
+                                              prompt: "x",
+                                              transcript: "y",
+                                              executablePathOverride: nil)
+        XCTAssertFalse(result.succeeded)
+        XCTAssertFalse(result.didLaunch)
+        XCTAssertNotNil(result.setupError)
+    }
+
+    func test_diagnose_reports_setup_error_for_missing_executable() async {
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "x",
+                                              transcript: "y",
+                                              executablePathOverride: "/definitely/not/here/claude")
+        XCTAssertFalse(result.succeeded)
+        XCTAssertFalse(result.didLaunch)
+        XCTAssertNotNil(result.setupError)
+    }
+
+    func test_diagnose_captures_command_stdout_and_success() async throws {
+        // `/bin/cat` echoes its argv? No — use a script that prints the prompt
+        // arg so we can assert stdout is captured and success is reported.
+        let script = makeScript("""
+            #!/bin/sh
+            printf '%s' "${@: -1}"
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "Title please",
+                                              transcript: "the audio",
+                                              executablePathOverride: script.path,
+                                              timeout: 30)
+        XCTAssertTrue(result.succeeded, "expected clean exit: \(result)")
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.didLaunch)
+        XCTAssertTrue(result.stdout.contains("Title please"), "stdout: \(result.stdout)")
+        XCTAssertTrue(result.stdout.contains("the audio"), "stdout: \(result.stdout)")
+        // Command is shown for copy/paste and points at the resolved binary.
+        XCTAssertTrue(result.command.contains(script.path), "command: \(result.command)")
+        XCTAssertNil(result.setupError)
+    }
+
+    func test_diagnose_captures_nonzero_exit_without_throwing() async {
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "x",
+                                              transcript: "y",
+                                              executablePathOverride: "/usr/bin/false")
+        XCTAssertFalse(result.succeeded)
+        XCTAssertTrue(result.didLaunch)
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertNil(result.setupError)
+    }
+
+    func test_run_appends_extra_args_after_prompt() async throws {
+        // Echo every argument on its own line so we can assert the extra
+        // args were forwarded to the child after the standard ones.
+        let script = makeScript("""
+            #!/bin/sh
+            for a in "$@"; do printf '%s\\n' "$a"; done
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let out = try await LLMRunner.run(tool: .claude,
+                                          prompt: "Title",
+                                          transcript: "body",
+                                          executablePathOverride: script.path,
+                                          extraArgs: ["--model", "some-model"],
+                                          timeout: 30)
+        XCTAssertTrue(out.contains("--model"), "extra flag missing: \(out)")
+        XCTAssertTrue(out.contains("some-model"), "extra value missing: \(out)")
+    }
+
+    func test_diagnose_appends_extra_args_to_command() async {
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "x",
+                                              transcript: "y",
+                                              extraArgs: ["--model", "claude sonnet"],
+                                              executablePathOverride: "/usr/bin/true")
+        // The space-bearing arg must round-trip through shell quoting.
+        XCTAssertTrue(result.command.contains("--model 'claude sonnet'"),
+                      "command: \(result.command)")
+    }
+
     func test_cursor_cli_returns_a_title_for_a_sample_transcript() async throws {
         guard let cursorPath = resolve("cursor-agent") else {
             throw XCTSkip("cursor-agent CLI not installed on this machine")

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -349,11 +349,13 @@ final class LLMRunnerTests: XCTestCase {
     }
 
     func test_run_appends_extra_args_after_prompt() async throws {
-        // Echo every argument on its own line so we can assert the extra
-        // args were forwarded to the child after the standard ones.
+        // Emit each argument NUL-delimited so we can reconstruct argv exactly
+        // and assert the extra args are the *trailing* tokens — the override
+        // behaviour (a user --model wins) depends on them coming last, not
+        // just being present.
         let script = makeScript("""
             #!/bin/sh
-            for a in "$@"; do printf '%s\\n' "$a"; done
+            for a in "$@"; do printf '%s\\0' "$a"; done
             """)
         defer { try? FileManager.default.removeItem(at: script) }
         let out = try await LLMRunner.run(tool: .claude,
@@ -362,8 +364,29 @@ final class LLMRunnerTests: XCTestCase {
                                           executablePathOverride: script.path,
                                           extraArgs: ["--model", "some-model"],
                                           timeout: 30)
-        XCTAssertTrue(out.contains("--model"), "extra flag missing: \(out)")
-        XCTAssertTrue(out.contains("some-model"), "extra value missing: \(out)")
+        let argv = out.split(separator: "\0").map(String.init)
+        XCTAssertEqual(Array(argv.suffix(2)), ["--model", "some-model"],
+                       "extra args must be appended after standard args: \(argv)")
+    }
+
+    func test_diagnose_reports_timeout_without_throwing() async throws {
+        // Script ignores args and sleeps past the 1s timeout. diagnose maps
+        // the timeout into the result fields the panel renders, never throws.
+        let script = makeScript("""
+            #!/bin/sh
+            sleep 5
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "x",
+                                              transcript: "y",
+                                              executablePathOverride: script.path,
+                                              timeout: 1)
+        XCTAssertFalse(result.succeeded)
+        XCTAssertTrue(result.didLaunch)
+        XCTAssertTrue(result.timedOut)
+        XCTAssertEqual(result.exitCode, -1)
+        XCTAssertNil(result.setupError)
     }
 
     func test_diagnose_appends_extra_args_to_command() async {


### PR DESCRIPTION
Closes #32.

## Problem
When the configured `claude` / `cursor-agent` integration isn't working, there was no way to see *why* — the only signal was a failed "Suggest" in the rename sheet, with no command, no output, and no error surfaced.

## What this adds

### Test panel (Settings → LLM)
Runs the configured prompt against an editable sample meeting transcript and shows exactly what ran:
- **Exact, shell-quoted command** Mila launched, with a Copy button — paste it into a terminal to reproduce.
- **Status / exit code / duration**, plus full **stdout** and **stderr** (each copyable).
- A **"Prompt to test"** picker (Name suggestion / Action) that sends the *actual* configured prompt — both the "meeting title suggestion" and the "end of meeting" action from the issue.
- Runs with the configured `cliTimeout`, so it faithfully reproduces real runs (and confirms whether raising the timeout fixes a slow agentic run).

### Persistent "Extra CLI args" (`llm.extraArgs`)
A free-text field in the tool-config section, **appended to every run**:
- Title suggestion, auto-summary, and the Send-action button — and the test run.
- Shell-style quoting supported; args are appended **last**, so for both CLIs a user-supplied flag (e.g. `--model …`) overrides an earlier one.
- **Live AI is intentionally excluded** — it pins its own model and a user `--model` would clash.

## Implementation
- **`LLMRunner`** — extracted a structured `ProcessOutcome` as the single source of truth for the subprocess core; `run()` maps it onto its existing throwing contract (behavior unchanged) and gains an `extraArgs` parameter. Added non-throwing `diagnose()` (captures command + streams + exit code even on failure), `tokenizeArguments` (shell-style quoting), and `shellQuote` (copy-pasteable rendering). New `LLMTestResult` model.
- **`LLMSettings`** — persisted `extraArgs` + `extraArgsTokens`, ephemeral test state + `runTest()`, and the sample transcript.
- **`SettingsView`** — Extra CLI args field, `testSection` UI, and `LLMTestResultView`.
- **Call sites** — `RenameRecordingSheet`, `SendToLLMSheet` → `PostRecordingCoordinator`, and `RecordingSummarizer` forward the persisted extra args.
- **Tests** — 11 new cases for the tokenizer, shell-quoting, `diagnose`, and `run()` arg forwarding.

## Verification
All **28 `LLMRunnerTests` pass**, including the new tests and the real `claude` / `cursor-agent` smoke tests. The full Mila app + test target builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an LLM “Test/diagnostics” panel with copyable command details, stdout/stderr capture, timeout and exit-status reporting, and clearer setup-error vs run-failure feedback.
  * Introduced a persisted **Extra CLI args** field (shell-style quoting supported) and apply it to LLM runs, including post-recording summary, rename, and send flows.
* **Bug Fixes**
  * Improved LLM execution handling for cancellations, timeouts, and non-zero exits with more reliable diagnostics and result reporting.
* **Tests**
  * Added coverage for argument tokenization, shell quoting, and the new diagnostics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->