### PR TITLE
Hebrew remote-transcription E2E: speaches Docker + GHCR + cross-runner tunnel

### DIFF
--- a/.github/workflows/build-speaches-image.yml
+++ b/.github/workflows/build-speaches-image.yml
@@ -3,12 +3,14 @@ name: Build Speaches Hebrew Image
 # Builds the speaches + Hebrew-model Docker image and pushes it to GHCR.
 #
 # WHY PATH-GATED: the image bakes in a ~1.6 GB model, so a build is slow and
-# bandwidth-heavy. We only rebuild when the image definition itself changes —
-# never on every push. The Hebrew E2E workflow pulls the already-published
-# `:latest` tag, so it costs nothing there.
+# bandwidth-heavy. We only rebuild + publish when the image definition itself
+# changes on `main` — never on every push. The Hebrew E2E workflow builds its
+# OWN image from the checkout (so PRs test the code under review and share the
+# `type=gha` layer cache this workflow populates), so it doesn't depend on the
+# published tag.
 #
-# The published image (ghcr.io/<owner>/mila-speaches-hebrew) is also a
-# standalone deliverable: `docker run -p 8000:8000 ghcr.io/<owner>/mila-speaches-hebrew`
+# The published image (ghcr.io/<owner>/mila-speaches-hebrew) is a standalone
+# deliverable: `docker run -p 8000:8000 ghcr.io/<owner>/mila-speaches-hebrew`
 # gives you a local Hebrew transcription endpoint.
 
 on:
@@ -43,27 +45,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Lowercase image name
         id: img
-        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: echo "name=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Only push on main / dispatch. On PRs we build (to catch breakage) but
       # don't push — PRs from forks can't get a write token anyway.
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: docker/speaches-hebrew
           # CI runner is linux/amd64; the E2E job runs the container on the same

