### PR TITLE
Run auto title suggestion in the background, not blocking save (#34)

### DIFF
--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -21,11 +21,17 @@ final class PostRecordingCoordinator: ObservableObject {
     @Published var activityStatus: String?
     @Published var activityIsError: Bool = false
 
+    /// Recordings whose title is currently being suggested by the background
+    /// auto-suggest job. The rename sheet reads this to show a "suggesting…"
+    /// affordance without owning the work itself.
+    @Published private(set) var autoSuggestingIDs: Set<UUID> = []
+
     private let store: RecordingStore
     private let transcription: TranscriptionService
+    private let llm: LLMSettings
 
-    /// LLM work spawned from inside the rename sheet (auto-suggest, manual
-    /// Suggest, Send-to-Claude). Tracked here — not in the sheet's view
+    /// LLM work spawned from inside the rename sheet (manual Suggest) plus
+    /// the background auto-suggest job. Tracked here — not in the sheet's view
     /// state — so the Cancel button can kill it even after the sheet is
     /// torn down, and so the in-flight handle survives the SwiftUI redraws
     /// that would otherwise re-create local `@State`.
@@ -52,9 +58,12 @@ final class PostRecordingCoordinator: ObservableObject {
     /// can still be transcribing minutes after the user walks away.
     var transcriptWaitTimeout: TimeInterval = 600
 
-    init(store: RecordingStore, transcription: TranscriptionService) {
+    init(store: RecordingStore,
+         transcription: TranscriptionService,
+         llm: LLMSettings) {
         self.store = store
         self.transcription = transcription
+        self.llm = llm
     }
 
     /// Open the rename sheet for a freshly-added recording. Called by
@@ -72,6 +81,94 @@ final class PostRecordingCoordinator: ObservableObject {
         if CommandLine.arguments.contains("--ui-test-finalize-regression") { return }
         guard pending == nil else { return }
         pending = recording
+        armAutoSuggestTitle(for: recording)
+    }
+
+    // MARK: - Background auto-suggest title
+
+    /// Kick off background title suggestion for a freshly-added recording.
+    ///
+    /// This is deliberately decoupled from the rename sheet: the LLM CLI can
+    /// take a long time to answer, and the old in-sheet path lost the result
+    /// the moment the user hit Save (the suggestion landed in discarded
+    /// `@State`). Running it here means the user can Save and move on
+    /// immediately — the title is written to the saved recording whenever the
+    /// CLI returns, as long as the user hasn't given it their own title in
+    /// the meantime. (Issue #34.)
+    ///
+    /// The transcript is usually still being finalized at add time, so we
+    /// reuse `awaitTranscript` (the same poller "Send to <LLM>" uses) to wait
+    /// for it before invoking the CLI.
+    private func armAutoSuggestTitle(for recording: Recording) {
+        guard llm.isConfigured, llm.nameGenerationEnabled else { return }
+        let id = recording.id
+        // The default, machine-generated title at add time. We only apply an
+        // AI suggestion later if the recording STILL carries this title —
+        // i.e. the user hasn't renamed it (in the sheet or the list).
+        let baselineTitle = recording.title
+        let tool = llm.tool
+        let prompt = llm.namePrompt
+        let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
+        let cliTimeout = llm.cliTimeout
+        let waitTimeout = transcriptWaitTimeout
+        autoSuggestingIDs.insert(id)
+        let task = Task { @MainActor [weak self] in
+            defer {
+                self?.autoSuggestingIDs.remove(id)
+                // Only relinquish the tracked-task slot if we finished on our
+                // own. If we were cancelled it's because a replacement task
+                // (manual Suggest) or `cancelAndDiscard` took over the slot —
+                // clearing it here would orphan their handle.
+                if !Task.isCancelled { self?.clearLLM(for: id) }
+            }
+            guard let self else { return }
+            guard let transcript = await self.awaitTranscript(for: id,
+                                                              timeout: waitTimeout) else {
+                return  // discarded, timed out, or empty transcript
+            }
+            if Task.isCancelled { return }
+            do {
+                let suggestion = try await LLMRunner.run(
+                    tool: tool,
+                    prompt: prompt,
+                    transcript: transcript,
+                    executablePathOverride: executableOverride,
+                    timeout: cliTimeout
+                )
+                if Task.isCancelled { return }
+                let title = Self.cleanedTitle(from: suggestion)
+                guard !title.isEmpty else { return }
+                self.applyAutoSuggestedTitle(title, to: id, baseline: baselineTitle)
+            } catch {
+                // Best-effort, background work — swallow. (Cancellation fires
+                // here too when the user Discards or manually re-Suggests.)
+            }
+        }
+        trackLLM(task, for: id)
+    }
+
+    /// Apply a background suggestion to the stored recording, but never
+    /// clobber a title the user chose themselves — if the recording's title
+    /// has diverged from the baseline default, the user (or a manual Suggest)
+    /// already named it and wins.
+    private func applyAutoSuggestedTitle(_ title: String, to id: UUID, baseline: String) {
+        guard var recording = store.recordings.first(where: { $0.id == id }),
+              recording.title == baseline,
+              recording.title != title else { return }
+        recording.title = title
+        store.update(recording)
+    }
+
+    /// Extract a bare title from raw CLI output: trim surrounding quotes /
+    /// punctuation and keep only the first non-empty line (some CLIs add
+    /// commentary even when asked for just a title).
+    static func cleanedTitle(from raw: String) -> String {
+        let cleaned = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`."))
+        let firstLine = cleaned.split(whereSeparator: \.isNewline)
+            .first.map(String.init) ?? cleaned
+        return firstLine.trimmingCharacters(in: CharacterSet(charactersIn: "\"'`. "))
     }
 
     /// Persist a user-supplied title and dismiss. `nil` / blank title means
@@ -239,6 +336,7 @@ final class PostRecordingCoordinator: ObservableObject {
     ///  4. dismiss the sheet
     func cancelAndDiscard() {
         guard let recording = pending else { pending = nil; return }
+        autoSuggestingIDs.remove(recording.id)
         if let task = llmTasks.removeValue(forKey: recording.id) {
             task.cancel()
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -280,7 +280,7 @@ struct MilaApp: App {
         let inputMonitor = InputLevelMonitor()
         inputMonitor.preferredUID = audioSettings.preferredUID
         let llm = LLMSettings()
-        let coordinator = PostRecordingCoordinator(store: store, transcription: svc)
+        let coordinator = PostRecordingCoordinator(store: store, transcription: svc, llm: llm)
         let actions = QuickActionsController(session: session,
                                              store: store,
                                              transcription: svc,

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -18,9 +18,12 @@ struct RenameRecordingSheet: View {
     @State private var title: String
     @State private var isFetchingName = false
     @State private var llmError: String?
-    /// One-shot guard so the auto-suggest doesn't re-fire every time the
-    /// store publishes (transcript edits, status flips, etc.).
-    @State private var didAutoSuggest = false
+    /// Set once the user types in the title field (or accepts a manual
+    /// Suggest). While false, the field mirrors the recording's stored title
+    /// so a background auto-suggestion that lands after the sheet opened shows
+    /// up here; once the user has expressed a preference we stop mirroring so
+    /// their choice is never clobbered.
+    @State private var userEditedTitle = false
     /// Confirmation gate before the destructive Discard button actually
     /// throws the recording away. Closing the sheet (ESC, X, app quit)
     /// always saves — discarding requires an explicit click + confirm,
@@ -109,22 +112,24 @@ struct RenameRecordingSheet: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Name").font(.callout.weight(.semibold))
                     HStack {
-                        TextField("Recording title", text: $title)
+                        TextField("Recording title", text: titleBinding)
                             .textFieldStyle(.roundedBorder)
                             .onSubmit { save() }
                         if llm.isConfigured && llm.nameGenerationEnabled {
                             Button {
-                                startFetchName(auto: false)
+                                startFetchName()
                             } label: {
-                                if isFetchingName {
+                                if isFetchingName || autoSuggesting {
                                     ProgressView().controlSize(.small)
                                 } else {
                                     Label("Suggest", systemImage: "sparkles")
                                 }
                             }
-                            .disabled(isFetchingName || !transcriptReady)
+                            .disabled(isFetchingName || autoSuggesting || !transcriptReady)
                             .help(transcriptReady
-                                  ? "Ask \(llm.tool.displayName) for a title"
+                                  ? (autoSuggesting
+                                     ? "Suggesting a title…"
+                                     : "Ask \(llm.tool.displayName) for a title")
                                   : "Available once the transcript is ready")
                         }
                     }
@@ -209,8 +214,14 @@ struct RenameRecordingSheet: View {
         // bind ESC to Discard — the whole point of this change is that
         // dismissing the sheet must never throw audio away.
         .onExitCommand { save() }
-        .onAppear { triggerAutoSuggestIfReady() }
-        .onChange(of: liveRecording.status) { _, _ in triggerAutoSuggestIfReady() }
+        // Mirror a background auto-suggestion into the field as it lands —
+        // but only until the user expresses their own preference. The
+        // coordinator owns the suggestion now (Issue #34): it keeps running
+        // even after the user Saves, writing the title straight to the stored
+        // recording, so the user is never blocked waiting for the LLM.
+        .onChange(of: liveRecording.title) { _, newTitle in
+            if !userEditedTitle { title = newTitle }
+        }
         .confirmationDialog("Discard this recording?",
                             isPresented: $confirmingDiscard,
                             titleVisibility: .visible) {
@@ -223,29 +234,40 @@ struct RenameRecordingSheet: View {
         }
     }
 
-    /// Auto-fire the LLM Suggest call as soon as the transcript is ready,
-    /// gated solely by the Settings toggle. The user does not get a
-    /// per-recording opt-out in the sheet — keeping that preference in one
-    /// place avoids "did I check the box?" confusion.
-    private func triggerAutoSuggestIfReady() {
-        guard llm.isConfigured,
-              llm.nameGenerationEnabled,
-              transcriptReady,
-              !didAutoSuggest,
-              !isFetchingName else { return }
-        startFetchName(auto: true)
+    /// Title field binding that records when the *user* edits the field, so
+    /// the background auto-suggestion (which writes through the store and is
+    /// mirrored via `onChange(of: liveRecording.title)`) never overwrites a
+    /// title the user is typing. Programmatic updates assign `title` directly
+    /// and bypass this setter, so they don't trip the flag.
+    private var titleBinding: Binding<String> {
+        Binding(
+            get: { title },
+            set: { newValue in
+                title = newValue
+                userEditedTitle = true
+            }
+        )
     }
 
-    /// Wrap `fetchNameFromLLM` in a Task tracked by the coordinator so the
-    /// rename-sheet's Cancel button can kill it (the auto-suggest path is
-    /// where users were most surprised that "things keep running" after
-    /// Cancel). Auto-clears its own handle on completion so we don't keep
-    /// dead Task references around.
-    private func startFetchName(auto: Bool) {
+    /// Whether the coordinator's background auto-suggest job is currently
+    /// running for this recording — drives the inline spinner.
+    private var autoSuggesting: Bool {
+        coordinator.autoSuggestingIDs.contains(liveRecording.id)
+    }
+
+    /// Wrap the manual-Suggest `fetchNameFromLLM` in a Task tracked by the
+    /// coordinator so the rename-sheet's Cancel button can kill it. Replaces
+    /// (cancels) any in-flight background auto-suggest for this recording so
+    /// the two don't run two CLIs at once. Auto-clears its own handle on
+    /// completion so we don't keep dead Task references around.
+    private func startFetchName() {
         let recordingID = liveRecording.id
         let task = Task { @MainActor in
-            await fetchNameFromLLM(auto: auto)
-            coordinator.clearLLM(for: recordingID)
+            await fetchNameFromLLM()
+            // Skip the slot cleanup if a newer task replaced (cancelled) us —
+            // otherwise we'd orphan its handle. (Matches the background
+            // auto-suggest path in PostRecordingCoordinator.)
+            if !Task.isCancelled { coordinator.clearLLM(for: recordingID) }
         }
         coordinator.trackLLM(task, for: recordingID)
     }
@@ -445,10 +467,12 @@ struct RenameRecordingSheet: View {
                               cliTimeout: llm.cliTimeout)
     }
 
-    private func fetchNameFromLLM(auto: Bool = false) async {
+    /// Foreground, user-initiated "Suggest" — fills the field so the user can
+    /// review/edit before saving. The hands-off background path lives in
+    /// `PostRecordingCoordinator`; this one stays for the explicit button.
+    private func fetchNameFromLLM() async {
         llmError = nil
         isFetchingName = true
-        if auto { didAutoSuggest = true }
         defer { isFetchingName = false }
         do {
             let suggestion = try await LLMRunner.run(
@@ -458,18 +482,14 @@ struct RenameRecordingSheet: View {
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
                 timeout: llm.cliTimeout
             )
-            let cleaned = suggestion
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`."))
+            let cleaned = PostRecordingCoordinator.cleanedTitle(from: suggestion)
             if cleaned.isEmpty {
                 throw LLMRunnerError.emptyOutput
             }
-            // Take the first line — some CLIs preface or append commentary
-            // even when asked for a bare title. The first non-empty line is
-            // almost always the intended answer.
-            let firstLine = cleaned.split(whereSeparator: \.isNewline)
-                .first.map(String.init) ?? cleaned
-            title = firstLine.trimmingCharacters(in: CharacterSet(charactersIn: "\"'`. "))
+            title = cleaned
+            // The user asked for this title — treat it as their choice so a
+            // later background write to the store doesn't overwrite it.
+            userEditedTitle = true
         } catch LLMRunnerError.cancelled {
             // User clicked Cancel — the sheet is about to be torn down. No
             // banner, no error state.

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -214,6 +214,13 @@ struct RenameRecordingSheet: View {
         // bind ESC to Discard — the whole point of this change is that
         // dismissing the sheet must never throw audio away.
         .onExitCommand { save() }
+        // Catch any suggestion that landed in the store between this view's
+        // init (which snapshotted `initialRecording.title`) and `onChange`
+        // being installed — otherwise a Save could write the stale default
+        // back over the stored suggestion.
+        .onAppear {
+            if !userEditedTitle { title = liveRecording.title }
+        }
         // Mirror a background auto-suggestion into the field as it lands —
         // but only until the user expresses their own preference. The
         // coordinator owns the suggestion now (Issue #34): it keeps running

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -35,7 +35,8 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
             diarizationSettings: DiarizationSettings(defaults: .init(suiteName: diarSuite)!),
             engine: stub
         )
-        coordinator = PostRecordingCoordinator(store: store, transcription: service)
+        coordinator = PostRecordingCoordinator(store: store, transcription: service,
+                                               llm: LLMSettings(defaults: UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.llm")!))
     }
 
     override func tearDown() async throws {

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -47,7 +47,8 @@ final class QuickActionsControllerTests: XCTestCase {
                                             languageSettings: languageSettings,
                                             postRecording: PostRecordingCoordinator(
                                                 store: store,
-                                                transcription: service))
+                                                transcription: service,
+                                                llm: LLMSettings(defaults: UserDefaults(suiteName: "QuickActionsControllerTests.llm")!)))
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
Fixes #34.

## Problem
The auto "Suggest a name" flow ran *inside* the rename sheet and wrote the result into the sheet's local `@State`. The LLM CLI can take a long time, so the user either had to wait on it before saving, or hit Save and lose the suggestion entirely (it landed in discarded `@State`). That's the "auto meeting suggestion blocks the conversation save" report.

## Fix
Move title suggestion into a background job so saving is never blocked, and the suggested title still lands on the saved recording. It reuses the existing `awaitTranscript` poller that the background "Send to <LLM>" feature already uses.

**`PostRecordingCoordinator`** now owns auto-suggest:
- `present()` arms the job; it waits for the recording's transcript to settle, runs the LLM, and writes the suggested title **straight to the stored recording** — fully decoupled from the sheet. The user can Save and move on; the title arrives whenever the CLI returns.
- Applied only if the recording still carries its baseline default title, so a manual rename / typed title is never clobbered.
- Tracked in `llmTasks` (Discard cancels it) and surfaced via `autoSuggestingIDs` so the sheet can show a "suggesting…" spinner.

**`RenameRecordingSheet`**:
- Dropped the in-sheet auto trigger; the field mirrors the stored title until the user edits it (a custom binding tracks user edits — a background suggestion that lands while the sheet is open still shows up, but never overwrites typing).
- Kept the manual "Suggest" button as an explicit foreground action.
- Hardened task-slot cleanup so a cancelled/replaced task can't orphan the replacement's handle.

**`MilaApp` / tests**: inject `LLMSettings` into the coordinator (tests use isolated `UserDefaults` suites per CLAUDE.md convention).

## Verification
- `make build` succeeds.
- `xcodebuild test` passes for `PostRecordingCoordinatorSendTests` and `QuickActionsControllerTests` (the directly-affected classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background auto-suggest title generation for recordings once transcription is available.
  * Updated the rename sheet to support smoother, persistent suggestions alongside manual editing, including improved loading/spinner states.
* **Bug Fixes**
  * Prevented background title suggestions from overwriting user-renamed titles.
  * Improved cancellation/discard handling to stop in-progress title suggestions.
* **Tests**
  * Updated coordinator setup in tests to use explicit LLM settings for better isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->