### PR TITLE
CI hardening: de-load build-and-test, universalize unit tests, skip-clean E2E so all checks are requirable & non-flaky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,19 @@ jobs:
             build | xcpretty || true
 
       - name: Run unit tests
-        # Scope to MilaTests only. UI tests can't reliably foreground on
-        # hosted runners (see ios-tests.yml for the full explanation);
-        # gating CI on them would mean a permanently red status, which
-        # is worse than no UI-test signal at all.
+        # Scope to ONLY WhisperEngineCoreMLTests — the CoreML/ANE E2E test
+        # that this job uniquely sets up the CoreML model + env for. The
+        # rest of MilaTests is covered by the unit-and-ui-tests job; running
+        # the full suite here too redundantly re-ran subprocess-spawning
+        # tests on this overloaded runner (build + diarization bundle +
+        # whisper download all on one host), which caused contention flakes.
+        # In unit-and-ui-tests WhisperEngineCoreMLTests auto-skips because
+        # MILA_COREML_E2E isn't set there, so coverage doesn't overlap.
+        #
+        # UI tests can't reliably foreground on hosted runners (see
+        # ios-tests.yml for the full explanation); gating CI on them would
+        # mean a permanently red status, which is worse than no UI-test
+        # signal at all.
         #
         # MILA_COREML_E2E + MILA_COREML_MODEL unblock
         # `WhisperEngineCoreMLTests`, which verifies that whisper.cpp's
@@ -141,7 +150,7 @@ jobs:
             -configuration Debug \
             -derivedDataPath build \
             -destination 'platform=macOS' \
-            -only-testing:MilaTests \
+            -only-testing:MilaTests/WhisperEngineCoreMLTests \
             -retry-tests-on-failure \
             -test-iterations 3 \
             -test-timeouts-enabled YES \

--- a/.github/workflows/e2e-diarization.yml
+++ b/.github/workflows/e2e-diarization.yml
@@ -3,17 +3,7 @@ name: E2E Diarization
 on:
   push:
     branches: [main]
-    paths:
-      - 'Mila/Transcription/SpeakerDiarizer.swift'
-      - 'Mila/Resources/DiarizationModels/**'
-      - 'scripts/diarize-e2e.py'
-      - '.github/workflows/e2e-diarization.yml'
   pull_request:
-    paths:
-      - 'Mila/Transcription/SpeakerDiarizer.swift'
-      - 'Mila/Resources/DiarizationModels/**'
-      - 'scripts/diarize-e2e.py'
-      - '.github/workflows/e2e-diarization.yml'
 
 # The bulk of CI time on a cold cache is the torch wheel download (~150 MB)
 # and pyannote.audio + numpy/scipy/etc (~50 MB more). Cache the entire venv
@@ -33,7 +23,18 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'Mila/Transcription/SpeakerDiarizer.swift'
+              - 'Mila/Resources/DiarizationModels/**'
+              - 'scripts/diarize-e2e.py'
+              - '.github/workflows/e2e-diarization.yml'
+
       - name: Cache pyannote venv
+        if: steps.changes.outputs.relevant == 'true'
         id: venv-cache
         uses: actions/cache@v4
         with:
@@ -41,7 +42,7 @@ jobs:
           key: diar-venv-${{ runner.os }}-py3.11-${{ env.VENV_VERSION }}
 
       - name: Set up Python venv (cold path only)
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.relevant == 'true' && (steps.venv-cache.outputs.cache-hit != 'true')
         run: |
           /usr/bin/python3 -m venv ~/diar-venv
           ~/diar-venv/bin/pip install --upgrade pip
@@ -54,6 +55,7 @@ jobs:
             'huggingface_hub<1.0'
 
       - name: Diarize fixture
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           ~/diar-venv/bin/python scripts/diarize-e2e.py \
             Mila/Resources/DiarizationModels \

--- a/.github/workflows/e2e-remote-transcription.yml
+++ b/.github/workflows/e2e-remote-transcription.yml
@@ -8,23 +8,7 @@ name: E2E Remote Transcription
 on:
   push:
     branches: [main]
-    paths:
-      - 'Mila/Transcription/RemoteWhisperEngine.swift'
-      - 'Mila/Models/RemoteTranscriptionSettings.swift'
-      - 'Mila/Transcription/TranscriptionService.swift'
-      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
-      - 'MilaTests/RemoteTranscriptionTests.swift'
-      - 'scripts/mock-openai-transcription-server.py'
-      - '.github/workflows/e2e-remote-transcription.yml'
   pull_request:
