### PR TITLE
Add file logging + MilaLog so a Finder-launched app is debuggable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,30 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
 - `TranscriptionService` now requires a `diarizationSettings:` parameter. In tests, always pass `DiarizationSettings(defaults: .init(suiteName: "TestClassName.diarization")!)` to isolate from user defaults.
 - Run tests with `make test` or via Xcode.
 
+### Logging
+- **Where:** the app writes a plain-text log to `~/Library/Logs/Mila/mila.log`.
+  Tail it with `make logs`. It is truncated when it grows past ~5 MB.
+- **When it's active:** file logging is set up by `redirectMilaLogsToFile()` (the
+  first line of `MilaApp.init()`), which redirects `stdout`/`stderr` to the file.
+  It is **skipped when the app is attached to a TTY** (`guard isatty(STDERR_FILENO) == 0`)
+  so that running under Xcode or a terminal still prints to the console. Practical
+  upshot: a **Finder/`open` launch logs to the file** (use `make reinstall`), but a
+  terminal launch (e.g. `make run`, or running the binary directly) does **not** —
+  it prints to the console instead.
+- **Scope (what lands in the file):**
+  1. Every `print(...)` in the app (most transcription-pipeline diagnostics).
+  2. Every `MilaLog` call. `MilaLog` (see `Mila/App/MilaLog.swift`) is the
+     app-wide logger that replaced raw `os.Logger`; it mirrors each entry to
+     **both** the unified log (`os.Logger`, subsystem `io.island.whisper.IslandWhisper`)
+     **and** stdout, so subsystem logs (VoiceMemos, ModelManager, MeetingDetector,
+     RemoteWhisperEngine, etc.) appear in the file prefixed with `[Category]`.
+- **New logging:** prefer `MilaLog` over `os.Logger`/`print` for new code so output
+  reaches both sinks. It accepts the same interpolation as `os.Logger`, including
+  `"\(value, privacy: .public)"`.
+- **Unified log alternative:** os_log entries are also visible in Console.app or via
+  `log show --predicate 'subsystem == "io.island.whisper.IslandWhisper"' --info`
+  (note: `.info`/`.debug` levels are not persisted by default).
+
 ## Release Process
 - **Release notes are REQUIRED, first.** Every release must add
   `RELEASE_NOTES/v<MARKETING_VERSION>.md` (Markdown, user-facing). This file

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all bootstrap project open build test run clean models models-coreml-tiny help dmg release-build e2e package-test bundle-diarization verify-ane
+.PHONY: all bootstrap project open build test run clean models models-coreml-tiny help dmg release-build e2e package-test bundle-diarization verify-ane reinstall logs
 
 XCODEPROJ := Mila.xcodeproj
 SCHEME := Mila
@@ -22,6 +22,8 @@ help:
 	@echo "  release-build - Release build into $(RELEASE_DERIVED)"
 	@echo "  test          - Run the MilaTests XCTest target"
 	@echo "  run           - Build and launch the app"
+	@echo "  reinstall     - Release-build, replace /Applications/Mila.app, and launch (engages file logging)"
+	@echo "  logs          - Tail the app log at ~/Library/Logs/Mila/mila.log"
 	@echo "  models        - Pre-download both ggml models into ~/Library/Application Support/Mila/Models"
 	@echo "  models-coreml-tiny - Download ggml-tiny + sibling -encoder.mlmodelc into ~/.cache/whisper-coreml-test/ (for CI ANE verification test)"
 	@echo "  dmg           - Build a release DMG ($(DMG)) suitable for upload"
@@ -59,6 +61,26 @@ test: project
 
 run: build
 	open $(APP)
