### PR TITLE
Don't read the Keychain at launch unless remote transcription is enabled

### DIFF
--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -58,6 +58,11 @@ final class RemoteTranscriptionSettings: ObservableObject {
         didSet {
             guard backend != oldValue else { return }
             defaults.set(backend.rawValue, forKey: Keys.backend)
+            // Defer the Keychain read until the user actually switches to the
+            // remote backend (see `loadAPIKeyIfNeeded`). Local-only users never
+            // trigger the macOS "Mila wants to use confidential information"
+            // prompt because we never touch the Keychain for them.
+            if backend == .remote { loadAPIKeyIfNeeded() }
         }
     }
 
@@ -82,6 +87,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
     @Published var apiKey: String {
         didSet {
             guard apiKey != oldValue else { return }
+            // Skip the write-back when we're just adopting the value we read
+            // from the Keychain — re-saving it would be a redundant write that
+            // could itself trigger a Keychain prompt.
+            guard !isAdoptingStoredAPIKey else { return }
             KeychainHelper.save(key: apiKeyKeychainKey, value: apiKey)
             testStatus = .idle
         }
@@ -98,6 +107,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
     /// previews / alternate instances don't read or clobber the real app's
     /// `remote.apiKey` item (mirrors how `defaults` is injected).
     private let apiKeyKeychainKey: String
+    /// Whether the stored token has been read from the Keychain yet. Guards the
+    /// lazy load so it happens at most once, and so an explicit user edit before
+    /// the first switch to remote isn't clobbered by a later load.
+    private var hasLoadedAPIKey = false
 
     init(defaults: UserDefaults = .standard,
          urlSession: URLSession = .shared,
@@ -109,8 +122,42 @@ final class RemoteTranscriptionSettings: ObservableObject {
             ?? .local
         self.endpoint = defaults.string(forKey: Keys.endpoint) ?? Self.defaultEndpoint
         self.model = defaults.string(forKey: Keys.model) ?? Self.defaultModel
-        self.apiKey = KeychainHelper.load(key: apiKeyKeychainKey) ?? ""
+        // Start empty and defer the Keychain read. Reading the token at launch
+        // unconditionally pops the macOS "Mila wants to use confidential
+        // information stored in your keychain" prompt for *every* user — even
+        // the local-only majority who never configure a remote endpoint. We
+        // only read once the user actually selects the remote backend (here if
+        // it's the restored choice, otherwise lazily in `backend.didSet`).
+        self.apiKey = ""
+        if backend == .remote { loadAPIKeyIfNeeded() }
     }
+
+    /// Lazily read the bearer token from the Keychain the first time the remote
+    /// backend is selected. Idempotent (guarded by `hasLoadedAPIKey`) and
+    /// non-destructive: if the user has already typed a key we keep theirs
+    /// rather than overwrite it with the stored value.
+    private func loadAPIKeyIfNeeded() {
+        guard !hasLoadedAPIKey else { return }
+        hasLoadedAPIKey = true
+        // Don't clobber an in-progress edit. Only adopt the stored token when
+        // the in-memory field is still empty.
+        guard apiKey.isEmpty else { return }
+        guard let stored = KeychainHelper.load(key: apiKeyKeychainKey), !stored.isEmpty else { return }
+        // Assigning here triggers `apiKey.didSet`, but since `stored != ""` only
+        // when it differs from the current empty value, the write-through guard
+        // (`guard apiKey != oldValue`) lets it pass and re-saves the identical
+        // value. KeychainHelper.save is delete-then-add, so writing the same
+        // value back is harmless — but to avoid even that redundant Keychain
+        // write (which could itself prompt), suppress the write-through for this
+        // one assignment.
+        isAdoptingStoredAPIKey = true
+        apiKey = stored
+        isAdoptingStoredAPIKey = false
+    }
+
+    /// Set only while `loadAPIKeyIfNeeded` adopts the stored token, so the
+    /// `apiKey.didSet` write-through skips re-saving a value we just read.
+    private var isAdoptingStoredAPIKey = false
 
     /// True when the user has chosen the remote backend (regardless of whether
     /// it's fully configured). Drives routing in `TranscriptionService`.

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -60,6 +60,95 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(config?.model, RemoteTranscriptionSettings.defaultModel)
     }
 
+    func test_localBackend_doesNotReadKeychain() {
+        // Seed a real token under an isolated key, then construct with the
+        // default (local) backend. A local-only user must come up with an empty
+        // apiKey and we must NOT have read the Keychain (which would prompt).
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        let settings = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        XCTAssertEqual(settings.backend, .local)
+        XCTAssertEqual(settings.apiKey, "", "Local-only launch must not load the stored token")
+    }
+
+    func test_switchingToRemote_lazilyLoadsStoredToken() {
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        let settings = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+        XCTAssertEqual(settings.apiKey, "")
+
+        settings.backend = .remote
+        XCTAssertEqual(settings.apiKey, "sk-stored",
+                       "Switching to remote must lazily load the stored token")
+    }
+
+    func test_remoteBackendAtLaunch_loadsStoredToken() {
+        // If remote was the persisted choice, the token should be present right
+        // after construction (the one case where reading at launch is correct).
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        suite.set(TranscriptionBackend.remote.rawValue, forKey: "transcription.backend")
+        let settings = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        XCTAssertEqual(settings.backend, .remote)
+        XCTAssertEqual(settings.apiKey, "sk-stored")
+    }
+
+    func test_lazyLoad_doesNotClobberInProgressEdit() {
+        // User typed a key before ever switching to remote. Switching must keep
+        // their edit, not overwrite it with the stored value.
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        let settings = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        settings.apiKey = "sk-user-typed"
+        settings.backend = .remote
+        XCTAssertEqual(settings.apiKey, "sk-user-typed",
+                       "An in-progress edit must not be clobbered by the lazy load")
+    }
+
+    func test_lazyLoad_isIdempotentAcrossBackendToggles() {
+        // Once loaded, toggling local <-> remote must not re-read or clobber.
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        let settings = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        settings.backend = .remote
+        XCTAssertEqual(settings.apiKey, "sk-stored")
+        // User clears the field, then flips back to local and to remote again.
+        settings.apiKey = ""
+        settings.backend = .local
+        settings.backend = .remote
+        XCTAssertEqual(settings.apiKey, "",
+                       "Already-loaded token must not be re-read on a later switch")
+    }
+
     func test_editingEndpointResetsTestStatus() async {
         // Stub the network so testConnection() actually seeds a non-idle
         // status (.ok), then assert that editing the endpoint resets it —


### PR DESCRIPTION
## Problem

`RemoteTranscriptionSettings.init()` unconditionally read the remote API bearer token from the macOS Keychain on **every** launch. The Keychain is used *only* for the remote-transcription API token, yet reading it pops the system prompt:

> "Mila wants to use confidential information stored in your keychain."

This fired for every user — including the local-only majority who never configure a remote endpoint and have nothing stored — turning a privacy-first, on-device app into one that nags about Keychain access at startup.

## Fix

Gate the Keychain read on the backend actually being remote:

- `init()` now starts `apiKey` empty and reads the Keychain only if the **restored** backend is `.remote`.
- When the user later switches `backend` to `.remote`, the token is **lazily** loaded the first time, in `backend.didSet`.
- The lazy load is guarded by a private `hasLoadedAPIKey` flag so it runs at most once, and it won't clobber an in-progress user edit (only adopts the stored value when the in-memory field is still empty).
- Adopting the stored value suppresses the `apiKey` `didSet` write-through (via a short-lived `isAdoptingStoredAPIKey` flag) so we don't issue a redundant Keychain write — which could itself prompt.
- Switching back to `.local` leaves the stored token in place (the user may switch back).

Local-only users now never trigger a Keychain prompt or read.

## Tests

Five new tests in `RemoteTranscriptionSettingsTests`, following the existing isolated-key/suite convention (and cleaning up their Keychain items):

- `test_localBackend_doesNotReadKeychain` — local-at-launch yields an empty `apiKey` even when a token exists under the key.
- `test_switchingToRemote_lazilyLoadsStoredToken` — switching to remote lazily loads the stored token.
- `test_remoteBackendAtLaunch_loadsStoredToken` — remote-as-restored-choice loads the token at construction.
- `test_lazyLoad_doesNotClobberInProgressEdit` — a key typed before switching is preserved.
- `test_lazyLoad_isIdempotentAcrossBackendToggles` — once loaded, toggling local↔remote doesn't re-read/clobber.

All 11 tests in the suite pass; the app builds (`make build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote transcription settings so saved login details are only loaded when remote transcription is selected.
  * Prevented stored credentials from overwriting any text already entered by the user.
  * Reduced unnecessary credential prompts by avoiding repeated reads and writes during backend switching.

* **Tests**
  * Added coverage for initial loading, backend switching, preserving user-entered values, and repeated local/remote toggles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->