-    paths:
-      - 'Mila/Transcription/RemoteWhisperEngine.swift'
-      - 'Mila/Models/RemoteTranscriptionSettings.swift'
-      - 'Mila/Transcription/TranscriptionService.swift'
-      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
-      - 'MilaTests/RemoteTranscriptionTests.swift'
-      - 'scripts/mock-openai-transcription-server.py'
-      - '.github/workflows/e2e-remote-transcription.yml'
 
 permissions:
   contents: read
@@ -42,18 +26,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'Mila/Transcription/RemoteWhisperEngine.swift'
+              - 'Mila/Models/RemoteTranscriptionSettings.swift'
+              - 'Mila/Transcription/TranscriptionService.swift'
+              - 'MilaTests/RemoteTranscriptionE2ETests.swift'
+              - 'MilaTests/RemoteTranscriptionTests.swift'
+              - 'scripts/mock-openai-transcription-server.py'
+              - '.github/workflows/e2e-remote-transcription.yml'
+
       - name: Show toolchain
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild -version
           python3 --version
 
       - name: Install xcodegen
+        if: steps.changes.outputs.relevant == 'true'
         run: brew install xcodegen
 
       # The .xcodeproj references Mila/Resources/PythonRuntime, so the bundle
       # must exist before project generation / build. Same cache key as ci.yml
       # so a single entry services both workflows.
       - name: Cache diarization bundle
+        if: steps.changes.outputs.relevant == 'true'
         id: diar-bundle-cache
         uses: actions/cache@v4
         with:
@@ -61,19 +61,22 @@ jobs:
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
 
       - name: Build diarization bundle (cold path only)
-        if: steps.diar-bundle-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.relevant == 'true' && (steps.diar-bundle-cache.outputs.cache-hit != 'true')
         run: make bundle-diarization
 
       - name: Generate Xcode project
+        if: steps.changes.outputs.relevant == 'true'
         run: make project
 
       - name: Clear SwiftPM caches
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           rm -rf ~/Library/Caches/org.swift.swiftpm
           rm -rf ~/Library/org.swift.swiftpm
           rm -rf ~/Library/Developer/Xcode/DerivedData/SourcePackages
 
       - name: Resolve Swift Package dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild \
             -project Mila.xcodeproj \
@@ -82,6 +85,7 @@ jobs:
             -resolvePackageDependencies
 
       - name: Start mock OpenAI transcription server
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           python3 scripts/mock-openai-transcription-server.py --port "$MOCK_PORT" \
             > mock-server.log 2>&1 &
@@ -101,6 +105,7 @@ jobs:
         # xcodebuild forwards env vars into the test process after stripping
         # the TEST_RUNNER_ prefix (see ci.yml for why the bare form doesn't
         # propagate reliably).
+        if: steps.changes.outputs.relevant == 'true'
         env:
           TEST_RUNNER_MILA_REMOTE_TEST_ENDPOINT: "http://127.0.0.1:8123/v1"
         run: |
@@ -115,7 +120,7 @@ jobs:
             test
 
       - name: Stop mock server
-        if: always()
+        if: steps.changes.outputs.relevant == 'true' && (always())
         run: |
           if [ -f mock-server.pid ]; then kill "$(cat mock-server.pid)" 2>/dev/null || true; fi
           echo "--- mock server log ---"; cat mock-server.log 2>/dev/null || true

--- a/.github/workflows/e2e-transcription.yml
+++ b/.github/workflows/e2e-transcription.yml
@@ -3,17 +3,7 @@ name: E2E Transcription
 on:
   push:
     branches: [main]
-    paths:
-      - 'Packages/TranscriptionCore/**'
-      - 'Mila/Transcription/**'
-      - '.github/workflows/e2e-transcription.yml'
-      - '.github/whisper-cpp-pin.txt'
   pull_request:
-    paths:
-      - 'Packages/TranscriptionCore/**'
-      - 'Mila/Transcription/**'
-      - '.github/workflows/e2e-transcription.yml'
-      - '.github/whisper-cpp-pin.txt'
 
 env:
   LIBRARY_PATH: /usr/local/lib
@@ -31,7 +21,18 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'Packages/TranscriptionCore/**'
+              - 'Mila/Transcription/**'
+              - '.github/workflows/e2e-transcription.yml'
+              - '.github/whisper-cpp-pin.txt'
+
       - name: Verify whisper.cpp submodule hash
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           EXPECTED=$(cat .github/whisper-cpp-pin.txt | tr -d '[:space:]')
           ACTUAL=$(git submodule status Packages/TranscriptionCore/vendor/whisper.cpp | awk '{print $1}' | tr -d '+')