+
+# Local dev loop for testing file logging: build a release, replace the
+# installed app, and launch it via `open` (NOT a terminal) so the stdout->file
+# redirect in MilaApp.init() engages. Logs land at ~/Library/Logs/Mila/mila.log.
+# User recordings/models/settings under Application Support are untouched.
+reinstall: release-build
+	@echo "Replacing /Applications/Mila.app with fresh release build..."
+	@pkill -x Mila 2>/dev/null || true
+	@if [ -e /Applications/Mila.app ]; then \
+		command -v trash >/dev/null 2>&1 && trash /Applications/Mila.app || rm -rf /Applications/Mila.app; \
+	fi
+	cp -R "$(RELEASE_APP)" /Applications/
+	@echo "Installed (ad-hoc signed). Launching via Finder so file logging engages..."
+	open -a /Applications/Mila.app
+
+# Tail the app log. File logging is only active for Finder/`open` launches
+# (it is skipped when the app is started from a TTY, e.g. via `make run`).
+logs:
+	@touch "$(HOME)/Library/Logs/Mila/mila.log" 2>/dev/null || true
+	@tail -f "$(HOME)/Library/Logs/Mila/mila.log"
 
 # Local (self-hosted) check: verify an upgrade doesn't recompile the CoreML/ANE
 # encoder. Needs a real Neural Engine + an installed model + a GUI session, so

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let liveAILog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveAISession")
+private let liveAILog = MilaLog(category: "LiveAISession")
 
 /// Drives the LLM half of Live AI mode. Holds an action-item list, fires a
 /// debounced one-shot LLM call against the latest transcript on each tick,

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -2,8 +2,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let postRecordingLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
-                                      category: "PostRecordingCoordinator")
+private let postRecordingLog = MilaLog(category: "PostRecordingCoordinator")
 
 /// Owns the "Name this recording" sheet lifecycle. The sheet pops the moment
 /// a recording is added (i.e. recording stopped) — NOT when transcription

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -7,8 +7,7 @@ import UniformTypeIdentifiers
 import AVFoundation
 import TranscriptionCore
 
-private let quickActionsLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
-                                     category: "QuickActionsController")
+private let quickActionsLog = MilaLog(category: "QuickActionsController")
 
 /// Single entry point used by the Home tiles + sidebar buttons.
 /// Hides recording/transcription orchestration from the UI layer.

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -2,8 +2,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let summarizerLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
-                                   category: "RecordingSummarizer")
+private let summarizerLog = MilaLog(category: "RecordingSummarizer")
 
 /// Fires a one-shot LLM call against a finished recording's transcript and
 /// stores the result on the `Recording.summary` field.

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -5,6 +5,36 @@ import OSLog
 import Sparkle
 import TranscriptionCore
 
+/// Redirect `stdout`/`stderr` to `~/Library/Logs/Mila/mila.log` so the app's
+/// many `print(...)` diagnostics (transcription progress, errors) — plus the
+/// inherited stderr of whisper.cpp and the pyannote Python subprocess — are
+/// persisted to a real file. GUI apps launched from Finder otherwise discard
+/// stdout/stderr entirely, leaving no logs to debug failures with.
+///
+/// Called as the very first thing in `MilaApp.init()`. Skipped when attached to
+/// a terminal (Xcode/CLI) so the dev console keeps working. The streams are set
+/// line-/un-buffered so entries appear promptly instead of only on exit.
+func redirectMilaLogsToFile() {
+    // Don't hijack the console when running under Xcode or a terminal.
+    guard isatty(STDERR_FILENO) == 0 else { return }
+    let fm = FileManager.default
+    guard let dir = fm.urls(for: .libraryDirectory, in: .userDomainMask).first?
+        .appendingPathComponent("Logs/Mila", isDirectory: true) else { return }
+    try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+    let file = dir.appendingPathComponent("mila.log")
+    // Simple rotation: start fresh if the file grew past ~5 MB.
+    if let size = (try? fm.attributesOfItem(atPath: file.path)[.size]) as? Int, size > 5_000_000 {
+        try? fm.removeItem(at: file)
+    }
+    freopen(file.path, "a", stdout)
+    freopen(file.path, "a", stderr)
+    setvbuf(stdout, nil, _IOLBF, 0)   // line-buffered
+    setvbuf(stderr, nil, _IONBF, 0)   // unbuffered
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+    print("=== Mila launched \(ISO8601DateFormatter().string(from: Date())) (v\(version) build \(build)) ===")
+}
+
 /// Wraps Sparkle's `SPUStandardUpdaterController` so SwiftUI menu items can
 /// observe `canCheckForUpdates` and disable themselves while a check is
 /// already in flight. Created once at app launch — Sparkle starts its
