### PR TITLE
Add CodeRabbit config (assertive AI PR review)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit config — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Free Pro features apply automatically to this public repo.
+language: en-US
+early_access: false
+
+reviews:
+  # "assertive" surfaces more findings (closer to a Bugbot-style firehose).
+  # Switch to "chill" if the volume gets noisy.
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # Review PRs targeting these branches.
+    base_branches:
+      - main
+
+  # Skip generated / vendored / binary artifacts so reviews stay signal-rich.
+  path_filters:
+    - "!**/*.xcodeproj/**"
+    - "!Mila/Resources/PythonRuntime/**"
+    - "!Mila/Resources/DiarizationModels/**"
+    - "!Mila/Resources/**/*.bin"
+    - "!Packages/TranscriptionCore/Fixtures/**"
+    - "!**/*.wav"
+    - "!**/Assets.xcassets/**"
+    - "!**/*.pbxproj"
+
+  # Domain context so the reviewer judges the right things for this codebase.
+  path_instructions:
+    - path: "**/*.swift"
+      instructions: >-
+        Swift 5.10 / SwiftUI macOS app (min macOS 14). Prioritise: Swift
+        concurrency correctness (@MainActor / actor isolation, Task ordering
+        and cancellation, data races, Sendable); retain cycles in escaping
+        closures (require [weak self] where a stored Task/closure outlives
+        the call); force-unwraps and force-tries on fallible paths; and
+        correct stdout/stderr handling + pipe-drain ordering for any Process
+        / Python subprocess integration (a known deadlock class in this repo).
+        Match the surrounding code's style and comment density.
+    - path: "Packages/TranscriptionCore/**"
+      instructions: >-
+        Cross-platform Swift package wrapping whisper.cpp. Flag any API that
+        would break the Linux build (Apple-only imports must be #if guarded)
+        and any unsafe pointer / C-bridging lifetime issue.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Sets up [CodeRabbit](https://www.coderabbit.ai/) — free Pro AI code review for public repos — as a standing replacement for Cursor Bugbot.

The GitHub App is already installed on the org; CodeRabbit reviews PRs on defaults even without this file. `.coderabbit.yaml` tunes it:

- **`profile: assertive`** — higher finding volume (closer to Bugbot's "finds a ton").
- **Auto-review** PRs targeting `main`, skipping drafts.
- **Path filters** drop binaries/generated artifacts (`*.xcodeproj`, `PythonRuntime/`, bundled `*.bin` models, `*.wav` fixtures, asset catalogs) so reviews stay signal-rich.
- **Path instructions** for Swift/SwiftUI and `TranscriptionCore` so it focuses on this codebase's real risk areas: Swift concurrency/actor isolation, retain cycles in escaping closures, force-unwraps, subprocess stdout/stderr + pipe-drain handling, and Linux-build breakage in the package.

Config takes effect on the default branch once merged. Tune `profile` to `chill` if it gets noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation settings for pull requests, including clearer review summaries and expanded walkthroughs.
  * Enabled automatic reviews for changes targeting the main branch.
  * Reduced noise by excluding generated and binary files from automated review.
  * Added project-specific guidance for Swift app and package code.
  * Turned on automated chat responses for quicker feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->