--- a/.github/workflows/build-speaches-image.yml
+++ b/.github/workflows/build-speaches-image.yml
@@ -1,0 +1,79 @@
+name: Build Speaches Hebrew Image
+
+# Builds the speaches + Hebrew-model Docker image and pushes it to GHCR.
+#
+# WHY PATH-GATED: the image bakes in a ~1.6 GB model, so a build is slow and
+# bandwidth-heavy. We only rebuild when the image definition itself changes —
+# never on every push. The Hebrew E2E workflow pulls the already-published
+# `:latest` tag, so it costs nothing there.
+#
+# The published image (ghcr.io/<owner>/mila-speaches-hebrew) is also a
+# standalone deliverable: `docker run -p 8000:8000 ghcr.io/<owner>/mila-speaches-hebrew`
+# gives you a local Hebrew transcription endpoint.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/speaches-hebrew/**'
+      - '.github/workflows/build-speaches-image.yml'
+  pull_request:
+    paths:
+      - 'docker/speaches-hebrew/**'
+      - '.github/workflows/build-speaches-image.yml'
+  # Allow a manual rebuild (e.g. to refresh after a base-image security update).
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # Lowercased at build time; ${{ github.repository_owner }} can contain capitals
+  # which the registry rejects.
+  IMAGE_NAME: ${{ github.repository_owner }}/mila-speaches-hebrew
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-speaches-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        id: img
+        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Only push on main / dispatch. On PRs we build (to catch breakage) but
+      # don't push — PRs from forks can't get a write token anyway.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/speaches-hebrew
+          # CI runner is linux/amd64; the E2E job runs the container on the same
+          # platform, so a single-arch build keeps the (already slow) model bake
+          # from doubling. Add linux/arm64 here if you want the image usable on
+          # Apple Silicon locally.
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.img.outputs.name }}:latest
+            ${{ env.REGISTRY }}/${{ steps.img.outputs.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/e2e-hebrew-remote.yml
+++ b/.github/workflows/e2e-hebrew-remote.yml
@@ -15,6 +15,16 @@ name: E2E Hebrew Remote Transcription
 # workflow artifact the client polls for. The server job stays alive serving
 # until the client signals "done" (another artifact), then tears down.
 #
+# WHY BUILD THE IMAGE IN-JOB (not pull `:latest` from GHCR)
+# ---------------------------------------------------------
+# The server job builds the speaches image from `docker/speaches-hebrew/` in the
+# checkout, so a PR that edits the Dockerfile (or the model) is tested against
+# the code UNDER REVIEW — not the last image published from `main`. The
+# `build-speaches-image.yml` workflow only pushes on `main`/dispatch, so a
+# `:latest` pull would silently test stale bytes on PRs (and fork PRs can't pull
+# a private package at all). Building shares the same `type=gha` layer cache as
+# the publish workflow, so the model bake is paid once and reused.
+#
 # This is heavier and inherently more network-dependent than the default
 # `e2e-remote-transcription` mock-server E2E. It is path-gated and also
 # manually dispatchable so it doesn't run on every push.
@@ -34,13 +44,15 @@ on:
     paths:
       - 'Mila/Transcription/RemoteWhisperEngine.swift'
       - 'Mila/Models/RemoteTranscriptionSettings.swift'
+      # Keep in sync with the `push` filter: the shared transcription service
+      # routes the remote path, so PRs touching it must run this E2E too.
+      - 'Mila/Transcription/TranscriptionService.swift'
       - 'MilaTests/RemoteTranscriptionE2ETests.swift'
       - 'docker/speaches-hebrew/**'
       - '.github/workflows/e2e-hebrew-remote.yml'
 
 permissions:
   contents: read
-  packages: read     # pull the speaches image from GHCR
   actions: read       # poll run artifacts via the REST API (handoff channel)
 
 concurrency:
@@ -48,41 +60,41 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_BASENAME: mila-speaches-hebrew
   TUNNEL_ARTIFACT: hebrew-tunnel-url
   DONE_ARTIFACT: hebrew-client-done
   HEBREW_MODEL: ivrit-ai/whisper-large-v3-turbo-ct2
 
 jobs:
   # ----------------------------------------------------------------------------
-  # SERVER: Linux. Runs the speaches container, opens a cloudflared quick tunnel,
-  # publishes the tunnel URL as an artifact, then stays alive serving until the
-  # client uploads the "done" artifact (or a hard timeout).
+  # SERVER: Linux. Builds the speaches image from the checkout, runs the
+  # container, opens a cloudflared quick tunnel, publishes the tunnel URL as an
+  # artifact, then stays alive serving until the client uploads the "done"
+  # artifact (or a hard timeout).
   # ----------------------------------------------------------------------------
   speaches-server:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Lowercase image ref
-        id: img
-        run: |
-          owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
-          echo "ref=${{ env.REGISTRY }}/${owner}/${{ env.IMAGE_BASENAME }}:latest" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      # Build the PR's own image (linux/amd64 == this runner) and load it into
+      # the local docker daemon. `cache-from: type=gha` reuses the layers the
+      # publish workflow baked, so the ~1.6 GB model download isn't repeated.
+      - name: Build speaches image (from the checkout under review)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: docker/speaches-hebrew
+          platforms: linux/amd64
+          load: true
+          tags: mila-speaches-hebrew:e2e
+          cache-from: type=gha
 
       - name: Start speaches container
         run: |
-          docker run -d --name speaches -p 8000:8000 \
-            "${{ steps.img.outputs.ref }}"
+          docker run -d --name speaches -p 8000:8000 mila-speaches-hebrew:e2e
           echo "Waiting for speaches /health (model preload can take a few minutes)..."
           for i in $(seq 1 60); do
             if curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
@@ -118,19 +130,25 @@ jobs:
             echo "::error::tunnel URL never appeared"; cat tunnel.log; exit 1
           fi
           echo "Tunnel URL: $URL"
-          # Verify the tunnel actually proxies to speaches before handing it off.
+          # Verify the tunnel actually proxies to speaches before handing it
+          # off. Fail fast if it never comes up — handing a dead URL to the
+          # client just produces a confusing downstream test failure.
+          tunnel_ok=""
           for i in $(seq 1 30); do
             if curl -fsS "$URL/health" >/dev/null 2>&1; then
-              echo "tunnel reaches speaches /health"; break
+              echo "tunnel reaches speaches /health"; tunnel_ok=1; break
             fi
             sleep 2
           done
+          if [ -z "$tunnel_ok" ]; then
+            echo "::error::tunnel never proxied to speaches /health"; cat tunnel.log; exit 1
+          fi
           # The remote endpoint Mila expects is the OpenAI-style /v1 base.
           printf '%s/v1' "$URL" > endpoint.txt
           echo "endpoint=$(cat endpoint.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Publish tunnel URL for the client job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.TUNNEL_ARTIFACT }}
           path: endpoint.txt
@@ -142,12 +160,15 @@ jobs:
       - name: Serve until client done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          DONE_ARTIFACT: ${{ env.DONE_ARTIFACT }}
         run: |
           echo "Serving; waiting for client 'done' signal (max ~30 min)..."
           for i in $(seq 1 180); do
             count=$(gh api \
-              "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-              --jq "[.artifacts[] | select(.name == \"${{ env.DONE_ARTIFACT }}\")] | length" \
+              "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"${DONE_ARTIFACT}\")] | length" \
               2>/dev/null || echo 0)
             if [ "$count" != "0" ] && [ -n "$count" ]; then
               echo "client signalled done"; exit 0
@@ -177,14 +198,14 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install xcodegen
         run: brew install xcodegen
 
       - name: Cache diarization bundle
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -229,13 +250,16 @@ jobs:
         id: endpoint
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          TUNNEL_ARTIFACT: ${{ env.TUNNEL_ARTIFACT }}
         run: |
-          echo "Polling for the '${{ env.TUNNEL_ARTIFACT }}' artifact..."
+          echo "Polling for the '${TUNNEL_ARTIFACT}' artifact..."
           ART_ID=""
           for i in $(seq 1 120); do   # up to ~20 min (server may bake/preload)
             ART_ID=$(gh api \
-              "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-              --jq "[.artifacts[] | select(.name == \"${{ env.TUNNEL_ARTIFACT }}\")][0].id" \
+              "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"${TUNNEL_ARTIFACT}\")][0].id" \
               2>/dev/null || true)
             if [ -n "$ART_ID" ] && [ "$ART_ID" != "null" ]; then break; fi
             sleep 10
@@ -243,18 +267,24 @@ jobs:
           if [ -z "$ART_ID" ] || [ "$ART_ID" = "null" ]; then
             echo "::error::tunnel URL artifact never appeared"; exit 1
           fi
-          gh api "repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip" > art.zip
+          gh api "repos/${REPO}/actions/artifacts/${ART_ID}/zip" > art.zip
           unzip -o art.zip -d art >/dev/null
           ENDPOINT=$(cat art/endpoint.txt)
           echo "Endpoint: $ENDPOINT"
-          # Health-gate the tunnel from the client side before testing.
+          # Health-gate the tunnel from the client side before testing. Fail
+          # fast if it never answers — better a clear "tunnel dead" error here
+          # than a misleading transcription failure in the test step.
+          base="${ENDPOINT%/v1}"
+          tunnel_ok=""
           for i in $(seq 1 30); do
-            base="${ENDPOINT%/v1}"
             if curl -fsS "${base}/health" >/dev/null 2>&1; then
-              echo "tunnel healthy from client"; break
+              echo "tunnel healthy from client"; tunnel_ok=1; break
             fi
             sleep 5
           done
+          if [ -z "$tunnel_ok" ]; then
+            echo "::error::tunnel endpoint never healthy from client: ${ENDPOINT}"; exit 1
+          fi
           echo "endpoint=$ENDPOINT" >> "$GITHUB_OUTPUT"
 
       - name: Run Hebrew remote E2E test
@@ -284,7 +314,7 @@ jobs:
 
       - name: Upload done marker
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.DONE_ARTIFACT }}
           path: done/done.txt

--- a/.github/workflows/e2e-hebrew-remote.yml
+++ b/.github/workflows/e2e-hebrew-remote.yml
@@ -1,0 +1,291 @@
+name: E2E Hebrew Remote Transcription
+
+# Real end-to-end Hebrew transcription over HTTP: a Linux job runs the speaches
+# Docker image (an Apache-2.0 ivrit.ai Hebrew CT2 model, OpenAI-compatible on
+# :8000) and exposes it through an ephemeral cloudflared quick tunnel; the macOS
+# MilaTests job points Mila's real `RemoteWhisperEngine` at that tunnel URL and
+# asserts it gets correct Hebrew text back.
+#
+# WHY TWO JOBS + A TUNNEL
+# -----------------------
+# Mila must build with Xcode (macOS runner); Docker only runs on the Linux
+# runner. The two runners are separate VMs with no shared network, so we bridge
+# them with a no-account `*.trycloudflare.com` tunnel. The dynamic tunnel URL is
+# handed from the (long-running) server job to the parallel client job via a
+# workflow artifact the client polls for. The server job stays alive serving
+# until the client signals "done" (another artifact), then tears down.
+#
+# This is heavier and inherently more network-dependent than the default
+# `e2e-remote-transcription` mock-server E2E. It is path-gated and also
+# manually dispatchable so it doesn't run on every push.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'Mila/Transcription/RemoteWhisperEngine.swift'
+      - 'Mila/Models/RemoteTranscriptionSettings.swift'
+      - 'Mila/Transcription/TranscriptionService.swift'
+      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
+      - 'docker/speaches-hebrew/**'
+      - '.github/workflows/e2e-hebrew-remote.yml'
+  pull_request:
+    paths:
+      - 'Mila/Transcription/RemoteWhisperEngine.swift'
+      - 'Mila/Models/RemoteTranscriptionSettings.swift'
+      - 'MilaTests/RemoteTranscriptionE2ETests.swift'
+      - 'docker/speaches-hebrew/**'
+      - '.github/workflows/e2e-hebrew-remote.yml'
+
+permissions:
+  contents: read
+  packages: read     # pull the speaches image from GHCR
+  actions: read       # poll run artifacts via the REST API (handoff channel)
+
+concurrency:
+  group: e2e-hebrew-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASENAME: mila-speaches-hebrew
+  TUNNEL_ARTIFACT: hebrew-tunnel-url
+  DONE_ARTIFACT: hebrew-client-done
+  HEBREW_MODEL: ivrit-ai/whisper-large-v3-turbo-ct2
+
+jobs:
+  # ----------------------------------------------------------------------------
+  # SERVER: Linux. Runs the speaches container, opens a cloudflared quick tunnel,
+  # publishes the tunnel URL as an artifact, then stays alive serving until the
+  # client uploads the "done" artifact (or a hard timeout).
+  # ----------------------------------------------------------------------------
+  speaches-server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase image ref
+        id: img
+        run: |
+          owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          echo "ref=${{ env.REGISTRY }}/${owner}/${{ env.IMAGE_BASENAME }}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start speaches container
+        run: |
+          docker run -d --name speaches -p 8000:8000 \
+            "${{ steps.img.outputs.ref }}"
+          echo "Waiting for speaches /health (model preload can take a few minutes)..."
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+              echo "speaches is healthy"; exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::speaches did not become healthy"; docker logs speaches; exit 1
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL -o cloudflared \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+          chmod +x cloudflared
+          sudo mv cloudflared /usr/local/bin/cloudflared
+          cloudflared --version
+
+      - name: Open quick tunnel and capture URL
+        id: tunnel
+        run: |
+          # No account/secret needed — quick tunnels mint a random
+          # *.trycloudflare.com hostname. cloudflared logs the URL to stderr.
+          cloudflared tunnel --no-autoupdate --url http://127.0.0.1:8000 \
+            > tunnel.log 2>&1 &
+          echo $! > tunnel.pid
+          URL=""
+          for i in $(seq 1 60); do
+            URL=$(grep -Eo 'https://[a-z0-9-]+\.trycloudflare\.com' tunnel.log | head -1 || true)
+            if [ -n "$URL" ]; then break; fi
+            sleep 2
+          done
+          if [ -z "$URL" ]; then
+            echo "::error::tunnel URL never appeared"; cat tunnel.log; exit 1
+          fi
+          echo "Tunnel URL: $URL"
+          # Verify the tunnel actually proxies to speaches before handing it off.
+          for i in $(seq 1 30); do
+            if curl -fsS "$URL/health" >/dev/null 2>&1; then
+              echo "tunnel reaches speaches /health"; break
+            fi
+            sleep 2
+          done
+          # The remote endpoint Mila expects is the OpenAI-style /v1 base.
+          printf '%s/v1' "$URL" > endpoint.txt
+          echo "endpoint=$(cat endpoint.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish tunnel URL for the client job
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TUNNEL_ARTIFACT }}
+          path: endpoint.txt
+          retention-days: 1
+
+      # Keep the server alive while the macOS client runs. Poll the run's
+      # artifacts for the client's "done" marker; bail after a hard cap so a
+      # crashed client can't pin the runner for the full timeout.
+      - name: Serve until client done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Serving; waiting for client 'done' signal (max ~30 min)..."
+          for i in $(seq 1 180); do
+            count=$(gh api \
+              "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"${{ env.DONE_ARTIFACT }}\")] | length" \
+              2>/dev/null || echo 0)
+            if [ "$count" != "0" ] && [ -n "$count" ]; then
+              echo "client signalled done"; exit 0
+            fi
+            # If speaches died, fail fast with logs rather than waiting it out.
+            if ! curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+              echo "::error::speaches became unhealthy while serving"; docker logs speaches; exit 1
+            fi
+            sleep 10
+          done
+          echo "::warning::client never signalled done within the window"
+
+      - name: Teardown
+        if: always()
+        run: |
+          [ -f tunnel.pid ] && kill "$(cat tunnel.pid)" 2>/dev/null || true
+          echo "--- tunnel log ---"; cat tunnel.log 2>/dev/null || true
+          echo "--- speaches log (tail) ---"; docker logs --tail 100 speaches 2>/dev/null || true
+          docker rm -f speaches 2>/dev/null || true
+
+  # ----------------------------------------------------------------------------
+  # CLIENT: macOS. Builds Mila, polls for the tunnel URL artifact, points the
+  # real RemoteWhisperEngine at it, runs the Hebrew E2E test, then uploads the
+  # "done" marker so the server job can tear down.
+  # ----------------------------------------------------------------------------
+  mila-client:
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Cache diarization bundle
+        id: diar-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: Mila/Resources/PythonRuntime
+          key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
+
+      - name: Build diarization bundle (cold path only)
+        if: steps.diar-bundle-cache.outputs.cache-hit != 'true'
+        run: make bundle-diarization
+
+      - name: Generate Xcode project
+        run: make project
+
+      - name: Clear SwiftPM caches
+        run: |
+          rm -rf ~/Library/Caches/org.swift.swiftpm
+          rm -rf ~/Library/org.swift.swiftpm
+          rm -rf ~/Library/Developer/Xcode/DerivedData/SourcePackages
+
+      - name: Resolve Swift Package dependencies
+        run: |
+          xcodebuild \
+            -project Mila.xcodeproj \
+            -scheme Mila \
+            -destination 'platform=macOS' \
+            -resolvePackageDependencies
+
+      # Build the test bundle FIRST so the (slow) tunnel handoff overlaps the
+      # build instead of adding to it. build-for-testing leaves a ready bundle
+      # that `test-without-building` runs once we have the endpoint.
+      - name: Build for testing
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Mila.xcodeproj \
+            -scheme Mila \
+            -configuration Debug \
+            -derivedDataPath build \
+            -destination 'platform=macOS' \
+            -only-testing:MilaTests/RemoteTranscriptionE2ETests \
+            build-for-testing
+
+      - name: Wait for tunnel URL from server job
+        id: endpoint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Polling for the '${{ env.TUNNEL_ARTIFACT }}' artifact..."
+          ART_ID=""
+          for i in $(seq 1 120); do   # up to ~20 min (server may bake/preload)
+            ART_ID=$(gh api \
+              "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"${{ env.TUNNEL_ARTIFACT }}\")][0].id" \
+              2>/dev/null || true)
+            if [ -n "$ART_ID" ] && [ "$ART_ID" != "null" ]; then break; fi
+            sleep 10
+          done
+          if [ -z "$ART_ID" ] || [ "$ART_ID" = "null" ]; then
+            echo "::error::tunnel URL artifact never appeared"; exit 1
+          fi
+          gh api "repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip" > art.zip
+          unzip -o art.zip -d art >/dev/null
+          ENDPOINT=$(cat art/endpoint.txt)
+          echo "Endpoint: $ENDPOINT"
+          # Health-gate the tunnel from the client side before testing.
+          for i in $(seq 1 30); do
+            base="${ENDPOINT%/v1}"
+            if curl -fsS "${base}/health" >/dev/null 2>&1; then
+              echo "tunnel healthy from client"; break
+            fi
+            sleep 5
+          done
+          echo "endpoint=$ENDPOINT" >> "$GITHUB_OUTPUT"
+
+      - name: Run Hebrew remote E2E test
+        env:
+          # xcodebuild strips the TEST_RUNNER_ prefix and forwards the rest into
+          # the test process (same pattern as ci.yml / e2e-remote-transcription).
+          TEST_RUNNER_MILA_REMOTE_TEST_ENDPOINT: ${{ steps.endpoint.outputs.endpoint }}
+          TEST_RUNNER_MILA_REMOTE_HEBREW: "1"
+          TEST_RUNNER_MILA_REMOTE_MODEL: ${{ env.HEBREW_MODEL }}
+          TEST_RUNNER_MILA_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Mila.xcodeproj \
+            -scheme Mila \
+            -configuration Debug \
+            -derivedDataPath build \
+            -destination 'platform=macOS' \
+            -only-testing:MilaTests/RemoteTranscriptionE2ETests \
+            test-without-building
+
+      - name: Signal server job to tear down
+        if: always()
+        run: |
+          mkdir -p done && date > done/done.txt
+          echo "uploading done marker"
+
+      - name: Upload done marker
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DONE_ARTIFACT }}
+          path: done/done.txt
+          retention-days: 1