@@ -43,11 +44,13 @@ jobs:
           echo "whisper.cpp submodule at expected commit $EXPECTED"
 
       - name: Install system dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake build-essential
 
       - name: Cache whisper.cpp build
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/cache@v4
         id: whisper-build-cache
         with:
@@ -61,7 +64,7 @@ jobs:
           key: whisper-build-${{ hashFiles('.github/whisper-cpp-pin.txt') }}
 
       - name: Build and install whisper.cpp
-        if: steps.whisper-build-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.relevant == 'true' && (steps.whisper-build-cache.outputs.cache-hit != 'true')
         working-directory: Packages/TranscriptionCore/vendor/whisper.cpp
         run: |
           cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON
@@ -69,20 +72,24 @@ jobs:
           sudo cmake --install build
 
       - name: Update linker cache
+        if: steps.changes.outputs.relevant == 'true'
         run: sudo ldconfig
 
       - name: Install Swift
+        if: steps.changes.outputs.relevant == 'true'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: '5.10'
 
       - name: Cache whisper model
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/whisper-models
           key: whisper-model-ggml-tiny-v1
 
       - name: Download ggml-tiny model
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           mkdir -p ~/.cache/whisper-models
           if [ ! -f ~/.cache/whisper-models/ggml-tiny.bin ]; then
@@ -92,14 +99,17 @@ jobs:
           fi
 
       - name: Run package unit tests
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: Packages/TranscriptionCore
         run: swift test
 
       - name: Build whisper-e2e
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: Packages/TranscriptionCore
         run: swift build --product whisper-e2e -c release
 
       - name: Run E2E transcription tests
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: Packages/TranscriptionCore
         run: |
           swift run -c release whisper-e2e \

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -3,19 +3,7 @@ name: App Tests
 on:
   push:
     branches: [main]
-    paths:
-      - 'Mila/**'
-      - 'MilaTests/**'
-      - 'MilaUITests/**'
-      - 'project.yml'
-      - '.github/workflows/ios-tests.yml'
   pull_request:
-    paths:
-      - 'Mila/**'
-      - 'MilaTests/**'
-      - 'MilaUITests/**'
-      - 'project.yml'
-      - '.github/workflows/ios-tests.yml'
 
 jobs:
   unit-and-ui-tests:

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -99,9 +99,11 @@ jobs:
           filters: |
             relevant:
               - 'scripts/llm-live-ai-e2e.py'
+              - 'scripts/llm-verify-screenshots.py'
               - 'scripts/fixtures/**'
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
+              - 'MilaUITests/DetailLayoutUITests.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
       - name: Install xcodegen
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -14,19 +14,7 @@ name: Live AI E2E
 on:
   push:
     branches: [main]
-    paths:
-      - 'scripts/llm-live-ai-e2e.py'
-      - 'scripts/fixtures/**'
-      - 'Mila/Models/LiveAISettings.swift'
-      - 'Mila/Actions/LiveAISession.swift'
-      - '.github/workflows/llm-live-ai-e2e.yml'
   pull_request:
-    paths:
-      - 'scripts/llm-live-ai-e2e.py'
-      - 'scripts/fixtures/**'
-      - 'Mila/Models/LiveAISettings.swift'
-      - 'Mila/Actions/LiveAISession.swift'
-      - '.github/workflows/llm-live-ai-e2e.yml'
   workflow_dispatch:
     inputs:
       minutes:
@@ -41,10 +29,22 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'scripts/llm-live-ai-e2e.py'
+              - 'scripts/fixtures/**'
+              - 'Mila/Models/LiveAISettings.swift'
+              - 'Mila/Actions/LiveAISession.swift'
+              - '.github/workflows/llm-live-ai-e2e.yml'
       - uses: actions/setup-python@v5
+        if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
       - name: Run E2E (English, mock backend — no key)
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           python scripts/llm-live-ai-e2e.py \
             --backend mock \
@@ -57,10 +57,22 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'scripts/llm-live-ai-e2e.py'
+              - 'scripts/fixtures/**'
+              - 'Mila/Models/LiveAISettings.swift'
+              - 'Mila/Actions/LiveAISession.swift'
+              - '.github/workflows/llm-live-ai-e2e.yml'
       - uses: actions/setup-python@v5
+        if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
       - name: Run E2E (Hebrew, mock backend — no key)
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           python scripts/llm-live-ai-e2e.py \
             --backend mock \