@@ -238,6 +268,9 @@ struct MilaApp: App {
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
+        // FIRST: capture stdout/stderr to a log file (see helper above) so the
+        // app's print(...) diagnostics survive a Finder launch.
+        redirectMilaLogsToFile()
         // RecordingStore's no-arg init handles the legacy migration and
         // opens at the default Application Support location. The
         // storage-settings instance owns the security-scoped bookmark
@@ -335,7 +368,7 @@ struct MilaApp: App {
         // than inside its init so the seed doesn't depend on whatever
         // order Swift evaluates the @MainActor isolation of init vs
         // CommandLine population — putting it here makes it deterministic.
-        os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+        MilaLog(category: "MilaApp")
             .log("MilaApp.init args=\(CommandLine.arguments.joined(separator: " "), privacy: .public)")
         // UI-test launch args that override persisted settings so the
         // workflow can pick the recording language without depending on
@@ -390,7 +423,7 @@ struct MilaApp: App {
                             text: "ונחלק את העבודה בין החברים",
                             speaker: nil, stable: true)
             ])
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("seeded \(liveTrans.segments.count, privacy: .public) Hebrew segments for UI test")
         }
         let liveDiar = LiveSpeakerDiarizer()
@@ -645,7 +678,7 @@ struct MilaApp: App {
         // Give the fake recording a moment to flip `actions.isRecording`.
         try? await Task.sleep(nanoseconds: 300_000_000)
         if let zoom = MeetingDetector.supportedApps.first {
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("simulate-meeting-ended: firing meetingEnded for \(zoom.displayName, privacy: .public)")
             meetingDetector.meetingEnded.send(zoom)
         }
@@ -687,7 +720,7 @@ struct MilaApp: App {
         }) else { return }
         let wavPath = String(arg.dropFirst("--ui-test-inject-fixture-wav=".count))
         guard FileManager.default.fileExists(atPath: wavPath) else {
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("inject-fixture: WAV missing at \(wavPath, privacy: .public)")
             return
         }
@@ -717,7 +750,7 @@ struct MilaApp: App {
             if sessionRef.onLiveSamples != nil { break }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
-        os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+        MilaLog(category: "MilaApp")
             .log("inject-fixture: pumping \(wavPath, privacy: .public) agc=\(agcEnabled ? "on" : "off", privacy: .public)")
         await Self.pumpFixtureWAV(path: wavPath, to: sessionRef, agcEnabled: agcEnabled)
     }
@@ -763,7 +796,7 @@ struct MilaApp: App {
         }) else { return }
         let wavPath = String(arg.dropFirst("--ui-test-inject-fixture-wav=".count))
         guard FileManager.default.fileExists(atPath: wavPath) else {
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("finalize-regression: WAV missing at \(wavPath, privacy: .public)")
             return
         }