--- a/MilaTests/RemoteTranscriptionE2ETests.swift
+++ b/MilaTests/RemoteTranscriptionE2ETests.swift
@@ -14,8 +14,12 @@ import TranscriptionCore
 ///
 ///   * `e2e-hebrew-remote` (real speaches server, `MILA_REMOTE_HEBREW=1`) — the
 ///     endpoint is a tunnel to a Docker speaches container serving an ivrit.ai
-///     Hebrew CT2 model. Proves (a) real Hebrew speech transcribes correctly via
-///     the remote backend (WER), and (b) Mila's neural VAD drops silence/noise.
+///     Hebrew CT2 model. Drives Mila's INTEGRATED live pipeline
+///     (`LiveTranscriber` + RMS `UtteranceDetector` + neural Silero
+///     `speechGate`) headlessly and proves, in ONE path, both that (a) real
+///     Hebrew survives the VAD gate and reaches speaches transcribed (WER), and
+///     (b) silence/noise in the same stream is dropped client-side by the VAD
+///     before it ever reaches the server.
 ///
 /// When `MILA_REMOTE_TEST_ENDPOINT` is absent (every normal `MilaTests` run) the
 /// whole suite XCTSkips. Within a workflow, the tests that don't apply to that
@@ -116,7 +120,7 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
         }
     }
 