@@ -81,24 +93,38 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'scripts/llm-live-ai-e2e.py'
+              - 'scripts/fixtures/**'
+              - 'Mila/Models/LiveAISettings.swift'
+              - 'Mila/Actions/LiveAISession.swift'
+              - '.github/workflows/llm-live-ai-e2e.yml'
       - name: Install xcodegen
+        if: steps.changes.outputs.relevant == 'true'
         run: brew install xcodegen
       # The .xcodeproj references Mila/Resources/PythonRuntime as a
       # bundled resource — the link step fails without it. Same cache
       # key as ios-tests.yml so cold builds across the two workflows
       # restore from a single entry.
       - name: Cache diarization bundle
+        if: steps.changes.outputs.relevant == 'true'
         id: diar-bundle-cache
         uses: actions/cache@v4
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
       - name: Build diarization bundle (cold path only)
-        if: steps.diar-bundle-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.relevant == 'true' && (steps.diar-bundle-cache.outputs.cache-hit != 'true')
         run: make bundle-diarization
       - name: Generate Xcode project
+        if: steps.changes.outputs.relevant == 'true'
         run: make project
       - name: Run UI tests (writes screenshots to /tmp/mila-ui-screenshots/)
+        if: steps.changes.outputs.relevant == 'true'
         env:
           MILA_UI_SCREENSHOTS_DIR: /tmp/mila-ui-screenshots
         run: |
@@ -113,16 +139,19 @@ jobs:
             -derivedDataPath build-uitests \
             CODE_SIGNING_ALLOWED=NO || (echo "UI tests failed — vision check skipped" && exit 1)
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.changes.outputs.relevant == 'true' && (always())
         with:
           name: ui-screenshots
           path: /tmp/mila-ui-screenshots/
           if-no-files-found: warn
       - uses: actions/setup-python@v5
+        if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
       - run: pip install --upgrade anthropic
+        if: steps.changes.outputs.relevant == 'true'
       - name: Visual regression check via Claude vision
+        if: steps.changes.outputs.relevant == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |


### PR DESCRIPTION
## Goal

Make every PR-gating check able to be a **required** status check that is **non-flaky** and **never blocks an unrelated PR**.

## Changes

### `ci.yml` — de-load `build-and-test`
The `build-and-test` job redundantly re-ran the **full** `MilaTests` suite (also run by `unit-and-ui-tests`) on an already-overloaded runner (build + diarization bundle + whisper/CoreML download all on one host). That contention made the subprocess-spawning / detached-Task tests flake. Its "Run unit tests" step is now scoped to `-only-testing:MilaTests/WhisperEngineCoreMLTests` — the CoreML/ANE E2E test this job *uniquely* provisions the CoreML model + env for. All other steps (model cache/env setup, retry/timeout flags, the What's New popup UI test) are unchanged. The rest of `MilaTests` is covered by `unit-and-ui-tests`, where `WhisperEngineCoreMLTests` auto-skips (no `MILA_COREML_E2E`), so coverage doesn't overlap.

### `ios-tests.yml` — universalize `unit-and-ui-tests`
Removed the `paths:` filters under both `pull_request` and `push` (kept `branches: [main]`). The full unit suite now runs on **every** PR and push to main — a universal gate that can be required without blocking any PR. Test/retry/timeout flags unchanged.

### 4 scoped E2E workflows — "always-run + skip-clean"
`e2e-transcription.yml`, `e2e-diarization.yml`, `e2e-remote-transcription.yml`, `llm-live-ai-e2e.yml`:
- Removed the `on.*` `paths:` lists so the workflows always trigger.
- Added a `dorny/paths-filter@v3` step (`id: changes`) right after `checkout` in **every** job, with the old path list as the `relevant` filter.
- Gated every real-work step on `if: steps.changes.outputs.relevant == 'true'` (ANDed with any pre-existing `if:`). Checkout + paths-filter stay ungated.

When a PR doesn't touch a subsystem, its job runs only checkout + paths-filter (~15–60s) and concludes **success**; when the subsystem is touched, it runs fully as before.

**No job-level `if:`** — a *skipped* job does not report success to branch-protection required checks and would block PRs. Gating is at the **step** level so every job always runs to a green conclusion.

## Follow-up
Branch protection should be updated to require all these checks once they're green on this PR. (Not modified here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI and E2E workflows to trigger on all pull requests, using in-job change detection to decide what work to run.
  * Reduced unnecessary setup, dependency installation, model/artifact fetching, and test execution by conditionally running only when relevant files change.
  * Narrowed the CoreML unit-test run to a smaller targeted test set to improve reliability on shared runners.
  * Improved cleanup so mock servers and related teardown run only when the corresponding steps actually executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->