### PR TITLE
Surface remote transcription failures + verify server at record start

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -165,6 +165,14 @@ final class QuickActionsController: ObservableObject {
     /// we never fire the warning for a recording that's already over.
     private var silenceWatchTask: Task<Void, Never>?
 
+    /// Active record-start remote-backend probe (see `startRecording`).
+    /// Single-owner: superseded when a new recording starts and cancelled
+    /// when one stops, so an older probe — whose `GET /models` is still in
+    /// flight against the same unchanged config (which `testConnection()`
+    /// can't detect as stale) — can't land an out-of-order failure into
+    /// `lastError`/`testStatus` after the user already moved on.
+    private var remoteProbeTask: Task<Void, Never>?
+
     /// Background finalize tasks, keyed by the recording id they're
     /// finalizing. After `stopRecording` drains the live pipeline and
     /// frees the record button, the HEAVY tail of finalization — the
@@ -373,7 +381,12 @@ final class QuickActionsController: ObservableObject {
             // recorded a whole meeting before learning it failed). Non-blocking
             // — recording already started and audio is being saved; this just
             // races an error banner to the user. No-op for the local backend.
-            Task { [transcription] in await transcription.probeRemoteBackendIfActive() }
+            // Single-owner: cancel any prior probe so its (possibly stale)
+            // result can't overwrite UI state for this newer recording.
+            remoteProbeTask?.cancel()
+            remoteProbeTask = Task { [transcription] in
+                await transcription.probeRemoteBackendIfActive()
+            }
         } catch SystemAudioRecorder.CaptureError.permissionDenied {
             screenRecordingPermissionMissing = true
         } catch {
@@ -493,6 +506,10 @@ final class QuickActionsController: ObservableObject {
         // user already stopped (especially common for sub-10s recordings).
         silenceWatchTask?.cancel()
         silenceWatchTask = nil
+        // Cancel any in-flight record-start remote probe for the same reason:
+        // its failure result must not land after the recording is over.
+        remoteProbeTask?.cancel()
+        remoteProbeTask = nil
         // Release the sleep assertion as soon as the engine is shutting
         // down — keeping it past `stop()` would block idle sleep while
         // the user is just looking at the rename sheet.

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -374,19 +374,7 @@ final class QuickActionsController: ObservableObject {
             activeJob = .recording(withSystemAudio: withSystemAudio)
             sleepGuard.preventIdleSleep(reason: "Mila is recording")
             startSilenceWatch(watching: source)
-            // Proactively verify a remote transcription backend now that
-            // capture is live. A bad key / unreachable endpoint otherwise
-            // stays invisible: the live path silently drops every utterance
-            // and the error only appears on the Stop batch pass (the user
-            // recorded a whole meeting before learning it failed). Non-blocking
-            // — recording already started and audio is being saved; this just
-            // races an error banner to the user. No-op for the local backend.
-            // Single-owner: cancel any prior probe so its (possibly stale)
-            // result can't overwrite UI state for this newer recording.
-            remoteProbeTask?.cancel()
-            remoteProbeTask = Task { [transcription] in
-                await transcription.probeRemoteBackendIfActive()
-            }
+            armRemoteProbe()
         } catch SystemAudioRecorder.CaptureError.permissionDenied {
             screenRecordingPermissionMissing = true
         } catch {
@@ -476,6 +464,7 @@ final class QuickActionsController: ObservableObject {
             activeJob = .recordingApp(processID: app?.processID, includeMic: includeMic)
             sleepGuard.preventIdleSleep(reason: "Mila is recording")
             startSilenceWatch(watching: source)
+            armRemoteProbe()
         } catch SystemAudioRecorder.CaptureError.permissionDenied {
             screenRecordingPermissionMissing = true
         } catch {
@@ -484,6 +473,23 @@ final class QuickActionsController: ObservableObject {
             } else {
                 transcription.lastError = "Could not start app recording: \(error.localizedDescription)"
             }
+        }
+    }
+
+    /// Proactively verify a remote transcription backend now that capture is
+    /// live. A bad key / unreachable endpoint otherwise stays invisible: the
+    /// live path silently drops every utterance and the error only appears on
+    /// the Stop batch pass (the user recorded a whole meeting before learning
+    /// it failed). Non-blocking — recording already started and audio is being
+    /// saved; this just races an error banner to the user. No-op for the local
+    /// backend. Single-owner: cancel any prior probe so its (possibly stale)
+    /// result can't overwrite UI state for this newer recording. Called from
+    /// every record-start entry point (mic/meeting and app-audio) so no live
+    /// path can fail silently. Cancelled in `stopRecording()`.
+    private func armRemoteProbe() {
+        remoteProbeTask?.cancel()
+        remoteProbeTask = Task { [transcription] in
+            await transcription.probeRemoteBackendIfActive()
         }
     }
 

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -489,6 +489,13 @@ final class QuickActionsController: ObservableObject {
     private func armRemoteProbe() {
         remoteProbeTask?.cancel()
         remoteProbeTask = Task { [transcription] in
+            // `cancel()` above is cooperative, so a just-superseded probe can
+            // still get scheduled. Bail before touching `transcription` —
+            // `probeRemoteBackendIfActive()`'s active-but-unconfigured branch
+            // writes `lastError` synchronously, before any await/cancellation
+            // check, so without this guard a stale probe could surface an
+            // error for a recording the user has already moved past.
+            guard !Task.isCancelled else { return }
             await transcription.probeRemoteBackendIfActive()
         }
     }

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -366,6 +366,14 @@ final class QuickActionsController: ObservableObject {
             activeJob = .recording(withSystemAudio: withSystemAudio)
             sleepGuard.preventIdleSleep(reason: "Mila is recording")
             startSilenceWatch(watching: source)
+            // Proactively verify a remote transcription backend now that
+            // capture is live. A bad key / unreachable endpoint otherwise
+            // stays invisible: the live path silently drops every utterance
+            // and the error only appears on the Stop batch pass (the user
+            // recorded a whole meeting before learning it failed). Non-blocking
+            // — recording already started and audio is being saved; this just
+            // races an error banner to the user. No-op for the local backend.
+            Task { [transcription] in await transcription.probeRemoteBackendIfActive() }
         } catch SystemAudioRecorder.CaptureError.permissionDenied {
             screenRecordingPermissionMissing = true
         } catch {

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -5,6 +5,17 @@ import TranscriptionCore
 private let remoteLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
                                category: "RemoteWhisperEngine")
 
+/// Injection seam for `TranscriptionService`: the remote engine refines
+/// `TranscribingEngine` with the remote-specific `configure(_:)` step the
+/// service calls before each run. Pulling it behind a protocol lets tests
+/// substitute an engine that fails deterministically (e.g. a simulated HTTP
+/// 401) without a real network round-trip — which is exactly the failure mode
+/// that previously went uncaught (a misconfigured remote key silently emptied
+/// the live transcript). `RemoteWhisperEngine` is the only production conformer.
+protocol RemoteTranscribing: TranscribingEngine {
+    func configure(_ config: RemoteTranscriptionConfig) async
+}
+
 /// A `TranscribingEngine` that offloads transcription to an OpenAI-compatible
 /// `/v1/audio/transcriptions` endpoint instead of running whisper.cpp locally.
 ///
@@ -18,7 +29,7 @@ private let remoteLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
 /// Config (endpoint, key, model) is injected via `configure(_:)` before each
 /// transcription — the protocol's `transcribe` signature is fixed by the local
 /// engine, so the remote-specific bits ride alongside on the actor's state.
-actor RemoteWhisperEngine: TranscribingEngine {
+actor RemoteWhisperEngine: RemoteTranscribing {
     enum RemoteError: LocalizedError {
         case notConfigured
         case http(status: Int, body: String)

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -289,6 +289,11 @@ final class TranscriptionService: ObservableObject {
             return
         }
         await remoteSettings.testConnection()
+        // Drop a superseded/cancelled probe: the caller cancels this task when
+        // the recording stops or a newer recording starts, so a late, out-of-
+        // order failure can't overwrite UI state for a recording the user has
+        // already moved past.
+        if Task.isCancelled { return }
         if case .failed(let message) = remoteSettings.testStatus {
             lastError = "Remote transcription server check failed: \(message) Your audio is still being recorded — fix the endpoint or API key in Settings → Models, then re-transcribe."
         }

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -63,8 +63,9 @@ final class TranscriptionService: ObservableObject {
 
     /// OpenAI-compatible remote engine. Constructed unconditionally but only
     /// exercised when `remoteSettings.isActive` — cheap to hold idle (no
-    /// weights, just a URLSession).
-    private let remoteEngine = RemoteWhisperEngine()
+    /// weights, just a URLSession). Injectable so tests can substitute an
+    /// engine that fails deterministically (see `RemoteTranscribing`).
+    private let remoteEngine: any RemoteTranscribing
 
     /// Hook fired once per recording that finished transcription
     /// successfully (status == .completed, non-empty text). MilaApp
@@ -110,7 +111,8 @@ final class TranscriptionService: ObservableObject {
          modelManager: ModelManager,
          diarizationSettings: DiarizationSettings,
          remoteSettings: RemoteTranscriptionSettings? = nil,
-         engine: any TranscribingEngine = WhisperEngine()) {
+         engine: any TranscribingEngine = WhisperEngine(),
+         remoteEngine: (any RemoteTranscribing)? = nil) {
         self.store = store
         self.modelManager = modelManager
         self.diarizationSettings = diarizationSettings
@@ -119,6 +121,7 @@ final class TranscriptionService: ObservableObject {
         // don't exercise the remote path simply omit it.
         self.remoteSettings = remoteSettings ?? RemoteTranscriptionSettings()
         self.engine = engine
+        self.remoteEngine = remoteEngine ?? RemoteWhisperEngine()
         // Bridge the engine's preparation callback onto the main
         // actor so SwiftUI subscribers see flips through `@Published`
         // (which is itself MainActor-isolated). The closure is
@@ -268,6 +271,29 @@ final class TranscriptionService: ObservableObject {
     /// There is no default — the wrong choice silently degrades transcription
     /// quality on one path or the other, so make every call site declare its
     /// intent.
+    /// Proactively verify a remote transcription backend at recording start so
+    /// a bad API key or unreachable endpoint surfaces IMMEDIATELY — as the
+    /// global "Transcription error" alert — instead of silently emptying the
+    /// live transcript for the whole recording and only erroring on the Stop
+    /// batch pass. No-op for the on-device backend.
+    ///
+    /// Reuses `RemoteTranscriptionSettings.testConnection()` (a cheap
+    /// `GET /models`), which also refreshes the Settings status pill, then
+    /// mirrors a failure into `lastError`. Non-fatal: recording proceeds and
+    /// audio is saved regardless — this only gets the user a fast, actionable
+    /// error rather than a mystery blank pane.
+    func probeRemoteBackendIfActive() async {
+        guard remoteSettings.isActive else { return }
+        guard remoteSettings.isConfigured else {
+            lastError = "Remote transcription is selected but not configured. Open Settings → Models to set the endpoint and API key."
+            return
+        }
+        await remoteSettings.testConnection()
+        if case .failed(let message) = remoteSettings.testStatus {
+            lastError = "Remote transcription server check failed: \(message) Your audio is still being recorded — fix the endpoint or API key in Settings → Models, then re-transcribe."
+        }
+    }
+
     func transcribeOnceSegments(samples: [Float], language: String, audioCtx: Int32?) async -> [TranscriptSegment] {
         // Remote backend: route dictation/live utterances to the configured
         // endpoint too, so the user's "global backend" choice holds for every
@@ -287,7 +313,20 @@ final class TranscriptionService: ObservableObject {
                                                              isCancelled: nil)
                 return segs
             } catch {
-                serviceLog.log("transcribeOnceSegments(remote): FAILED error=\(error.localizedDescription, privacy: .public)")
+                // Log at .error: a remote failure (401/transport/server) repeats
+                // on every utterance for the whole recording and silently empties
+                // the live pane. Error level so it's visible in `log show`
+                // WITHOUT --debug and stands out from the debug firehose.
+                serviceLog.error("transcribeOnceSegments(remote): FAILED error=\(error.localizedDescription, privacy: .public)")
+                // Surface the failure instead of returning a silently-empty
+                // result that's indistinguishable from "no speech". Set once
+                // (only when nothing is already showing) so a per-utterance
+                // failure loop doesn't churn the alert every few seconds — the
+                // record-start probe (`probeRemoteBackendIfActive`) is the
+                // primary, up-front surfacing; this is the mid-recording backstop.
+                if lastError == nil {
+                    lastError = "Live transcription failed: \(error.localizedDescription)"
+                }
                 return []
             }
         }
@@ -314,7 +353,7 @@ final class TranscriptionService: ObservableObject {
             serviceLog.log("transcribeOnceSegments: model=\(model.name, privacy: .public) lang=\(language, privacy: .public) samples=\(samples.count, privacy: .public) elapsed=\(Date().timeIntervalSince(startedAt), privacy: .public)s segs=\(segs.count, privacy: .public)")
             return segs
         } catch {
-            serviceLog.log("transcribeOnceSegments: FAILED model=\(model.name, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            serviceLog.error("transcribeOnceSegments: FAILED model=\(model.name, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             return []
         }
     }

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -173,6 +173,34 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         settings.endpoint = "https://example.com/v2"
         XCTAssertEqual(settings.testStatus, .idle, "Editing the endpoint must reset the status")
     }
+
+    func test_testConnection_failsOnAuthError() async {
+        // A 401 from /models must surface as .failed with an actionable
+        // "check the API key" message. This is the guard that would have
+        // caught a bad key (e.g. `test-key-123`) at record-start — BEFORE a
+        // whole recording was silently lost to per-utterance 401s. Its
+        // absence is why CI never flagged the original bug: the remote E2E
+        // suite only ever exercised the happy path against an accepting mock.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [Stub401URLProtocol.self]
+        let session = URLSession(configuration: config)
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.auth401")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.auth401")
+        let keychainKey = "RemoteTranscriptionSettingsTests.auth401.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let settings = RemoteTranscriptionSettings(
+            defaults: suite, urlSession: session, apiKeyKeychainKey: keychainKey)
+        settings.backend = .remote
+        settings.endpoint = "https://api.openai.com/v1"
+        settings.apiKey = "test-key-123"
+
+        await settings.testConnection()
+
+        guard case .failed(let message) = settings.testStatus else {
+            return XCTFail("Expected .failed for a 401, got \(settings.testStatus)")
+        }
+        XCTAssertTrue(message.contains("401"), "Failure should name the status code: \(message)")
+    }
 }
 
 /// Returns 200 for any request — lets `testConnection()` reach `.ok` without a
@@ -185,6 +213,20 @@ private final class StubOKURLProtocol: URLProtocol {
                                        httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+/// Returns 401 with an OpenAI-style error body — simulates a bad API key.
+private final class Stub401URLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 401,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"error":{"message":"Incorrect API key provided: test-key-123"}}"#.utf8))
         client?.urlProtocolDidFinishLoading(self)
     }
     override func stopLoading() {}

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -37,6 +37,74 @@ final class TranscriptionServiceTests: XCTestCase {
         try await super.tearDown()
     }
 
+    // MARK: - Remote backend error surfacing
+    //
+    // Regression coverage for the silent-failure bug: a remote backend with a
+    // bad key (or unreachable endpoint) used to empty the live transcript with
+    // NO visible error — the failure only appeared on the Stop batch pass, and
+    // CI never caught it because the remote E2E suite only tested the happy
+    // path against an accepting mock. These tests pin the two new guards.
+
+    func test_probeRemoteBackendIfActive_isNoopForLocalBackend() async {
+        // The default `service` uses the on-device backend. Probing must do
+        // nothing — never touch the network or the Keychain, never error.
+        XCTAssertNil(service.lastError)
+        await service.probeRemoteBackendIfActive()
+        XCTAssertNil(service.lastError, "Local backend must not be probed")
+    }
+
+    func test_probeRemoteBackendIfActive_surfacesAuthFailure() async {
+        // The record-start probe must turn a 401 into an immediate, actionable
+        // error instead of a blank live pane discovered 13 minutes later.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [Probe401URLProtocol.self]
+        let session = URLSession(configuration: config)
+        let suite = UserDefaults(suiteName: "TranscriptionServiceTests.probe401")!
+        suite.removePersistentDomain(forName: "TranscriptionServiceTests.probe401")
+        let keychainKey = "TranscriptionServiceTests.probe401.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let remote = RemoteTranscriptionSettings(
+            defaults: suite, urlSession: session, apiKeyKeychainKey: keychainKey)
+        remote.backend = .remote
+        remote.endpoint = "https://api.openai.com/v1"
+        remote.apiKey = "test-key-123"
+        let svc = TranscriptionService(
+            store: store, modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "TranscriptionServiceTests.probe401.diar")!),
+            remoteSettings: remote, engine: StubWhisperEngine())
+
+        XCTAssertNil(svc.lastError)
+        await svc.probeRemoteBackendIfActive()
+        XCTAssertNotNil(svc.lastError, "A 401 at record-start must surface immediately")
+        XCTAssertTrue(svc.lastError?.contains("Settings") ?? false,
+                      "Error should point the user at Settings: \(svc.lastError ?? "nil")")
+    }
+
+    func test_liveRemoteFailure_setsLastError() async {
+        // The live/dictation path must surface a remote failure, not return a
+        // silently-empty result indistinguishable from "no speech detected".
+        let suite = UserDefaults(suiteName: "TranscriptionServiceTests.liveRemoteFail")!
+        suite.removePersistentDomain(forName: "TranscriptionServiceTests.liveRemoteFail")
+        let keychainKey = "TranscriptionServiceTests.liveRemoteFail.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let remote = RemoteTranscriptionSettings(
+            defaults: suite, apiKeyKeychainKey: keychainKey)
+        remote.backend = .remote
+        // Self-hosted endpoint → isConfigured without a key, so routing reaches
+        // the (injected, always-throwing) remote engine.
+        remote.endpoint = "http://localhost:8080/v1"
+        let svc = TranscriptionService(
+            store: store, modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "TranscriptionServiceTests.liveRemoteFail.diar")!),
+            remoteSettings: remote, engine: StubWhisperEngine(),
+            remoteEngine: ThrowingRemoteEngine())
+
+        XCTAssertNil(svc.lastError)
+        let segs = await svc.transcribeOnceSegments(samples: [0.1, 0.2, 0.3], language: "he", audioCtx: nil)
+        XCTAssertTrue(segs.isEmpty, "A remote failure yields no segments")
+        XCTAssertNotNil(svc.lastError, "A live remote failure must surface, not silently empty the pane")
+    }
+
     // MARK: - Single recording happy path
 
     func test_enqueue_single_recording_marks_running_then_completed() async throws {
@@ -501,5 +569,39 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(normalized[0].speaker, "SPEAKER_00")
         XCTAssertNil(normalized[1].speaker)
         XCTAssertEqual(normalized[2].speaker, "SPEAKER_01")
+    }
+}
+
+/// Returns 401 for any request — lets the record-start probe reach `.failed`
+/// without a real server. (Distinct from `RemoteTranscriptionTests`' copy so
+/// each test file is self-contained.)
+private final class Probe401URLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 401,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"error":{"message":"Incorrect API key provided: test-key-123"}}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+/// A remote engine that always throws an HTTP 401 — stands in for a
+/// misconfigured remote backend so the live-path error-surfacing can be tested
+/// without a network round-trip.
+private actor ThrowingRemoteEngine: RemoteTranscribing {
+    func configure(_ config: RemoteTranscriptionConfig) async {}
+    func loadIfNeeded(modelURL: URL, displayName: String) async throws {}
+    func shutdown() async {}
+    func transcribe(samples: [Float],
+                    language: String,
+                    audioCtx: Int32?,
+                    progress: (@Sendable (Float) -> Void)?,
+                    isCancelled: (@Sendable () -> Bool)?) async throws -> [TranscriptSegment] {
+        throw RemoteWhisperEngine.RemoteError.http(
+            status: 401,
+            body: #"{"error":{"message":"Incorrect API key provided: test-key-123"}}"#)
     }
 }


### PR DESCRIPTION
## What & why

Recording with the **remote (OpenAI-compatible) transcription backend** and a bad/expired API key — or an unreachable endpoint — failed **silently** on the live path. Every utterance hit the error, `transcribeOnceSegments` swallowed it (`return []`), and the live transcript pane stayed blank, indistinguishable from "no speech detected". The error only surfaced on the **Stop batch pass**, i.e. after a full meeting had already been recorded into the void.

(Found via a real session: a 13.5-min recording landed `status: failed`, `Remote · whisper-1`, 0 segments — every utterance was an `HTTP 401: Incorrect API key provided: test-key-123`.)

## Changes

- **Surface live failures** — `TranscriptionService` now logs remote failures at `.error` and sets `lastError` (once, to avoid per-utterance churn); the existing global alert shows it mid-recording.
- **Proactive server check** — `probeRemoteBackendIfActive()` reuses `testConnection()` (cheap `GET /models`, already maps 401 → "check the API key"), fired **non-blocking** at record start so a bad key surfaces in ~1s. The probe is a **single-owner task** (cancels/supersedes a stale run on the next start, cancels on stop). No-op for the on-device backend.
- **Log level** — both transcribe-failure sites log at `.error` (visible in `log show` without `--debug`).
- **Testability** — small `RemoteTranscribing` protocol seam makes the remote engine injectable.

## Why CI didn't catch it

The remote path was only tested on the happy path: the remote E2E ran only in its dedicated workflow against a mock that always accepts the key, and nothing exercised the *live* path against the remote backend. Regression tests added (network-free, normal suite): `test_testConnection_failsOnAuthError`, `test_probeRemoteBackendIfActive_surfacesAuthFailure`, `test_liveRemoteFailure_setsLastError`, `test_probeRemoteBackendIfActive_isNoopForLocalBackend`.

Verified locally: `** TEST BUILD SUCCEEDED **`; the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote transcription error handling, including clearer messaging for authentication failures during recording.
  * Added an automatic, non-blocking remote backend connectivity/auth probe when recording starts, with user-facing guidance to update model settings when needed.
  * Prevented stale remote probe/transcription results from overwriting status after recording stops.
  * Live transcription failure reporting is now more consistent, avoiding silent empty results.
* **Tests**
  * Added coverage for auth-error (HTTP 401) scenarios and remote probe behavior, including regression checks for error surfacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->