-    // MARK: - Real Hebrew transcription (against a live speaches server)
+    // MARK: - Real Hebrew transcription through the INTEGRATED VAD→remote path
 
     /// Repo root. On CI the `e2e-hebrew-remote` workflow exports it via
     /// `MILA_REPO_ROOT`; locally we derive it from this file's path.
@@ -145,84 +149,152 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
             .trimmingCharacters(in: .whitespaces)
     }
 
-    /// (a) REAL HEBREW SPEECH transcribes correctly via the remote backend.
+    /// THE INTEGRATED PROOF: real Hebrew speech flows through Mila's live
+    /// pipeline (`LiveTranscriber` + RMS `UtteranceDetector` + neural Silero
+    /// `speechGate`) out to the live speaches server — AND noise/silence in the
+    /// SAME stream is dropped client-side before it ever reaches the server.
     ///
-    /// Uploads a Hebrew fixture WAV to the live speaches server (the
-    /// `e2e-hebrew-remote` workflow stands it up with an ivrit.ai model) through
-    /// the production `RemoteWhisperEngine`, and asserts the returned Hebrew
-    /// transcript is close to the reference (WER). Gated on `MILA_REMOTE_HEBREW`
-    /// so it stays dormant in the echo-mock workflow (where it would fail — the
-    /// mock doesn't transcribe).
-    func test_hebrew_realSpeech_transcribesViaRemote() async throws {
-        try XCTSkipUnless(isRealServer, "Hebrew transcription runs only against a real speaches server (MILA_REMOTE_HEBREW=1).")
+    /// Earlier this suite proved the two halves *separately*: it called
+    /// `RemoteWhisperEngine.transcribe()` directly for Hebrew, and poked
+    /// `SileroVAD.containsSpeech()` directly for noise. That bypassed the real
+    /// pipeline — nothing tied "the VAD gate" to "the remote backend." Here we
+    /// drive the production `LiveTranscriber` path end to end, headlessly (no
+    /// mic): `ingest()` a single concatenated stream of
+    /// `silence → Hebrew speech → silence → loud white noise → silence`, then
+    /// `transcribeNow()` to flush. Two things must hold at once:
+    ///
+    ///   (a) the Hebrew speech IS transcribed (WER/substring vs the reference)
+    ///       — proving real Hebrew survives the VAD gate and reaches speaches;
+    ///   (b) the silence + noise produce ZERO segments — proving the neural VAD
+    ///       dropped them LOCALLY (pure silence never even trips the RMS
+    ///       detector; the loud-noise burst trips RMS but Silero rejects it) so
+    ///       speaches never sees them and can't hallucinate the classic Hebrew
+    ///       filler (`תודה רבה אדוני יושב ראש הכנסת`).
+    ///
+    /// Gated on `MILA_REMOTE_HEBREW=1` so it's dormant in the echo-mock
+    /// workflow (where speaches isn't up and the mock doesn't transcribe).
+    @MainActor
+    func test_hebrewSpeech_throughVADGate_reachesRemote_noiseDropped() async throws {
+        try XCTSkipUnless(isRealServer, "Integrated VAD→remote Hebrew E2E runs only against a real speaches server (MILA_REMOTE_HEBREW=1).")
         let model = ProcessInfo.processInfo.environment["MILA_REMOTE_MODEL"]
             ?? "ivrit-ai/whisper-large-v3-turbo-ct2"
 
-        let engine = RemoteWhisperEngine()
+        // 1. Point a real RemoteTranscriptionSettings at the speaches server.
+        //    Isolated UserDefaults suite + keychain key so we never touch the
+        //    user's real config (project convention).
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionE2ETests.integrated")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionE2ETests.integrated")
+        let remoteSettings = RemoteTranscriptionSettings(
+            defaults: suite,
+            apiKeyKeychainKey: "RemoteTranscriptionE2ETests.integrated.apiKey")
+        remoteSettings.backend = .remote
+        remoteSettings.endpoint = endpoint.absoluteString
         // Self-hosted speaches accepts anonymous requests; a dummy non-empty key
         // is fine (OpenAI SDKs require one, speaches ignores it).
-        await engine.configure(RemoteTranscriptionConfig(
-            endpoint: endpoint, apiKey: "speaches", model: model))
+        remoteSettings.apiKey = "speaches"
+        remoteSettings.model = model
 
-        // he_toda_raba — the exact phrase whisper hallucinates on Hebrew
-        // silence; as real speech it must come back transcribed.
+        // 2. Build a TranscriptionService routed to the remote backend. The
+        //    local `engine` is never exercised once `remoteSettings.isActive`
+        //    (TranscriptionService routes every call through its internal
+        //    RemoteWhisperEngine), so a stub keeps us off the 1.5 GB whisper
+        //    weights. The diarization settings stay unconfigured (default
+        //    isolated suite) so no pyannote subprocess spins up.
+        let tempRoot = TestSupport.makeTempRoot(label: "RemoteIntegratedE2E")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        let service = TranscriptionService(
+            store: store,
+            modelManager: manager,
+            diarizationSettings: DiarizationSettings(
+                defaults: .init(suiteName: "RemoteTranscriptionE2ETests.integrated.diar")!),
+            remoteSettings: remoteSettings,
+            engine: StubWhisperEngine()
+        )
+
+        // 3. Build the LiveTranscriber on it with the neural VAD gate attached —
+        //    exactly how `MilaApp.wireLiveAIPipeline` wires it in production.
+        let modelPath = repoRoot
+            .appendingPathComponent("Mila/Resources/ggml-silero-v5.1.2.bin").path
+        let transcriber = LiveTranscriber(transcription: service)
+        transcriber.useVAD = true
+        transcriber.speechGate = try SileroVAD(modelPath: modelPath)
+        transcriber.start(language: "he")
+
+        // 4. Build ONE concatenated stream: silence → Hebrew speech → silence →
+        //    loud white noise → silence. The RMS UtteranceDetector emits an
+        //    utterance on each speech→silence boundary, so we get two candidate
+        //    utterances: the Hebrew (real speech) and the loud-noise burst
+        //    (clears the energy cutoff). The pure silence never trips RMS.
+        let rate = Int(WhisperAudioFormat.sampleRate)
         let name = "he_toda_raba"
         let wavURL = hebrewFixturesDir.appendingPathComponent("\(name).wav")
-        let samples = try WAVReader.loadSamples(url: wavURL)
+        let speech = try WAVReader.loadSamples(url: wavURL)
         let reference = try expectedText(for: name)
+        XCTAssertGreaterThan(speech.count, rate / 2, "Hebrew fixture suspiciously short")
 
-        let segments = try await engine.transcribe(
-            samples: samples, language: "he", audioCtx: 0,
-            progress: nil, isCancelled: nil)
+        let gap = [Float](repeating: 0, count: rate)          // 1s silence
+        // Loud white noise (~0.3 amplitude) — the energy is well above the
+        // detector's RMS cutoff, so the RMS stage emits it as an "utterance";
+        // the neural Silero gate must then reject it (no human speech). This is
+        // the exact shape that, ungated, makes whisper hallucinate Hebrew filler.
+        var prng: UInt64 = 0x9E3779B97F4A7C15
+        func nextNoise() -> Float {
+            prng ^= prng << 13; prng ^= prng >> 7; prng ^= prng << 17
+            return Float(Double(prng % 20001) / 10000.0 - 1.0) * 0.3
+        }
+        let noise = (0..<(rate * 2)).map { _ in nextNoise() }   // 2s loud noise
+        let stream = gap + speech + gap + noise + gap
 
-        let transcript = segments.map(\.text).joined()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        XCTAssertFalse(transcript.isEmpty, "remote returned an empty Hebrew transcript")
+        // 5. Pump the stream through ingest() in 30 ms frames (the UtteranceDetector
+        //    frame size), then flush. transcribeNow() force-emits any in-progress
+        //    utterance and awaits every queued remote transcribe.
+        let chunkSize = 480
+        var offset = 0
+        while offset < stream.count {
+            let end = min(offset + chunkSize, stream.count)
+            transcriber.ingest(stream[offset..<end])
+            offset = end
+        }
+        await transcriber.transcribeNow()
 
+        let segments = transcriber.segments
+        let transcript = transcriber.fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        print("IntegratedVADRemote[he]: \(segments.count) segments -> \"\(transcript)\"")
+
+        // (a) Real Hebrew reached speaches and came back transcribed.
+        XCTAssertFalse(
+            transcript.isEmpty,
+            "No Hebrew transcript — speech was dropped before the remote, or the remote returned nothing.")
         let wer = WERCalculator.calculate(reference: reference, hypothesis: transcript)
-        // Loose bound: this is an HTTP round trip through a tunnel against a
-        // turbo CT2 model at int8 — we're proving "real Hebrew came back", not
-        // benchmarking accuracy. (The local whisper.cpp E2E owns the tight WER
-        // gate.)
+        // Loose bound: HTTP round trip through a tunnel to a turbo CT2 model at
+        // int8 — proving "real Hebrew survived the gate and came back", not
+        // benchmarking accuracy. NOISE LEAKING THROUGH would inflate this WER
+        // (extra hallucinated tokens), so the bound also guards half (b).
         XCTAssertLessThanOrEqual(
             wer, 0.5,
             "Hebrew WER \(wer) too high.\n  reference: \"\(reference)\"\n  got:       \"\(transcript)\"")
-    }
 
