### PR TITLE
Voice Memos folder integration: sync & transcribe iPhone recordings (#25)

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -231,6 +231,8 @@ struct MilaApp: App {
     /// SwiftUI redraws and so its in-flight task table survives
     /// alongside everything else.
     @StateObject private var recordingSummarizer: RecordingSummarizer
+    @StateObject private var voiceMemosSettings: VoiceMemosSettings
+    @StateObject private var voiceMemosImporter: VoiceMemosImporter
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -436,6 +438,17 @@ struct MilaApp: App {
         _liveSpeakerDiarizer = StateObject(wrappedValue: liveDiar)
         _liveAISession = StateObject(wrappedValue: liveSession)
         _recordingSummarizer = StateObject(wrappedValue: summarizer)
+        // Voice Memos (iPhone) folder integration. Settings are opt-in and
+        // default-off; the importer wires up its FSEvents watcher + initial
+        // backfill from its `start()` launch task (below), so constructing
+        // it here is cheap (no DB / filesystem work in init).
+        let vmSettings = VoiceMemosSettings()
+        let vmImporter = VoiceMemosImporter(store: store,
+                                            transcription: svc,
+                                            settings: vmSettings,
+                                            languageSettings: langSettings)
+        _voiceMemosSettings = StateObject(wrappedValue: vmSettings)
+        _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,
@@ -481,8 +494,11 @@ struct MilaApp: App {
                 .task { await injectFixtureWavIfRequested() }
                 .task { await runFinalizeRegressionIfRequested() }
                 .task { recordingSummarizer.backfillIfNeeded() }
+                .task { voiceMemosImporter.start() }
                 .environmentObject(recordingSummarizer)
                 .environmentObject(meetingDetectionSettings)
+                .environmentObject(voiceMemosSettings)
+                .environmentObject(voiceMemosImporter)
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -533,6 +549,8 @@ struct MilaApp: App {
                 .environmentObject(diarizationSettings)
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(liveAISettings)
+                .environmentObject(voiceMemosSettings)
+                .environmentObject(voiceMemosImporter)
         }
     }
 

--- a/Mila/Audio/FileTranscriber.swift
+++ b/Mila/Audio/FileTranscriber.swift
@@ -19,7 +19,14 @@ enum FileTranscriber {
         defer { if didStart { sourceURL.stopAccessingSecurityScopedResource() } }
 
         let title = titleOverride ?? sourceURL.deletingPathExtension().lastPathComponent
-        let destURL = store.freshAudioURL(suggestedName: title)
+        // `freshAudioURL` appends the suggested name as a path component, so a
+        // title containing "/" (or ":", which Finder maps to "/") would create
+        // nested/invalid paths. Sanitize the stem used for the audio file;
+        // the recording keeps the original `title` for display.
+        let safeStem = title
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+        let destURL = store.freshAudioURL(suggestedName: safeStem)
 
         let duration = try await reencode(source: sourceURL, destination: destURL)
 

--- a/Mila/Audio/FileTranscriber.swift
+++ b/Mila/Audio/FileTranscriber.swift
@@ -10,21 +10,27 @@ enum FileTranscriber {
 
     static func importFile(at sourceURL: URL,
                            into store: RecordingStore,
-                           language: RecordingLanguage = .hebrew) async throws -> Recording {
+                           language: RecordingLanguage = .hebrew,
+                           source: RecordingSource = .systemAudio,
+                           title titleOverride: String? = nil,
+                           createdAt: Date? = nil,
+                           voiceMemoUniqueID: String? = nil) async throws -> Recording {
         let didStart = sourceURL.startAccessingSecurityScopedResource()
         defer { if didStart { sourceURL.stopAccessingSecurityScopedResource() } }
 
-        let title = sourceURL.deletingPathExtension().lastPathComponent
+        let title = titleOverride ?? sourceURL.deletingPathExtension().lastPathComponent
         let destURL = store.freshAudioURL(suggestedName: title)
 
         let duration = try await reencode(source: sourceURL, destination: destURL)
 
         let recording = Recording(
             title: title,
+            createdAt: createdAt ?? Date(),
             duration: duration,
-            source: .systemAudio, // imported file: counts as "from app/system"
+            source: source,
             audioFileName: destURL.lastPathComponent,
-            language: language.rawValue
+            language: language.rawValue,
+            voiceMemoUniqueID: voiceMemoUniqueID
         )
         store.add(recording)
         return recording

--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -5,6 +5,11 @@ enum RecordingSource: String, Codable, CaseIterable, Identifiable {
     case microphone
     case systemAudio
     case meeting
+    /// Imported from the iPhone's Voice Memos app via the iCloud-synced
+    /// folder on this Mac. Distinct from Mila's own mic capture (which is
+    /// `.microphone`) so the origin is visible in the UI and so the sync
+    /// importer can dedup these against `Recording.voiceMemoUniqueID`.
+    case voiceMemo
 
     var id: String { rawValue }
 
@@ -13,6 +18,7 @@ enum RecordingSource: String, Codable, CaseIterable, Identifiable {
         case .microphone: return "Microphone"
         case .systemAudio: return "System audio"
         case .meeting: return "Meeting (mic + system)"
+        case .voiceMemo: return "Voice Memo"
         }
     }
 
@@ -21,6 +27,7 @@ enum RecordingSource: String, Codable, CaseIterable, Identifiable {
         case .microphone: return "mic.fill"
         case .systemAudio: return "speaker.wave.3.fill"
         case .meeting: return "person.2.wave.2.fill"
+        case .voiceMemo: return "waveform"
         }
     }
 }
@@ -67,6 +74,13 @@ struct Recording: Identifiable, Codable, Hashable {
     /// nothing (rare — usually means the LLM CLI returned an error).
     var actionItems: [ActionItem]?
 
+    /// Stable per-recording identifier from the iPhone Voice Memos library
+    /// (`ZCLOUDRECORDING.ZUNIQUEID`) when `source == .voiceMemo`. The sync
+    /// importer keys on this to skip recordings it already imported, so a
+    /// rescan or app restart never re-imports the same memo. nil for every
+    /// non-Voice-Memo recording.
+    var voiceMemoUniqueID: String?
+
     init(id: UUID = UUID(),
          title: String,
          createdAt: Date = Date(),
@@ -82,7 +96,8 @@ struct Recording: Identifiable, Codable, Hashable {
          folder: String? = nil,
          appName: String? = nil,
          summary: String? = nil,
-         actionItems: [ActionItem]? = nil) {
+         actionItems: [ActionItem]? = nil,
+         voiceMemoUniqueID: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -99,6 +114,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.appName = appName
         self.summary = summary
         self.actionItems = actionItems
+        self.voiceMemoUniqueID = voiceMemoUniqueID
     }
 
     var isTrashed: Bool { deletedAt != nil }
@@ -133,7 +149,7 @@ struct Recording: Identifiable, Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,
-             summary, actionItems
+             summary, actionItems, voiceMemoUniqueID
         // `fullText` deliberately excluded — lives in a sidecar .txt file.
         // Legacy records that had it inline are decoded via the custom init.
         case fullText
@@ -156,6 +172,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.appName = try c.decodeIfPresent(String.self, forKey: .appName)
         self.summary = try c.decodeIfPresent(String.self, forKey: .summary)
         self.actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
+        self.voiceMemoUniqueID = try c.decodeIfPresent(String.self, forKey: .voiceMemoUniqueID)
         // Legacy records still have fullText inline; new records leave it
         // empty here and RecordingStore loads it from the sidecar .txt.
         self.fullText = try c.decodeIfPresent(String.self, forKey: .fullText) ?? ""
@@ -178,6 +195,7 @@ struct Recording: Identifiable, Codable, Hashable {
         try c.encodeIfPresent(appName, forKey: .appName)
         try c.encodeIfPresent(summary, forKey: .summary)
         try c.encodeIfPresent(actionItems, forKey: .actionItems)
+        try c.encodeIfPresent(voiceMemoUniqueID, forKey: .voiceMemoUniqueID)
         // fullText intentionally omitted — sidecar .txt is the source of truth.
     }
 

--- a/Mila/Models/VoiceMemosSettings.swift
+++ b/Mila/Models/VoiceMemosSettings.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Combine
+
+/// User settings for iPhone Voice Memos folder integration. Persists which
+/// Voice Memos folders Mila watches + auto-transcribes. Follows the same
+/// shape as `DiarizationSettings`: `@Published` properties that write through
+/// to namespaced `UserDefaults` keys, with an injectable `defaults` suite so
+/// tests stay isolated from the user's real preferences.
+///
+/// Folders are keyed by their stable `ZFOLDER.ZUUID` (not their display name,
+/// which the user can rename). The unfiled bucket — recordings with no folder,
+/// usually the bulk of a library — is tracked by a separate flag.
+@MainActor
+final class VoiceMemosSettings: ObservableObject {
+
+    /// Master switch. Off by default: Voice Memos sync reads another app's
+    /// data and kicks off bulk transcription, so it's strictly opt-in.
+    @Published var isEnabled: Bool {
+        didSet { defaults.set(isEnabled, forKey: Keys.enabled) }
+    }
+
+    /// `ZUUID`s of the Voice Memos folders the user chose to watch.
+    @Published var selectedFolderUUIDs: Set<String> {
+        didSet {
+            defaults.set(Array(selectedFolderUUIDs).sorted(), forKey: Keys.folderUUIDs)
+        }
+    }
+
+    /// Whether to also watch the unfiled bucket (`ZFOLDER IS NULL`).
+    @Published var includeUnfiled: Bool {
+        didSet { defaults.set(includeUnfiled, forKey: Keys.includeUnfiled) }
+    }
+
+    private let defaults: UserDefaults
+
+    private enum Keys {
+        static let enabled = "voiceMemos.enabled"
+        static let folderUUIDs = "voiceMemos.folderUUIDs"
+        static let includeUnfiled = "voiceMemos.includeUnfiled"
+    }
+
+    /// Skip accidental sub-`minDurationSeconds` taps during bulk import. Voice
+    /// Memos libraries are full of 1–2s pocket recordings; transcribing them
+    /// is pure noise. Not user-configurable — a sensible fixed floor.
+    static let minDurationSeconds: Double = 3.0
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.isEnabled = defaults.bool(forKey: Keys.enabled)
+        let stored = defaults.stringArray(forKey: Keys.folderUUIDs) ?? []
+        self.selectedFolderUUIDs = Set(stored)
+        self.includeUnfiled = defaults.bool(forKey: Keys.includeUnfiled)
+    }
+
+    /// True when the user has actually picked something to watch — gates the
+    /// importer so enabling the feature without choosing a folder is a no-op
+    /// rather than silently importing nothing (or everything).
+    var hasSelection: Bool {
+        !selectedFolderUUIDs.isEmpty || includeUnfiled
+    }
+
+    /// Convenience toggle used by the folder multiselect in Settings.
+    func setFolder(_ uuid: String, selected: Bool) {
+        if selected {
+            selectedFolderUUIDs.insert(uuid)
+        } else {
+            selectedFolderUUIDs.remove(uuid)
+        }
+    }
+}

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import AppKit
 import Carbon.HIToolbox
 
 enum SettingsTab: Int, Hashable {
-    case hotkeys, audio, models, llm, speakers, meetings, liveAI, storage
+    case hotkeys, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage
 }
 
 @Observable
@@ -39,6 +39,9 @@ struct SettingsView: View {
             LiveAISettingsTab()
                 .tabItem { Label("Live AI", systemImage: "sparkles.tv") }
                 .tag(SettingsTab.liveAI)
+            VoiceMemosSettingsTab()
+                .tabItem { Label("Voice Memos", systemImage: "waveform") }
+                .tag(SettingsTab.voiceMemos)
             StorageSettingsTab()
                 .tabItem { Label("Storage", systemImage: "externaldrive") }
                 .tag(SettingsTab.storage)

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -19,16 +19,17 @@ struct VoiceMemosSettingsTab: View {
         VStack(alignment: .leading, spacing: 14) {
             header
 
+            // Always render the master toggle — otherwise a user who enabled
+            // sync and then lost the library (iCloud off, etc.) would have no
+            // control left to turn the integration back off.
+            Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
+                .toggleStyle(.switch)
+
             if !library.isAvailable {
                 unavailableNotice
-            } else {
-                Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
-                    .toggleStyle(.switch)
-
-                if settings.isEnabled {
-                    folderPicker
-                    statusFooter
-                }
+            } else if settings.isEnabled {
+                folderPicker
+                statusFooter
             }
             Spacer()
         }
@@ -162,6 +163,10 @@ struct VoiceMemosSettingsTab: View {
             folders = loaded.folders
             unfiledCount = loaded.unfiled
         } catch {
+            // Drop stale data so a failed refresh can't leave the user
+            // interacting with folder choices that no longer reflect the DB.
+            folders = []
+            unfiledCount = 0
             loadError = error.localizedDescription
         }
     }

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// Settings → Voice Memos. Lets the user sync recordings made on their iPhone
+/// (synced to this Mac via iCloud) into Mila, picking which Voice Memos
+/// folders to watch. New recordings in those folders are imported and
+/// transcribed automatically; see `VoiceMemosImporter`.
+struct VoiceMemosSettingsTab: View {
+    @EnvironmentObject private var settings: VoiceMemosSettings
+    @EnvironmentObject private var importer: VoiceMemosImporter
+
+    @State private var folders: [VoiceMemosLibrary.Folder] = []
+    @State private var unfiledCount = 0
+    @State private var loadError: String?
+    @State private var isLoading = false
+
+    private let library = VoiceMemosLibrary()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+
+            if !library.isAvailable {
+                unavailableNotice
+            } else {
+                Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
+                    .toggleStyle(.switch)
+
+                if settings.isEnabled {
+                    folderPicker
+                    statusFooter
+                }
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task(id: settings.isEnabled) {
+            if settings.isEnabled { await loadFolders() }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Voice Memos")
+                .font(.title2).bold()
+            Text("Automatically transcribe recordings you make on your iPhone. "
+                 + "Mila watches the Voice Memos folders you choose and imports new recordings as they sync over iCloud.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var unavailableNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "iphone.slash")
+                .foregroundStyle(.secondary)
+            Text("No Voice Memos library was found on this Mac. Make sure Voice Memos iCloud sync "
+                 + "is turned on for both your iPhone and this Mac, then reopen this tab.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    private var folderPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Folders to watch")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    Task { await loadFolders() }
+                    importer.rescan()
+                } label: {
+                    Label("Rescan", systemImage: "arrow.clockwise")
+                }
+                .disabled(isLoading || importer.isSyncing)
+            }
+
+            if let loadError {
+                Text(loadError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            List {
+                Toggle(isOn: $settings.includeUnfiled) {
+                    folderRow(name: "Unfiled", count: unfiledCount, systemImage: "tray")
+                }
+                ForEach(folders) { folder in
+                    Toggle(isOn: binding(for: folder)) {
+                        folderRow(name: folder.name, count: folder.count, systemImage: "folder")
+                    }
+                }
+            }
+            .frame(height: 220)
+            .overlay {
+                if folders.isEmpty && unfiledCount == 0 && !isLoading && loadError == nil {
+                    Text("No recordings found.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if !settings.hasSelection {
+                Text("Choose at least one folder to start syncing.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func folderRow(name: String, count: Int, systemImage: String) -> some View {
+        HStack {
+            Image(systemName: systemImage)
+                .foregroundStyle(.secondary)
+            Text(name)
+            Spacer()
+            Text("\(count)")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusFooter: some View {
+        HStack(spacing: 6) {
+            if importer.isSyncing {
+                ProgressView().controlSize(.small)
+                Text("Syncing…").foregroundStyle(.secondary)
+            } else if let error = importer.lastError {
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                Text(error).foregroundStyle(.secondary)
+            } else if let date = importer.lastSyncDate {
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                Text("Last synced \(date.formatted(date: .abbreviated, time: .shortened)) — "
+                     + "\(importer.totalImported) imported this session")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func binding(for folder: VoiceMemosLibrary.Folder) -> Binding<Bool> {
+        Binding(
+            get: { settings.selectedFolderUUIDs.contains(folder.uuid) },
+            set: { settings.setFolder(folder.uuid, selected: $0) }
+        )
+    }
+
+    private func loadFolders() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        let lib = library
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) {
+                (folders: try lib.folders(), unfiled: try lib.unfiledCount())
+            }.value
+            folders = loaded.folders
+            unfiledCount = loaded.unfiled
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+}

--- a/Mila/VoiceMemos/DirectoryWatcher.swift
+++ b/Mila/VoiceMemos/DirectoryWatcher.swift
@@ -1,0 +1,72 @@
+import Foundation
+import CoreServices
+
+/// Thin FSEvents wrapper that fires `onChange` whenever anything under a
+/// directory tree changes. Used to notice when `voicememod` drops a freshly
+/// iCloud-synced recording into the Voice Memos folder so Mila can pick it
+/// up without the user lifting a finger.
+///
+/// FSEvents (rather than a `DispatchSource` vnode source) because vnode
+/// sources watch a single file descriptor and miss new files created deeper
+/// in the tree — exactly the event we care about. The callback is coalesced
+/// (`latency`) so a burst of sync writes triggers one `onChange`.
+final class DirectoryWatcher {
+    private var stream: FSEventStreamRef?
+    private let path: String
+    private let latency: CFTimeInterval
+    private let queue = DispatchQueue(label: "io.island.mila.voicememos.fsevents")
+    private let onChange: () -> Void
+
+    init(path: String, latency: CFTimeInterval = 1.0, onChange: @escaping () -> Void) {
+        self.path = path
+        self.latency = latency
+        self.onChange = onChange
+    }
+
+    func start() {
+        guard stream == nil else { return }
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let callback: FSEventStreamCallback = { _, info, _, _, _, _ in
+            guard let info else { return }
+            let watcher = Unmanaged<DirectoryWatcher>.fromOpaque(info).takeUnretainedValue()
+            watcher.onChange()
+        }
+
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer
+        )
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            callback,
+            &context,
+            [path] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            latency,
+            flags
+        ) else {
+            return
+        }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    func stop() {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)  // blocks until in-flight callbacks drain
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+
+    deinit { stop() }
+}

--- a/Mila/VoiceMemos/DirectoryWatcher.swift
+++ b/Mila/VoiceMemos/DirectoryWatcher.swift
@@ -55,9 +55,17 @@ final class DirectoryWatcher {
             return
         }
 
-        self.stream = stream
         FSEventStreamSetDispatchQueue(stream, queue)
-        FSEventStreamStart(stream)
+        // FSEventStreamStart "ought to always succeed" but can fail under
+        // resource pressure. On failure, tear the stream down and leave
+        // `self.stream` nil so a later `start()` can retry instead of looking
+        // active while no events ever arrive.
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            return
+        }
+        self.stream = stream
     }
 
     func stop() {

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -61,16 +61,14 @@ final class VoiceMemosImporter: ObservableObject {
         guard !started else { return }
         started = true
         // React to the user toggling sync on/off or changing folder choices.
-        // Debounced so dragging through several checkboxes triggers one sync.
-        Publishers.Merge3(
-            settings.$isEnabled.map { _ in () },
-            settings.$selectedFolderUUIDs.map { _ in () },
-            settings.$includeUnfiled.map { _ in () }
-        )
-        .dropFirst()  // skip the initial value emitted on subscribe
-        .debounce(for: .milliseconds(400), scheduler: RunLoop.main)
-        .sink { [weak self] in self?.reconfigure() }
-        .store(in: &cancellables)
+        // `objectWillChange` (rather than merging the `@Published` projections)
+        // fires only on an actual change — no initial-value emissions to skip —
+        // and the debounce coalesces dragging through several checkboxes into
+        // one sync.
+        settings.objectWillChange
+            .debounce(for: .milliseconds(400), scheduler: RunLoop.main)
+            .sink { [weak self] in self?.reconfigure() }
+            .store(in: &cancellables)
 
         reconfigure()
     }
@@ -117,7 +115,17 @@ final class VoiceMemosImporter: ObservableObject {
         guard settings.isEnabled, settings.hasSelection else { return }
         isSyncing = true
         lastError = nil
-        defer { isSyncing = false }
+        defer {
+            isSyncing = false
+            // A folder change / FSEvents burst that arrived mid-sync set
+            // `pendingResync`; kick the next pass now that `isSyncing` is
+            // clear (doing this before clearing it would just re-set the flag
+            // and the second pass would never run).
+            if pendingResync {
+                pendingResync = false
+                requestSync()
+            }
+        }
 
         let folderUUIDs = settings.selectedFolderUUIDs
         let includeUnfiled = settings.includeUnfiled
@@ -173,11 +181,5 @@ final class VoiceMemosImporter: ObservableObject {
         totalImported += imported
         lastSyncDate = Date()
         log.log("VoiceMemos sync: imported \(imported), skipped short=\(skippedShort) format=\(skippedFormat) composition=\(skippedComposition) missing=\(skippedMissing)")
-
-        // A folder change / FSEvents burst arrived mid-sync — run once more.
-        if pendingResync {
-            pendingResync = false
-            requestSync()
-        }
     }
 }

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Combine
+import OSLog
+
+/// Bridges the iPhone Voice Memos library into Mila's transcription queue.
+///
+/// Responsibilities:
+///  - **Backfill:** when the user enables sync or picks a new folder, import
+///    every not-yet-seen recording from the selected folders and enqueue it.
+///  - **Ongoing sync:** an FSEvents watcher on the Voice Memos folder notices
+///    newly iCloud-synced recordings and imports the eligible ones.
+///  - **Dedup:** every imported recording carries its `ZUNIQUEID` in
+///    `Recording.voiceMemoUniqueID`; a rescan skips anything already present,
+///    so restarts / repeated FSEvents bursts never re-import a memo.
+///  - **Filtering:** short pocket recordings, `.qta` (unsupported format) and
+///    `.composition` (multi-take) bundles are skipped, with counts surfaced.
+///
+/// Imports reuse `FileTranscriber.importFile`, which re-encodes into the
+/// library and enqueues exactly like a drag-and-drop import — no new
+/// transcription infrastructure.
+@MainActor
+final class VoiceMemosImporter: ObservableObject {
+    private let store: RecordingStore
+    private let transcription: TranscriptionService
+    private let settings: VoiceMemosSettings
+    private let languageSettings: RecordingLanguageSettings
+    private let library: VoiceMemosLibrary
+
+    private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceMemos")
+
+    /// Last successful sync timestamp, for the Settings status line.
+    @Published private(set) var lastSyncDate: Date?
+    /// Recordings enqueued by the most recent sync.
+    @Published private(set) var lastImportedCount = 0
+    /// Cumulative recordings imported this session.
+    @Published private(set) var totalImported = 0
+    @Published private(set) var isSyncing = false
+    @Published private(set) var lastError: String?
+
+    private var watcher: DirectoryWatcher?
+    private var cancellables: Set<AnyCancellable> = []
+    private var started = false
+    /// Coalesces FSEvents bursts and overlapping triggers into one run.
+    private var pendingResync = false
+
+    init(store: RecordingStore,
+         transcription: TranscriptionService,
+         settings: VoiceMemosSettings,
+         languageSettings: RecordingLanguageSettings,
+         library: VoiceMemosLibrary = VoiceMemosLibrary()) {
+        self.store = store
+        self.transcription = transcription
+        self.settings = settings
+        self.languageSettings = languageSettings
+        self.library = library
+    }
+
+    /// Wire up settings observation + the watcher, and run an initial sync.
+    /// Called once from MilaApp's launch `.task`.
+    func start() {
+        guard !started else { return }
+        started = true
+        // React to the user toggling sync on/off or changing folder choices.
+        // Debounced so dragging through several checkboxes triggers one sync.
+        Publishers.Merge3(
+            settings.$isEnabled.map { _ in () },
+            settings.$selectedFolderUUIDs.map { _ in () },
+            settings.$includeUnfiled.map { _ in () }
+        )
+        .dropFirst()  // skip the initial value emitted on subscribe
+        .debounce(for: .milliseconds(400), scheduler: RunLoop.main)
+        .sink { [weak self] in self?.reconfigure() }
+        .store(in: &cancellables)
+
+        reconfigure()
+    }
+
+    func stop() {
+        watcher?.stop()
+        watcher = nil
+    }
+
+    /// Apply the current settings: start/stop the watcher and trigger a sync.
+    private func reconfigure() {
+        guard settings.isEnabled, settings.hasSelection, library.isAvailable else {
+            stop()
+            return
+        }
+        startWatcherIfNeeded()
+        requestSync()
+    }
+
+    private func startWatcherIfNeeded() {
+        guard watcher == nil else { return }
+        let watcher = DirectoryWatcher(path: library.recordingsDirectory.path) { [weak self] in
+            // FSEvents fires on a background queue; hop to the main actor.
+            Task { @MainActor in self?.requestSync() }
+        }
+        watcher.start()
+        self.watcher = watcher
+        log.log("VoiceMemos watcher started on \(self.library.recordingsDirectory.path, privacy: .public)")
+    }
+
+    /// Public entry point for the "Rescan now" button in Settings.
+    func rescan() { requestSync() }
+
+    /// Run a sync, coalescing requests so two never overlap.
+    private func requestSync() {
+        guard !isSyncing else {
+            pendingResync = true
+            return
+        }
+        Task { await sync() }
+    }
+
+    private func sync() async {
+        guard settings.isEnabled, settings.hasSelection else { return }
+        isSyncing = true
+        lastError = nil
+        defer { isSyncing = false }
+
+        let folderUUIDs = settings.selectedFolderUUIDs
+        let includeUnfiled = settings.includeUnfiled
+
+        // Read the (private, WAL-mode) DB off the main actor.
+        let lib = library
+        let memos: [VoiceMemosLibrary.Memo]
+        do {
+            memos = try await Task.detached(priority: .utility) {
+                try lib.recordings(folderUUIDs: folderUUIDs, includeUnfiled: includeUnfiled)
+            }.value
+        } catch {
+            lastError = error.localizedDescription
+            log.error("VoiceMemos sync failed reading DB: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let alreadyImported = Set(store.recordings.compactMap { $0.voiceMemoUniqueID })
+        let fm = FileManager.default
+
+        var imported = 0
+        var skippedShort = 0, skippedFormat = 0, skippedComposition = 0, skippedMissing = 0
+
+        for memo in memos where !alreadyImported.contains(memo.uniqueID) {
+            if memo.isComposition { skippedComposition += 1; continue }
+            if memo.isUnsupportedFormat { skippedFormat += 1; continue }
+            if memo.duration < VoiceMemosSettings.minDurationSeconds { skippedShort += 1; continue }
+            guard fm.fileExists(atPath: memo.fileURL.path) else {
+                // Not downloaded from iCloud yet (or evicted); a later
+                // FSEvents fire will catch it once it lands.
+                skippedMissing += 1
+                continue
+            }
+
+            do {
+                let recording = try await FileTranscriber.importFile(
+                    at: memo.fileURL,
+                    into: store,
+                    language: languageSettings.current,
+                    source: .voiceMemo,
+                    title: memo.title,
+                    createdAt: memo.date,
+                    voiceMemoUniqueID: memo.uniqueID
+                )
+                transcription.enqueue(recording)
+                imported += 1
+            } catch {
+                log.error("VoiceMemos import failed for \(memo.fileURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        lastImportedCount = imported
+        totalImported += imported
+        lastSyncDate = Date()
+        log.log("VoiceMemos sync: imported \(imported), skipped short=\(skippedShort) format=\(skippedFormat) composition=\(skippedComposition) missing=\(skippedMissing)")
+
+        // A folder change / FSEvents burst arrived mid-sync — run once more.
+        if pendingResync {
+            pendingResync = false
+            requestSync()
+        }
+    }
+}

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -247,14 +247,14 @@ struct VoiceMemosLibrary {
 
     private func open() throws -> OpaquePointer {
         guard isAvailable else { throw LibraryError.databaseMissing }
-        // Read-only. The DB is WAL-mode and actively written by voicememod;
-        // a read-only connection reads through the WAL so freshly-synced
-        // rows are visible, and SQLite guarantees readers never block or
-        // corrupt a concurrent writer. We never issue a write.
-        let uri = "file:\(databaseURL.path)?mode=ro"
+        // Read-only, opened by literal path (NOT a `file:` URI — a "?" or "#"
+        // in the path would be parsed as URI query/fragment). The DB is
+        // WAL-mode and actively written by voicememod; a read-only connection
+        // reads through the WAL so freshly-synced rows are visible, and SQLite
+        // guarantees readers never block or corrupt a concurrent writer. We
+        // never issue a write.
         var db: OpaquePointer?
-        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_URI
-        guard sqlite3_open_v2(uri, &db, flags, nil) == SQLITE_OK, let db else {
+        guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
             let msg = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
             if let db { sqlite3_close(db) }
             throw LibraryError.openFailed(msg)
@@ -311,6 +311,10 @@ struct VoiceMemosLibrary {
     /// filename relative to the Recordings dir, but tolerate an absolute path
     /// just in case.
     private static func resolve(path: String, relativeTo base: URL) -> URL {
+        // `ZURL`-style columns may carry a full "file:///…" URL string.
+        if let url = URL(string: path), url.isFileURL {
+            return url
+        }
         if path.hasPrefix("/") {
             return URL(fileURLWithPath: path)
         }

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -1,0 +1,335 @@
+import Foundation
+import SQLite3
+
+/// Read-only reader over the iPhone Voice Memos library that iCloud syncs
+/// to this Mac. Everything lives in a Core Data SQLite store inside the
+/// Voice Memos group container:
+///
+///   ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/
+///       CloudRecordings.db        (+ -wal / -shm siblings while in use)
+///       20250509 121919-XXXX.m4a  (the audio files, named by ZPATH)
+///
+/// The schema is private and shifts between macOS releases, so every column
+/// this reader depends on is resolved at runtime via `PRAGMA table_info`
+/// rather than hard-coded — if Apple renames or drops one we degrade to an
+/// empty result instead of crashing. We open the DB **read-only** and never
+/// write to it; `voicememod` owns it and keeps it in WAL mode, so concurrent
+/// reads are safe while the daemon syncs new recordings in.
+///
+/// This type is a stateless value: each call opens, queries, and closes its
+/// own connection, so it's safe to use from any thread / `Task.detached`.
+struct VoiceMemosLibrary {
+
+    /// Directory holding `CloudRecordings.db` and the audio files. Audio
+    /// paths from the DB (`ZPATH`) are resolved relative to this.
+    let recordingsDirectory: URL
+
+    init(recordingsDirectory: URL = VoiceMemosLibrary.defaultRecordingsDirectory) {
+        self.recordingsDirectory = recordingsDirectory
+    }
+
+    /// The standard on-disk location of the synced Voice Memos library.
+    static var defaultRecordingsDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Group Containers")
+            .appendingPathComponent("group.com.apple.VoiceMemos.shared")
+            .appendingPathComponent("Recordings")
+    }
+
+    var databaseURL: URL {
+        recordingsDirectory.appendingPathComponent("CloudRecordings.db")
+    }
+
+    /// True when the Voice Memos DB is present — i.e. the user has the app
+    /// and at least one synced recording. Drives whether the Settings tab
+    /// offers the feature or shows a "no library found" hint.
+    var isAvailable: Bool {
+        FileManager.default.fileExists(atPath: databaseURL.path)
+    }
+
+    // MARK: - Public API
+
+    /// A folder in the Voice Memos library. `uuid` is the stable
+    /// `ZFOLDER.ZUUID` (survives renames) — use it as the persisted key.
+    /// `name` is for display only.
+    struct Folder: Identifiable, Hashable {
+        let uuid: String
+        let name: String
+        let count: Int
+        var id: String { uuid }
+    }
+
+    /// One recording row, normalised. `folderUUID == nil` means the memo is
+    /// unfiled (`ZFOLDER IS NULL`).
+    struct Memo: Identifiable, Hashable {
+        let uniqueID: String
+        let fileURL: URL
+        let folderUUID: String?
+        let title: String
+        let duration: Double
+        let date: Date
+        var id: String { uniqueID }
+
+        /// `.composition` directories are multi-take/edited recordings, not
+        /// flat audio files — out of scope for transcription.
+        var isComposition: Bool {
+            fileURL.pathExtension.lowercased() == "composition"
+        }
+
+        /// `.qta` is the newer (2025+) Voice Memos container that whisper /
+        /// AVAudioFile can't open directly — flagged so the importer can
+        /// skip it until a conversion step exists.
+        var isUnsupportedFormat: Bool {
+            fileURL.pathExtension.lowercased() == "qta"
+        }
+    }
+
+    enum LibraryError: LocalizedError, Equatable {
+        case databaseMissing
+        case openFailed(String)
+        case schemaUnsupported
+
+        var errorDescription: String? {
+            switch self {
+            case .databaseMissing:
+                return "No Voice Memos library was found on this Mac."
+            case .openFailed(let msg):
+                return "Could not open the Voice Memos database: \(msg)"
+            case .schemaUnsupported:
+                return "The Voice Memos database has an unexpected layout this version of Mila can't read."
+            }
+        }
+    }
+
+    /// All real folders (unfiled recordings are not a folder — see
+    /// `unfiledCount()`), each with its recording count.
+    func folders() throws -> [Folder] {
+        let db = try open()
+        defer { sqlite3_close(db) }
+
+        let folderCols = try columns(of: "ZFOLDER", db: db)
+        guard folderCols.contains("ZUUID"), folderCols.contains("Z_PK") else {
+            throw LibraryError.schemaUnsupported
+        }
+        let nameCol = Self.firstPresent(["ZENCRYPTEDNAME", "ZNAME", "ZCUSTOMLABEL"], in: folderCols)
+
+        // Tally recordings per folder PK so we can show counts even for
+        // schemas without ZNUMBEROFCONTAINEDRECORDINGS.
+        let counts = try recordingCountsByFolderPK(db: db)
+
+        let nameSelect = nameCol ?? "NULL"
+        let sql = "SELECT Z_PK, ZUUID, \(nameSelect) FROM ZFOLDER WHERE ZUUID IS NOT NULL;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw LibraryError.openFailed(String(cString: sqlite3_errmsg(db)))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var result: [Folder] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let pk = sqlite3_column_int64(stmt, 0)
+            guard let uuid = Self.text(stmt, 1) else { continue }
+            let name = Self.text(stmt, 2) ?? "Folder"
+            result.append(Folder(uuid: uuid, name: name, count: counts[pk] ?? 0))
+        }
+        return result.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Number of unfiled recordings (`ZFOLDER IS NULL`). Often the majority
+    /// of a library, so the UI surfaces it as an explicit "Unfiled" option.
+    func unfiledCount() throws -> Int {
+        let db = try open()
+        defer { sqlite3_close(db) }
+        let recCols = try columns(of: "ZCLOUDRECORDING", db: db)
+        guard recCols.contains("ZFOLDER") else { return 0 }
+        let evictionFilter = Self.firstPresent(["ZEVICTIONDATE"], in: recCols)
+            .map { " AND \($0) IS NULL" } ?? ""
+        let sql = "SELECT COUNT(*) FROM ZCLOUDRECORDING WHERE ZFOLDER IS NULL\(evictionFilter);"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return 0 }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+        return Int(sqlite3_column_int64(stmt, 0))
+    }
+
+    /// Recordings belonging to any of `folderUUIDs`, optionally including
+    /// the unfiled bucket. Pass an empty set + `includeUnfiled: true` to get
+    /// only unfiled memos. Evicted (Recently-Deleted-in-Voice-Memos)
+    /// recordings are excluded.
+    func recordings(folderUUIDs: Set<String>, includeUnfiled: Bool) throws -> [Memo] {
+        let all = try fetchAllRecordings()
+        return all.filter { memo in
+            if let folder = memo.folderUUID {
+                return folderUUIDs.contains(folder)
+            } else {
+                return includeUnfiled
+            }
+        }
+    }
+
+    // MARK: - Core fetch
+
+    /// Every (non-evicted) recording in the library, normalised. The single
+    /// scan that `recordings(...)` filters and that folder counts derive from.
+    func fetchAllRecordings() throws -> [Memo] {
+        let db = try open()
+        defer { sqlite3_close(db) }
+
+        let recCols = try columns(of: "ZCLOUDRECORDING", db: db)
+        guard let pathCol = Self.firstPresent(["ZPATH", "ZURL"], in: recCols),
+              let uniqueCol = Self.firstPresent(["ZUNIQUEID"], in: recCols) else {
+            throw LibraryError.schemaUnsupported
+        }
+        let durationCol = Self.firstPresent(["ZDURATION"], in: recCols)
+        let dateCol = Self.firstPresent(["ZDATE"], in: recCols)
+        let titleCol = Self.firstPresent(["ZENCRYPTEDTITLE", "ZCUSTOMLABEL", "ZTITLE"], in: recCols)
+        let folderCol = recCols.contains("ZFOLDER") ? "ZFOLDER" : nil
+        let evictionCol = Self.firstPresent(["ZEVICTIONDATE"], in: recCols)
+
+        let folderJoin = folderCol != nil
+            ? "LEFT JOIN ZFOLDER f ON r.\(folderCol!) = f.Z_PK"
+            : ""
+        let folderSelect = folderCol != nil ? "f.ZUUID" : "NULL"
+        let whereClause = evictionCol.map { "WHERE r.\($0) IS NULL" } ?? ""
+
+        let sql = """
+        SELECT r.\(uniqueCol), r.\(pathCol), \
+        \(durationCol.map { "r.\($0)" } ?? "0"), \
+        \(dateCol.map { "r.\($0)" } ?? "0"), \
+        \(titleCol.map { "r.\($0)" } ?? "NULL"), \
+        \(folderSelect) \
+        FROM ZCLOUDRECORDING r \(folderJoin) \(whereClause);
+        """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw LibraryError.openFailed(String(cString: sqlite3_errmsg(db)))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var result: [Memo] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let uniqueID = Self.text(stmt, 0),
+                  let path = Self.text(stmt, 1) else { continue }
+            let duration = sqlite3_column_double(stmt, 2)
+            let coreDataDate = sqlite3_column_double(stmt, 3)
+            let title = Self.text(stmt, 4)
+            let folderUUID = Self.text(stmt, 5)
+
+            let fileURL = Self.resolve(path: path, relativeTo: recordingsDirectory)
+            // ZDATE is a Core Data timestamp (seconds since 2001-01-01). Fall
+            // back to the filename's leading timestamp, then the file's own
+            // creation date, so a row with a zero/garbage ZDATE still sorts
+            // sensibly instead of landing in 2001.
+            let date = coreDataDate > 0
+                ? Date(timeIntervalSinceReferenceDate: coreDataDate)
+                : (Self.dateFromFilename(fileURL.lastPathComponent)
+                   ?? Self.fileCreationDate(fileURL)
+                   ?? Date(timeIntervalSinceReferenceDate: coreDataDate))
+
+            let displayTitle = (title?.isEmpty == false)
+                ? title!
+                : fileURL.deletingPathExtension().lastPathComponent
+
+            result.append(Memo(
+                uniqueID: uniqueID,
+                fileURL: fileURL,
+                folderUUID: folderUUID,
+                title: displayTitle,
+                duration: duration,
+                date: date
+            ))
+        }
+        return result
+    }
+
+    // MARK: - SQLite helpers
+
+    private func open() throws -> OpaquePointer {
+        guard isAvailable else { throw LibraryError.databaseMissing }
+        // Read-only. The DB is WAL-mode and actively written by voicememod;
+        // a read-only connection reads through the WAL so freshly-synced
+        // rows are visible, and SQLite guarantees readers never block or
+        // corrupt a concurrent writer. We never issue a write.
+        let uri = "file:\(databaseURL.path)?mode=ro"
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_URI
+        guard sqlite3_open_v2(uri, &db, flags, nil) == SQLITE_OK, let db else {
+            let msg = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            if let db { sqlite3_close(db) }
+            throw LibraryError.openFailed(msg)
+        }
+        return db
+    }
+
+    /// Column names of `table`, upper-cased for case-insensitive matching.
+    private func columns(of table: String, db: OpaquePointer) throws -> Set<String> {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "PRAGMA table_info(\(table));", -1, &stmt, nil) == SQLITE_OK else {
+            throw LibraryError.schemaUnsupported
+        }
+        defer { sqlite3_finalize(stmt) }
+        var cols: Set<String> = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let name = Self.text(stmt, 1) {
+                cols.insert(name.uppercased())
+            }
+        }
+        if cols.isEmpty { throw LibraryError.schemaUnsupported }
+        return cols
+    }
+
+    /// Map of folder `Z_PK` → recording count (non-evicted), for `folders()`.
+    private func recordingCountsByFolderPK(db: OpaquePointer) throws -> [Int64: Int] {
+        let recCols = try columns(of: "ZCLOUDRECORDING", db: db)
+        guard recCols.contains("ZFOLDER") else { return [:] }
+        let evictionFilter = Self.firstPresent(["ZEVICTIONDATE"], in: recCols)
+            .map { " WHERE \($0) IS NULL" } ?? ""
+        let sql = "SELECT ZFOLDER, COUNT(*) FROM ZCLOUDRECORDING\(evictionFilter) GROUP BY ZFOLDER;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [:] }
+        defer { sqlite3_finalize(stmt) }
+        var counts: [Int64: Int] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard sqlite3_column_type(stmt, 0) != SQLITE_NULL else { continue }
+            counts[sqlite3_column_int64(stmt, 0)] = Int(sqlite3_column_int64(stmt, 1))
+        }
+        return counts
+    }
+
+    private static func text(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
+        guard let stmt, sqlite3_column_type(stmt, index) != SQLITE_NULL,
+              let cString = sqlite3_column_text(stmt, index) else { return nil }
+        return String(cString: cString)
+    }
+
+    private static func firstPresent(_ candidates: [String], in columns: Set<String>) -> String? {
+        candidates.first { columns.contains($0.uppercased()) }
+    }
+
+    /// Resolve a `ZPATH` value to an on-disk URL. ZPATH is normally a bare
+    /// filename relative to the Recordings dir, but tolerate an absolute path
+    /// just in case.
+    private static func resolve(path: String, relativeTo base: URL) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        return base.appendingPathComponent(path)
+    }
+
+    /// Voice Memos names files `YYYYMMDD HHMMSS-XXXX.ext`; parse that leading
+    /// stamp as a creation-date fallback.
+    private static func dateFromFilename(_ name: String) -> Date? {
+        let stem = (name as NSString).deletingPathExtension
+        let parts = stem.split(separator: "-", maxSplits: 1)
+        guard let stamp = parts.first else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd HHmmss"
+        return formatter.date(from: String(stamp))
+    }
+
+    private static func fileCreationDate(_ url: URL) -> Date? {
+        (try? url.resourceValues(forKeys: [.creationDateKey]))?.creationDate
+    }
+}

--- a/MilaTests/VoiceMemosLibraryTests.swift
+++ b/MilaTests/VoiceMemosLibraryTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import SQLite3
+@testable import Mila
+
+/// Exercises the read-only `CloudRecordings.db` reader against a synthetic
+/// database that mimics the Core Data layout the iPhone Voice Memos app uses
+/// (we can't ship the real, private DB into CI). Validates the folder join,
+/// the unfiled bucket, eviction filtering, date conversion and the
+/// format/composition flags the importer keys on.
+final class VoiceMemosLibraryTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = TestSupport.makeTempRoot(label: "VoiceMemosLibraryTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+    }
+
+    // MARK: - Fixture
+
+    /// Build a minimal CloudRecordings.db. Z_PK 1=Work, 2=Ideas.
+    private func makeFixtureLibrary() throws -> VoiceMemosLibrary {
+        let dbURL = tempRoot.appendingPathComponent("CloudRecordings.db")
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(dbURL.path, &db,
+                                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil), SQLITE_OK)
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        CREATE TABLE ZFOLDER (Z_PK INTEGER PRIMARY KEY, ZUUID TEXT, ZENCRYPTEDNAME TEXT);
+        CREATE TABLE ZCLOUDRECORDING (
+            Z_PK INTEGER PRIMARY KEY, ZFOLDER INTEGER, ZUNIQUEID TEXT, ZPATH TEXT,
+            ZDURATION FLOAT, ZDATE FLOAT, ZENCRYPTEDTITLE TEXT, ZEVICTIONDATE FLOAT
+        );
+        INSERT INTO ZFOLDER VALUES (1, 'UUID-WORK', 'Work'), (2, 'UUID-IDEAS', 'Ideas');
+        INSERT INTO ZCLOUDRECORDING VALUES
+            (1, 1,    'rec-1', 'file1.m4a',        12.0, 700000000.0, 'Memo One',     NULL),
+            (2, 1,    'rec-2', 'file2.m4a',         2.0, 700000100.0, 'Short Clip',   NULL),
+            (3, 2,    'rec-3', 'file3.m4a',        30.0, 700000200.0, 'An Idea',      NULL),
+            (4, NULL, 'rec-4', 'file4.m4a',        20.0, 700000300.0, 'Unfiled One',  NULL),
+            (5, 1,    'rec-5', 'file5.m4a',        40.0, 700000400.0, 'Deleted',  123456.0),
+            (6, 1,    'rec-6', 'file6.qta',        15.0, 700000500.0, 'New Format',   NULL),
+            (7, NULL, 'rec-7', 'file7.composition',15.0, 700000600.0, 'Multi Take',   NULL);
+        """
+        var errMsg: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(db, sql, nil, nil, &errMsg)
+        if rc != SQLITE_OK {
+            let message = errMsg.map { String(cString: $0) } ?? "unknown"
+            sqlite3_free(errMsg)
+            XCTFail("Failed to seed fixture DB: \(message)")
+        }
+        return VoiceMemosLibrary(recordingsDirectory: tempRoot)
+    }
+
+    // MARK: - Tests
+
+    func test_isAvailable_falseWhenDatabaseMissing() {
+        let lib = VoiceMemosLibrary(recordingsDirectory: tempRoot)
+        XCTAssertFalse(lib.isAvailable)
+        XCTAssertThrowsError(try lib.fetchAllRecordings()) { error in
+            XCTAssertEqual(error as? VoiceMemosLibrary.LibraryError, .databaseMissing)
+        }
+    }
+
+    func test_folders_returnsSortedFoldersWithNonEvictedCounts() throws {
+        let lib = try makeFixtureLibrary()
+        let folders = try lib.folders()
+        XCTAssertEqual(folders.map(\.name), ["Ideas", "Work"])  // sorted by name
+
+        let work = try XCTUnwrap(folders.first { $0.uuid == "UUID-WORK" })
+        // ZFOLDER=1, non-evicted: rec-1, rec-2, rec-6 (rec-5 is evicted).
+        XCTAssertEqual(work.count, 3)
+        let ideas = try XCTUnwrap(folders.first { $0.uuid == "UUID-IDEAS" })
+        XCTAssertEqual(ideas.count, 1)
+    }
+
+    func test_unfiledCount_excludesEvicted() throws {
+        let lib = try makeFixtureLibrary()
+        // ZFOLDER IS NULL, non-evicted: rec-4, rec-7.
+        XCTAssertEqual(try lib.unfiledCount(), 2)
+    }
+
+    func test_recordings_filtersByFolderAndExcludesEvicted() throws {
+        let lib = try makeFixtureLibrary()
+        let work = try lib.recordings(folderUUIDs: ["UUID-WORK"], includeUnfiled: false)
+        XCTAssertEqual(Set(work.map(\.uniqueID)), ["rec-1", "rec-2", "rec-6"])
+        XCTAssertTrue(work.allSatisfy { $0.folderUUID == "UUID-WORK" })
+        XCTAssertFalse(work.contains { $0.uniqueID == "rec-5" })  // evicted
+    }
+
+    func test_recordings_includeUnfiledOnly() throws {
+        let lib = try makeFixtureLibrary()
+        let unfiled = try lib.recordings(folderUUIDs: [], includeUnfiled: true)
+        XCTAssertEqual(Set(unfiled.map(\.uniqueID)), ["rec-4", "rec-7"])
+        XCTAssertTrue(unfiled.allSatisfy { $0.folderUUID == nil })
+    }
+
+    func test_memo_metadataAndFlags() throws {
+        let lib = try makeFixtureLibrary()
+        let all = try lib.fetchAllRecordings()
+        let byID = Dictionary(uniqueKeysWithValues: all.map { ($0.uniqueID, $0) })
+
+        let rec1 = try XCTUnwrap(byID["rec-1"])
+        XCTAssertEqual(rec1.title, "Memo One")
+        XCTAssertEqual(rec1.duration, 12.0, accuracy: 0.001)
+        XCTAssertEqual(rec1.date, Date(timeIntervalSinceReferenceDate: 700000000.0))
+        XCTAssertEqual(rec1.fileURL, tempRoot.appendingPathComponent("file1.m4a"))
+        XCTAssertFalse(rec1.isUnsupportedFormat)
+        XCTAssertFalse(rec1.isComposition)
+
+        XCTAssertTrue(try XCTUnwrap(byID["rec-6"]).isUnsupportedFormat)  // .qta
+        XCTAssertTrue(try XCTUnwrap(byID["rec-7"]).isComposition)        // .composition
+    }
+}

--- a/MilaTests/VoiceMemosSettingsTests.swift
+++ b/MilaTests/VoiceMemosSettingsTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class VoiceMemosSettingsTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "VoiceMemosSettingsTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    func test_defaults_areOffAndEmpty() {
+        let settings = VoiceMemosSettings(defaults: defaults)
+        XCTAssertFalse(settings.isEnabled)
+        XCTAssertTrue(settings.selectedFolderUUIDs.isEmpty)
+        XCTAssertFalse(settings.includeUnfiled)
+        XCTAssertFalse(settings.hasSelection)
+    }
+
+    func test_selectionPersistsAcrossInstances() {
+        let settings = VoiceMemosSettings(defaults: defaults)
+        settings.isEnabled = true
+        settings.setFolder("UUID-A", selected: true)
+        settings.setFolder("UUID-B", selected: true)
+        settings.includeUnfiled = true
+
+        let reloaded = VoiceMemosSettings(defaults: defaults)
+        XCTAssertTrue(reloaded.isEnabled)
+        XCTAssertEqual(reloaded.selectedFolderUUIDs, ["UUID-A", "UUID-B"])
+        XCTAssertTrue(reloaded.includeUnfiled)
+        XCTAssertTrue(reloaded.hasSelection)
+    }
+
+    func test_setFolder_removesDeselected() {
+        let settings = VoiceMemosSettings(defaults: defaults)
+        settings.setFolder("UUID-A", selected: true)
+        settings.setFolder("UUID-A", selected: false)
+        XCTAssertTrue(settings.selectedFolderUUIDs.isEmpty)
+    }
+
+    func test_hasSelection_trueWithOnlyUnfiled() {
+        let settings = VoiceMemosSettings(defaults: defaults)
+        settings.includeUnfiled = true
+        XCTAssertTrue(settings.hasSelection)
+    }
+}


### PR DESCRIPTION
Closes #25.

Opt-in integration with the iPhone Voice Memos app: recordings made on an iPhone and synced to this Mac over iCloud are picked up and transcribed automatically — no manual export/import.

## What's included

**Reading the library** — `VoiceMemosLibrary` (`Mila/VoiceMemos/VoiceMemosLibrary.swift`)
- Opens the synced `CloudRecordings.db` in the Voice Memos group container **read-only** (WAL-safe; we never write).
- The Core Data schema is private and shifts between macOS releases, so every column is resolved at runtime via `PRAGMA table_info` — a renamed/dropped column degrades to an empty result instead of crashing.
- Folders keyed by the stable `ZFOLDER.ZUUID` (survives renames); display name is for UI only.
- Unfiled recordings (`ZFOLDER IS NULL`, usually the bulk of a library) surfaced as an explicit "Unfiled" bucket.
- Evicted (Recently-Deleted-in-Voice-Memos) rows excluded.

**Settings** — `VoiceMemosSettings` (default **off**, fully opt-in): persists watched folder UUIDs + "include unfiled" under namespaced `voiceMemos.*` UserDefaults keys, injectable suite for tests.

**Sync** — `VoiceMemosImporter` + `DirectoryWatcher` (FSEvents)
- Backfills selected folders on enable / folder-change.
- FSEvents watcher imports newly-synced recordings as they land.
- Dedup by `ZUNIQUEID` stored on each `Recording` → rescans/restarts never re-import.
- Skips clips <3s, `.qta` (unsupported format) and `.composition` (multi-take) bundles, with logged counts.
- Reuses `FileTranscriber` + the existing FIFO transcription queue — no new transcription infrastructure.

**Model / UI**
- New `RecordingSource.voiceMemo` case + `Recording.voiceMemoUniqueID` (Codable, back-compatible).
- New **Voice Memos** Settings tab: enable toggle, folder multiselect (incl. Unfiled), Rescan, sync status; "no library found" hint when Voice Memos isn't synced.

## Tests
- `VoiceMemosLibraryTests` — synthetic `CloudRecordings.db`: folder join, unfiled bucket, eviction filtering, Core Data date conversion, `.qta`/`.composition` flags.
- `VoiceMemosSettingsTests` — persistence / selection logic.

All new + touched existing tests (`RecordingTests`, `FileTranscriberTests`, `RecordingStoreTests`) pass; app builds clean.

## Notes / deferred
- Reading another app's container requires the app to stay **non-sandboxed** (it already is). `~/Library/Group Containers` is not TCC-protected, so no extra prompt is expected.
- `.qta` conversion and `.composition` (multi-take) support are deferred — those memos are skipped for now (counted in logs), per the issue's scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Voice Memos syncing in Settings, including folder selection, unfiled memo support, rescan, and sync status updates.
  * Voice Memos can now appear as a recording source with its own display and icon.
  * Imported recordings now preserve more details, including original title, date, and memo-specific identifier.

* **Bug Fixes**
  * Improved handling of Voice Memos folders and recordings, including filtering out unsupported or incomplete items.
  * Added more reliable syncing and background monitoring for newly added memo files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->