### PR TITLE
Add project skills: uninstall-mila + build-mila-locally

### DIFF
--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -21,7 +21,7 @@ All build commands run from the repo root (wherever your checkout lives).
 | Release build | `make release-build` | `build-release/Build/Products/Release/Mila.app` |
 | Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (ad-hoc signed) |
 | Run tests | `make test` | XCTest run |
-| Clean | `make clean` | removes `.xcodeproj`, `build`, `build-release`, `*.dmg` |
+| Clean | `make clean` | removes `Mila.xcodeproj`, `build`, `build-release`, `*.dmg` |
 
 `make` targets chain: `dmg → release-build → project → bootstrap`, so a single command regenerates the project and builds.
 

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -28,15 +28,18 @@ All build commands run from the repo root (`~/ClonedProjects/mila`).
 ## CRITICAL: `make dmg` needs an explicit VERSION
 
 `make dmg` **fails on a clean checkout** with:
-```
+
+```text
 /bin/sh: MARKETING_VERSION: command not found
 ./scripts/make-dmg.sh: ... usage: make-dmg.sh APP_PATH DMG_PATH VERSION
 ```
-**Why:** `Info.plist` stores the literal `$(MARKETING_VERSION)` (resolved only at Xcode build time). The Makefile's version fallback reads `Info.plist` with `PlistBuddy`, gets the literal string back, and the shell tries to *execute* `MARKETING_VERSION`. The build itself SUCCEEDS — only DMG packaging breaks.
 
-**Fix:** pass the real version (it lives in `project.yml`) explicitly:
+**Why:** the Makefile's `VERSION` fallback reads `CFBundleShortVersionString` from `Info.plist`, but that key stores the literal `$(MARKETING_VERSION)` (Xcode resolves it only at build time). Make passes that literal into the recipe, the shell tries to *command-substitute* `$(MARKETING_VERSION)` — hence the `MARKETING_VERSION: command not found` line — and `VERSION` collapses to an empty string. `scripts/make-dmg.sh` then aborts on its empty-`VERSION` guard (`${3:?usage…}`). The release build itself SUCCEEDS — only DMG packaging breaks.
+
+**Fix:** the canonical version lives in `project.yml` (`MARKETING_VERSION`). Pass it explicitly:
+
 ```bash