-    /// (b) NOISE/SILENCE is DROPPED by Mila's neural VAD with zero hallucinated
-    /// segments.
-    ///
-    /// The VAD (`SileroVAD`) is a CLIENT-SIDE gate that runs in `LiveTranscriber`
-    /// BEFORE any engine (local or remote) — it is not part of the remote HTTP
-    /// path, so the right place to prove "noise is dropped" is the gate itself.
-    /// This asserts the gate rejects pure silence and loud white noise (which,
-    /// ungated, make whisper emit the classic Hebrew filler hallucination). It
-    /// runs alongside the Hebrew remote check so this one workflow validates
-    /// BOTH halves the VAD exists for.
-    ///
-    /// (The cross-platform `SileroVADTests` cover this on Linux too; asserted
-    /// here as well so the Hebrew-VAD story is self-contained.)
-    func test_noiseAndSilence_droppedByVADGate() async throws {
-        try XCTSkipUnless(isRealServer, "Runs only in the Hebrew VAD E2E workflow (MILA_REMOTE_HEBREW=1).")
-        let modelPath = repoRoot
-            .appendingPathComponent("Mila/Resources/ggml-silero-v5.1.2.bin").path
-        let vad = try SileroVAD(modelPath: modelPath)
-        let rate = Int(WhisperAudioFormat.sampleRate)
-
-        // Pure silence.
-        let silence = [Float](repeating: 0, count: rate * 3)
-        let silenceHasSpeech = await vad.containsSpeech(silence)
-        XCTAssertFalse(silenceHasSpeech, "3s of silence must be dropped by the VAD")
-
-        // Loud white noise (~0.3 amplitude) — clears the live RMS energy cutoff,
-        // so the OLD detector emitted it and whisper hallucinated Hebrew filler.
-        var state: UInt64 = 0x9E3779B97F4A7C15
-        func next() -> Float {
-            state ^= state << 13; state ^= state >> 7; state ^= state << 17
-            return Float(Double(state % 20001) / 10000.0 - 1.0) * 0.3
-        }
-        let noise = (0..<(rate * 3)).map { _ in next() }
-        let noiseHasSpeech = await vad.containsSpeech(noise)
-        XCTAssertFalse(noiseHasSpeech, "loud white noise must be dropped by the VAD")
+        // (b) The silence + loud-noise segments were dropped LOCALLY by the VAD
+        //     gate. With the gate working we expect a small number of segments,
+        //     all of them from the Hebrew utterance — never the noise window.
+        //     The Hebrew clip is short (a single phrase) so speaches returns a
+        //     handful of segments at most; the noise burst would add its own if
+        //     it leaked. A tight cap catches a regression where the gate stops
+        //     dropping noise (the segments collection would balloon with filler).
+        XCTAssertLessThanOrEqual(
+            segments.count, 4,
+            "Too many segments (\(segments.count)) — noise likely leaked past the VAD gate to the remote. Transcript: \"\(transcript)\"")
+        // No segment may start inside the noise window. The Hebrew sits in
+        // [1s, 1s+speechDur]; the noise sits after a further 1s gap. Any segment
+        // whose absolute start lands at/after the noise onset proves the noise
+        // burst reached the remote and produced a (hallucinated) segment.
+        let noiseOnsetSeconds = 1.0 + Double(speech.count) / Double(rate) + 1.0
+        let leaked = segments.filter { $0.startSeconds >= noiseOnsetSeconds - 0.25 }
+        XCTAssertTrue(
+            leaked.isEmpty,
+            "VAD gate failed: \(leaked.count) segment(s) originate in the noise window (>= \(noiseOnsetSeconds)s): \(leaked.map(\.text))")
     }
 }

--- a/MilaTests/RemoteTranscriptionE2ETests.swift
+++ b/MilaTests/RemoteTranscriptionE2ETests.swift
@@ -2,30 +2,41 @@ import XCTest
 import TranscriptionCore
 @testable import Mila
 
-/// End-to-end test of the remote transcription client against a live HTTP
-/// server. The server is the stdlib mock in
-/// `scripts/mock-openai-transcription-server.py`, spawned by the
-/// `e2e-remote-transcription` CI workflow, which passes its base URL in
-/// `MILA_REMOTE_TEST_ENDPOINT`.
+/// End-to-end tests of the remote transcription client against a live HTTP
+/// server. Two workflows drive this suite, distinguished by `MILA_REMOTE_HEBREW`:
 ///