@@ -776,7 +809,7 @@ struct MilaApp: App {
             switch state {
             case .recording:
                 guard pumpTask == nil else { break }
-                os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+                MilaLog(category: "MilaApp")
                     .log("finalize-regression: .recording — arming one-shot fixture pump")
                 pumpTask = Task { @MainActor in
                     // Wait for wireLiveAIPipeline to install onLiveSamples
@@ -806,7 +839,7 @@ struct MilaApp: App {
                                            agcEnabled: Bool) async {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
               let (samples, sampleRate) = Self.decodeWAV(data: data) else {
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("finalize-regression: failed to decode WAV at \(path, privacy: .public)")
             return
         }
@@ -853,7 +886,7 @@ struct MilaApp: App {
         // but parsing it lets us tolerate fmt chunks of different
         // sizes (e.g. with an `fact` chunk for float WAVs).
         guard let (samples, sampleRate) = Self.decodeWAV(data: data) else {
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("inject-fixture: failed to decode WAV at \(path, privacy: .public)")
             return
         }
@@ -893,7 +926,7 @@ struct MilaApp: App {
                     try? await Task.sleep(nanoseconds: napNs)
                 }
             }
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            MilaLog(category: "MilaApp")
                 .log("inject-fixture: looping, pumped=\(pumped, privacy: .public) samples so far gain=\(agc.currentGain, privacy: .public)")
         }
     }
@@ -1055,7 +1088,7 @@ struct MilaApp: App {
                     // to a recording that never ran the LLM loop.
                     // Cursor flagged on c95d2bb.
                     aiSession.cancel()
-                    os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+                    MilaLog(category: "MilaApp")
                         .log("wireLiveAIPipeline: .recording skipped — hardware below Live AI bar (model=\(aiSettings.capabilities.marketingName, privacy: .public))")
                     continue
                 }

--- a/Mila/App/MilaLog.swift
+++ b/Mila/App/MilaLog.swift
@@ -1,0 +1,55 @@
+import Foundation
+import OSLog
+
+/// Privacy markers mirroring `os.Logger`'s interpolation, so existing call
+/// sites written as `log.error("… \(x, privacy: .public)")` compile unchanged
+/// against `MilaLog`. For the file sink, `.private`/`.sensitive` values are
+/// redacted; everything else is rendered.
+enum MilaLogPrivacy { case `public`, `private`, auto, sensitive }
+
+/// A log message built with the same string-interpolation syntax `os.Logger`
+/// accepts (including the optional `, privacy:` argument). Renders to a plain
+/// `String` for the stdout/file sink.
+struct MilaLogMessage: ExpressibleByStringInterpolation, ExpressibleByStringLiteral {
+    let rendered: String
+    init(stringLiteral value: String) { rendered = value }
+    init(stringInterpolation: Interpolation) { rendered = stringInterpolation.text }
+
+    struct Interpolation: StringInterpolationProtocol {
+        var text = ""
+        init(literalCapacity: Int, interpolationCount: Int) { text.reserveCapacity(literalCapacity) }
+        mutating func appendLiteral(_ s: String) { text += s }
+        mutating func appendInterpolation<T>(_ value: T) { text += String(describing: value) }
+        mutating func appendInterpolation<T>(_ value: T, privacy: MilaLogPrivacy) {
+            text += (privacy == .private || privacy == .sensitive) ? "<private>" : String(describing: value)
+        }
+    }
+}
+
+/// Drop-in replacement for `os.Logger` that mirrors every entry to BOTH the
+/// unified log (via `os.Logger`) AND stdout. Because `MilaApp.init()` redirects
+/// stdout to `~/Library/Logs/Mila/mila.log`, this makes ALL subsystems —
+/// VoiceMemos, RemoteWhisperEngine, ModelManager, etc. — show up in the file
+/// log alongside the `print(...)`-based transcription diagnostics, instead of
+/// being invisible in the unified log only.
+struct MilaLog {
+    let category: String
+    private let osLogger: Logger
+
+    init(category: String) {
+        self.category = category
+        osLogger = Logger(subsystem: "io.island.whisper.IslandWhisper", category: category)
+    }
+
+    func log(_ m: MilaLogMessage)     { osLogger.log("\(m.rendered, privacy: .public)");     sink("",       m) }
+    func info(_ m: MilaLogMessage)    { osLogger.info("\(m.rendered, privacy: .public)");    sink("INFO",   m) }
+    func notice(_ m: MilaLogMessage)  { osLogger.notice("\(m.rendered, privacy: .public)");  sink("NOTICE", m) }
+    func debug(_ m: MilaLogMessage)   { osLogger.debug("\(m.rendered, privacy: .public)");   sink("DEBUG",  m) }
+    func warning(_ m: MilaLogMessage) { osLogger.warning("\(m.rendered, privacy: .public)"); sink("WARN",   m) }
+    func error(_ m: MilaLogMessage)   { osLogger.error("\(m.rendered, privacy: .public)");   sink("ERROR",  m) }
+
+    private func sink(_ level: String, _ m: MilaLogMessage) {
+        let tag = level.isEmpty ? "[\(category)]" : "[\(category)] \(level)"
+        print("\(tag) \(m.rendered)")
+    }
+}

--- a/Mila/Audio/AudioCompressor.swift
+++ b/Mila/Audio/AudioCompressor.swift
@@ -2,7 +2,7 @@ import Foundation
 import AVFoundation
 import OSLog
 
-private let compressorLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "AudioCompressor")
+private let compressorLog = MilaLog(category: "AudioCompressor")
 
 /// Transcodes recordings from the on-disk WAV (written live during a
 /// session — crash-recoverable, which the launch recovery relies on) to

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -3,7 +3,7 @@ import Combine
 import OSLog
 import TranscriptionCore
 
-private let liveLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveTranscriber")
+private let liveLog = MilaLog(category: "LiveTranscriber")
 
 /// Per-tick output of the live transcriber. Kept around for back-compat
 /// with `LiveSpeakerDiarizer` (which still publishes intervals that view

--- a/Mila/Audio/MeetingDetector.swift
+++ b/Mila/Audio/MeetingDetector.swift
@@ -27,8 +27,7 @@ import OSLog
 /// joined a meeting" notification.
 @MainActor
 final class MeetingDetector: ObservableObject {
-    private static let log = Logger(
-        subsystem: "io.island.whisper.IslandWhisper", category: "MeetingDetector")
+    private static let log = MilaLog(category: "MeetingDetector")
 
     /// One supported app. `bundleID` is the canonical ID used for the
     /// prompt's snooze / silence keys and display; `captureBundlePrefixes`

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -3,7 +3,7 @@ import AVFoundation
 import Combine
 import os
 
-private let micLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MicrophoneRecorder")
+private let micLog = MilaLog(category: "MicrophoneRecorder")
 
 enum MicrophoneError: Error, Equatable {
     case noInputDevice

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -5,7 +5,7 @@ import OSLog
 import ScreenCaptureKit
 import TranscriptionCore
 
-private let recLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "RecordingSession")
+private let recLog = MilaLog(category: "RecordingSession")
 
 /// Orchestrates microphone + system audio capture into a single mono 16kHz WAV file.
 @MainActor

--- a/Mila/Audio/UtteranceDetector.swift
+++ b/Mila/Audio/UtteranceDetector.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-private let vadLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VAD")
+private let vadLog = MilaLog(category: "VAD")
 
 /// RMS-based voice-activity detector. Ingests mono16k PCM frames and
 /// emits a complete utterance (samples + recording-time start) when a

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let recStoreLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "RecordingStore")
+private let recStoreLog = MilaLog(category: "RecordingStore")
 
 /// Persists recordings + their metadata under Application Support/Mila.
 ///

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let diarLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveSpeakerDiarizer")
+private let diarLog = MilaLog(category: "LiveSpeakerDiarizer")
 
 /// Streams speaker labels during a live recording by sending 5 s WAV chunks
 /// to a long-running Python daemon that computes a pyannote/wespeaker

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -3,8 +3,7 @@ import Combine
 import CryptoKit
 import os.log
 
-private let modelLogger = Logger(subsystem: "io.island.mila.Mila",
-                                 category: "models")
+private let modelLogger = MilaLog(category: "models")
 
 /// Catalog of supported ggml models. Add more here as needed.
 struct WhisperModel: Identifiable, Hashable, Codable {

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -2,8 +2,7 @@ import Foundation
 import OSLog
 import TranscriptionCore
 
-private let remoteLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
-                               category: "RemoteWhisperEngine")
+private let remoteLog = MilaLog(category: "RemoteWhisperEngine")
 
 /// Injection seam for `TranscriptionService`: the remote engine refines
 /// `TranscribingEngine` with the remote-specific `configure(_:)` step the

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -3,7 +3,7 @@ import Combine
 import OSLog
 import TranscriptionCore
 
-private let serviceLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "TranscriptionService")
+private let serviceLog = MilaLog(category: "TranscriptionService")
 
 /// Coordinates batch transcription of recordings + one-shot transcription
 /// for dictation.

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -301,7 +301,7 @@ struct LiveAIRecordingView: View {
                     // grew ~linearly with recording length. Lazy keeps it
                     // O(visible) — flat regardless of transcript size.
                     LazyVStack(alignment: .leading, spacing: 6) {
-                        let _ = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveAIRecordingView")
+                        let _ = MilaLog(category: "LiveAIRecordingView")
                             .log("render segments.count=\(transcriber.segments.count, privacy: .public)")
                         if transcriber.segments.isEmpty {
                             Text("Listening…")

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -26,7 +26,7 @@ final class VoiceMemosImporter: ObservableObject {
     private let languageSettings: RecordingLanguageSettings
     private let library: VoiceMemosLibrary
 
-    private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceMemos")
+    private let log = MilaLog(category: "VoiceMemos")
 
     /// Last successful sync timestamp, for the Settings status line.
     @Published private(set) var lastSyncDate: Date?


### PR DESCRIPTION
## Why

Diagnosing failures in a **Finder/`open`-launched Mila** was effectively impossible: GUI apps discard `stdout`/`stderr`, so none of the app's `print(...)` transcription diagnostics survived, and `os.Logger` subsystem entries were only reachable via Console.app after the fact. This started while trying to debug a real issue and I kept having no logs to look at - so this adds a persistent file log.

## What

- **`redirectMilaLogsToFile()`** - first line of `MilaApp.init()`. Redirects `stdout`/`stderr` to `~/Library/Logs/Mila/mila.log`. **Skipped when attached to a TTY** (`isatty(STDERR_FILENO) == 0`) so `make run`/Xcode keep printing to the console. ~5 MB rotation.
- **`MilaLog`** - a drop-in `os.Logger` replacement that mirrors every entry to **both** the unified log **and** stdout, so subsystem logs (VoiceMemos, ModelManager, RemoteWhisperEngine, MeetingDetector, ...) land in the file too. Same interpolation syntax including `, privacy: .public`, so existing call sites compile unchanged. Migrated the existing `os.Logger` sites across the app.
- **Makefile** - `make reinstall` (release-build -> replace `/Applications/Mila.app` -> `open` so file logging engages) and `make logs` (tail the log).
- **CLAUDE.md** - documents the logging setup, scope, and gotchas.

## Testing status

Builds cleanly (`make build` / `make release-build`) against current `main`.

**Verified E2E:** after `make reinstall` + a Finder launch, `~/Library/Logs/Mila/mila.log` captured live output from both sinks - `print(...)` lines (WhisperEngine, TranscriptionService) **and** `MilaLog` subsystem lines (`[MeetingDetector] NOTICE ...`, `[LiveTranscriber] ...`, `[RecordingSummarizer] ...`). Core capture + the TTY gate work.

⚠️ **Still unverified:** the ~5 MB log rotation path and `.private`/`.sensitive` redaction in the file sink. Keeping this a **draft** until those are exercised - feedback on the approach welcome in the meantime.