### PR TITLE
Remote transcription backend (OpenAI-compatible API)

### DIFF
--- a/.github/workflows/e2e-remote-transcription.yml
+++ b/.github/workflows/e2e-remote-transcription.yml
@@ -1,0 +1,121 @@
+name: E2E Remote Transcription
+
+# End-to-end test of the remote transcription backend: spawns a local
+# OpenAI-compatible mock server and drives the real `RemoteWhisperEngine`
+# client against it over HTTP. Path-gated so it only runs when the remote
+# backend (or this workflow) changes — not on every push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Mila/Transcription/RemoteWhisperEngine.swift'
+      - 'Mila/Models/RemoteTranscriptionSettings.swift'
+      - 'Mila/Transcription/TranscriptionService.swift'
+      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
+      - 'MilaTests/RemoteTranscriptionTests.swift'
+      - 'scripts/mock-openai-transcription-server.py'
+      - '.github/workflows/e2e-remote-transcription.yml'
+  pull_request:
+    paths:
+      - 'Mila/Transcription/RemoteWhisperEngine.swift'
+      - 'Mila/Models/RemoteTranscriptionSettings.swift'
+      - 'Mila/Transcription/TranscriptionService.swift'
+      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
+      - 'MilaTests/RemoteTranscriptionTests.swift'
+      - 'scripts/mock-openai-transcription-server.py'
+      - '.github/workflows/e2e-remote-transcription.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remote-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  remote-transcription-e2e:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      MOCK_PORT: "8123"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          python3 --version
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      # The .xcodeproj references Mila/Resources/PythonRuntime, so the bundle
+      # must exist before project generation / build. Same cache key as ci.yml
+      # so a single entry services both workflows.
+      - name: Cache diarization bundle
+        id: diar-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: Mila/Resources/PythonRuntime
+          key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
+
+      - name: Build diarization bundle (cold path only)
+        if: steps.diar-bundle-cache.outputs.cache-hit != 'true'
+        run: make bundle-diarization
+
+      - name: Generate Xcode project
+        run: make project
+
+      - name: Clear SwiftPM caches
+        run: |
+          rm -rf ~/Library/Caches/org.swift.swiftpm
+          rm -rf ~/Library/org.swift.swiftpm
+          rm -rf ~/Library/Developer/Xcode/DerivedData/SourcePackages
+
+      - name: Resolve Swift Package dependencies
+        run: |
+          xcodebuild \
+            -project Mila.xcodeproj \
+            -scheme Mila \
+            -destination 'platform=macOS' \
+            -resolvePackageDependencies
+
+      - name: Start mock OpenAI transcription server
+        run: |
+          python3 scripts/mock-openai-transcription-server.py --port "$MOCK_PORT" \
+            > mock-server.log 2>&1 &
+          echo $! > mock-server.pid
+          # Wait for the server to accept connections before pointing the
+          # client at it (up to ~15s).
+          for i in $(seq 1 30); do
+            if curl -fsS "http://127.0.0.1:${MOCK_PORT}/v1/models" >/dev/null 2>&1; then
+              echo "mock server is up"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "::error::mock server did not come up"; cat mock-server.log; exit 1
+
+      - name: Run remote-transcription E2E test
+        # xcodebuild forwards env vars into the test process after stripping
+        # the TEST_RUNNER_ prefix (see ci.yml for why the bare form doesn't
+        # propagate reliably).
+        env:
+          TEST_RUNNER_MILA_REMOTE_TEST_ENDPOINT: "http://127.0.0.1:8123/v1"
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Mila.xcodeproj \
+            -scheme Mila \
+            -configuration Debug \
+            -derivedDataPath build \
+            -destination 'platform=macOS' \
+            -only-testing:MilaTests/RemoteTranscriptionE2ETests \
+            test
+
+      - name: Stop mock server
+        if: always()
+        run: |
+          if [ -f mock-server.pid ]; then kill "$(cat mock-server.pid)" 2>/dev/null || true; fi
+          echo "--- mock server log ---"; cat mock-server.log 2>/dev/null || true

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -218,6 +218,7 @@ struct MilaApp: App {
     @StateObject private var llmSettings: LLMSettings
     @StateObject private var postRecording: PostRecordingCoordinator
     @StateObject private var diarizationSettings: DiarizationSettings
+    @StateObject private var remoteTranscriptionSettings: RemoteTranscriptionSettings
     @StateObject private var meetingDetectionSettings: MeetingDetectionSettings
     @StateObject private var meetingDetector: MeetingDetector
     @StateObject private var meetingPrompt: MeetingPromptCoordinator
@@ -273,7 +274,14 @@ struct MilaApp: App {
             UserDefaults.standard.set(true, forKey: diarForceOffKey)
         }
         let diarSettings = DiarizationSettings(defaultEnabledIfUnset: false)
-        let svc = TranscriptionService(store: store, modelManager: mgr, diarizationSettings: diarSettings)
+        // Remote transcription backend (opt-in, off by default). Constructed
+        // here so the same instance backs both the Settings UI and the
+        // transcription router.
+        let remoteSettings = RemoteTranscriptionSettings()
+        let svc = TranscriptionService(store: store,
+                                       modelManager: mgr,
+                                       diarizationSettings: diarSettings,
+                                       remoteSettings: remoteSettings)
         let session = RecordingSession()
         let langSettings = RecordingLanguageSettings()
         let audioSettings = AudioInputSettings()
@@ -420,6 +428,7 @@ struct MilaApp: App {
         _modelManager = StateObject(wrappedValue: mgr)
         _transcription = StateObject(wrappedValue: svc)
         _diarizationSettings = StateObject(wrappedValue: diarSettings)
+        _remoteTranscriptionSettings = StateObject(wrappedValue: remoteSettings)
         _session = StateObject(wrappedValue: session)
         _actions = StateObject(wrappedValue: actions)
         _hotkeySettings = StateObject(wrappedValue: hotkeys)
@@ -461,6 +470,7 @@ struct MilaApp: App {
                 .environmentObject(llmSettings)
                 .environmentObject(postRecording)
                 .environmentObject(diarizationSettings)
+                .environmentObject(remoteTranscriptionSettings)
                 .environmentObject(liveAISettings)
                 .environmentObject(liveTranscriber)
                 .environmentObject(liveSpeakerDiarizer)
@@ -531,6 +541,7 @@ struct MilaApp: App {
                 .environmentObject(actions)
                 .environmentObject(llmSettings)
                 .environmentObject(diarizationSettings)
+                .environmentObject(remoteTranscriptionSettings)
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(liveAISettings)
         }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -82,7 +82,7 @@ final class RemoteTranscriptionSettings: ObservableObject {
     @Published var apiKey: String {
         didSet {
             guard apiKey != oldValue else { return }
-            KeychainHelper.save(key: Keys.apiKey, value: apiKey)
+            KeychainHelper.save(key: apiKeyKeychainKey, value: apiKey)
             testStatus = .idle
         }
     }
@@ -94,15 +94,22 @@ final class RemoteTranscriptionSettings: ObservableObject {
 
     private let defaults: UserDefaults
     private let urlSession: URLSession
+    /// Keychain item the API token is stored under. Injectable so tests /
+    /// previews / alternate instances don't read or clobber the real app's
+    /// `remote.apiKey` item (mirrors how `defaults` is injected).
+    private let apiKeyKeychainKey: String
 
-    init(defaults: UserDefaults = .standard, urlSession: URLSession = .shared) {
+    init(defaults: UserDefaults = .standard,
+         urlSession: URLSession = .shared,
+         apiKeyKeychainKey: String = Keys.apiKey) {
         self.defaults = defaults
         self.urlSession = urlSession
+        self.apiKeyKeychainKey = apiKeyKeychainKey
         self.backend = TranscriptionBackend(rawValue: defaults.string(forKey: Keys.backend) ?? "")
             ?? .local
         self.endpoint = defaults.string(forKey: Keys.endpoint) ?? Self.defaultEndpoint
         self.model = defaults.string(forKey: Keys.model) ?? Self.defaultModel
-        self.apiKey = KeychainHelper.load(key: Keys.apiKey) ?? ""
+        self.apiKey = KeychainHelper.load(key: apiKeyKeychainKey) ?? ""
     }
 
     /// True when the user has chosen the remote backend (regardless of whether
@@ -175,6 +182,11 @@ final class RemoteTranscriptionSettings: ObservableObject {
         }
         do {
             let (_, response) = try await urlSession.data(for: request)
+            // Drop the result if the user edited the endpoint/key while the
+            // request was in flight — `didSet` already reset status to .idle,
+            // and a stale result for the previous values would be misleading.
+            guard endpointURL == url,
+                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key else { return }
             guard let http = response as? HTTPURLResponse else {
                 testStatus = .failed("No HTTP response.")
                 return
@@ -191,6 +203,8 @@ final class RemoteTranscriptionSettings: ObservableObject {
                 testStatus = .failed("Server returned HTTP \(http.statusCode).")
             }
         } catch {
+            guard endpointURL == url,
+                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key else { return }
             testStatus = .failed(error.localizedDescription)
         }
     }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Combine
+
+/// Which engine Mila uses to turn audio into text. A single app-wide choice,
+/// mirroring the privacy-first default: on-device whisper.cpp unless the user
+/// deliberately opts into a remote endpoint.
+enum TranscriptionBackend: String, CaseIterable, Identifiable, Codable {
+    /// In-process whisper.cpp (the default). Audio never leaves the device.
+    case local
+    /// An OpenAI-compatible `/v1/audio/transcriptions` endpoint — OpenAI's own
+    /// API or any self-hosted server that speaks the same protocol (e.g.
+    /// `speaches` serving an ivrit.ai model). Audio is uploaded off-device.
+    case remote
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .local:  return "On-device"
+        case .remote: return "Remote API"
+        }
+    }
+}
+
+/// Immutable snapshot handed to `RemoteWhisperEngine` for one transcription.
+/// `Sendable` so it can cross from the `@MainActor` settings object to the
+/// engine actor without a data race.
+struct RemoteTranscriptionConfig: Sendable, Equatable {
+    /// Base URL, e.g. `https://api.openai.com/v1`. The engine appends
+    /// `audio/transcriptions`.
+    var endpoint: URL
+    /// Bearer token. Empty for self-hosted servers that don't authenticate.
+    var apiKey: String
+    /// Model identifier the server expects, e.g. `whisper-1` (OpenAI) or
+    /// `ivrit-ai/whisper-large-v3-turbo-ct2` (a self-hosted faster-whisper).
+    var model: String
+}
+
+/// User-configurable remote transcription backend. Opt-in, off by default.
+///
+/// Follows the app's settings conventions: namespaced `UserDefaults` keys for
+/// non-secret values, and the **Keychain** for the API token so it's encrypted
+/// at rest rather than sitting in the plist. Constructed once in
+/// `MilaApp.init()` and injected via `.environmentObject` on both scenes.
+@MainActor
+final class RemoteTranscriptionSettings: ObservableObject {
+    /// Result of the last "Test connection" attempt. Advisory only — it never
+    /// gates transcription (a server may not implement `/models`); it just
+    /// gives the user fast feedback that the endpoint + token are plausible.
+    enum TestStatus: Equatable {
+        case idle
+        case testing
+        case ok(String)
+        case failed(String)
+    }
+
+    @Published var backend: TranscriptionBackend {
+        didSet {
+            guard backend != oldValue else { return }
+            defaults.set(backend.rawValue, forKey: Keys.backend)
+        }
+    }
+
+    @Published var endpoint: String {
+        didSet {
+            guard endpoint != oldValue else { return }
+            defaults.set(endpoint, forKey: Keys.endpoint)
+            testStatus = .idle
+        }
+    }
+
+    @Published var model: String {
+        didSet {
+            guard model != oldValue else { return }
+            defaults.set(model, forKey: Keys.model)
+        }
+    }
+
+    /// The bearer token. Stored in the Keychain, never in `UserDefaults`. The
+    /// `@Published` mirror lets SwiftUI bind a `SecureField` directly; every
+    /// edit writes through to the Keychain.
+    @Published var apiKey: String {
+        didSet {
+            guard apiKey != oldValue else { return }
+            KeychainHelper.save(key: Keys.apiKey, value: apiKey)
+            testStatus = .idle
+        }
+    }
+
+    @Published private(set) var testStatus: TestStatus = .idle
+
+    static let defaultEndpoint = "https://api.openai.com/v1"
+    static let defaultModel = "whisper-1"
+
+    private let defaults: UserDefaults
+    private let urlSession: URLSession
+
+    init(defaults: UserDefaults = .standard, urlSession: URLSession = .shared) {
+        self.defaults = defaults
+        self.urlSession = urlSession
+        self.backend = TranscriptionBackend(rawValue: defaults.string(forKey: Keys.backend) ?? "")
+            ?? .local
+        self.endpoint = defaults.string(forKey: Keys.endpoint) ?? Self.defaultEndpoint
+        self.model = defaults.string(forKey: Keys.model) ?? Self.defaultModel
+        self.apiKey = KeychainHelper.load(key: Keys.apiKey) ?? ""
+    }
+
+    /// True when the user has chosen the remote backend (regardless of whether
+    /// it's fully configured). Drives routing in `TranscriptionService`.
+    var isActive: Bool { backend == .remote }
+
+    /// Parsed, validated base URL — `nil` if the string isn't a usable
+    /// absolute http(s) URL.
+    var endpointURL: URL? {
+        let trimmed = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else { return nil }
+        return url
+    }
+
+    /// "Enabled AND ready to use" — the invariant the routing layer relies on
+    /// before it skips the local-model gate. The endpoint must parse, and
+    /// OpenAI's own endpoint additionally needs an API key (self-hosted servers
+    /// usually accept anonymous requests, so we don't force a token there).
+    var isConfigured: Bool {
+        guard isActive, let url = endpointURL else { return false }
+        if Self.requiresAPIKey(url) {
+            return !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return true
+    }
+
+    /// Snapshot for the engine, or `nil` if the endpoint can't be parsed.
+    func currentConfig() -> RemoteTranscriptionConfig? {
+        guard let url = endpointURL else { return nil }
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RemoteTranscriptionConfig(
+            endpoint: url,
+            apiKey: apiKey.trimmingCharacters(in: .whitespacesAndNewlines),
+            model: trimmedModel.isEmpty ? Self.defaultModel : trimmedModel
+        )
+    }
+
+    /// Human-readable label written to `Recording.modelName` when a remote
+    /// transcription completes (so the detail view shows where the text came
+    /// from).
+    var modelLabel: String {
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "Remote · \(trimmedModel.isEmpty ? Self.defaultModel : trimmedModel)"
+    }
+
+    /// OpenAI's hosted API rejects unauthenticated requests, so we treat a key
+    /// as mandatory there. Self-hosted endpoints are assumed open unless the
+    /// user supplies one.
+    static func requiresAPIKey(_ url: URL) -> Bool {
+        (url.host ?? "").lowercased().hasSuffix("openai.com")
+    }
+
+    /// Probe the endpoint with a cheap `GET /models`. Treats any 2xx as
+    /// reachable. Purely advisory — surfaced as a status pill in Settings.
+    func testConnection() async {
+        guard let url = endpointURL else {
+            testStatus = .failed("Enter a valid http(s) URL.")
+            return
+        }
+        testStatus = .testing
+        var request = URLRequest(url: url.appendingPathComponent("models"))
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !key.isEmpty {
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        }
+        do {
+            let (_, response) = try await urlSession.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                testStatus = .failed("No HTTP response.")
+                return
+            }
+            switch http.statusCode {
+            case 200..<300:
+                testStatus = .ok("Reachable")
+            case 401, 403:
+                testStatus = .failed("Authentication failed (HTTP \(http.statusCode)). Check the API key.")
+            case 404:
+                // Some servers don't implement /models but still transcribe.
+                testStatus = .ok("Reachable (no /models endpoint)")
+            default:
+                testStatus = .failed("Server returned HTTP \(http.statusCode).")
+            }
+        } catch {
+            testStatus = .failed(error.localizedDescription)
+        }
+    }
+
+    private enum Keys {
+        static let backend = "transcription.backend"
+        static let endpoint = "remote.endpoint"
+        static let model = "remote.model"
+        static let apiKey = "remote.apiKey"
+    }
+}

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -109,7 +109,9 @@ actor RemoteWhisperEngine: TranscribingEngine {
                                       model: config.model,
                                       language: language)
 
-        remoteLog.log("transcribe: POST \(request.url?.absoluteString ?? "?", privacy: .public) model=\(config.model, privacy: .public) lang=\(language, privacy: .public) bytes=\(body.count, privacy: .public)")
+        // Endpoint kept .private — a user-configured URL can carry private
+        // hostnames or credentials/query tokens we must not leak to the log.
+        remoteLog.log("transcribe: POST \(request.url?.absoluteString ?? "?", privacy: .private) model=\(config.model, privacy: .public) lang=\(language, privacy: .public) bytes=\(body.count, privacy: .public)")
 
         // The protocol's `isCancelled` is a polled flag (the batch Cancel
         // button), not Swift task cancellation. Bridge it: run the upload in a

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -1,0 +1,249 @@
+import Foundation
+import OSLog
+import TranscriptionCore
+
+private let remoteLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                               category: "RemoteWhisperEngine")
+
+/// A `TranscribingEngine` that offloads transcription to an OpenAI-compatible
+/// `/v1/audio/transcriptions` endpoint instead of running whisper.cpp locally.
+///
+/// The protocol hands us 16 kHz mono `Float` samples (the same buffer the
+/// local engine would consume), so the recording's audio never has to be
+/// re-read from disk — we encode the samples to a compact AAC/`.m4a` blob and
+/// upload that. We ask for `verbose_json` so we get per-segment timestamps,
+/// which map straight onto `TranscriptSegment` and keep diarization /
+/// SRT-export working exactly as they do for the local path.
+///
+/// Config (endpoint, key, model) is injected via `configure(_:)` before each
+/// transcription — the protocol's `transcribe` signature is fixed by the local
+/// engine, so the remote-specific bits ride alongside on the actor's state.
+actor RemoteWhisperEngine: TranscribingEngine {
+    enum RemoteError: LocalizedError {
+        case notConfigured
+        case http(status: Int, body: String)
+        case badResponse
+        case emptyResult
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured:
+                return "Remote transcription endpoint is not configured."
+            case .http(let status, let body):
+                let detail = Self.shortMessage(from: body)
+                return "Remote server returned HTTP \(status)\(detail.map { ": \($0)" } ?? "")."
+            case .badResponse:
+                return "Remote server returned a response Mila couldn't parse."
+            case .emptyResult:
+                return "Remote server returned no transcript."
+            }
+        }
+
+        /// Pull a human-readable `error.message` out of an OpenAI-style error
+        /// body, falling back to a trimmed prefix of the raw body.
+        private static func shortMessage(from body: String) -> String? {
+            let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if let data = trimmed.data(using: .utf8),
+               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = obj["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                return message
+            }
+            return String(trimmed.prefix(200))
+        }
+    }
+
+    private var config: RemoteTranscriptionConfig?
+    private let session: URLSession
+
+    init() {
+        let configuration = URLSessionConfiguration.default
+        // A long meeting can take a while to transcribe server-side; the
+        // resource timeout has to clear the whole round trip, not just the
+        // upload.
+        configuration.timeoutIntervalForRequest = 120
+        configuration.timeoutIntervalForResource = 60 * 60
+        self.session = URLSession(configuration: configuration)
+    }
+
+    func configure(_ config: RemoteTranscriptionConfig) {
+        self.config = config
+    }
+
+    // MARK: - TranscribingEngine
+
+    /// No local weights to load. The connectivity check lives in
+    /// `RemoteTranscriptionSettings.testConnection()`; here we just confirm
+    /// the engine was configured.
+    func loadIfNeeded(modelURL: URL, displayName: String) async throws {
+        guard config != nil else { throw RemoteError.notConfigured }
+    }
+
+    func shutdown() async {
+        session.invalidateAndCancel()
+    }
+
+    func transcribe(samples: [Float],
+                    language: String,
+                    audioCtx: Int32?,
+                    progress: (@Sendable (Float) -> Void)?,
+                    isCancelled: (@Sendable () -> Bool)?) async throws -> [TranscriptSegment] {
+        guard let config else { throw RemoteError.notConfigured }
+        if isCancelled?() == true { throw CancellationError() }
+
+        progress?(0.05)
+        let audioData = try await Self.encodeM4A(samples: samples)
+        progress?(0.2)
+
+        let boundary = "MilaBoundary-\(UUID().uuidString)"
+        var request = URLRequest(url: config.endpoint.appendingPathComponent("audio/transcriptions"))
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)",
+                         forHTTPHeaderField: "Content-Type")
+        if !config.apiKey.isEmpty {
+            request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        let body = Self.multipartBody(boundary: boundary,
+                                      audio: audioData,
+                                      model: config.model,
+                                      language: language)
+
+        remoteLog.log("transcribe: POST \(request.url?.absoluteString ?? "?", privacy: .public) model=\(config.model, privacy: .public) lang=\(language, privacy: .public) bytes=\(body.count, privacy: .public)")
+
+        // The protocol's `isCancelled` is a polled flag (the batch Cancel
+        // button), not Swift task cancellation. Bridge it: run the upload in a
+        // child task and a watchdog that cancels it the moment the flag flips.
+        let netTask = Task { try await session.upload(for: request, from: body) }
+        let watchdog = Task {
+            while !Task.isCancelled {
+                if isCancelled?() == true { netTask.cancel(); return }
+                try? await Task.sleep(nanoseconds: 200_000_000)
+            }
+        }
+        defer { watchdog.cancel() }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await netTask.value
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if isCancelled?() == true { throw CancellationError() }
+            throw error
+        }
+
+        guard let http = response as? HTTPURLResponse else { throw RemoteError.badResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            throw RemoteError.http(status: http.statusCode,
+                                   body: String(data: data, encoding: .utf8) ?? "")
+        }
+
+        progress?(0.95)
+        let segments = try Self.parseSegments(data: data)
+        progress?(1.0)
+        remoteLog.log("transcribe: ok segs=\(segments.count, privacy: .public)")
+        return segments
+    }
+
+    // MARK: - Encoding
+
+    /// Encode 16 kHz mono float samples to an in-memory AAC/`.m4a` blob via the
+    /// app's existing WAV → m4a path (~14 MB/hour vs ~230 MB/hour for raw WAV),
+    /// keeping uploads well under typical API size limits. Temp files are
+    /// cleaned up before returning.
+    static func encodeM4A(samples: [Float]) async throws -> Data {
+        let tmp = FileManager.default.temporaryDirectory
+        let token = UUID().uuidString
+        let wavURL = tmp.appendingPathComponent("mila-remote-\(token).wav")
+        let m4aURL = tmp.appendingPathComponent("mila-remote-\(token).m4a")
+        defer {
+            try? FileManager.default.removeItem(at: wavURL)
+            try? FileManager.default.removeItem(at: m4aURL)
+        }
+        try AudioConvert.writeWhisperWAV(samples: samples, to: wavURL)
+        try await AudioCompressor.compress(wavURL: wavURL, toM4A: m4aURL)
+        return try Data(contentsOf: m4aURL)
+    }
+
+    /// Build a `multipart/form-data` body for the transcription request.
+    /// Fields: `file` (the m4a), `model`, `response_format=verbose_json`, and
+    /// `language` (omitted when "auto" so the server detects it).
+    static func multipartBody(boundary: String,
+                              audio: Data,
+                              model: String,
+                              language: String) -> Data {
+        var body = Data()
+        func appendField(_ name: String, _ value: String) {
+            body.append("--\(boundary)\r\n")
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.append("\(value)\r\n")
+        }
+
+        appendField("model", model)
+        appendField("response_format", "verbose_json")
+        let lang = language.lowercased()
+        if !lang.isEmpty && lang != "auto" {
+            // OpenAI expects ISO-639-1; Mila already uses "he"/"en".
+            appendField("language", lang)
+        }
+
+        body.append("--\(boundary)\r\n")
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.m4a\"\r\n")
+        body.append("Content-Type: audio/mp4\r\n\r\n")
+        body.append(audio)
+        body.append("\r\n")
+        body.append("--\(boundary)--\r\n")
+        return body
+    }
+
+    // MARK: - Parsing
+
+    private struct VerboseResponse: Decodable {
+        struct Segment: Decodable {
+            let start: Double
+            let end: Double
+            let text: String
+        }
+        let text: String?
+        let duration: Double?
+        let segments: [Segment]?
+    }
+
+    /// Parse a `verbose_json` (preferred) or plain `json` transcription
+    /// response into `TranscriptSegment`s. Static + pure so it can be unit
+    /// tested without a server.
+    static func parseSegments(data: Data) throws -> [TranscriptSegment] {
+        let decoder = JSONDecoder()
+        guard let parsed = try? decoder.decode(VerboseResponse.self, from: data) else {
+            throw RemoteError.badResponse
+        }
+
+        if let segments = parsed.segments, !segments.isEmpty {
+            let mapped = segments.compactMap { seg -> TranscriptSegment? in
+                let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { return nil }
+                return TranscriptSegment(start: seg.start, end: seg.end, text: seg.text)
+            }
+            if !mapped.isEmpty { return mapped }
+        }
+
+        // No segment array (server returned `response_format=json`, or an empty
+        // segment list with a top-level transcript). Fall back to one segment
+        // spanning the whole clip.
+        if let text = parsed.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !text.isEmpty {
+            return [TranscriptSegment(start: 0, end: parsed.duration ?? 0, text: text)]
+        }
+
+        throw RemoteError.emptyResult
+    }
+}
+
+private extension Data {
+    /// Append UTF-8 bytes of a string. Used to assemble multipart bodies.
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) { append(data) }
+    }
+}

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -422,7 +422,10 @@ final class TranscriptionService: ObservableObject {
             }
             await remoteEngine.configure(config)
             localModel = nil
