### PR TITLE
Remote transcription: address CodeRabbit nitpicks from #36

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1264,6 +1264,8 @@ struct MilaApp: App {
     /// button, and any too-eager Record press during the window finds
     /// the model already loaded.
     private func prewarmDefaultModel() {
+        // No local weights to warm when the remote backend is selected.
+        guard !remoteTranscriptionSettings.isActive else { return }
         transcription.prewarm(language: languageSettings.current.rawValue)
     }
 
@@ -1274,6 +1276,11 @@ struct MilaApp: App {
     /// same `URLSession` so they don't actually saturate the network, and
     /// the in-app banner shows whichever is currently selected.
     private func ensureDefaultModelsInstalled() {
+        // Skip the multi-GB local model downloads + CoreML prep entirely for
+        // users who've opted into the remote backend — they don't need any
+        // local weights. (The Models tab still offers manual downloads, and
+        // switching back to local re-triggers this on next launch.)
+        guard !remoteTranscriptionSettings.isActive else { return }
         modelManager.setSelected(WhisperModel.ivritLarge)
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
             if !modelManager.isInstalled(model) && modelManager.downloads[model.name] == nil {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -60,13 +60,45 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(config?.model, RemoteTranscriptionSettings.defaultModel)
     }
 
-    func test_editingEndpointResetsTestStatus() {
-        let settings = makeSettings()
+    func test_editingEndpointResetsTestStatus() async {
+        // Stub the network so testConnection() actually seeds a non-idle
+        // status (.ok), then assert that editing the endpoint resets it —
+        // exercising the real reset path rather than a no-op from .idle.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubOKURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.reset")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.reset")
+        let settings = RemoteTranscriptionSettings(
+            defaults: suite,
+            urlSession: session,
+            apiKeyKeychainKey: "RemoteTranscriptionSettingsTests.reset.apiKey")
+        settings.backend = .remote
         settings.endpoint = "https://example.com/v1"
-        // testStatus starts .idle; just assert mutation path doesn't crash and
-        // stays idle without a network call.
-        XCTAssertEqual(settings.testStatus, .idle)
+
+        await settings.testConnection()
+        guard case .ok = settings.testStatus else {
+            return XCTFail("Expected testConnection to seed .ok, got \(settings.testStatus)")
+        }
+
+        settings.endpoint = "https://example.com/v2"
+        XCTAssertEqual(settings.testStatus, .idle, "Editing the endpoint must reset the status")
     }
+}
+
+/// Returns 200 for any request — lets `testConnection()` reach `.ok` without a
+/// real server.
+private final class StubOKURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
 }
 
 final class RemoteWhisperEngineParsingTests: XCTestCase {


### PR DESCRIPTION
Follow-up to #36 (merged). CodeRabbit posted two nitpicks on that PR after it had already been squash-merged, so they couldn't land there — applying them here.

## Changes

1. **Skip local-model startup work when the remote backend is selected** (`MilaApp`). `ensureDefaultModelsInstalled()` and `prewarmDefaultModel()` now early-return when `remoteTranscriptionSettings.isActive`, so a persisted remote-only user doesn't trigger the ~4.6 GB local-model downloads or CoreML prep at launch. Guarded inside the helpers so every caller is covered. (The Models tab still offers manual downloads, and switching back to local re-triggers this on next launch.)

2. **Make the reset test actually exercise the reset path** (`RemoteTranscriptionTests`). `test_editingEndpointResetsTestStatus` previously only mutated `endpoint` while `testStatus` was already `.idle`, so it passed even if the reset broke. It now seeds a non-idle `.ok` via a stubbed `URLSession` (200) before mutating the endpoint, then asserts the `didSet` reset to `.idle`.

## Testing
- `make build` ✅
- `RemoteTranscriptionSettingsTests` + `RemoteWhisperEngineParsingTests` pass ✅
- The remote-transcription E2E workflow added in #36 will also run here (this touches `MilaTests/RemoteTranscriptionTests.swift`, which is in its path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Remote Transcription Experience**
  * Remote transcription users will now skip large local model downloads, setup, and warmup steps, making startup faster and reducing disk usage.

* **Bug Fixes**
  * Fixed endpoint changes so transcription connection status resets correctly after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->