-VERSION=$(grep -E 'MARKETING_VERSION:' project.yml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+VERSION=$(awk -F'"' '/^[[:space:]]*MARKETING_VERSION:/{print $2; exit}' project.yml)
 make dmg VERSION="$VERSION"
 ```
 

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -40,6 +40,7 @@ All build commands run from the repo root (wherever your checkout lives).
 
 ```bash
 VERSION=$(awk -F'"' '/^[[:space:]]*MARKETING_VERSION:/{print $2; exit}' project.yml)
+[ -n "$VERSION" ] || { echo "MARKETING_VERSION not found in project.yml" >&2; exit 1; }
 make dmg VERSION="$VERSION"
 ```
 

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: build-mila-locally
+description: Use when building, compiling, or running the Mila app locally from source on a Mac — debug build, release build, self-signed DMG, or installing a locally-built Mila into /Applications. Covers "build Mila", "run Mila locally", "make a DMG", "install my local build", and the common version/signing/PythonRuntime build failures.
+---
+
+# Build Mila Locally
+
+## Overview
+
+Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are **ad-hoc signed** ("Sign to Run Locally") — that is the only "self-signed" path this repo supports. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
+
+All build commands run from the repo root (`~/ClonedProjects/mila`).
+
+## Quick Reference
+
+| Goal | Command | Output |
+|---|---|---|
+| Generate Xcode project | `make project` | `Mila.xcodeproj` (regenerated from `project.yml`) |
+| Debug build | `make build` | `build/Build/Products/Debug/Mila.app` |
+| Build **and launch** | `make run` | builds Debug, then `open`s it |
+| Release build | `make release-build` | `build-release/Build/Products/Release/Mila.app` |
+| Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (ad-hoc signed) |
+| Run tests | `make test` | XCTest run |
+| Clean | `make clean` | removes `.xcodeproj`, `build`, `build-release`, `*.dmg` |
+
+`make` targets chain: `dmg → release-build → project → bootstrap`, so a single command regenerates the project and builds.
+
+## CRITICAL: `make dmg` needs an explicit VERSION
+
+`make dmg` **fails on a clean checkout** with:
+```
+/bin/sh: MARKETING_VERSION: command not found
+./scripts/make-dmg.sh: ... usage: make-dmg.sh APP_PATH DMG_PATH VERSION
+```
+**Why:** `Info.plist` stores the literal `$(MARKETING_VERSION)` (resolved only at Xcode build time). The Makefile's version fallback reads `Info.plist` with `PlistBuddy`, gets the literal string back, and the shell tries to *execute* `MARKETING_VERSION`. The build itself SUCCEEDS — only DMG packaging breaks.
+
+**Fix:** pass the real version (it lives in `project.yml`) explicitly:
+```bash
+VERSION=$(grep -E 'MARKETING_VERSION:' project.yml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+make dmg VERSION="$VERSION"
+```
+
+## Other known build gotchas
+
+- **PythonRuntime placeholder:** `Mila/Resources/PythonRuntime/` is a `.gitignored` folder reference. If missing, `xcodebuild` fails on the copy-resources phase. The `make project` target auto-creates an empty placeholder (the app falls back to system Python for diarization). For a *real* bundled diarization runtime, run `make bundle-diarization` first (~150-200 MB, slow, cached).
+- **Models are NOT bundled.** Whisper weights download at first launch into `~/Library/Application Support/Mila/Models/` (or pre-fetch with `make models`, ~4.6 GB). A fresh build with no models will prompt/download on first transcription.
+- **`xcodegen` must be installed.** `make bootstrap` installs it via Homebrew if missing.
+
+## Verifying the signature
+
+A correct local build is ad-hoc signed:
+```bash
+codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature"
+# Identifier=io.island.whisper.IslandWhisper
+# Signature=adhoc
+```
+
+## Installing a local build into /Applications
+
+A `make run`/`make dmg` build lives in the repo's `build/` folder — it runs fine but won't appear in the Applications folder. To install it like a normal app:
+
+```bash
+# from a DMG (preferred — matches the distributed artifact):
+MNT=$(mktemp -d)
+hdiutil attach Mila-<x.y.z>.dmg -nobrowse -mountpoint "$MNT" -quiet
+[ -e /Applications/Mila.app ] && trash /Applications/Mila.app          # use trash, not rm
+cp -R "$MNT/Mila.app" /Applications/
+hdiutil detach "$MNT" -quiet
+open -a /Applications/Mila.app    # verify it launches
+```
+
+Ad-hoc-signed apps copied (not downloaded) have no quarantine flag, so they launch without the Gatekeeper right-click dance. If the app WAS downloaded, Gatekeeper shows a "right-click → Open" prompt on first launch.
+
+## Common Mistakes
+
+- **Running `make dmg` without `VERSION=`** → the `MARKETING_VERSION: command not found` failure above. Always pass it.
+- **Editing `Mila.xcodeproj` directly** → overwritten on next `make project`. Edit `project.yml` instead.
+- **Hardcoding a version in `Info.plist`** → it must stay `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`; bump versions only in `project.yml`.
+- **Expecting a Developer-ID / notarized build** → not available locally; this repo only ad-hoc signs.
+- **`rm`-ing an old `/Applications/Mila.app`** → use `trash` so it's recoverable.

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -9,7 +9,7 @@ description: Use when building, compiling, or running the Mila app locally from 
 
 Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are **ad-hoc signed** ("Sign to Run Locally") — that is the only "self-signed" path this repo supports. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
 
-All build commands run from the repo root (`~/ClonedProjects/mila`).
+All build commands run from the repo root (wherever your checkout lives).
 
 ## Quick Reference
 

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -74,8 +74,13 @@ pgrep -f "Mila.app/Contents/MacOS" && osascript -e 'quit app "Mila"' || true
 
 # 3. Remove app bundles + build artifacts (to Trash)
 trash /Applications/Mila.app 2>/dev/null || true
-REPO="$HOME/ClonedProjects/mila"          # ← set to your checkout location
-trash "$REPO/build" 2>/dev/null || true   # only the build/ output, NOT the repo itself
+# Build artifacts — only relevant if Mila was built from source. Point REPO at
+# your checkout (or `export MILA_REPO=...`); the project.yml check guards against
+# trashing an unrelated build/ tree if REPO is wrong.
+REPO="${MILA_REPO:-$HOME/ClonedProjects/mila}"
+if [ -f "$REPO/project.yml" ]; then
+  trash "$REPO/build" 2>/dev/null || true   # only the build/ output, NOT the repo itself
+fi
 for d in "$HOME/Library/Developer/Xcode/DerivedData/"Mila-*; do [ -d "$d" ] && trash "$d"; done
 
 # 4. Remove system footprint (bundle id, NOT "Mila").

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -13,7 +13,7 @@ Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io ori
 
 ## The Iron Rules
 
-1. **Back up recordings BEFORE deleting anything.** Copy `Recordings/` + `recordings.json` to a safe location outside Application Support (e.g. `~/Desktop/Mila-Recordings-Backup-<date>`). Verify file counts match before proceeding.
+1. **Back up recordings BEFORE deleting anything.** Copy `Recordings/` + `recordings.json` + `folders.json` to a safe location outside Application Support (e.g. `~/Desktop/Mila-Recordings-Backup-<date>`). Verify file counts match before proceeding.
 2. **Use `trash`, never `rm`.** Every removal must be reversible.
 3. **Keep-by-default items are NOT deleted unless the user says so.** You MUST ASK the user about each one (see below). Default = keep. This includes the **settings/preferences plist** — never wipe the user's configuration as part of a routine uninstall; preserving it means a reinstall comes back with the same model, language, and settings.
 4. **Never touch the source repo** at `~/ClonedProjects/mila` — only its `build/` output is an app artifact.
@@ -24,6 +24,7 @@ Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io ori
 |---|---|---|
 | `~/Library/Application Support/Mila/Recordings/` | **User data — irreplaceable** | **Always keep + back up** |
 | `~/Library/Application Support/Mila/recordings.json` | **User data — the index** | **Always keep + back up** |
+| `~/Library/Application Support/Mila/folders.json` | **User data — folder organization** | **Always keep + back up** |
 | `~/Library/Application Support/Mila/Models/` (~6.8 GB) | Regenerable (whisper weights, re-downloaded) | **Keep — ASK before deleting** |
 | `~/Library/Application Support/Mila/torch-site-packages/` (~444 MB) | Regenerable (Python runtime, re-installed) | **Keep — ASK before deleting** |
 | App bundle in `/Applications/Mila.app` | App | Remove |
@@ -58,8 +59,10 @@ SRC="$HOME/Library/Application Support/Mila"
 DST="$HOME/Desktop/Mila-Recordings-Backup-$(date +%Y-%m-%d)"
 mkdir -p "$DST"
 cp -Rp "$SRC/Recordings" "$DST/" && cp -p "$SRC/recordings.json" "$DST/"
+cp -p "$SRC/folders.json" "$DST/" 2>/dev/null || true   # folder map — may not exist yet (optional)
 # verify counts match before continuing:
 echo "src=$(find "$SRC/Recordings" -type f | wc -l)  bak=$(find "$DST/Recordings" -type f | wc -l)"
+ls "$DST/recordings.json" "$DST/folders.json" 2>/dev/null   # confirm index + folder map backed up
 
 # 2. Quit the app if running
 pgrep -f "Mila.app/Contents/MacOS" && osascript -e 'quit app "Mila"' || true
@@ -127,7 +130,7 @@ ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l
 
 - **Deleting the whole `~/Library/Application Support/Mila` folder.** It contains the irreplaceable `Recordings/` + `recordings.json`. Never blanket-delete it.
 - **Searching only for "Mila".** The prefs/caches are under `io.island.whisper.IslandWhisper`. Search the bundle id too.
-- **Forgetting `recordings.json`.** Backing up `Recordings/` without the index leaves a reinstall with an empty library.
+- **Forgetting `recordings.json` / `folders.json`.** Backing up `Recordings/` without the index leaves a reinstall with an empty library; dropping `folders.json` loses the user's folder organization.
 - **Using `rm`.** Always `trash` so the user can recover.
 - **Deleting `Models/`/`torch-site-packages/` without asking.** These are keep-by-default; deleting them forces multi-GB re-downloads on reinstall.
 - **Wiping the preferences plist on a routine uninstall.** That destroys the user's settings (model, language, diarization, LLM config). Keep it unless the user explicitly wants a full reset — and if they do, clear `cfprefsd` too or it gets rewritten.

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -16,7 +16,7 @@ Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io ori
 1. **Back up recordings BEFORE deleting anything.** Copy `Recordings/` + `recordings.json` + `folders.json` to a safe location outside Application Support (e.g. `~/Desktop/Mila-Recordings-Backup-<date>`). Verify file counts match before proceeding.
 2. **Use `trash`, never `rm`.** Every removal must be reversible.
 3. **Keep-by-default items are NOT deleted unless the user says so.** You MUST ASK the user about each one (see below). Default = keep. This includes the **settings/preferences plist** — never wipe the user's configuration as part of a routine uninstall; preserving it means a reinstall comes back with the same model, language, and settings.
-4. **Never touch the source repo** at `~/ClonedProjects/mila` — only its `build/` output is an app artifact.
+4. **Never touch the source repo** (your `mila` checkout, wherever it lives) — only its `build/` output is an app artifact.
 
 ## What is what (map before you touch)
 
@@ -74,7 +74,8 @@ pgrep -f "Mila.app/Contents/MacOS" && osascript -e 'quit app "Mila"' || true
 
 # 3. Remove app bundles + build artifacts (to Trash)
 trash /Applications/Mila.app 2>/dev/null || true
-trash "$HOME/ClonedProjects/mila/build" 2>/dev/null || true       # only the build/ output, NOT the repo
+REPO="$HOME/ClonedProjects/mila"          # ← set to your checkout location
+trash "$REPO/build" 2>/dev/null || true   # only the build/ output, NOT the repo itself
 for d in "$HOME/Library/Developer/Xcode/DerivedData/"Mila-*; do [ -d "$d" ] && trash "$d"; done
 
 # 4. Remove system footprint (bundle id, NOT "Mila").
@@ -125,7 +126,7 @@ killall Dock
 
 ```bash
 mdfind -name "Mila.app" 2>/dev/null | grep -v "/.Trash/" || echo "(no app outside Trash)"
-ls -d ~/Library/{Preferences/io.island.whisper.IslandWhisper.plist,Caches/io.island.whisper.IslandWhisper} 2>/dev/null || echo "(footprint gone)"
+ls -d ~/Library/{Preferences/io.island.whisper.IslandWhisper.plist,Caches/io.island.whisper.IslandWhisper,HTTPStorages/io.island.whisper.IslandWhisper,WebKit/io.island.whisper.IslandWhisper} 2>/dev/null || echo "(footprint gone)"
 defaults read com.apple.dock persistent-apps 2>/dev/null | grep -i mila || echo "(no Mila in Dock)"
 # user data intact:
 ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l
@@ -139,4 +140,4 @@ ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l
 - **Using `rm`.** Always `trash` so the user can recover.
 - **Deleting `Models/`/`torch-site-packages/` without asking.** These are keep-by-default; deleting them forces multi-GB re-downloads on reinstall.
 - **Wiping the preferences plist on a routine uninstall.** That destroys the user's settings (model, language, diarization, LLM config). Keep it unless the user explicitly wants a full reset — and if they do, clear `cfprefsd` too or it gets rewritten.
-- **Trashing the source repo.** Only `build/` inside `~/ClonedProjects/mila` is an artifact; the rest is source.
+- **Trashing the source repo.** Only `build/` inside your `mila` checkout is an artifact; the rest is source.

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -54,15 +54,20 @@ Only delete `Models/` / `torch-site-packages/` if the user chooses to reclaim th
 mdfind -name "Mila.app" 2>/dev/null
 /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" /Applications/Mila.app/Contents/Info.plist   # -> io.island.whisper.IslandWhisper
 
-# 1. BACK UP user data first (always)
+# 1. BACK UP user data first (always). Fail fast: an incomplete backup must
+#    NEVER let the uninstall proceed.
+set -euo pipefail
 SRC="$HOME/Library/Application Support/Mila"
 DST="$HOME/Desktop/Mila-Recordings-Backup-$(date +%Y-%m-%d)"
 mkdir -p "$DST"
-cp -Rp "$SRC/Recordings" "$DST/" && cp -p "$SRC/recordings.json" "$DST/"
-cp -p "$SRC/folders.json" "$DST/" 2>/dev/null || true   # folder map — may not exist yet (optional)
-# verify counts match before continuing:
+cp -Rp "$SRC/Recordings" "$DST/"
+cp -p "$SRC/recordings.json" "$DST/"
+[[ -f "$SRC/folders.json" ]] && cp -p "$SRC/folders.json" "$DST/"   # folder map — optional, may not exist yet
+# verify before continuing — counts must match, and the index (plus any
+# existing folder map) must have copied, or the script aborts here:
 echo "src=$(find "$SRC/Recordings" -type f | wc -l)  bak=$(find "$DST/Recordings" -type f | wc -l)"
-ls "$DST/recordings.json" "$DST/folders.json" 2>/dev/null   # confirm index + folder map backed up
+test -f "$DST/recordings.json"
+test ! -e "$SRC/folders.json" || test -f "$DST/folders.json"
 
 # 2. Quit the app if running
 pgrep -f "Mila.app/Contents/MacOS" && osascript -e 'quit app "Mila"' || true

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -131,7 +131,12 @@ killall Dock
 
 ```bash
 mdfind -name "Mila.app" 2>/dev/null | grep -v "/.Trash/" || echo "(no app outside Trash)"
-ls -d ~/Library/{Preferences/io.island.whisper.IslandWhisper.plist,Caches/io.island.whisper.IslandWhisper,HTTPStorages/io.island.whisper.IslandWhisper,WebKit/io.island.whisper.IslandWhisper} 2>/dev/null || echo "(footprint gone)"
+# Removable footprint should be gone. The Preferences plist is kept by default,
+# so it's checked separately below — don't list it here or a routine uninstall
+# looks like it failed.
+ls -d ~/Library/{Caches/io.island.whisper.IslandWhisper,HTTPStorages/io.island.whisper.IslandWhisper,WebKit/io.island.whisper.IslandWhisper} 2>/dev/null || echo "(removable footprint gone)"
+# Preferences plist: present on a routine uninstall (kept), absent only after a full reset.
+ls -d ~/Library/Preferences/io.island.whisper.IslandWhisper.plist 2>/dev/null && echo "(prefs kept — routine)" || echo "(prefs removed — full reset)"
 defaults read com.apple.dock persistent-apps 2>/dev/null | grep -i mila || echo "(no Mila in Dock)"
 # user data intact:
 ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: uninstall-mila
+description: Use when uninstalling, removing, or deleting the Mila transcription app from a Mac — clearing the app bundle, Dock tile, and system caches/preferences while protecting the user's recordings and transcripts. Covers "uninstall Mila", "remove Mila", "delete Mila but keep my recordings".
+---
+
+# Uninstall Mila
+
+## Overview
+
+Mila stores user recordings/transcripts and large regenerable assets in the SAME folder (`~/Library/Application Support/Mila`). A naive "delete everything Mila" destroys irreplaceable transcripts. This skill removes the app cleanly while **protecting user data by default** and **never deleting the keep-by-default assets without explicit user confirmation**.
+
+Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io origin) — system caches/prefs are filed under that ID, NOT under "Mila". A search for "Mila" alone misses them.
+
+## The Iron Rules
+
+1. **Back up recordings BEFORE deleting anything.** Copy `Recordings/` + `recordings.json` to a safe location outside Application Support (e.g. `~/Desktop/Mila-Recordings-Backup-<date>`). Verify file counts match before proceeding.
+2. **Use `trash`, never `rm`.** Every removal must be reversible.
+3. **Keep-by-default items are NOT deleted unless the user says so.** You MUST ASK the user about each one (see below). Default = keep.
+4. **Never touch the source repo** at `~/ClonedProjects/mila` — only its `build/` output is an app artifact.
+
+## What is what (map before you touch)
+
+| Path | Class | Default action |
+|---|---|---|
+| `~/Library/Application Support/Mila/Recordings/` | **User data — irreplaceable** | **Always keep + back up** |
+| `~/Library/Application Support/Mila/recordings.json` | **User data — the index** | **Always keep + back up** |
+| `~/Library/Application Support/Mila/Models/` (~6.8 GB) | Regenerable (whisper weights, re-downloaded) | **Keep — ASK before deleting** |
+| `~/Library/Application Support/Mila/torch-site-packages/` (~444 MB) | Regenerable (Python runtime, re-installed) | **Keep — ASK before deleting** |
+| App bundle in `/Applications/Mila.app` | App | Remove |
+| Repo `build/` + `~/Library/Developer/Xcode/DerivedData/Mila-*` | Build artifacts (Dock dev build lives here) | Remove |
+| `~/Library/Preferences/io.island.whisper.IslandWhisper.plist` | App prefs / UserDefaults | Remove |
+| `~/Library/Caches/io.island.whisper.IslandWhisper` | Cache | Remove |
+| `~/Library/HTTPStorages/io.island.whisper.IslandWhisper` | HTTP cache | Remove |
+| `~/Library/WebKit/io.island.whisper.IslandWhisper` | WebKit data | Remove |
+| Dock tile pointing at any `Mila.app` | Dock entry | Remove |
+
+`recordings.json` is the index that ties the audio/transcript files together — it MUST be kept alongside `Recordings/`, or a reinstalled Mila shows an empty library.
+
+## MANDATORY: Ask before deleting keep-by-default items
+
+Before removing the regenerable assets, ask the user explicitly. Default to KEEP if they don't clearly opt in. Recommended question:
+
+> "Mila keeps ~7.2 GB of regenerable data — `Models/` (6.8 GB whisper weights) and `torch-site-packages/` (444 MB Python runtime). Your recordings + `recordings.json` are kept either way. Delete the regenerable data to reclaim space, or keep it so a future reinstall is instant?"
+
+Only delete `Models/` / `torch-site-packages/` if the user chooses to reclaim the space.
+
+## Procedure
+
+```bash
+# 0. Locate the app & confirm bundle id (sanity check before deleting)
+mdfind -name "Mila.app" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" /Applications/Mila.app/Contents/Info.plist   # -> io.island.whisper.IslandWhisper
+
+# 1. BACK UP user data first (always)
+SRC="$HOME/Library/Application Support/Mila"
+DST="$HOME/Desktop/Mila-Recordings-Backup-$(date +%Y-%m-%d)"
+mkdir -p "$DST"
+cp -Rp "$SRC/Recordings" "$DST/" && cp -p "$SRC/recordings.json" "$DST/"
+# verify counts match before continuing:
+echo "src=$(find "$SRC/Recordings" -type f | wc -l)  bak=$(find "$DST/Recordings" -type f | wc -l)"
+
+# 2. Quit the app if running
+pgrep -f "Mila.app/Contents/MacOS" && osascript -e 'quit app "Mila"' || true
+
+# 3. Remove app bundles + build artifacts (to Trash)
+trash /Applications/Mila.app 2>/dev/null || true
+trash "$HOME/ClonedProjects/mila/build" 2>/dev/null || true       # only the build/ output, NOT the repo
+for d in "$HOME/Library/Developer/Xcode/DerivedData/"Mila-*; do [ -d "$d" ] && trash "$d"; done
+
+# 4. Remove system footprint (bundle id, NOT "Mila")
+BID="io.island.whisper.IslandWhisper"
+for p in \
+  "$HOME/Library/Preferences/$BID.plist" \
+  "$HOME/Library/Caches/$BID" \
+  "$HOME/Library/HTTPStorages/$BID" \
+  "$HOME/Library/WebKit/$BID" ; do
+  [ -e "$p" ] && trash "$p"
+done
+
+# 5. (ONLY IF USER OPTED IN) reclaim regenerable data
+# trash "$SRC/Models" "$SRC/torch-site-packages"
+```
+
+### Remove the Dock tile
+
+`dockutil` is usually not installed; edit the Dock plist directly (filters out any tile whose label is "Mila" or whose URL contains `Mila.app`):
+
+```bash
+python3 - <<'PY'
+import subprocess, plistlib
+pl = plistlib.loads(subprocess.run(["defaults","export","com.apple.dock","-"],capture_output=True).stdout)
+apps = pl.get("persistent-apps", [])
+def is_mila(e):
+    try:
+        td = e["tile-data"]
+        return td.get("file-label","") == "Mila" or "Mila.app" in td["file-data"].get("_CFURLString","")
+    except Exception:
+        return False
+pl["persistent-apps"] = [e for e in apps if not is_mila(e)]
+subprocess.run(["defaults","import","com.apple.dock","-"],input=plistlib.dumps(pl),check=True)
+print(f"persistent-apps: {len(apps)} -> {len(pl['persistent-apps'])}")
+PY
+killall Dock
+```
+
+## Verify
+
+```bash
+mdfind -name "Mila.app" 2>/dev/null | grep -v "/.Trash/" || echo "(no app outside Trash)"
+ls -d ~/Library/{Preferences/io.island.whisper.IslandWhisper.plist,Caches/io.island.whisper.IslandWhisper} 2>/dev/null || echo "(footprint gone)"
+defaults read com.apple.dock persistent-apps 2>/dev/null | grep -i mila || echo "(no Mila in Dock)"
+# user data intact:
+ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l
+```
+
+## Common Mistakes
+
+- **Deleting the whole `~/Library/Application Support/Mila` folder.** It contains the irreplaceable `Recordings/` + `recordings.json`. Never blanket-delete it.
+- **Searching only for "Mila".** The prefs/caches are under `io.island.whisper.IslandWhisper`. Search the bundle id too.
+- **Forgetting `recordings.json`.** Backing up `Recordings/` without the index leaves a reinstall with an empty library.
+- **Using `rm`.** Always `trash` so the user can recover.
+- **Deleting `Models/`/`torch-site-packages/` without asking.** These are keep-by-default; deleting them forces multi-GB re-downloads on reinstall.
+- **Trashing the source repo.** Only `build/` inside `~/ClonedProjects/mila` is an artifact; the rest is source.

--- a/.claude/skills/uninstall-mila/SKILL.md
+++ b/.claude/skills/uninstall-mila/SKILL.md
@@ -15,7 +15,7 @@ Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io ori
 
 1. **Back up recordings BEFORE deleting anything.** Copy `Recordings/` + `recordings.json` to a safe location outside Application Support (e.g. `~/Desktop/Mila-Recordings-Backup-<date>`). Verify file counts match before proceeding.
 2. **Use `trash`, never `rm`.** Every removal must be reversible.
-3. **Keep-by-default items are NOT deleted unless the user says so.** You MUST ASK the user about each one (see below). Default = keep.
+3. **Keep-by-default items are NOT deleted unless the user says so.** You MUST ASK the user about each one (see below). Default = keep. This includes the **settings/preferences plist** — never wipe the user's configuration as part of a routine uninstall; preserving it means a reinstall comes back with the same model, language, and settings.
 4. **Never touch the source repo** at `~/ClonedProjects/mila` — only its `build/` output is an app artifact.
 
 ## What is what (map before you touch)
@@ -28,8 +28,8 @@ Mila's bundle identifier is **`io.island.whisper.IslandWhisper`** (Island.io ori
 | `~/Library/Application Support/Mila/torch-site-packages/` (~444 MB) | Regenerable (Python runtime, re-installed) | **Keep — ASK before deleting** |
 | App bundle in `/Applications/Mila.app` | App | Remove |
 | Repo `build/` + `~/Library/Developer/Xcode/DerivedData/Mila-*` | Build artifacts (Dock dev build lives here) | Remove |
-| `~/Library/Preferences/io.island.whisper.IslandWhisper.plist` | App prefs / UserDefaults | Remove |
-| `~/Library/Caches/io.island.whisper.IslandWhisper` | Cache | Remove |
+| `~/Library/Preferences/io.island.whisper.IslandWhisper.plist` | **App settings / UserDefaults** (selected model, language, diarization, LLM config, window state) | **Keep — ASK before deleting** |
+| `~/Library/Caches/io.island.whisper.IslandWhisper` | Cache (no user settings) | Remove |
 | `~/Library/HTTPStorages/io.island.whisper.IslandWhisper` | HTTP cache | Remove |
 | `~/Library/WebKit/io.island.whisper.IslandWhisper` | WebKit data | Remove |
 | Dock tile pointing at any `Mila.app` | Dock entry | Remove |
@@ -43,6 +43,8 @@ Before removing the regenerable assets, ask the user explicitly. Default to KEEP
 > "Mila keeps ~7.2 GB of regenerable data — `Models/` (6.8 GB whisper weights) and `torch-site-packages/` (444 MB Python runtime). Your recordings + `recordings.json` are kept either way. Delete the regenerable data to reclaim space, or keep it so a future reinstall is instant?"
 
 Only delete `Models/` / `torch-site-packages/` if the user chooses to reclaim the space.
+
+**Settings/preferences are also keep-by-default.** Do NOT delete the preferences plist as part of a routine uninstall — it holds the user's configuration (selected model, language, diarization, LLM settings). Only delete it if the user explicitly asks for a **full reset / wipe everything**. If they do, also run `defaults delete io.island.whisper.IslandWhisper` + `killall cfprefsd`, because `cfprefsd` caches prefs in memory and will rewrite the plist on next launch otherwise.
 
 ## Procedure
 
@@ -67,18 +69,26 @@ trash /Applications/Mila.app 2>/dev/null || true
 trash "$HOME/ClonedProjects/mila/build" 2>/dev/null || true       # only the build/ output, NOT the repo
 for d in "$HOME/Library/Developer/Xcode/DerivedData/"Mila-*; do [ -d "$d" ] && trash "$d"; done
 
-# 4. Remove system footprint (bundle id, NOT "Mila")
+# 4. Remove system footprint (bundle id, NOT "Mila").
+#    NOTE: the Preferences plist is intentionally EXCLUDED here — it holds the
+#    user's settings/configuration and is keep-by-default. Caches/HTTPStorages/
+#    WebKit hold no settings and are safe to remove.
 BID="io.island.whisper.IslandWhisper"
 for p in \
-  "$HOME/Library/Preferences/$BID.plist" \
   "$HOME/Library/Caches/$BID" \
   "$HOME/Library/HTTPStorages/$BID" \
   "$HOME/Library/WebKit/$BID" ; do
   [ -e "$p" ] && trash "$p"
 done
+# NOTE: also reset cfprefsd's in-memory cache if you DID delete the plist, or it
+# may be rewritten on next launch: `defaults delete $BID` + `killall cfprefsd`.
 
-# 5. (ONLY IF USER OPTED IN) reclaim regenerable data
+# 5. (ONLY IF USER EXPLICITLY OPTED IN) reclaim regenerable data
 # trash "$SRC/Models" "$SRC/torch-site-packages"
+
+# 6. (ONLY IF USER WANTS A FULL RESET, incl. settings) remove preferences
+# trash "$HOME/Library/Preferences/$BID.plist"
+# defaults delete "$BID" 2>/dev/null; killall cfprefsd 2>/dev/null
 ```
 
 ### Remove the Dock tile
@@ -120,4 +130,5 @@ ls "$HOME/Library/Application Support/Mila/Recordings" | wc -l
 - **Forgetting `recordings.json`.** Backing up `Recordings/` without the index leaves a reinstall with an empty library.
 - **Using `rm`.** Always `trash` so the user can recover.
 - **Deleting `Models/`/`torch-site-packages/` without asking.** These are keep-by-default; deleting them forces multi-GB re-downloads on reinstall.
+- **Wiping the preferences plist on a routine uninstall.** That destroys the user's settings (model, language, diarization, LLM config). Keep it unless the user explicitly wants a full reset — and if they do, clear `cfprefsd` too or it gets rewritten.
 - **Trashing the source repo.** Only `build/` inside `~/ClonedProjects/mila` is an artifact; the rest is source.


### PR DESCRIPTION
Adds two project-level Claude Code skills under `.claude/skills/` documenting common local dev operations for Mila.

## Skills

- **`build-mila-locally`** — debug/release builds, the self-signed (ad-hoc) DMG flow, and installing a local build into `/Applications`. Captures real build gotchas: `make dmg` needing an explicit `VERSION=` (Info.plist stores the literal `$(MARKETING_VERSION)`), the gitignored `PythonRuntime/` placeholder, and where whisper models live.
- **`uninstall-mila`** — safe removal of the app, Dock tile, and system caches/prefs (filed under bundle id `io.island.whisper.IslandWhisper`, not "Mila"), while protecting `~/Library/Application Support/Mila/Recordings/` + `recordings.json`. Backs up recordings first, uses `trash` (reversible), and requires explicit user confirmation before deleting the ~7.2 GB regenerable Models/torch data.

## Notes

- Documentation only — no code or build changes.
- Both verified this session: build → DMG → install → launch, and a full uninstall round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a macOS “build from source” guide with quick-reference `make` commands (project generation, debug/release builds, `run`, tests, DMG creation, cleanup), plus troubleshooting for local DMG signing and Gatekeeper/quarantine behavior. Notes `make dmg` requires explicitly providing `VERSION=`.
  * Added a safe macOS uninstall guide that removes the app and bundle-id–scoped caches/build artifacts while protecting recordings/transcripts by default. Includes an optional full reset, removes the Dock tile, and provides verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->