-/// When that env var is absent (every normal `MilaTests` run, local or in the
-/// regular CI jobs) the whole suite XCTSkips — so it only does real work in the
-/// dedicated workflow, while still being a first-class test there.
+///   * `e2e-remote-transcription` (echo mock) — `MILA_REMOTE_TEST_ENDPOINT`
+///     points at the stdlib mock in `scripts/mock-openai-transcription-server.py`,
+///     which validates the request *contract* and echoes `model`/`language`
+///     back. Proves, over a real socket, that `RemoteWhisperEngine` encodes
+///     samples to m4a, uploads a well-formed multipart request with Bearer auth,
+///     and parses `verbose_json` segments + timestamps back.
 ///
-/// What it proves, over a real socket:
-///   * `RemoteWhisperEngine` encodes samples to m4a and uploads a well-formed
-///     multipart request with the right `model` / `language` fields + Bearer
-///     auth (the mock rejects the request otherwise),
-///   * it parses `verbose_json` segments + timestamps back correctly,
-///   * `RemoteTranscriptionSettings.testConnection()` reaches `/models`.
+///   * `e2e-hebrew-remote` (real speaches server, `MILA_REMOTE_HEBREW=1`) — the
+///     endpoint is a tunnel to a Docker speaches container serving an ivrit.ai
+///     Hebrew CT2 model. Proves (a) real Hebrew speech transcribes correctly via
+///     the remote backend (WER), and (b) Mila's neural VAD drops silence/noise.
+///
+/// When `MILA_REMOTE_TEST_ENDPOINT` is absent (every normal `MilaTests` run) the
+/// whole suite XCTSkips. Within a workflow, the tests that don't apply to that
+/// server (echo-mock assertions vs. real-Hebrew) skip via `isRealServer`.
 final class RemoteTranscriptionE2ETests: XCTestCase {
 
     private var endpoint: URL!
 
+    /// True when the endpoint is the real speaches server (the
+    /// `e2e-hebrew-remote` workflow) rather than the echo mock. The echo-mock
+    /// tests below assert mock-specific behaviour (echoed `model=`/`lang=`
+    /// segments), which a real transcription server won't produce — so they
+    /// skip in the Hebrew workflow, and the Hebrew tests skip in the mock one.
+    private var isRealServer: Bool {
+        ProcessInfo.processInfo.environment["MILA_REMOTE_HEBREW"] == "1"
+    }
+
     override func setUpWithError() throws {
         guard let raw = ProcessInfo.processInfo.environment["MILA_REMOTE_TEST_ENDPOINT"],
               let url = URL(string: raw) else {
-            throw XCTSkip("MILA_REMOTE_TEST_ENDPOINT not set — remote E2E runs only in the e2e-remote-transcription workflow.")
+            throw XCTSkip("MILA_REMOTE_TEST_ENDPOINT not set — remote E2E runs only in the e2e-remote-transcription / e2e-hebrew-remote workflows.")
         }
         endpoint = url
     }
@@ -41,6 +52,7 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
     }
 
     func test_roundTrip_uploadsAndParsesSegments() async throws {
+        try XCTSkipIf(isRealServer, "echo-mock assertions don't apply to a real transcription server.")
         let engine = RemoteWhisperEngine()
         await engine.configure(RemoteTranscriptionConfig(
             endpoint: endpoint,
@@ -66,6 +78,7 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
     }
 
     func test_autoLanguage_isOmitted() async throws {
+        try XCTSkipIf(isRealServer, "echo-mock assertions don't apply to a real transcription server.")
         let engine = RemoteWhisperEngine()
         await engine.configure(RemoteTranscriptionConfig(
             endpoint: endpoint,
@@ -101,5 +114,115 @@ final class RemoteTranscriptionE2ETests: XCTestCase {
         guard case .ok = settings.testStatus else {
             return XCTFail("Expected .ok, got \(settings.testStatus)")
         }
+    }
+
+    // MARK: - Real Hebrew transcription (against a live speaches server)
+
+    /// Repo root. On CI the `e2e-hebrew-remote` workflow exports it via
+    /// `MILA_REPO_ROOT`; locally we derive it from this file's path.
+    private var repoRoot: URL {
+        if let v = ProcessInfo.processInfo.environment["MILA_REPO_ROOT"] {
+            return URL(fileURLWithPath: v)
+        }
+        // `#filePath` → `…/MilaTests/RemoteTranscriptionE2ETests.swift`
+        return URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // MilaTests
+            .deletingLastPathComponent()   // repo root
+    }
+
+    private var hebrewFixturesDir: URL {
+        repoRoot.appendingPathComponent("Packages/TranscriptionCore/Fixtures")
+    }
+
+    /// Load a `*.expected.txt` fixture: first line is the language, the rest is
+    /// the reference transcript (same format the WhisperE2E CLI uses).
+    private func expectedText(for name: String) throws -> String {
+        let url = hebrewFixturesDir.appendingPathComponent("\(name).expected.txt")
+        let lines = try String(contentsOf: url, encoding: .utf8)
+            .components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+        return lines.dropFirst().joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    /// (a) REAL HEBREW SPEECH transcribes correctly via the remote backend.
+    ///
+    /// Uploads a Hebrew fixture WAV to the live speaches server (the
+    /// `e2e-hebrew-remote` workflow stands it up with an ivrit.ai model) through
+    /// the production `RemoteWhisperEngine`, and asserts the returned Hebrew
+    /// transcript is close to the reference (WER). Gated on `MILA_REMOTE_HEBREW`
+    /// so it stays dormant in the echo-mock workflow (where it would fail — the
+    /// mock doesn't transcribe).
+    func test_hebrew_realSpeech_transcribesViaRemote() async throws {
+        try XCTSkipUnless(isRealServer, "Hebrew transcription runs only against a real speaches server (MILA_REMOTE_HEBREW=1).")
+        let model = ProcessInfo.processInfo.environment["MILA_REMOTE_MODEL"]
+            ?? "ivrit-ai/whisper-large-v3-turbo-ct2"
+
+        let engine = RemoteWhisperEngine()
+        // Self-hosted speaches accepts anonymous requests; a dummy non-empty key
+        // is fine (OpenAI SDKs require one, speaches ignores it).
+        await engine.configure(RemoteTranscriptionConfig(
+            endpoint: endpoint, apiKey: "speaches", model: model))
+
+        // he_toda_raba — the exact phrase whisper hallucinates on Hebrew
+        // silence; as real speech it must come back transcribed.
+        let name = "he_toda_raba"
+        let wavURL = hebrewFixturesDir.appendingPathComponent("\(name).wav")
+        let samples = try WAVReader.loadSamples(url: wavURL)
+        let reference = try expectedText(for: name)
+
+        let segments = try await engine.transcribe(
+            samples: samples, language: "he", audioCtx: 0,
+            progress: nil, isCancelled: nil)
+
+        let transcript = segments.map(\.text).joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(transcript.isEmpty, "remote returned an empty Hebrew transcript")
+
+        let wer = WERCalculator.calculate(reference: reference, hypothesis: transcript)
+        // Loose bound: this is an HTTP round trip through a tunnel against a
+        // turbo CT2 model at int8 — we're proving "real Hebrew came back", not
+        // benchmarking accuracy. (The local whisper.cpp E2E owns the tight WER
+        // gate.)
+        XCTAssertLessThanOrEqual(
+            wer, 0.5,
+            "Hebrew WER \(wer) too high.\n  reference: \"\(reference)\"\n  got:       \"\(transcript)\"")
+    }
+
+    /// (b) NOISE/SILENCE is DROPPED by Mila's neural VAD with zero hallucinated
+    /// segments.
+    ///
+    /// The VAD (`SileroVAD`) is a CLIENT-SIDE gate that runs in `LiveTranscriber`
+    /// BEFORE any engine (local or remote) — it is not part of the remote HTTP
+    /// path, so the right place to prove "noise is dropped" is the gate itself.
+    /// This asserts the gate rejects pure silence and loud white noise (which,
+    /// ungated, make whisper emit the classic Hebrew filler hallucination). It
+    /// runs alongside the Hebrew remote check so this one workflow validates
+    /// BOTH halves the VAD exists for.
+    ///
+    /// (The cross-platform `SileroVADTests` cover this on Linux too; asserted
+    /// here as well so the Hebrew-VAD story is self-contained.)
+    func test_noiseAndSilence_droppedByVADGate() async throws {
+        try XCTSkipUnless(isRealServer, "Runs only in the Hebrew VAD E2E workflow (MILA_REMOTE_HEBREW=1).")
+        let modelPath = repoRoot
+            .appendingPathComponent("Mila/Resources/ggml-silero-v5.1.2.bin").path
+        let vad = try SileroVAD(modelPath: modelPath)
+        let rate = Int(WhisperAudioFormat.sampleRate)
+
+        // Pure silence.
+        let silence = [Float](repeating: 0, count: rate * 3)
+        let silenceHasSpeech = await vad.containsSpeech(silence)
+        XCTAssertFalse(silenceHasSpeech, "3s of silence must be dropped by the VAD")
+
+        // Loud white noise (~0.3 amplitude) — clears the live RMS energy cutoff,
+        // so the OLD detector emitted it and whisper hallucinated Hebrew filler.
+        var state: UInt64 = 0x9E3779B97F4A7C15
+        func next() -> Float {
+            state ^= state << 13; state ^= state >> 7; state ^= state << 17
+            return Float(Double(state % 20001) / 10000.0 - 1.0) * 0.3
+        }
+        let noise = (0..<(rate * 3)).map { _ in next() }
+        let noiseHasSpeech = await vad.containsSpeech(noise)
+        XCTAssertFalse(noiseHasSpeech, "loud white noise must be dropped by the VAD")
     }
 }

--- a/docker/speaches-hebrew/Dockerfile
+++ b/docker/speaches-hebrew/Dockerfile
@@ -44,13 +44,14 @@ RUN python -c "from huggingface_hub import snapshot_download; \
 # Server config (speaches reads these env vars; see src/speaches/config.py).
 #   - PRELOAD_MODELS: a JSON list. Load the model into memory at startup so the
 #     very first transcription request doesn't pay the load cost (CI health-gates
-#     on it). The default below matches the default MODEL_ID; if you override
-#     MODEL_ID with a different repo, also pass that repo here.
+#     on it). DERIVED from MODEL_ID (expanded at build time) so a custom
+#     `--build-arg MODEL_ID=...` build preloads the model it actually baked into
+#     the HF cache above — never a stale hard-coded repo.
 #   - WHISPER__INFERENCE_DEVICE/COMPUTE_TYPE: CPU int8 — the GitHub runner has no
 #     GPU, and int8 keeps the turbo model's latency tolerable.
 #   - ENABLE_UI=false: no gradio UI; this is an API-only server.
 #   - ALLOW_ORIGINS=["*"]: the E2E client reaches it through a tunnel hostname.
-ENV PRELOAD_MODELS=["ivrit-ai/whisper-large-v3-turbo-ct2"] \
+ENV PRELOAD_MODELS=["${MODEL_ID}"] \
     WHISPER__INFERENCE_DEVICE=cpu \
     WHISPER__COMPUTE_TYPE=int8 \
     ENABLE_UI=false \

--- a/docker/speaches-hebrew/Dockerfile
+++ b/docker/speaches-hebrew/Dockerfile
@@ -50,12 +50,20 @@ RUN python -c "from huggingface_hub import snapshot_download; \
 #   - WHISPER__INFERENCE_DEVICE/COMPUTE_TYPE: CPU int8 — the GitHub runner has no
 #     GPU, and int8 keeps the turbo model's latency tolerable.
 #   - ENABLE_UI=false: no gradio UI; this is an API-only server.
-#   - ALLOW_ORIGINS=["*"]: the E2E client reaches it through a tunnel hostname.
-ENV PRELOAD_MODELS=["${MODEL_ID}"] \
+#   - ALLOW_ORIGINS: the E2E client reaches it through a tunnel hostname.
+#
+# NOTE on the JSON-list vars (PRELOAD_MODELS, ALLOW_ORIGINS): speaches parses
+# these with pydantic-settings as JSON, so the value must be a valid JSON list —
+# `["*"]`, with the inner double-quotes intact. Docker's `ENV KEY=value` parser
+# STRIPS surrounding double-quotes, so a bare `ALLOW_ORIGINS=["*"]` reaches the
+# app as `[*]`, which pydantic rejects (`Input should be a valid list`) and the
+# container crashes on boot. Escape the inner quotes (`\"`) so the env value is
+# literally `["*"]`.
+ENV PRELOAD_MODELS=["\"${MODEL_ID}\""] \
     WHISPER__INFERENCE_DEVICE=cpu \
     WHISPER__COMPUTE_TYPE=int8 \
     ENABLE_UI=false \
-    ALLOW_ORIGINS=["*"] \
+    ALLOW_ORIGINS=["\"*\""] \
     UVICORN_HOST=0.0.0.0 \
     UVICORN_PORT=8000
 

--- a/docker/speaches-hebrew/Dockerfile
+++ b/docker/speaches-hebrew/Dockerfile
@@ -1,0 +1,69 @@
+# Speaches (faster-whisper / CTranslate2) serving a Hebrew whisper model,
+# OpenAI-compatible at /v1/audio/transcriptions on port 8000.
+#
+# WHY THIS IMAGE EXISTS
+# ---------------------
+# Mila's remote-transcription backend (`RemoteWhisperEngine`) speaks the OpenAI
+# `/v1/audio/transcriptions` protocol. Its E2E test normally runs against the
+# stdlib echo mock (scripts/mock-openai-transcription-server.py), which proves
+# the request *contract* but never actually transcribes. This image stands up a
+# REAL self-hosted server with a REAL Hebrew model so the Hebrew E2E can prove
+# Mila gets correct Hebrew text back over HTTP — the production "speaches serving
+# an ivrit.ai model" path the app's own docs describe
+# (Mila/Models/RemoteTranscriptionSettings.swift).
+#
+# It's also a standalone deliverable: `docker run -p 8000:8000 <image>` gives you
+# a local Hebrew transcription endpoint for manual testing.
+#
+# MODEL
+# -----
+# ivrit-ai/whisper-large-v3-turbo-ct2 — Apache-2.0 (redistributable), CTranslate2
+# format, model.bin ~1.62 GB. Baked into the image's HuggingFace hub cache at
+# build time so the container is fully self-contained and needs no network at
+# run time (important for hermetic CI). Override with --build-arg MODEL_ID=... .
+
+ARG SPEACHES_TAG=latest-cpu
+FROM ghcr.io/speaches-ai/speaches:${SPEACHES_TAG}
+
+# Redeclare after FROM so it's visible in the build stage.
+ARG MODEL_ID=ivrit-ai/whisper-large-v3-turbo-ct2
+
+LABEL org.opencontainers.image.source="https://github.com/island-io/mila"
+LABEL org.opencontainers.image.description="Speaches serving the Apache-2.0 ivrit.ai Hebrew whisper model (CT2), OpenAI-compatible on :8000. Used by Mila's Hebrew remote-transcription E2E."
+LABEL org.opencontainers.image.licenses="MIT AND Apache-2.0"
+LABEL io.island.mila.model="${MODEL_ID}"
+
+# Bake the model weights into the image's HF cache. The base image runs as the
+# non-root `ubuntu` user with HOME=/home/ubuntu and pre-creates
+# ~/.cache/huggingface/hub, so the download lands exactly where faster-whisper
+# looks for it at run time — no network needed once the image is built.
+ENV HF_HUB_DISABLE_TELEMETRY=1
+RUN python -c "from huggingface_hub import snapshot_download; \
+    snapshot_download(repo_id='${MODEL_ID}')"
+
+# Server config (speaches reads these env vars; see src/speaches/config.py).
+#   - PRELOAD_MODELS: a JSON list. Load the model into memory at startup so the
+#     very first transcription request doesn't pay the load cost (CI health-gates
+#     on it). The default below matches the default MODEL_ID; if you override
+#     MODEL_ID with a different repo, also pass that repo here.
+#   - WHISPER__INFERENCE_DEVICE/COMPUTE_TYPE: CPU int8 — the GitHub runner has no
+#     GPU, and int8 keeps the turbo model's latency tolerable.
+#   - ENABLE_UI=false: no gradio UI; this is an API-only server.
+#   - ALLOW_ORIGINS=["*"]: the E2E client reaches it through a tunnel hostname.
+ENV PRELOAD_MODELS=["ivrit-ai/whisper-large-v3-turbo-ct2"] \
+    WHISPER__INFERENCE_DEVICE=cpu \
+    WHISPER__COMPUTE_TYPE=int8 \
+    ENABLE_UI=false \
+    ALLOW_ORIGINS=["*"] \
+    UVICORN_HOST=0.0.0.0 \
+    UVICORN_PORT=8000
+
+EXPOSE 8000
+
+# Healthcheck so `docker run --health-*` / compose can gate on readiness. The
+# base image installs curl. /health returns 200 once the app is up; we give it a
+# long start period because PRELOAD_MODELS warms the ~1.6 GB model first.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=12 \
+    CMD curl --fail http://localhost:8000/health || exit 1
+
+# Inherit the base image's entrypoint/CMD (uvicorn serving the speaches app).

--- a/docker/speaches-hebrew/README.md
+++ b/docker/speaches-hebrew/README.md
@@ -1,0 +1,59 @@
+# Speaches Hebrew transcription image
+
+A self-contained [speaches](https://github.com/speaches-ai/speaches)
+(faster-whisper / CTranslate2) server that transcribes **Hebrew**, exposing the
+OpenAI-compatible `/v1/audio/transcriptions` API on port **8000**.
+
+It's the production "self-hosted server speaking the OpenAI protocol" that
+Mila's remote backend (`RemoteWhisperEngine`) is designed to talk to — see
+`Mila/Models/RemoteTranscriptionSettings.swift`.
+
+## Model & licensing
+
+- **Model:** [`ivrit-ai/whisper-large-v3-turbo-ct2`](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ct2)
+  (`model.bin` ≈ 1.62 GB), CTranslate2 format.
+- **License:** **Apache-2.0** — redistributable, so it's safe to bake into the
+  public GHCR image. The speaches runtime itself is **MIT**. (Image label:
+  `org.opencontainers.image.licenses="MIT AND Apache-2.0"`.)
+
+The weights are downloaded into the image's HuggingFace cache **at build time**,
+so the container needs no network at run time.
+
+## Build
+
+```bash
+docker build -t mila-speaches-hebrew docker/speaches-hebrew
+# Different model (must be a faster-whisper / CT2 repo):
+docker build --build-arg MODEL_ID=ivrit-ai/whisper-large-v3-ct2 \
+  -t mila-speaches-hebrew docker/speaches-hebrew
+```
+
+CI builds and publishes it to GHCR via `.github/workflows/build-speaches-image.yml`
+(`ghcr.io/<owner>/mila-speaches-hebrew:latest`), only when this directory changes.
+
+## Run
+
+```bash
+docker run --rm -p 8000:8000 ghcr.io/island-io/mila-speaches-hebrew:latest
+# Wait for readiness (model preloads at startup):
+curl --fail http://localhost:8000/health
+
+# Transcribe Hebrew:
+curl -s http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@Packages/TranscriptionCore/Fixtures/he_toda_raba.wav" \
+  -F "model=ivrit-ai/whisper-large-v3-turbo-ct2" \
+  -F "language=he" \
+  -F "response_format=verbose_json"
+```
+
+Point Mila at it: Settings → Remote API → endpoint `http://localhost:8000/v1`,
+model `ivrit-ai/whisper-large-v3-turbo-ct2` (no API key needed).
+
+## Notes
+
+- **CPU int8.** The image runs faster-whisper on CPU (`WHISPER__COMPUTE_TYPE=int8`)
+  — no GPU on CI runners. A turbo model at int8 is the latency/quality sweet spot
+  for a Hebrew CT2 model on CPU.
+- **speaches' own VAD** (`vad_filter`) is faster-whisper's, *not* Mila's Silero
+  VAD. Mila's VAD is a client-side gate that runs before any backend; the Hebrew
+  E2E asserts it separately (`MilaTests/RemoteTranscriptionE2ETests.swift`).


### PR DESCRIPTION
> **Draft — parked from #50.** This was accidentally stacked onto the remote-failure-fix branch; it's been split out here against `main`. Not ready to merge: the image build + tunnel handoff are **unverified end-to-end** (no Docker in the dev env) and need a first CI run, and the test design is still open (see below).

## What this adds (option B: Linux Docker + cross-runner tunnel)

- `docker/speaches-hebrew/` — a **speaches** (faster-whisper/CT2) image serving `ivrit-ai/whisper-large-v3-turbo-ct2` (Apache-2.0, 1.62 GB), OpenAI-compatible on `:8000`.
- `.github/workflows/build-speaches-image.yml` — builds & pushes to **GHCR**, path-gated.
- `.github/workflows/e2e-hebrew-remote.yml` — Linux job runs the container behind an ephemeral **cloudflared** tunnel (no secret) and hands the dynamic URL to the parallel macOS MilaTests job via a polled artifact; Mila points at it via `MILA_REMOTE_TEST_ENDPOINT`.
- `MilaTests/RemoteTranscriptionE2ETests.swift` — `MILA_REMOTE_HEBREW`-gated: (a) Hebrew fixture through the real `RemoteWhisperEngine`, assert low WER; (b) `SileroVAD` drops silence/noise.

## Open questions before this is ready
1. **Test design:** the VAD is asserted *separately* from the remote (the VAD is a client-side gate, so noise-drop is checked against `SileroVAD` directly, not through speaches). An alternative is an **integrated** test that drives `LiveTranscriber` headlessly (feed a Hebrew+noise WAV via `ingest()` with the VAD gate on + remote backend) so the whole VAD→remote wiring is exercised in one path. `LiveTranscriber.ingest()` makes this feasible (existing tests already drive the VAD path headlessly). Decide which.
2. **Cross-job handoff** relies on `upload-artifact@v4` artifacts being listable mid-run — needs a first CI run to confirm it isn't flaky. Documented fallback: **option A** (speaches natively on the macOS runner; CTranslate2 arm64 wheels verified — no Docker/tunnel).
3. The GHCR image is useful as a local/dev artifact regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Hebrew transcription container image with a ready-to-run, OpenAI-compatible API.
  * Added automated CI workflows to build and publish the image, plus run real end-to-end Hebrew transcription tests.
  * Expanded test coverage for live remote Hebrew transcription with noise handling and quality checks.

* **Documentation**
  * Added setup, build, and run instructions for the Hebrew container image, including example API usage and notes on model loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->