### PR TITLE
Log Voice Memos access denials + distinguish them from a missing library (#45)

### DIFF
--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// Settings → Voice Memos. Lets the user sync recordings made on their iPhone
 /// (synced to this Mac via iCloud) into Mila, picking which Voice Memos
@@ -25,11 +26,16 @@ struct VoiceMemosSettingsTab: View {
             Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
                 .toggleStyle(.switch)
 
-            if !library.isAvailable {
+            switch library.availability {
+            case .available:
+                if settings.isEnabled {
+                    folderPicker
+                    statusFooter
+                }
+            case .databaseMissing:
                 unavailableNotice
-            } else if settings.isEnabled {
-                folderPicker
-                statusFooter
+            case .accessDenied:
+                accessDeniedNotice
             }
             Spacer()
         }
@@ -63,6 +69,30 @@ struct VoiceMemosSettingsTab: View {
         }
         .padding(12)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    /// Shown when the Voice Memos DB exists but macOS blocked access. Mila is
+    /// not sandboxed, so reading the Voice Memos group container needs Full
+    /// Disk Access — point the user straight at the right pane (issue #45).
+    private var accessDeniedNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "lock.shield")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Mila can't read your Voice Memos library. macOS needs you to grant "
+                     + "Mila Full Disk Access, then reopen this tab.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Open Full Disk Access Settings…") {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.08)))
     }
 
     private var folderPicker: some View {

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -92,11 +92,11 @@ final class VoiceMemosImporter: ObservableObject {
         case .available:
             break
         case .databaseMissing:
-            log.notice("VoiceMemos sync is enabled but no library was found at \(self.library.databaseURL.path, privacy: .public) — nothing to sync (iCloud sync off, or no recordings yet).")
+            log.notice("VoiceMemos sync is enabled but no library was found at \(self.library.databaseDisplayPath, privacy: .public) — nothing to sync (iCloud sync off, or no recordings yet).")
             stop()
             return
         case .accessDenied(let reason):
-            log.error("VoiceMemos sync is enabled but macOS denied access to \(self.library.databaseURL.path, privacy: .public) (\(reason, privacy: .public)). Grant Mila Full Disk Access in System Settings → Privacy & Security → Full Disk Access.")
+            log.error("VoiceMemos sync is enabled but macOS denied access to \(self.library.databaseDisplayPath, privacy: .public) (\(reason, privacy: .public)). Grant Mila Full Disk Access in System Settings → Privacy & Security → Full Disk Access.")
             lastError = VoiceMemosLibrary.LibraryError.accessDenied(reason).localizedDescription
             stop()
             return
@@ -113,7 +113,7 @@ final class VoiceMemosImporter: ObservableObject {
         }
         watcher.start()
         self.watcher = watcher
-        log.log("VoiceMemos watcher started on \(self.library.recordingsDirectory.path, privacy: .public)")
+        log.log("VoiceMemos watcher started on \(self.library.recordingsDirectoryDisplayPath, privacy: .public)")
     }
 
     /// Public entry point for the "Rescan now" button in Settings.

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -80,7 +80,24 @@ final class VoiceMemosImporter: ObservableObject {
 
     /// Apply the current settings: start/stop the watcher and trigger a sync.
     private func reconfigure() {
-        guard settings.isEnabled, settings.hasSelection, library.isAvailable else {
+        guard settings.isEnabled, settings.hasSelection else {
+            stop()
+            return
+        }
+        // Sync is on and folders are chosen, but the library may still be
+        // unreadable. Log *why* rather than silently bailing — a TCC / Full
+        // Disk Access denial is the one failure that otherwise leaves no
+        // trace in the logs at all (issue #45).
+        switch library.availability {
+        case .available:
+            break
+        case .databaseMissing:
+            log.notice("VoiceMemos sync is enabled but no library was found at \(self.library.databaseURL.path, privacy: .public) — nothing to sync (iCloud sync off, or no recordings yet).")
+            stop()
+            return
+        case .accessDenied(let reason):
+            log.error("VoiceMemos sync is enabled but macOS denied access to \(self.library.databaseURL.path, privacy: .public) (\(reason, privacy: .public)). Grant Mila Full Disk Access in System Settings → Privacy & Security → Full Disk Access.")
+            lastError = VoiceMemosLibrary.LibraryError.accessDenied(reason).localizedDescription
             stop()
             return
         }

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -41,6 +41,18 @@ struct VoiceMemosLibrary {
         recordingsDirectory.appendingPathComponent("CloudRecordings.db")
     }
 
+    /// `databaseURL.path` / `recordingsDirectory.path` with the home directory
+    /// shortened to `~`. The absolute form embeds the macOS account name, so
+    /// these are the variants safe to log at `.public` — they keep full
+    /// diagnostic value (which path Mila probed) without leaking a user
+    /// identifier into the unified log. See issue #45.
+    var databaseDisplayPath: String {
+        (databaseURL.path as NSString).abbreviatingWithTildeInPath
+    }
+    var recordingsDirectoryDisplayPath: String {
+        (recordingsDirectory.path as NSString).abbreviatingWithTildeInPath
+    }
+
     /// Why the Voice Memos library can — or can't — be read right now.
     ///
     /// A bare `fileExists` check can't tell "the user has no synced library"

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SQLite3
+import Darwin
 
 /// Read-only reader over the iPhone Voice Memos library that iCloud syncs
 /// to this Mac. Everything lives in a Core Data SQLite store inside the
@@ -40,11 +41,51 @@ struct VoiceMemosLibrary {
         recordingsDirectory.appendingPathComponent("CloudRecordings.db")
     }
 
-    /// True when the Voice Memos DB is present — i.e. the user has the app
-    /// and at least one synced recording. Drives whether the Settings tab
-    /// offers the feature or shows a "no library found" hint.
+    /// Why the Voice Memos library can — or can't — be read right now.
+    ///
+    /// A bare `fileExists` check can't tell "the user has no synced library"
+    /// from "macOS denied us access": Mila is **not** sandboxed, so reading
+    /// another app's group container needs Full Disk Access (or a
+    /// Files-and-Folders grant). When that's missing, the OS blocks the path
+    /// and the probe fails with `EPERM`/`EACCES` rather than `ENOENT`.
+    /// Classifying the two lets the importer log the difference and the
+    /// Settings tab show an actionable hint instead of a misleading
+    /// "no library found" message. See issue #45.
+    enum Availability: Equatable {
+        /// The DB is present and readable.
+        case available
+        /// No DB on disk — Voice Memos iCloud sync is off, or there are no
+        /// recordings yet.
+        case databaseMissing
+        /// The DB path is blocked by the OS (missing Full Disk Access /
+        /// Files-and-Folders grant). `reason` is the underlying errno text.
+        case accessDenied(reason: String)
+    }
+
+    /// Classify whether — and why — the Voice Memos DB can be read. Probes
+    /// real read permission with `access(2)` (not just presence) so a TCC
+    /// denial is reported distinctly from a genuinely-absent library.
+    var availability: Availability {
+        if access(databaseURL.path, R_OK) == 0 {
+            return .available
+        }
+        let err = errno
+        switch err {
+        case ENOENT, ENOTDIR:
+            // A path component is genuinely absent — no synced library.
+            return .databaseMissing
+        default:
+            // EPERM / EACCES (TCC denial) and any other unexpected failure:
+            // the read didn't succeed and the file isn't simply missing, so
+            // treat it as "blocked" and carry the reason for the log.
+            return .accessDenied(reason: String(cString: strerror(err)))
+        }
+    }
+
+    /// True when the Voice Memos DB is present and readable. Drives whether
+    /// the Settings tab offers the feature or shows a hint.
     var isAvailable: Bool {
-        FileManager.default.fileExists(atPath: databaseURL.path)
+        availability == .available
     }
 
     // MARK: - Public API
@@ -86,6 +127,7 @@ struct VoiceMemosLibrary {
 
     enum LibraryError: LocalizedError, Equatable {
         case databaseMissing
+        case accessDenied(String)
         case openFailed(String)
         case schemaUnsupported
 
@@ -93,6 +135,9 @@ struct VoiceMemosLibrary {
             switch self {
             case .databaseMissing:
                 return "No Voice Memos library was found on this Mac."
+            case .accessDenied:
+                return "Mila can't read your Voice Memos library. Grant Mila Full Disk Access in "
+                    + "System Settings → Privacy & Security → Full Disk Access, then reopen this tab."
             case .openFailed(let msg):
                 return "Could not open the Voice Memos database: \(msg)"
             case .schemaUnsupported:
@@ -246,7 +291,17 @@ struct VoiceMemosLibrary {
     // MARK: - SQLite helpers
 
     private func open() throws -> OpaquePointer {
-        guard isAvailable else { throw LibraryError.databaseMissing }
+        // Distinguish "no library" from "access denied" before touching
+        // SQLite, so callers (and the log) get the right diagnostic instead
+        // of a generic open failure. See issue #45.
+        switch availability {
+        case .available:
+            break
+        case .databaseMissing:
+            throw LibraryError.databaseMissing
+        case .accessDenied(let reason):
+            throw LibraryError.accessDenied(reason)
+        }
         // Read-only, opened by literal path (NOT a `file:` URI — a "?" or "#"
         // in the path would be parsed as URI query/fragment). The DB is
         // WAL-mode and actively written by voicememod; a read-only connection

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -41,14 +41,18 @@ struct VoiceMemosLibrary {
         recordingsDirectory.appendingPathComponent("CloudRecordings.db")
     }
 
-    /// `databaseURL.path` / `recordingsDirectory.path` with the home directory
-    /// shortened to `~`. The absolute form embeds the macOS account name, so
-    /// these are the variants safe to log at `.public` — they keep full
-    /// diagnostic value (which path Mila probed) without leaking a user
-    /// identifier into the unified log. See issue #45.
+    /// `databaseURL.path` with the home directory shortened to `~`. The
+    /// absolute form embeds the macOS account name, so this is the variant
+    /// safe to log at `.public` — it keeps full diagnostic value (which path
+    /// Mila probed) without leaking a user identifier into the unified log.
+    /// See issue #45.
     var databaseDisplayPath: String {
         (databaseURL.path as NSString).abbreviatingWithTildeInPath
     }
+
+    /// `recordingsDirectory.path` with the home directory shortened to `~`;
+    /// the `.public`-safe counterpart used by the watcher-started log line.
+    /// See `databaseDisplayPath`.
     var recordingsDirectoryDisplayPath: String {
         (recordingsDirectory.path as NSString).abbreviatingWithTildeInPath
     }

--- a/MilaTests/VoiceMemosLibraryTests.swift
+++ b/MilaTests/VoiceMemosLibraryTests.swift
@@ -61,8 +61,43 @@ final class VoiceMemosLibraryTests: XCTestCase {
     func test_isAvailable_falseWhenDatabaseMissing() {
         let lib = VoiceMemosLibrary(recordingsDirectory: tempRoot)
         XCTAssertFalse(lib.isAvailable)
+        XCTAssertEqual(lib.availability, .databaseMissing)
         XCTAssertThrowsError(try lib.fetchAllRecordings()) { error in
             XCTAssertEqual(error as? VoiceMemosLibrary.LibraryError, .databaseMissing)
+        }
+    }
+
+    func test_availability_availableForReadableDatabase() throws {
+        let lib = try makeFixtureLibrary()
+        XCTAssertEqual(lib.availability, .available)
+        XCTAssertTrue(lib.isAvailable)
+    }
+
+    /// A present-but-unreadable DB (the TCC / Full Disk Access denial case,
+    /// simulated here by stripping read permission) must classify as
+    /// `accessDenied` — distinct from "missing" — and surface a thrown
+    /// `.accessDenied` rather than a generic open failure. See issue #45.
+    func test_availability_accessDeniedWhenUnreadable() throws {
+        // access(2) ignores permission bits for the superuser, so this can't
+        // be exercised as root; skip rather than report a false failure.
+        try XCTSkipIf(getuid() == 0, "access(2) bypasses permission checks as root")
+
+        let lib = try makeFixtureLibrary()
+        let dbURL = tempRoot.appendingPathComponent("CloudRecordings.db")
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: dbURL.path)
+        defer {
+            // Restore so tearDown's cleanup isn't affected on any platform.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: dbURL.path)
+        }
+
+        XCTAssertFalse(lib.isAvailable)
+        guard case .accessDenied = lib.availability else {
+            return XCTFail("expected .accessDenied, got \(lib.availability)")
+        }
+        XCTAssertThrowsError(try lib.fetchAllRecordings()) { error in
+            guard case .accessDenied = error as? VoiceMemosLibrary.LibraryError else {
+                return XCTFail("expected LibraryError.accessDenied, got \(error)")
+            }
         }
     }
 

--- a/MilaTests/VoiceMemosLibraryTests.swift
+++ b/MilaTests/VoiceMemosLibraryTests.swift
@@ -58,6 +58,8 @@ final class VoiceMemosLibraryTests: XCTestCase {
 
     // MARK: - Tests
 
+    /// A genuinely-absent DB classifies as `.databaseMissing` (not denied),
+    /// and reads throw the matching `.databaseMissing` error.
     func test_isAvailable_falseWhenDatabaseMissing() {
         let lib = VoiceMemosLibrary(recordingsDirectory: tempRoot)
         XCTAssertFalse(lib.isAvailable)
@@ -67,6 +69,7 @@ final class VoiceMemosLibraryTests: XCTestCase {
         }
     }
 
+    /// A present, readable fixture DB classifies as `.available`.
     func test_availability_availableForReadableDatabase() throws {
         let lib = try makeFixtureLibrary()
         XCTAssertEqual(lib.availability, .available)


### PR DESCRIPTION
Fixes #45.

## Problem
Mila is **not** sandboxed, so reading the iPhone Voice Memos group container (`~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/CloudRecordings.db`) requires Full Disk Access (or a Files-and-Folders grant). When that grant is missing or invalidated (e.g. after a re-signed/reinstalled build), the failure was **invisible in the logs**:

- `VoiceMemosImporter.reconfigure()` silently `return`ed on `library.isAvailable == false`.
- `isAvailable` was a bare `fileExists` check that can't tell a TCC denial from a genuinely-absent library.
- The only signal was a UI error when picking folders in Settings — nothing written to `~/Library/Logs/Mila/mila.log` or the unified log.

## Fix
- **`VoiceMemosLibrary`** — new `availability` classifier that probes *real read permission* with `access(2)` and inspects `errno`, returning `.available` / `.databaseMissing` / `.accessDenied(reason:)`. A TCC denial fails with `EPERM`/`EACCES`; a genuinely-missing library fails with `ENOENT`. `isAvailable` now derives from this. `open()` throws a new `LibraryError.accessDenied` (with an actionable Full Disk Access message) instead of a generic open failure when the path is blocked.
- **`VoiceMemosImporter.reconfigure()`** — logs distinctly instead of silently bailing: `.notice` when no library is found, `.error` (with the errno reason + a Full Disk Access hint) on a denial.
- **`VoiceMemosSettingsTab`** — shows an actionable **"Open Full Disk Access Settings…"** notice on `.accessDenied`, separate from the existing neutral "no library found" hint, so the user isn't misled into thinking iCloud sync is off when it's really a permissions problem.

## Tests
`VoiceMemosLibraryTests` now covers `.available`, `.databaseMissing`, and the `.accessDenied` path (simulated by stripping read permission; skipped under root since `access(2)` bypasses permission bits for the superuser).

Built clean (`make build`) and the `VoiceMemosLibraryTests` suite passes (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Voice Memos settings and syncing status display with clearer, state-specific notices for missing databases vs Full Disk Access denial.
  * Added a one-tap button to open macOS Full Disk Access settings when access is blocked.
* **Bug Fixes**
  * Improved detection of whether the Voice Memos database is readable, preventing sync attempts when it isn’t.
  * Updated sync flow and messaging to stop appropriately and report the correct reason.
* **Tests**
  * Expanded coverage for available, database-missing, and access-denied scenarios (including unreadable DB permissions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->