-            modelDisplayName = remoteSettings.modelLabel
+            // Label from the captured config, not remoteSettings — a Settings
+            // edit mid-run must not change what's persisted to this
+            // recording's modelName.
+            modelDisplayName = "Remote · \(config.model)"
         } else {
             guard let model = modelManager.model(for: recording.language) else {
                 lastError = "No model selected."

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -54,6 +54,18 @@ final class TranscriptionService: ObservableObject {
     private let modelManager: ModelManager
     private let diarizationSettings: DiarizationSettings
 
+    /// User's transcription backend choice (on-device vs remote API). When the
+    /// remote backend is active + configured, transcription is routed through
+    /// `remoteEngine` instead of the local whisper.cpp `engine`, and the
+    /// local-model install gate is skipped (a remote user may have no `.bin`
+    /// downloaded at all).
+    private let remoteSettings: RemoteTranscriptionSettings
+
+    /// OpenAI-compatible remote engine. Constructed unconditionally but only
+    /// exercised when `remoteSettings.isActive` — cheap to hold idle (no
+    /// weights, just a URLSession).
+    private let remoteEngine = RemoteWhisperEngine()
+
     /// Hook fired once per recording that finished transcription
     /// successfully (status == .completed, non-empty text). MilaApp
     /// wires this to `RecordingSummarizer.summarizeIfNeeded` so every
@@ -97,10 +109,15 @@ final class TranscriptionService: ObservableObject {
     init(store: RecordingStore,
          modelManager: ModelManager,
          diarizationSettings: DiarizationSettings,
+         remoteSettings: RemoteTranscriptionSettings? = nil,
          engine: any TranscribingEngine = WhisperEngine()) {
         self.store = store
         self.modelManager = modelManager
         self.diarizationSettings = diarizationSettings
+        // Default constructed inside this @MainActor init (a default argument
+        // can't, since those evaluate in a nonisolated context). Tests that
+        // don't exercise the remote path simply omit it.
+        self.remoteSettings = remoteSettings ?? RemoteTranscriptionSettings()
         self.engine = engine
         // Bridge the engine's preparation callback onto the main
         // actor so SwiftUI subscribers see flips through `@Published`
@@ -241,6 +258,28 @@ final class TranscriptionService: ObservableObject {
     /// quality on one path or the other, so make every call site declare its
     /// intent.
     func transcribeOnceSegments(samples: [Float], language: String, audioCtx: Int32?) async -> [TranscriptSegment] {
+        // Remote backend: route dictation/live utterances to the configured
+        // endpoint too, so the user's "global backend" choice holds for every
+        // path. Misconfiguration degrades to an empty result (same contract as
+        // a missing local model) rather than throwing into the live loop.
+        if remoteSettings.isActive {
+            guard remoteSettings.isConfigured, let config = remoteSettings.currentConfig() else {
+                serviceLog.log("transcribeOnceSegments: SKIP — remote backend active but not configured")
+                return []
+            }
+            await remoteEngine.configure(config)
+            do {
+                let segs = try await remoteEngine.transcribe(samples: samples,
+                                                             language: language,
+                                                             audioCtx: audioCtx,
+                                                             progress: nil,
+                                                             isCancelled: nil)
+                return segs
+            } catch {
+                serviceLog.log("transcribeOnceSegments(remote): FAILED error=\(error.localizedDescription, privacy: .public)")
+                return []
+            }
+        }
         let candidate = modelManager.model(for: language)
         guard let model = candidate,
               modelManager.isInstalled(model) else {
@@ -315,6 +354,7 @@ final class TranscriptionService: ObservableObject {
     /// global destructors run (which is what triggered SIGABRT on quit).
     func shutdown() async {
         await engine.shutdown()
+        await remoteEngine.shutdown()
     }
 
     /// Abandon the transcription of `recordingID`. If it's still in the queue
@@ -368,17 +408,37 @@ final class TranscriptionService: ObservableObject {
             return
         }
 
-        guard let model = modelManager.model(for: recording.language) else {
-            lastError = "No model selected."
-            markFailed(recording)
-            return
+        // Resolve the backend up front. Remote skips the local-model gate
+        // entirely (a remote-only user may never have downloaded a `.bin`);
+        // local keeps the existing "is the model installed yet?" guards.
+        let useRemote = remoteSettings.isActive
+        let localModel: WhisperModel?
+        let modelDisplayName: String
+        if useRemote {
+            guard remoteSettings.isConfigured, let config = remoteSettings.currentConfig() else {
+                lastError = "Remote transcription is selected but not configured. Open Settings → Models to set the endpoint and API key."
+                markFailed(recording)
+                return
+            }
+            await remoteEngine.configure(config)
+            localModel = nil
+            modelDisplayName = remoteSettings.modelLabel
+        } else {
+            guard let model = modelManager.model(for: recording.language) else {
+                lastError = "No model selected."
+                markFailed(recording)
+                return
+            }
+            guard modelManager.isInstalled(model) else {
+                lastError = "Whisper model is still downloading. Try again once it's ready."
+                print("Transcribe skipped: model \(model.name) not installed yet")
+                markFailed(recording)
+                return
+            }
+            localModel = model
+            modelDisplayName = model.displayName
         }
-        guard modelManager.isInstalled(model) else {
-            lastError = "Whisper model is still downloading. Try again once it's ready."
-            print("Transcribe skipped: model \(model.name) not installed yet")
-            markFailed(recording)
-            return
-        }
+        let activeEngine: any TranscribingEngine = useRemote ? remoteEngine : engine
 
         // Re-fetch from the store so we work against the latest persisted version.
         // (The recording may have been edited or even soft-deleted between
@@ -401,7 +461,7 @@ final class TranscriptionService: ObservableObject {
             .isEmpty
 
         working.status = .running
-        working.modelName = model.displayName
+        working.modelName = modelDisplayName
         store.update(working)
 
         let recordingID = recording.id
@@ -425,8 +485,13 @@ final class TranscriptionService: ObservableObject {
         await observerSetupTask.value
 
         do {
-            try await engine.loadIfNeeded(modelURL: modelManager.url(for: model),
-                                          displayName: model.displayName)
+            // Local backend needs the whisper weights loaded (and the CoreML
+            // encoder compiled) before transcribing. The remote engine has no
+            // weights — `configure` already ran above.
+            if let localModel {
+                try await engine.loadIfNeeded(modelURL: modelManager.url(for: localModel),
+                                              displayName: localModel.displayName)
+            }
             let audioURL = store.audioURL(for: recording)
             let samples = try AudioConvert.loadAsWhisperSamples(url: audioURL)
             let durationSeconds = Double(samples.count) / Double(WhisperAudioFormat.sampleRate)
@@ -480,7 +545,7 @@ final class TranscriptionService: ObservableObject {
                 }
             }()
 
-            async let transcribeTask = engine.transcribe(
+            async let transcribeTask = activeEngine.transcribe(
                 samples: samples,
                 language: working.language,
                 // Batch path: imported files / post-record full-WAV

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -398,11 +398,44 @@ final class HotkeyCaptureNSView: NSView {
 private struct ModelsSettingsTab: View {
     @EnvironmentObject private var manager: ModelManager
     @EnvironmentObject private var transcription: TranscriptionService
+    @EnvironmentObject private var remote: RemoteTranscriptionSettings
 
     var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Transcription backend")
+                    .font(.title3.weight(.semibold))
+                Text("Mila transcribes on-device by default — audio never leaves your Mac. Switch to a remote API to offload transcription to OpenAI's Whisper API or any self-hosted OpenAI-compatible server.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Picker("Backend", selection: $remote.backend) {
+                    ForEach(TranscriptionBackend.allCases) { backend in
+                        Text(backend.displayName).tag(backend)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                switch remote.backend {
+                case .local:
+                    localModelsSection
+                case .remote:
+                    RemoteBackendSection(remote: remote)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var localModelsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Whisper models")
-                .font(.title3.weight(.semibold))
+                .font(.headline)
             Text("English dictation uses the OpenAI turbo model; Hebrew uses ivrit.ai. Both download automatically on first launch (~1.6 GB each). The optional ivrit.ai large model is higher accuracy but ~2× slower.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -413,9 +446,111 @@ private struct ModelsSettingsTab: View {
                     ModelRow(model: model)
                 }
             }
-            Spacer()
         }
+    }
+}
+
+/// Endpoint / model / API-key configuration for the remote transcription
+/// backend, plus a connectivity test and the mandatory "audio leaves your
+/// device" warning.
+private struct RemoteBackendSection: View {
+    @ObservedObject var remote: RemoteTranscriptionSettings
+
+    private static let setupGuideURL = URL(string: "https://github.com/island-io/mila/blob/main/docs/REMOTE_TRANSCRIPTION_SERVER.md")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            privacyWarning
+
+            VStack(alignment: .leading, spacing: 8) {
+                fieldRow(label: "Endpoint") {
+                    TextField(RemoteTranscriptionSettings.defaultEndpoint, text: $remote.endpoint)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                }
+                Text("Base URL of an OpenAI-compatible API. Mila appends `/audio/transcriptions`. Defaults to OpenAI; point it at your own server for ivrit.ai or other models.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                fieldRow(label: "Model") {
+                    TextField(RemoteTranscriptionSettings.defaultModel, text: $remote.model)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                }
+
+                fieldRow(label: "API key") {
+                    SecureField("Stored in your Keychain", text: $remote.apiKey)
+                        .textFieldStyle(.roundedBorder)
+                }
+                Text("Sent as a Bearer token and stored encrypted in the macOS Keychain — never written to disk in plaintext. Leave blank for self-hosted servers that don't require auth.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    Task { await remote.testConnection() }
+                } label: {
+                    if case .testing = remote.testStatus {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Test connection")
+                    }
+                }
+                .disabled(remote.endpointURL == nil || remote.testStatus == .testing)
+
+                testStatusLabel
+                Spacer()
+            }
+
+            Divider()
+
+            Link(destination: Self.setupGuideURL) {
+                Label("How to host ivrit.ai (or any model) behind this API", systemImage: "book")
+                    .font(.callout)
+            }
+        }
+    }
+
+    private var privacyWarning: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("Audio leaves your device. When the remote backend is active, every recording is uploaded to the endpoint below for transcription. Use a server you trust.")
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var testStatusLabel: some View {
+        switch remote.testStatus {
+        case .idle, .testing:
+            EmptyView()
+        case .ok(let message):
+            Label(message, systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .font(.caption)
+        case .failed(let message):
+            Label(message, systemImage: "xmark.circle.fill")
+                .foregroundStyle(.red)
+                .font(.caption)
+                .lineLimit(2)
+        }
+    }
+
+    private func fieldRow<Content: View>(label: String,
+                                         @ViewBuilder content: () -> Content) -> some View {
+        HStack {
+            Text(label).frame(width: 80, alignment: .leading)
+            content()
+        }
+        .font(.callout)
     }
 }
 

--- a/MilaTests/RemoteTranscriptionE2ETests.swift
+++ b/MilaTests/RemoteTranscriptionE2ETests.swift
@@ -89,7 +89,9 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
     func test_testConnection_reachesModelsEndpoint() async {
         let suite = UserDefaults(suiteName: "RemoteTranscriptionE2ETests.conn")!
         suite.removePersistentDomain(forName: "RemoteTranscriptionE2ETests.conn")
-        let settings = RemoteTranscriptionSettings(defaults: suite)
+        let settings = RemoteTranscriptionSettings(
+            defaults: suite,
+            apiKeyKeychainKey: "RemoteTranscriptionE2ETests.conn.apiKey")
         settings.backend = .remote
         settings.endpoint = endpoint.absoluteString
         settings.apiKey = "test-key-123"

--- a/MilaTests/RemoteTranscriptionE2ETests.swift
+++ b/MilaTests/RemoteTranscriptionE2ETests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+/// End-to-end test of the remote transcription client against a live HTTP
+/// server. The server is the stdlib mock in
+/// `scripts/mock-openai-transcription-server.py`, spawned by the
+/// `e2e-remote-transcription` CI workflow, which passes its base URL in
+/// `MILA_REMOTE_TEST_ENDPOINT`.
+///
+/// When that env var is absent (every normal `MilaTests` run, local or in the
+/// regular CI jobs) the whole suite XCTSkips — so it only does real work in the
+/// dedicated workflow, while still being a first-class test there.
+///
+/// What it proves, over a real socket:
+///   * `RemoteWhisperEngine` encodes samples to m4a and uploads a well-formed
+///     multipart request with the right `model` / `language` fields + Bearer
+///     auth (the mock rejects the request otherwise),
+///   * it parses `verbose_json` segments + timestamps back correctly,
+///   * `RemoteTranscriptionSettings.testConnection()` reaches `/models`.
+final class RemoteTranscriptionE2ETests: XCTestCase {
+
+    private var endpoint: URL!
+
+    override func setUpWithError() throws {
+        guard let raw = ProcessInfo.processInfo.environment["MILA_REMOTE_TEST_ENDPOINT"],
+              let url = URL(string: raw) else {
+            throw XCTSkip("MILA_REMOTE_TEST_ENDPOINT not set — remote E2E runs only in the e2e-remote-transcription workflow.")
+        }
+        endpoint = url
+    }
+
+    /// 1 second of a 220 Hz sine at 16 kHz — real, non-silent audio for the
+    /// engine to encode and upload.
+    private func sineSamples(seconds: Double = 1.0) -> [Float] {
+        let rate = WhisperAudioFormat.sampleRate
+        let count = Int(rate * seconds)
+        return (0..<count).map { i in
+            0.3 * Float(sin(2.0 * Double.pi * 220.0 * Double(i) / rate))
+        }
+    }
+
+    func test_roundTrip_uploadsAndParsesSegments() async throws {
+        let engine = RemoteWhisperEngine()
+        await engine.configure(RemoteTranscriptionConfig(
+            endpoint: endpoint,
+            apiKey: "test-key-123",
+            model: "mila-echo-model"
+        ))
+
+        let segments = try await engine.transcribe(
+            samples: sineSamples(),
+            language: "he",
+            audioCtx: 0,
+            progress: nil,
+            isCancelled: nil
+        )
+
+        // The mock echoes the received model + language into the segments, so
+        // these assertions prove the client transmitted them and parsed the
+        // verbose_json (segments + timestamps) back.
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments.first?.text, "model=mila-echo-model")
+        XCTAssertEqual(segments.last?.text, "lang=he")
+        XCTAssertEqual(try XCTUnwrap(segments.last?.end), 1.0, accuracy: 0.0001)
+    }
+
+    func test_autoLanguage_isOmitted() async throws {
+        let engine = RemoteWhisperEngine()
+        await engine.configure(RemoteTranscriptionConfig(
+            endpoint: endpoint,
+            apiKey: "test-key-123",
+            model: "m"
+        ))
+
+        let segments = try await engine.transcribe(
+            samples: sineSamples(),
+            language: "auto",
+            audioCtx: 0,
+            progress: nil,
+            isCancelled: nil
+        )
+
+        // "auto" must NOT send a language field; the mock reports "none" then.
+        XCTAssertEqual(segments.last?.text, "lang=none")
+    }
+
+    @MainActor
+    func test_testConnection_reachesModelsEndpoint() async {
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionE2ETests.conn")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionE2ETests.conn")
+        let settings = RemoteTranscriptionSettings(defaults: suite)
+        settings.backend = .remote
+        settings.endpoint = endpoint.absoluteString
+        settings.apiKey = "test-key-123"
+
+        await settings.testConnection()
+
+        guard case .ok = settings.testStatus else {
+            return XCTFail("Expected .ok, got \(settings.testStatus)")
+        }
+    }
+}

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -8,7 +8,10 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
     private func makeSettings(_ label: String = #function) -> RemoteTranscriptionSettings {
         let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(label)")!
         suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(label)")
-        return RemoteTranscriptionSettings(defaults: suite)
+        // Isolated Keychain item so these tests never read/clobber the real
+        // app's `remote.apiKey`.
+        return RemoteTranscriptionSettings(defaults: suite,
+                                           apiKeyKeychainKey: "RemoteTranscriptionSettingsTests.\(label).apiKey")
     }
 
     func test_defaults_areLocalAndOpenAI() {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+@MainActor
+final class RemoteTranscriptionSettingsTests: XCTestCase {
+
+    private func makeSettings(_ label: String = #function) -> RemoteTranscriptionSettings {
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(label)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(label)")
+        return RemoteTranscriptionSettings(defaults: suite)
+    }
+
+    func test_defaults_areLocalAndOpenAI() {
+        let settings = makeSettings()
+        XCTAssertEqual(settings.backend, .local)
+        XCTAssertFalse(settings.isActive)
+        XCTAssertEqual(settings.endpoint, RemoteTranscriptionSettings.defaultEndpoint)
+        XCTAssertEqual(settings.model, RemoteTranscriptionSettings.defaultModel)
+    }
+
+    func test_isConfigured_requiresKeyForOpenAI() {
+        let settings = makeSettings()
+        settings.backend = .remote
+        settings.endpoint = "https://api.openai.com/v1"
+        settings.apiKey = ""
+        XCTAssertFalse(settings.isConfigured, "OpenAI endpoint must require a key")
+        settings.apiKey = "sk-test"
+        XCTAssertTrue(settings.isConfigured)
+    }
+
+    func test_isConfigured_allowsAnonymousSelfHosted() {
+        let settings = makeSettings()
+        settings.backend = .remote
+        settings.endpoint = "http://localhost:8000/v1"
+        settings.apiKey = ""
+        XCTAssertTrue(settings.isConfigured, "Self-hosted endpoints may be anonymous")
+    }
+
+    func test_endpointURL_rejectsGarbage() {
+        let settings = makeSettings()
+        settings.endpoint = "not a url"
+        XCTAssertNil(settings.endpointURL)
+        settings.endpoint = "ftp://example.com"
+        XCTAssertNil(settings.endpointURL, "Only http(s) is allowed")
+        settings.endpoint = "https://example.com/v1"
+        XCTAssertNotNil(settings.endpointURL)
+    }
+
+    func test_currentConfig_trimsAndFallsBackModel() {
+        let settings = makeSettings()
+        settings.backend = .remote
+        settings.endpoint = "  https://example.com/v1  "
+        settings.model = "   "
+        let config = settings.currentConfig()
+        XCTAssertEqual(config?.endpoint.absoluteString, "https://example.com/v1")
+        XCTAssertEqual(config?.model, RemoteTranscriptionSettings.defaultModel)
+    }
+
+    func test_editingEndpointResetsTestStatus() {
+        let settings = makeSettings()
+        settings.endpoint = "https://example.com/v1"
+        // testStatus starts .idle; just assert mutation path doesn't crash and
+        // stays idle without a network call.
+        XCTAssertEqual(settings.testStatus, .idle)
+    }
+}
+
+final class RemoteWhisperEngineParsingTests: XCTestCase {
+
+    func test_parsesVerboseJSONSegments() throws {
+        let json = """
+        {
+          "task": "transcribe",
+          "language": "hebrew",
+          "duration": 5.0,
+          "text": "שלום עולם",
+          "segments": [
+            { "id": 0, "start": 0.0, "end": 2.5, "text": " שלום" },
+            { "id": 1, "start": 2.5, "end": 5.0, "text": " עולם" }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let segments = try RemoteWhisperEngine.parseSegments(data: json)
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].start, 0.0)
+        XCTAssertEqual(segments[1].end, 5.0)
+        // Original text preserved (leading space intact for joining).
+        XCTAssertEqual(segments[0].text, " שלום")
+    }
+
+    func test_fallsBackToSingleSegmentWhenNoSegments() throws {
+        let json = """
+        { "text": "hello world", "duration": 3.2 }
+        """.data(using: .utf8)!
+
+        let segments = try RemoteWhisperEngine.parseSegments(data: json)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].start, 0)
+        XCTAssertEqual(segments[0].end, 3.2)
+        XCTAssertEqual(segments[0].text, "hello world")
+    }
+
+    func test_throwsOnEmptyResult() {
+        let json = """
+        { "text": "   ", "segments": [] }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try RemoteWhisperEngine.parseSegments(data: json))
+    }
+
+    func test_multipartBodyContainsRequiredFields() {
+        let audio = Data([0x00, 0x01, 0x02, 0x03])
+        let body = RemoteWhisperEngine.multipartBody(boundary: "B",
+                                                     audio: audio,
+                                                     model: "whisper-1",
+                                                     language: "he")
+        let text = String(decoding: body, as: UTF8.self)
+        XCTAssertTrue(text.contains("name=\"model\""))
+        XCTAssertTrue(text.contains("whisper-1"))
+        XCTAssertTrue(text.contains("name=\"response_format\""))
+        XCTAssertTrue(text.contains("verbose_json"))
+        XCTAssertTrue(text.contains("name=\"language\""))
+        XCTAssertTrue(text.contains("filename=\"audio.m4a\""))
+        XCTAssertTrue(text.contains("--B--"), "Must be terminated with the closing boundary")
+    }
+
+    func test_multipartBodyOmitsLanguageWhenAuto() {
+        let body = RemoteWhisperEngine.multipartBody(boundary: "B",
+                                                     audio: Data(),
+                                                     model: "whisper-1",
+                                                     language: "auto")
+        let text = String(decoding: body, as: UTF8.self)
+        XCTAssertFalse(text.contains("name=\"language\""),
+                       "Auto-detect must omit the language field")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ Models live at:
 
 The app picks them up from that directory automatically.
 
+### Remote transcription (optional)
+
+By default Mila transcribes entirely on-device — audio never leaves your Mac.
+If you'd rather offload transcription (e.g. on a low-powered Mac, or to use a
+Hebrew-tuned model that's too large to run locally), **Settings → Models** lets
+you switch the backend to any OpenAI-compatible `/v1/audio/transcriptions`
+endpoint: OpenAI's own Whisper API, or a self-hosted server. The API key is
+stored in your Keychain, and the UI flags that audio leaves the device while
+this backend is active.
+
+To run [ivrit.ai](https://www.ivrit.ai/)'s Hebrew models (or any other Whisper
+model) behind this API on your own machine, see
+**[docs/REMOTE_TRANSCRIPTION_SERVER.md](docs/REMOTE_TRANSCRIPTION_SERVER.md)**.
+
 ## Required permissions
 
 On first use macOS will prompt for the following — all are required for the

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -1,0 +1,125 @@
+# Self-hosting a transcription server for Mila (ivrit.ai & other models)
+
+Mila can offload transcription to any server that implements OpenAI's
+[`POST /v1/audio/transcriptions`](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+endpoint. This guide shows how to stand up such a server with an **[ivrit.ai](https://www.ivrit.ai/)**
+Hebrew model — but the same setup works for any Whisper model.
+
+Once it's running, point Mila at it under **Settings → Models → Backend → Remote API**.
+
+---
+
+## Background: what ivrit.ai ships
+
+ivrit.ai is a non-profit project providing high-quality **Hebrew** speech models.
+It publishes **model weights**, not a turnkey API. The fine-tuned models are
+distributed in [CTranslate2](https://github.com/OpenNMT/CTranslate2) form — the
+format the [faster-whisper](https://github.com/SYSTRAN/faster-whisper) runtime
+consumes:
+
+- [`ivrit-ai/whisper-large-v3-ct2`](https://huggingface.co/ivrit-ai/whisper-large-v3-ct2) — most accurate
+- [`ivrit-ai/whisper-large-v3-turbo-ct2`](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ct2) — faster, smaller
+
+> **Note.** ivrit.ai's own serving project,
+> [`ivrit-ai/runpod-serverless`](https://github.com/ivrit-ai/runpod-serverless),
+> speaks RunPod's job protocol — **not** the OpenAI API. So you don't use it
+> directly with Mila; instead you put an OpenAI-compatible server in front of
+> the same weights, as below.
+
+---
+
+## Option A — `speaches` (recommended)
+
+[`speaches`](https://github.com/speaches-ai/speaches) (formerly
+`faster-whisper-server`) is an OpenAI-compatible server built on faster-whisper.
+It can load **any** HuggingFace CTranslate2 model by ID, including ivrit.ai's.
+
+### 1. Run the server (Docker)
+
+GPU (NVIDIA/CUDA — strongly recommended for `large-v3`):
+
+```bash
+docker run --rm -d --gpus=all \
+  -p 8000:8000 \
+  -e WHISPER__MODEL=ivrit-ai/whisper-large-v3-turbo-ct2 \
+  -v hf-hub-cache:/home/ubuntu/.cache/huggingface/hub \
+  ghcr.io/speaches-ai/speaches:latest-cuda
+```
+
+CPU-only (fine for the `turbo` model on short clips; slow for `large-v3`):
+
+```bash
+docker run --rm -d \
+  -p 8000:8000 \
+  -e WHISPER__MODEL=ivrit-ai/whisper-large-v3-turbo-ct2 \
+  -v hf-hub-cache:/home/ubuntu/.cache/huggingface/hub \
+  ghcr.io/speaches-ai/speaches:latest-cpu
+```
+
+The first request downloads the model into the mounted cache volume; subsequent
+runs reuse it.
+
+> Check the [speaches docs](https://speaches-ai.github.io/speaches/) for the
+> current image tags and env-var names — the project moves quickly.
+
+### 2. Verify it's up
+
+```bash
+# Lists available models — Mila's "Test connection" button hits this too.
+curl http://localhost:8000/v1/models
+
+# Transcribe a sample file end-to-end.
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample-he.m4a \
+  -F model=ivrit-ai/whisper-large-v3-turbo-ct2 \
+  -F language=he \
+  -F response_format=verbose_json
+```
+
+### 3. Point Mila at it
+
+In **Settings → Models**:
+
+| Field      | Value                                          |
+|------------|------------------------------------------------|
+| Backend    | **Remote API**                                 |
+| Endpoint   | `http://localhost:8000/v1`                     |
+| Model      | `ivrit-ai/whisper-large-v3-turbo-ct2`          |
+| API key    | *(leave blank — speaches doesn't require auth)* |
+
+Click **Test connection**, then record. Mila uploads each recording as a compact
+`.m4a` and asks for `verbose_json`, so per-segment timestamps (and therefore
+SRT export + speaker diarization) keep working exactly as with the local engine.
+
+---
+
+## Option B — OpenAI's hosted Whisper API
+
+No server to run. In **Settings → Models**:
+
+| Field      | Value                          |
+|------------|--------------------------------|
+| Backend    | **Remote API**                 |
+| Endpoint   | `https://api.openai.com/v1`    |
+| Model      | `whisper-1`                    |
+| API key    | your OpenAI API key            |
+
+This uses OpenAI's general-purpose Whisper model (not the ivrit.ai Hebrew
+finetune). Note OpenAI's per-request file-size limit (25 MB at time of writing);
+Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
+
+---
+
+## Notes & caveats
+
+- **Privacy.** With the remote backend active, audio is uploaded off-device.
+  Mila flags this in the UI. For a privacy-preserving setup, self-host
+  (Option A) on a machine you control rather than using a third-party API.
+- **Exposing the server beyond localhost.** If you run the server on another
+  host, terminate TLS (e.g. behind a reverse proxy) and require an API key —
+  then set that key in Mila. Don't send audio over plaintext HTTP across a
+  network you don't trust.
+- **Language.** Mila forwards the recording language (`he` / `en`); on
+  "Auto-detect" it omits the field and lets the server detect it.
+- **Diarization** still runs locally (it reads the on-disk audio), so speaker
+  labels work regardless of which transcription backend you choose.

--- a/scripts/mock-openai-transcription-server.py
+++ b/scripts/mock-openai-transcription-server.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI-compatible transcription server for end-to-end testing.
+
+Stands in for OpenAI's API (or a self-hosted faster-whisper server like
+`speaches`) so CI can exercise Mila's `RemoteWhisperEngine` over a real HTTP
+socket — without downloading a multi-GB model or running Docker (which the
+macOS GitHub runners can't do).
+
+It does NOT transcribe. Instead it *validates the request contract* and
+**echoes** what it received back through the response, so the client test can
+prove it built the request correctly:
+
+  GET  /v1/models                 -> 200 {"data":[...]}    (the connectivity probe)
+  POST /v1/audio/transcriptions   -> verbose_json whose segments encode the
+                                     received `model` and `language` fields.
+
+The POST is rejected (4xx) unless the request satisfies the contract a real
+server would require:
+  * Authorization: Bearer <token>      (we require a token here)
+  * a non-empty `model` form field
+  * a `file` part that is a real MP4/M4A payload (contains the `ftyp` box)
+
+A 2xx + echoed values therefore proves the client sent a well-formed multipart
+upload with the right headers, and that it parsed `verbose_json` (segments +
+timestamps) back correctly.
+
+Stdlib only — no pip install, so it starts instantly and can't break on a
+dependency resolution.
+"""
+
+import argparse
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def _parse_multipart(body: bytes, boundary: bytes):
+    """Return (fields: dict[str,str], file_bytes: bytes|None).
+
+    Deliberately small/forgiving — just enough to pull form field values and
+    the file part out of a well-formed multipart/form-data body.
+    """
+    fields = {}
+    file_bytes = None
+    delimiter = b"--" + boundary
+    for part in body.split(delimiter):
+        part = part.strip(b"\r\n")
+        if not part or part == b"--":
+            continue
+        header_blob, _, content = part.partition(b"\r\n\r\n")
+        if not _:
+            continue
+        headers = header_blob.decode("utf-8", "replace")
+        disp = next((l for l in headers.splitlines()
+                     if l.lower().startswith("content-disposition")), "")
+        name_match = re.search(r'name="([^"]*)"', disp)
+        if not name_match:
+            continue
+        name = name_match.group(1)
+        if "filename=" in disp:
+            file_bytes = content
+        else:
+            fields[name] = content.decode("utf-8", "replace").strip()
+    return fields, file_bytes
+
+
+class Handler(BaseHTTPRequestHandler):
+    # Quieter logs; CI captures stderr anyway.
+    def log_message(self, *args):
+        sys.stderr.write("[mock-server] " + (args[0] % args[1:]) + "\n")
+
+    def _send_json(self, status: int, payload: dict):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path.rstrip("/").endswith("/models"):
+            self._send_json(200, {
+                "object": "list",
+                "data": [{"id": "mock-whisper", "object": "model"}],
+            })
+        else:
+            self._send_json(404, {"error": {"message": "not found"}})
+
+    def do_POST(self):
+        if not self.path.endswith("/audio/transcriptions"):
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+
+        # Contract: a real OpenAI endpoint requires a bearer token.
+        auth = self.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            self._send_json(401, {"error": {"message": "missing bearer token"}})
+            return
+
+        ctype = self.headers.get("Content-Type", "")
+        m = re.search(r"boundary=([^;]+)", ctype)
+        if "multipart/form-data" not in ctype or not m:
+            self._send_json(400, {"error": {"message": "expected multipart/form-data"}})
+            return
+        boundary = m.group(1).strip().strip('"').encode("utf-8")
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        fields, file_bytes = _parse_multipart(body, boundary)
+
+        model = fields.get("model", "")
+        if not model:
+            self._send_json(400, {"error": {"message": "missing model field"}})
+            return
+        if not file_bytes or b"ftyp" not in file_bytes[:64]:
+            self._send_json(400, {"error": {"message": "missing or non-m4a file part"}})
+            return
+
+        language = fields.get("language", "none")
+
+        # Echo the received model + language back through the transcript so the
+        # client test can assert it transmitted them (and parsed the segments).
+        self._send_json(200, {
+            "task": "transcribe",
+            "language": language,
+            "duration": 1.0,
+            "text": f"model={model} lang={language}",
+            "segments": [
+                {"id": 0, "seek": 0, "start": 0.0, "end": 0.5, "text": f"model={model}"},
+                {"id": 1, "seek": 0, "start": 0.5, "end": 1.0, "text": f"lang={language}"},
+            ],
+        })
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8123)
+    args = ap.parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    # Flushed line CI can wait on before pointing the client at us.
+    print(f"mock-openai-transcription-server listening on "
+          f"http://{args.host}:{args.port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #20.

Adds an **opt-in remote transcription backend** selectable in **Settings → Models**, alongside the default on-device whisper.cpp engine. Local stays the default to preserve the privacy-first story, and the UI clearly flags that audio leaves the device when remote is active.

## Why

On lower-powered Macs — or to use a Hebrew-tuned model too large to run locally — users may want to offload transcription. This wires any **OpenAI-compatible `/v1/audio/transcriptions` endpoint** (OpenAI's own API, or a self-hosted server like [`speaches`](https://github.com/speaches-ai/speaches) serving an [ivrit.ai](https://www.ivrit.ai/) model) in behind the existing `TranscribingEngine` abstraction.

## What's in it

- **`RemoteTranscriptionSettings`** — global backend choice (Local/Remote), endpoint (defaults to OpenAI), model, and API key. The key is stored in the **Keychain** (via the existing `KeychainHelper`), never UserDefaults. Includes a `Test connection` probe and an `isConfigured` readiness gate (OpenAI requires a key; self-hosted may be anonymous).
- **`RemoteWhisperEngine`** — actor conforming to `TranscribingEngine`. Re-encodes the 16 kHz sample buffer to compact `.m4a` (reusing `AudioCompressor`), POSTs multipart to `/audio/transcriptions` with `response_format=verbose_json`, and maps the timestamped segments straight onto `TranscriptSegment` (so SRT export + diarization keep working). Honors the `progress` / `isCancelled` contract.
- **`TranscriptionService`** — `process()` and the dictation/live path route to the active backend. Remote skips the local-model-install gate; **diarization still runs locally** in parallel.
- **Settings → Models** — backend picker, remote endpoint/model/key fields, Test button, and a prominent "audio leaves your device" warning.
- **`MilaApp`** — `@StateObject` + injection on both scenes.
- **Docs** — `docs/REMOTE_TRANSCRIPTION_SERVER.md` explains how to self-host ivrit.ai (or any Whisper model) behind this API with `speaches`; linked from the README.
- **Tests** — unit coverage for settings behavior (defaults, `isConfigured`, URL validation, config snapshot) and `verbose_json` / multipart encoding.

## Design notes

- **Live/dictation also route to remote** when that backend is selected (consistent with a "global setting") — a network round-trip per utterance, slower/costlier than local. Easy to restrict to batch-only later.
- OpenAI's hosted API has a 25 MB request cap (~1.5 hr at our m4a bitrate); self-hosted servers generally don't.

## Testing

- `make build` ✅
- New unit tests pass ✅ (`RemoteTranscriptionSettingsTests`, `RemoteWhisperEngineParsingTests`)
- ⚠️ Not yet verified against a live server end-to-end — recommend a manual round-trip against a `speaches` instance (and/or OpenAI) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional remote transcription support with a new backend choice in Settings.
  * Users can now configure a remote endpoint, model, and API key, and test the connection from the app.
  * Remote transcription results are now supported alongside local transcription.

* **Documentation**
  * Added setup guidance for self-hosted and hosted remote transcription services.
  * Updated the README with remote transcription usage, privacy notes, and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->