### PR TITLE
Bug-hunt sweep: 29 fixes across engine, capture, subprocess handling, and UI (+24 regression tests)

### DIFF
--- a/Mila/Actions/DiagnosticReporter.swift
+++ b/Mila/Actions/DiagnosticReporter.swift
@@ -189,8 +189,13 @@ enum DiagnosticReporter {
     private static func writeSettings(at dir: URL) throws {
         // Whitelist of UserDefaults key prefixes we know are Mila-owned.
         // Avoids leaking unrelated app or system defaults into the zip.
+        // "recording." covers `recording.language` — the key the language
+        // picker actually persists (RecordingLanguageSettings). The old
+        // entry here was "recordingLanguage", which matches no real key,
+        // so the one setting most language-related support reports need
+        // was silently missing from settings.json.
         let prefixes = ["diarization.", "audio.", "llm.", "hotkeys.",
-                        "home.", "rename.", "recordingLanguage", "selectedModelName"]
+                        "home.", "rename.", "recording.", "selectedModelName"]
         let defaults = UserDefaults.standard.dictionaryRepresentation()
         var scoped: [String: Any] = [:]
         for (key, value) in defaults {

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -478,14 +478,24 @@ enum LLMRunner {
                 print("LLMRunner: pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
             }
         } else {
-            // Normal exit: UNBOUNDED, deliberately. The child closed its
-            // write ends when it died, so the readers hit EOF as soon as
-            // they get CPU — but on a loaded macos-26 CI VM "as soon as"
-            // can be 10s+ of dispatch latency, and a fixed grace here
-            // truncated perfectly good output mid-stream (caught by
-            // LLMRunnerTests.test_runner_spawns_child_in_isolated_temp_directory
-            // going flaky on CI).
-            group.wait()
+            // Normal exit: bounded too, but with a GENEROUS grace. Two
+            // opposing constraints meet here:
+            //  * The child closed its write ends when it died, so the
+            //    readers hit EOF as soon as they get CPU — on a loaded
+            //    macos-26 CI VM that can be 10s+ of dispatch latency, and
+            //    a tight 3s bound truncated perfectly good output
+            //    mid-stream (test_runner_spawns_child_in_isolated_temp_
+            //    directory went flaky on CI).
+            //  * EOF is not GUARANTEED even after exit 0 — a helper the
+            //    CLI spawned (MCP server, node daemon) can inherit the
+            //    pipes and keep them open indefinitely; an unbounded wait
+            //    hung the caller forever.
+            // 30s clears any realistic dispatch latency while still
+            // returning the (fully buffered by then) output if a
+            // pipe-holding helper never lets EOF arrive.
+            if group.wait(timeout: .now() + 30) == .timedOut {
+                print("LLMRunner: pipe drain timed out after normal exit — a helper process is still holding stdout/stderr; returning buffered output")
+            }
         }
 
         let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Errors surfaced from the CLI invocation. The Settings UI / rename sheet
 /// renders `errorDescription` directly so users can self-diagnose path /
@@ -417,18 +418,23 @@ enum LLMRunner {
 
         // Read stdout/stderr eagerly on background queues so a chatty CLI
         // can't deadlock by filling the OS pipe buffer while we waitUntilExit.
-        var outData = Data()
-        var errData = Data()
+        // Chunked reads into lock-guarded boxes (not one readDataToEndOfFile
+        // into a captured var) so the bounded drain below can snapshot what
+        // arrived so far without racing a still-blocked reader.
+        let outBox = OSAllocatedUnfairLock(initialState: Data())
+        let errBox = OSAllocatedUnfairLock(initialState: Data())
         let group = DispatchGroup()
-        group.enter()
-        DispatchQueue.global().async {
-            outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            group.leave()
-        }
-        group.enter()
-        DispatchQueue.global().async {
-            errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-            group.leave()
+        for (pipe, box) in [(stdoutPipe, outBox), (stderrPipe, errBox)] {
+            group.enter()
+            DispatchQueue.global().async {
+                let handle = pipe.fileHandleForReading
+                while true {
+                    let chunk = handle.availableData   // blocks until data or EOF
+                    if chunk.isEmpty { break }
+                    box.withLock { $0.append(chunk) }
+                }
+                group.leave()
+            }
         }
 
         // Bounded wait — kill the process if it's still running at deadline.
@@ -450,12 +456,21 @@ enum LLMRunner {
                 runningGroup.wait()
             }
         }
-        // Drain the pipe readers once the process is known to be gone (either it
-        // exited on its own or we killed it above).
-        group.wait()
+        // Drain the pipe readers once the process is known to be gone (either
+        // it exited on its own or we killed it above). BOUNDED: the write
+        // ends normally close the instant the child dies and the readers hit
+        // EOF immediately — but a grandchild that inherited the pipes and
+        // survived the kill (an MCP server or node helper the CLI spawned)
+        // holds them open indefinitely, and an unbounded wait here hung this
+        // method (and the awaiting continuation, and the caller's in-flight
+        // slot) forever. After the grace we return whatever was captured;
+        // the leaked reader threads exit when the pipes finally close.
+        if group.wait(timeout: .now() + 3) == .timedOut {
+            print("LLMRunner: pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
+        }
 
-        let stdout = String(data: outData, encoding: .utf8) ?? ""
-        let stderr = String(data: errData, encoding: .utf8) ?? ""
+        let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""
+        let stderr = String(data: errBox.withLock { $0 }, encoding: .utf8) ?? ""
 
         return ProcessOutcome(stdout: stdout,
                               stderr: stderr,

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -456,17 +456,28 @@ enum LLMRunner {
                 runningGroup.wait()
             }
         }
-        // Drain the pipe readers once the process is known to be gone (either
-        // it exited on its own or we killed it above). BOUNDED: the write
-        // ends normally close the instant the child dies and the readers hit
-        // EOF immediately — but a grandchild that inherited the pipes and
-        // survived the kill (an MCP server or node helper the CLI spawned)
-        // holds them open indefinitely, and an unbounded wait here hung this
-        // method (and the awaiting continuation, and the caller's in-flight
-        // slot) forever. After the grace we return whatever was captured;
-        // the leaked reader threads exit when the pipes finally close.
-        if group.wait(timeout: .now() + 3) == .timedOut {
-            print("LLMRunner: pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
+        // Drain the pipe readers once the process is known to be gone.
+        if timedOut || handle.wasTerminated {
+            // Killed path: BOUNDED. A grandchild that inherited the pipes
+            // and survived the kill (an MCP server or node helper the CLI
+            // spawned) holds them open indefinitely, and an unbounded wait
+            // here hung this method (and the awaiting continuation, and
+            // the caller's in-flight slot) forever. The output is being
+            // discarded anyway (the caller sees .timedOut / .cancelled),
+            // so after the grace we move on; the leaked reader threads
+            // exit when the pipes finally close.
+            if group.wait(timeout: .now() + 3) == .timedOut {
+                print("LLMRunner: pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
+            }
+        } else {
+            // Normal exit: UNBOUNDED, deliberately. The child closed its
+            // write ends when it died, so the readers hit EOF as soon as
+            // they get CPU — but on a loaded macos-26 CI VM "as soon as"
+            // can be 10s+ of dispatch latency, and a fixed grace here
+            // truncated perfectly good output mid-stream (caught by
+            // LLMRunnerTests.test_runner_spawns_child_in_isolated_temp_directory
+            // going flaky on CI).
+            group.wait()
         }
 
         let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -453,7 +453,15 @@ enum LLMRunner {
             process.terminate()
             if runningGroup.wait(timeout: .now() + 1) == .timedOut {
                 kill(process.processIdentifier, SIGKILL)
-                runningGroup.wait()
+                // BOUNDED: `waitUntilExit` has been observed never returning
+                // even after a SIGKILL (macOS 26, sampled live — likely a
+                // reaping race inside NSTask). The child is dead-or-dying
+                // either way, and this is the timedOut path so its exit
+                // status is already being discarded — don't hang the caller
+                // (and its awaiting continuation) on the obituary.
+                if runningGroup.wait(timeout: .now() + 5) == .timedOut {
+                    print("LLMRunner: waitUntilExit didn't return after SIGKILL — abandoning the wait")
+                }
             }
         }
         // Drain the pipe readers once the process is known to be gone.
@@ -593,11 +601,20 @@ enum LLMRunner {
 final class ProcessHandle: @unchecked Sendable {
     private let lock = NSLock()
     private var process: Process?
-    private(set) var wasTerminated = false
+    private var _wasTerminated = false
+
+    /// Lock-protected read: `terminate()` sets the flag from whatever
+    /// thread cancellation lands on while `executeProcess` reads it from
+    /// its own context — an unlocked read is a data race (and could steer
+    /// the drain-path choice wrong).
+    var wasTerminated: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _wasTerminated
+    }
 
     func attach(_ p: Process) {
         lock.lock(); defer { lock.unlock() }
-        if wasTerminated {
+        if _wasTerminated {
             // Cancel beat us to attach — the Task was already cancelled
             // before the Process even started. Reach out and SIGTERM right
             // now so the child doesn't even get a head start.
@@ -609,7 +626,7 @@ final class ProcessHandle: @unchecked Sendable {
 
     func terminate() {
         lock.lock(); defer { lock.unlock() }
-        wasTerminated = true
+        _wasTerminated = true
         process?.terminate()
     }
 }

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -248,7 +248,12 @@ final class PostRecordingCoordinator: ObservableObject {
         let timeout = transcriptWaitTimeout
         let task = Task { @MainActor [weak self] in
             defer {
-                if let self { self.sendTasks[recordingID] = nil }
+                // Only relinquish the slot if we finished on our own. If we
+                // were cancelled, a replacement send (or `cancelAndDiscard`)
+                // took over the slot — clearing it here would orphan the
+                // replacement's handle (isSending would go false mid-flight
+                // and a later cancel couldn't reach it).
+                if let self, !Task.isCancelled { self.sendTasks[recordingID] = nil }
             }
             guard let self else { return }
             // Resolve the transcript: use the click-time snapshot if it

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1118,8 +1118,14 @@ struct MilaApp: App {
                 diarizer.similarityThreshold = aiSettings.speakerSimilarityThreshold
                 // Detach the diarizer start so a quick stop-after-start
                 // doesn't block the state observer on pyannote cold-init.
+                // The session token (claimed synchronously HERE) lets a
+                // stop() that lands before/while the detached body runs
+                // supersede it — otherwise a fast start→stop recording
+                // booted the ~1 GB daemon after the recording ended and
+                // left it idling.
+                let diarSession = diarizer.beginSession()
                 Task.detached(priority: .userInitiated) { [diarizer, diarSettings] in
-                    await diarizer.start(diarization: diarSettings)
+                    await diarizer.start(diarization: diarSettings, session: diarSession)
                 }
                 // Watch for off→on transitions on the Live AI toggle.
                 // The feed loop only kicks when new segments land, so

--- a/Mila/Audio/AudioUtilities.swift
+++ b/Mila/Audio/AudioUtilities.swift
@@ -98,6 +98,80 @@ enum AudioConvert {
     }
 }
 
+/// Stateful streaming variant of `AudioConvert.toWhisperFormat` for capture
+/// sessions.
+///
+/// Sample-rate conversion is stateful: the resampler carries filter history
+/// across buffers. `toWhisperFormat` builds a fresh `AVAudioConverter` per
+/// call and flushes it with `.endOfStream` — correct for one-shot
+/// (whole-file) conversion, wrong for a live tap: restarting the filter at
+/// every ~85ms tap buffer zero-pads its history and independently rounds
+/// the fractional frame ratio (48k→16k = 1365⅓ frames per 4096), leaving a
+/// small waveform discontinuity at every buffer boundary of every recording
+/// made from a non-16kHz device. One instance per capture session keeps the
+/// filter warm across buffers; the only cost is that the last few samples of
+/// filter latency are never flushed at stream end (a sub-millisecond tail,
+/// vs. an artifact every 85ms).
+///
+/// NOT thread-safe: feed it from a single serial context (the AVAudioEngine
+/// tap or the SCK sample-handler queue).
+final class StreamingWhisperConverter {
+    /// nil when the input is already whisper-shaped (pass-through).
+    private let converter: AVAudioConverter?
+    let inputFormat: AVAudioFormat
+
+    /// Fails only if `AVAudioConverter` can't be built for `inputFormat`.
+    init?(inputFormat: AVAudioFormat) {
+        self.inputFormat = inputFormat
+        let target = WhisperAudioFormat.pcmFloat32
+        if inputFormat.sampleRate == target.sampleRate &&
+            inputFormat.channelCount == target.channelCount &&
+            inputFormat.commonFormat == .pcmFormatFloat32 {
+            self.converter = nil
+        } else if let converter = AVAudioConverter(from: inputFormat, to: target) {
+            self.converter = converter
+        } else {
+            return nil
+        }
+    }
+
+    /// Convert one buffer, retaining resampler state for the next call.
+    /// Pass-through inputs return the SAME buffer instance — callers that
+    /// mutate the result in place must copy first (same contract as
+    /// `toWhisperFormat`).
+    func convert(_ buffer: AVAudioPCMBuffer) throws -> AVAudioPCMBuffer {
+        guard let converter else { return buffer }
+        let target = WhisperAudioFormat.pcmFloat32
+        let ratio = target.sampleRate / inputFormat.sampleRate
+        let outputCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio + 1024)
+        guard let output = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: outputCapacity) else {
+            throw NSError(domain: "AudioConvert", code: 2)
+        }
+
+        var error: NSError?
+        var fed = false
+        let status = converter.convert(to: output, error: &error) { _, statusPointer in
+            if fed {
+                // `.noDataNow`, NOT `.endOfStream`: the filter history must
+                // stay alive for the next buffer — flushing here is exactly
+                // the per-chunk restart this class exists to avoid.
+                statusPointer.pointee = .noDataNow
+                return nil
+            }
+            statusPointer.pointee = .haveData
+            fed = true
+            return buffer
+        }
+
+        if let error { throw error }
+        if status == .error {
+            throw NSError(domain: "AudioConvert", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "Converter returned error."])
+        }
+        return output
+    }
+}
+
 /// Computes a 0...1 RMS level from an audio buffer for VU meters.
 enum AudioMeter {
     static func level(from buffer: AVAudioPCMBuffer) -> Float {

--- a/Mila/Audio/FileTranscriber.swift
+++ b/Mila/Audio/FileTranscriber.swift
@@ -71,12 +71,19 @@ enum FileTranscriber {
                 throw NSError(domain: "FileTranscriber", code: 1)
             }
 
+            // One converter for the whole file: resampling is stateful, and
+            // a fresh converter per 32k-frame chunk left a discontinuity at
+            // every chunk edge of the re-encoded WAV (see
+            // StreamingWhisperConverter).
+            let converter = StreamingWhisperConverter(inputFormat: inFile.processingFormat)
+
             var totalFramesIn: AVAudioFramePosition = 0
             while inFile.framePosition < inFile.length {
                 let toRead = min(chunk, AVAudioFrameCount(inFile.length - inFile.framePosition))
                 inputBuffer.frameLength = toRead
                 try inFile.read(into: inputBuffer, frameCount: toRead)
-                let converted = try AudioConvert.toWhisperFormat(inputBuffer)
+                let converted = try converter?.convert(inputBuffer)
+                    ?? AudioConvert.toWhisperFormat(inputBuffer)
                 try outFile.write(from: converted)
                 totalFramesIn += AVAudioFramePosition(toRead)
             }

--- a/Mila/Audio/InputLevelMonitor.swift
+++ b/Mila/Audio/InputLevelMonitor.swift
@@ -29,7 +29,21 @@ final class InputLevelMonitor: ObservableObject {
 
     private var engine: AVAudioEngine?
 
+    /// Bumped by every `start()` and `stop()`. The off-main bring-up can
+    /// take seconds on a wireless mic, and `engine`/`isRunning` are only
+    /// assigned AFTER it completes — so a `stop()` (view closed) or a
+    /// second `start()` (device changed) landing inside that window used
+    /// to be lost: the late-completing engine was adopted anyway and ran
+    /// forever, holding the mic open with no view left to stop it. Each
+    /// bring-up records the generation it started under and abandons its
+    /// engine if anything bumped it since.
+    private var generation = 0
+
     func start() async {
+        // Supersede any in-flight bring-up first: if two starts race, the
+        // later one wins and the earlier tears its engine down on arrival.
+        generation += 1
+        let myGeneration = generation
         guard !isRunning, engine == nil else { return }
         let preferredUID = self.preferredUID
         let onLevel: @Sendable (Float) -> Void = { [weak self] lvl in
@@ -56,7 +70,14 @@ final class InputLevelMonitor: ObservableObject {
             }
         }.value
         guard let built else {
-            self.level = 0
+            if generation == myGeneration { self.level = 0 }
+            return
+        }
+        guard generation == myGeneration, engine == nil else {
+            // A stop() or newer start() took over while we were coming up
+            // — nobody owns this engine, so tear it down instead of
+            // adopting it.
+            await Self.teardown(built)
             return
         }
         self.engine = built
@@ -64,14 +85,19 @@ final class InputLevelMonitor: ObservableObject {
     }
 
     func stop() async {
+        generation += 1
         let toTeardown = engine
         engine = nil
         isRunning = false
         level = 0
         guard let toTeardown else { return }
+        await Self.teardown(toTeardown)
+    }
+
+    private static func teardown(_ engine: AVAudioEngine) async {
         await Task.detached(priority: .utility) {
-            toTeardown.inputNode.removeTap(onBus: 0)
-            toTeardown.stop()
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
         }.value
     }
 

--- a/Mila/Audio/InputLevelMonitor.swift
+++ b/Mila/Audio/InputLevelMonitor.swift
@@ -40,14 +40,20 @@ final class InputLevelMonitor: ObservableObject {
     private var generation = 0
 
     func start() async {
-        // Supersede any in-flight bring-up first: if two starts race, the
-        // later one wins and the earlier tears its engine down on arrival.
+        guard !isRunning, engine == nil else { return }
+        // Supersede any in-flight bring-up: if two starts race, the later
+        // one wins and the earlier tears its engine down on arrival.
         generation += 1
         let myGeneration = generation
-        guard !isRunning, engine == nil else { return }
         let preferredUID = self.preferredUID
         let onLevel: @Sendable (Float) -> Void = { [weak self] lvl in
-            Task { @MainActor in self?.level = lvl }
+            Task { @MainActor [weak self] in
+                // Generation gate: a superseded engine keeps tapping until
+                // its teardown lands — its queued updates must not repaint
+                // the meter after stop() zeroed it.
+                guard let self, self.generation == myGeneration else { return }
+                self.level = lvl
+            }
         }
         let built: AVAudioEngine? = await Task.detached(priority: .utility) {
             let engine = AVAudioEngine()

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -144,7 +144,17 @@ final class MicrophoneRecorder: ObservableObject {
         let sessionStats = OSAllocatedUnfairLock(initialState: MicFrameStats())
         self.stats = sessionStats
 
-        let result = try await Self.withTimeout(seconds: bringUpTimeout) {
+        let result = try await Self.withTimeout(
+            seconds: bringUpTimeout,
+            onAbandoned: { box in
+                // The bring-up finished after the timeout already threw.
+                // Nobody owns this engine — tear it down (off-main, same as
+                // stop()'s detached teardown) or the mic stays hot forever.
+                micLog.error("mic bring-up completed after the timeout had thrown — tearing down the abandoned engine")
+                box.engine.inputNode.removeTap(onBus: 0)
+                box.engine.stop()
+            }
+        ) {
             try await Self.realBringUp(continuation: continuationForTap,
                                        onLevel: onLevel,
                                        gain: agc,
@@ -224,12 +234,20 @@ final class MicrophoneRecorder: ObservableObject {
                 micLog.error("input format reports sampleRate=0 — no usable input device; throwing noInputDevice")
                 throw MicrophoneError.noInputDevice
             }
+            // One converter for the whole session: resampling is stateful,
+            // and a fresh converter per tap buffer put a small discontinuity
+            // at every ~85ms boundary (see StreamingWhisperConverter). Tap
+            // callbacks for one engine are serial, so no locking needed.
+            // Fallback to the per-buffer path only if the converter can't
+            // be built for this format (effectively never).
+            let sessionConverter = StreamingWhisperConverter(inputFormat: nativeFormat)
             input.installTap(onBus: 0,
                              bufferSize: 4096,
                              format: nativeFormat) { buffer, _ in
                 onLevel(AudioMeter.level(from: buffer))
                 do {
-                    let converted = try AudioConvert.toWhisperFormat(buffer)
+                    let converted = try sessionConverter?.convert(buffer)
+                        ?? AudioConvert.toWhisperFormat(buffer)
                     // Apply adaptive digital gain in-place on the whisper-
                     // format buffer so the WAV writer AND the live VAD/
                     // whisper feed both see the same boosted signal —
@@ -298,25 +316,52 @@ final class MicrophoneRecorder: ObservableObject {
     }
 
     /// Race `operation` against a sleep; whichever completes first wins.
-    /// On timeout the in-flight operation is cancelled at the Swift-task
-    /// level — note this does NOT actually unblock an underlying CoreAudio
-    /// `dispatch_sync` if that's what's stalling. The detached worker
-    /// thread may keep waiting (and the engine may never come up) until
-    /// CoreAudio finally returns. The crucial thing is that the *main
-    /// actor* is never blocked, so the UI / hotkeys stay responsive.
+    ///
+    /// Implemented as a first-wins continuation race rather than a
+    /// `withThrowingTaskGroup` race on purpose: a task group cannot return
+    /// until ALL of its children finish, and the real bring-up child awaits
+    /// a detached task's `.value` — an await that is NOT cancellation-
+    /// responsive. With the group version, a wedged CoreAudio call kept
+    /// `start()` suspended long past the deadline (the timeout error
+    /// couldn't propagate out of the group), so the "throw after 5s, caller
+    /// beeps, user retries" behavior never actually happened on the real
+    /// path — or never happened at all if CoreAudio stayed stuck.
+    ///
+    /// On timeout the loser is *abandoned*, not cancelled: nothing can
+    /// unblock a stalled CoreAudio `dispatch_sync`, so the detached worker
+    /// keeps waiting. If it eventually succeeds after we already threw,
+    /// `onAbandoned` is called with the result so the caller can tear down
+    /// the now-ownerless resource (otherwise the engine would keep the mic
+    /// hot forever). The main actor is never blocked either way.
     private static func withTimeout<T: Sendable>(
         seconds: TimeInterval,
+        onAbandoned: @escaping @Sendable (T) -> Void = { _ in },
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask { try await operation() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw MicrophoneError.bringUpTimedOut
+        let claimed = OSAllocatedUnfairLock(initialState: false)
+        return try await withCheckedThrowingContinuation { cont in
+            // Returns true when this call won the race and resumed `cont`.
+            let finish: @Sendable (Result<T, Error>) -> Bool = { result in
+                let isFirst = claimed.withLock { done -> Bool in
+                    if done { return false }
+                    done = true
+                    return true
+                }
+                if isFirst { cont.resume(with: result) }
+                return isFirst
             }
-            let result = try await group.next()!
-            group.cancelAll()
-            return result
+            Task.detached(priority: .userInitiated) {
+                do {
+                    let value = try await operation()
+                    if !finish(.success(value)) { onAbandoned(value) }
+                } catch {
+                    _ = finish(.failure(error))
+                }
+            }
+            Task.detached {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                _ = finish(.failure(MicrophoneError.bringUpTimedOut))
+            }
         }
     }
 }

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -83,39 +83,61 @@ final class RecordingSession: ObservableObject {
         self.fileURL = outputURL
         self.writesSinceStart = 0
         self.isFakeForTesting = false
+        // Never inherit a stale system-audio tail from the previous
+        // recording: a `consumeSystem` call that was already dequeued when
+        // the last stop() ran its flush can append to `pendingSystem`
+        // after the flush, and stop() doesn't clear the buffer.
+        pendingSystem.removeAll(keepingCapacity: false)
 
-        let format = WhisperAudioFormat.pcmFloat32
-        let settings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: format.sampleRate,
-            AVNumberOfChannelsKey: format.channelCount,
-            AVLinearPCMBitDepthKey: 32,
-            AVLinearPCMIsFloatKey: true,
-            AVLinearPCMIsBigEndianKey: false,
-            AVLinearPCMIsNonInterleaved: false
-        ]
-        self.audioFile = try AVAudioFile(forWriting: outputURL, settings: settings,
-                                         commonFormat: .pcmFormatFloat32, interleaved: false)
+        do {
+            let format = WhisperAudioFormat.pcmFloat32
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: format.sampleRate,
+                AVNumberOfChannelsKey: format.channelCount,
+                AVLinearPCMBitDepthKey: 32,
+                AVLinearPCMIsFloatKey: true,
+                AVLinearPCMIsBigEndianKey: false,
+                AVLinearPCMIsNonInterleaved: false
+            ]
+            self.audioFile = try AVAudioFile(forWriting: outputURL, settings: settings,
+                                             commonFormat: .pcmFormatFloat32, interleaved: false)
 
-        if source == .microphone || source == .meeting {
-            _ = await mic.requestAccess()
-            try await mic.start()
-            micTask = Task { [weak self] in
-                guard let self else { return }
-                for await buf in self.mic.audioStream {
-                    await self.consumeMic(buf)
+            if source == .microphone || source == .meeting {
+                _ = await mic.requestAccess()
+                try await mic.start()
+                micTask = Task { [weak self] in
+                    guard let self else { return }
+                    for await buf in self.mic.audioStream {
+                        await self.consumeMic(buf)
+                    }
                 }
             }
-        }
 
-        if source == .systemAudio || source == .meeting {
-            try await system.start()
-            systemTask = Task { [weak self] in
-                guard let self else { return }
-                for await buf in self.system.audioStream {
-                    await self.consumeSystem(buf)
+            if source == .systemAudio || source == .meeting {
+                try await system.start()
+                systemTask = Task { [weak self] in
+                    guard let self else { return }
+                    for await buf in self.system.audioStream {
+                        await self.consumeSystem(buf)
+                    }
                 }
             }
+        } catch {
+            // A partial bring-up must not leak. Without this teardown, a
+            // meeting-mode start whose system leg throws (typically Screen
+            // Recording permission denied) left the mic engine hot and the
+            // WAV file open, appending mic audio indefinitely — and since
+            // `state` is still .idle, `cancelAll()` refused to clean it up.
+            recLog.error("start(\(source.rawValue, privacy: .public)) failed mid-bring-up — tearing down partial session: \(error.localizedDescription, privacy: .public)")
+            micTask?.cancel(); micTask = nil
+            systemTask?.cancel(); systemTask = nil
+            await mic.stop()
+            await system.stop()
+            audioFile = nil
+            fileURL = nil
+            pendingSystem.removeAll(keepingCapacity: false)
+            throw error
         }
 
         startTime = Date()

--- a/Mila/Audio/SystemAudioRecorder.swift
+++ b/Mila/Audio/SystemAudioRecorder.swift
@@ -154,6 +154,12 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
         try stream.addStreamOutput(audioOutput,
                                    type: .screen,
                                    sampleHandlerQueue: .global(qos: .utility))
+        // `audioOutput` outlives capture sessions — drop the previous
+        // session's resampler state (filter history must not smear the
+        // last recording's tail into this one's first buffers). On the
+        // sample queue, since that's the only context that touches it;
+        // it's idle until startCapture below.
+        sampleQueue.sync { audioOutput.resetConverter() }
         try await stream.startCapture()
         self.stream = stream
         self.isRunning = true
@@ -190,6 +196,10 @@ extension SystemAudioRecorder: SCStreamDelegate {
         let message = error.localizedDescription
         print("SCStream stopped with error: \(message)")
         Task { @MainActor in
+            // Only act for the CURRENTLY active stream — a stale callback
+            // from a previous session's stream arriving after a restart
+            // must not clear the new stream or surface an old error.
+            guard self.stream === stream else { return }
             // SCK killed the stream from its side (TCC revocation, display
             // config change, ...). Release the dead stream and record the
             // failure — before this, `stream` stayed set (leaked) and the
@@ -219,6 +229,11 @@ private final class AudioStreamOutput: NSObject, SCStreamOutput {
     /// the first buffer's format and rebuilt if SCK ever changes it; only
     /// touched on the serial sample-handler queue.
     private var converter: StreamingWhisperConverter?
+
+    /// Called (on the sample queue) at the start of each capture session.
+    func resetConverter() {
+        converter = nil
+    }
 
     func stream(_ stream: SCStream,
                 didOutputSampleBuffer sampleBuffer: CMSampleBuffer,

--- a/Mila/Audio/SystemAudioRecorder.swift
+++ b/Mila/Audio/SystemAudioRecorder.swift
@@ -37,11 +37,27 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
     @Published var selectedApp: SCRunningApplication?
     @Published private(set) var level: Float = 0
 
+    /// Set when SCK kills the stream from its own side mid-capture (TCC
+    /// revocation, display disconnect). Cleared on the next successful
+    /// `start()`. Lets callers tell "meeting silently lost its app-audio
+    /// leg" apart from a normal stop.
+    @Published private(set) var lastStreamError: String?
+
     let audioStream: AsyncStream<AVAudioPCMBuffer>
     private let audioContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation
 
     private var stream: SCStream?
     private let audioOutput = AudioStreamOutput()
+
+    /// Serial delivery queue for the audio sample callbacks. `.global()`
+    /// is a CONCURRENT queue: two SCK callbacks can run in parallel, and
+    /// the per-buffer Task hop the old code used added a second unordered
+    /// step — under CPU load, consecutive ~10-20ms chunks could land in
+    /// `audioStream` out of capture order (audible garbling in the saved
+    /// mix). A private serial queue plus a direct yield (below) preserves
+    /// capture order end-to-end.
+    private let sampleQueue = DispatchQueue(label: "io.island.mila.system-audio-samples",
+                                            qos: .userInitiated)
 
     override init() {
         var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation!
@@ -49,6 +65,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
         self.audioContinuation = continuation
         super.init()
         self.audioOutput.parent = self
+        self.audioOutput.continuation = continuation
     }
 
     func refreshShareableContent() async {
@@ -133,27 +150,34 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(audioOutput,
                                    type: .audio,
-                                   sampleHandlerQueue: .global(qos: .userInitiated))
+                                   sampleHandlerQueue: sampleQueue)
         try stream.addStreamOutput(audioOutput,
                                    type: .screen,
                                    sampleHandlerQueue: .global(qos: .utility))
         try await stream.startCapture()
         self.stream = stream
         self.isRunning = true
+        self.lastStreamError = nil
     }
 
     func stop() async {
-        guard isRunning, let stream else { return }
+        // Deliberately NOT gated on `isRunning`: when SCK killed the stream
+        // itself (`didStopWithError` flips isRunning to false), the old
+        // `guard isRunning` made this a no-op and the dead SCStream stayed
+        // retained for the app's lifetime.
+        guard let stream else {
+            isRunning = false
+            level = 0
+            return
+        }
         do { try await stream.stopCapture() } catch { print("stopCapture: \(error)") }
         self.stream = nil
         self.isRunning = false
         self.level = 0
     }
 
-    fileprivate func handle(buffer: AVAudioPCMBuffer) {
-        let level = AudioMeter.level(from: buffer)
-        Task { @MainActor in self.level = level }
-        audioContinuation.yield(buffer)
+    fileprivate func publishLevel(_ level: Float) {
+        self.level = level
     }
 
     deinit {
@@ -163,16 +187,38 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
 
 extension SystemAudioRecorder: SCStreamDelegate {
     nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
-        print("SCStream stopped with error: \(error)")
+        let message = error.localizedDescription
+        print("SCStream stopped with error: \(message)")
         Task { @MainActor in
+            // SCK killed the stream from its side (TCC revocation, display
+            // config change, ...). Release the dead stream and record the
+            // failure — before this, `stream` stayed set (leaked) and the
+            // meeting recording silently degraded to mic-only with no
+            // signal anywhere.
+            self.stream = nil
             self.isRunning = false
             self.level = 0
+            self.lastStreamError = message
         }
     }
 }
 
 private final class AudioStreamOutput: NSObject, SCStreamOutput {
     weak var parent: SystemAudioRecorder?
+
+    /// Handed over once at recorder init. Yielding directly here — on the
+    /// recorder's serial sample-handler queue — keeps buffers in capture
+    /// order end-to-end (`AsyncStream.Continuation.yield` is thread-safe);
+    /// only the cosmetic level meter hops to the main actor. The old
+    /// per-buffer `Task { @MainActor … yield }` hop gave every chunk its
+    /// own unordered task, so delivery order wasn't guaranteed.
+    var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+    /// Session-scoped stateful converter (resampling keeps filter history
+    /// across buffers — see StreamingWhisperConverter). Built lazily from
+    /// the first buffer's format and rebuilt if SCK ever changes it; only
+    /// touched on the serial sample-handler queue.
+    private var converter: StreamingWhisperConverter?
 
     func stream(_ stream: SCStream,
                 didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
@@ -181,9 +227,15 @@ private final class AudioStreamOutput: NSObject, SCStreamOutput {
               CMSampleBufferIsValid(sampleBuffer),
               let buffer = sampleBuffer.toPCMBuffer() else { return }
         do {
-            let converted = try AudioConvert.toWhisperFormat(buffer)
+            if converter == nil || converter?.inputFormat != buffer.format {
+                converter = StreamingWhisperConverter(inputFormat: buffer.format)
+            }
+            let converted = try converter?.convert(buffer)
+                ?? AudioConvert.toWhisperFormat(buffer)
+            continuation?.yield(converted)
+            let level = AudioMeter.level(from: converted)
             Task { @MainActor [weak parent] in
-                parent?.handle(buffer: converted)
+                parent?.publishLevel(level)
             }
         } catch {
             print("System audio convert: \(error)")

--- a/Mila/Dictation/DictationController.swift
+++ b/Mila/Dictation/DictationController.swift
@@ -26,6 +26,10 @@ final class DictationController: ObservableObject {
     private let recorder = MicrophoneRecorder()
     private var samples: [Float] = []
     private var streamTask: Task<Void, Never>?
+    /// True while `start(action:)` is between its entry and setting
+    /// `state = .recording` — the two awaits in that window (mic permission,
+    /// engine bring-up) are where a hotkey double-press could re-enter.
+    private var isStarting = false
 
     /// Live transcriber used to surface partial transcripts in the
     /// dictation overlay AND to remove the post-release transcription
@@ -112,6 +116,19 @@ final class DictationController: ObservableObject {
     // MARK: - Recording
 
     private func start(action: HotkeyAction) async {
+        // Re-entrancy guard: `state` only becomes .recording AFTER the two
+        // awaits below (mic permission + engine bring-up), so a nervous
+        // double-tap of the hotkey inside that window saw .idle twice and
+        // ran two overlapping starts — the second streamTask overwrote the
+        // first without cancelling it and the recorder was restarted
+        // mid-flight. Set synchronously, so the second entry bails.
+        guard !isStarting else {
+            NSSound.beep()
+            return
+        }
+        isStarting = true
+        defer { isStarting = false }
+
         // Storage cap: a full library blocks new dictation clips too
         // (consistent with Settings copy). A beep is the right-sized signal
         // for the hotkey flow — rare edge, and the user can free space.
@@ -291,7 +308,7 @@ final class DictationController: ObservableObject {
 
     private func paste(_ text: String) {
         let pasteboard = NSPasteboard.general
-        let priorContents = pasteboard.string(forType: .string)
+        let priorContents = Self.snapshotPasteboard(pasteboard)
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
 
@@ -324,12 +341,49 @@ final class DictationController: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
             Self.postCommandV()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                if let prior = priorContents {
-                    pasteboard.clearContents()
-                    pasteboard.setString(prior, forType: .string)
+                if !priorContents.isEmpty {
+                    Self.restorePasteboard(pasteboard, from: priorContents)
                 }
             }
         }
+    }
+
+    // MARK: - Pasteboard snapshot/restore
+
+    /// Full-fidelity pasteboard snapshot: every item with every type it
+    /// carries. The old `string(forType: .string)`-only snapshot destroyed
+    /// any non-text clipboard content — copy a screenshot, dictate a
+    /// caption, and the screenshot was gone forever (the restore step was
+    /// skipped entirely because the string snapshot came back nil).
+    ///
+    /// Static + pasteboard-parameterized so tests can exercise the round
+    /// trip against a private named pasteboard instead of the user's real
+    /// clipboard.
+    static func snapshotPasteboard(_ pasteboard: NSPasteboard) -> [[NSPasteboard.PasteboardType: Data]] {
+        (pasteboard.pasteboardItems ?? []).map { item in
+            var entry: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types {
+                // Lazily-promised types can resolve to nil; skip those
+                // rather than fail the whole snapshot.
+                if let data = item.data(forType: type) {
+                    entry[type] = data
+                }
+            }
+            return entry
+        }
+    }
+
+    static func restorePasteboard(_ pasteboard: NSPasteboard,
+                                  from snapshot: [[NSPasteboard.PasteboardType: Data]]) {
+        pasteboard.clearContents()
+        let items: [NSPasteboardItem] = snapshot.map { entry in
+            let item = NSPasteboardItem()
+            for (type, data) in entry {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        pasteboard.writeObjects(items)
     }
 
     /// Synthesize a Cmd+V at the HID event-tap level. Requires the process

--- a/Mila/Dictation/HotkeyManager.swift
+++ b/Mila/Dictation/HotkeyManager.swift
@@ -144,11 +144,15 @@ final class HotkeyManager {
 
     private struct RegisteredHotkey {
         let action: HotkeyAction
+        let binding: HotkeyBinding
         let ref: EventHotKeyRef
         var handler: () -> Void
     }
 
     private var registrations: [HotkeyAction: RegisteredHotkey] = [:]
+    /// Registrations parked by `suspendAll()` (capture mode) so
+    /// `resumeAll()` can restore them with their handlers intact.
+    private var suspended: [HotkeyAction: (binding: HotkeyBinding, handler: () -> Void)] = [:]
     private var eventHandler: EventHandlerRef?
     private let signature: OSType = OSType(0x49575350) // 'IWSP'
 
@@ -181,6 +185,7 @@ final class HotkeyManager {
             return false
         }
         registrations[action] = RegisteredHotkey(action: action,
+                                                 binding: binding,
                                                  ref: validRef,
                                                  handler: onPressed)
         print("Hotkey: registered \(action) -> \(binding.displayName)")
@@ -190,6 +195,58 @@ final class HotkeyManager {
     func unregister(_ action: HotkeyAction) {
         if let existing = registrations.removeValue(forKey: action) {
             UnregisterEventHotKey(existing.ref)
+        }
+    }
+
+    /// Whether `action` currently holds a live Carbon registration. False
+    /// means pressing the bound combo does nothing — e.g. another app owns
+    /// it globally and `register` failed. Settings uses this to warn
+    /// instead of silently showing a dead binding as active.
+    func isRegistered(_ action: HotkeyAction) -> Bool {
+        registrations[action] != nil
+    }
+
+    /// Probe whether `binding` can be registered globally right now,
+    /// without keeping the registration: registers a throwaway hotkey and
+    /// releases it immediately. Used by Settings to validate a newly
+    /// captured combo BEFORE persisting it — the old flow persisted first,
+    /// dropped the registration failure on the floor, and (because
+    /// `register` unregisters the previous combo before trying the new
+    /// one) left the user with NO working hotkey at all.
+    func canRegister(_ binding: HotkeyBinding) -> Bool {
+        let id = EventHotKeyID(signature: signature, id: UInt32.max)
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(binding.keyCode,
+                                         binding.modifiers,
+                                         id,
+                                         GetApplicationEventTarget(),
+                                         0,
+                                         &ref)
+        if let ref { UnregisterEventHotKey(ref) }
+        return status == noErr
+    }
+
+    /// Park every live registration (keeping bindings + handlers) so a
+    /// Settings capture field can see raw keyDowns. Carbon consumes
+    /// registered combos before the responder chain, so without this,
+    /// pressing a currently-bound hotkey while recording a new binding
+    /// STARTED DICTATION instead of being captured. Balanced by
+    /// `resumeAll()`; nested suspends are no-ops.
+    func suspendAll() {
+        guard suspended.isEmpty else { return }
+        for (action, reg) in registrations {
+            suspended[action] = (reg.binding, reg.handler)
+            UnregisterEventHotKey(reg.ref)
+        }
+        registrations.removeAll()
+    }
+
+    /// Restore the registrations parked by `suspendAll()`.
+    func resumeAll() {
+        let toRestore = suspended
+        suspended.removeAll()
+        for (action, entry) in toRestore {
+            register(action, binding: entry.binding, onPressed: entry.handler)
         }
     }
 

--- a/Mila/Models/DiarizationSettings.swift
+++ b/Mila/Models/DiarizationSettings.swift
@@ -9,6 +9,16 @@ final class DiarizationSettings: ObservableObject {
             if isEnabled && pythonFound && lastVerifyResult == nil && !isVerified {
                 Task { await checkDeps() }
             }
+            // Enabling with a previously-persisted verification: restore it.
+            // `restoreVerifiedState()` otherwise only runs in init (and only
+            // when the app launched with diarization already on), so flipping
+            // the toggle on mid-session skipped `checkDeps` above (isVerified
+            // is true) but left `verificationStatus` at .disabled — `status`
+            // showed "Setup needed" and `isConfigured` stayed false for a
+            // fully verified setup until a manual re-verify.
+            if isEnabled && isVerified {
+                restoreVerifiedState()
+            }
             if isEnabled, hasBundledRuntime {
                 Task { await bootstrap.bootstrapIfNeeded() }
             }

--- a/Mila/Models/LiveAISettings.swift
+++ b/Mila/Models/LiveAISettings.swift
@@ -213,10 +213,12 @@ final class LiveAISettings: ObservableObject {
         self.model = defaults.string(forKey: Keys.model) ?? Self.defaultModel
         // Migrate pre-1.6.1 persisted values (default was 5s, range 3-20s).
         // 5s windows cut words mid-utterance and made the trailing-window
-        // merge stitch together inconsistent segments. 30s = one full
-        // window per tick, non-overlapping, clean boundaries.
+        // merge stitch together inconsistent segments. Only values below
+        // the current slider minimum (15s) are treated as stale — 15 and
+        // 20 are legal choices on today's 15-60s slider and must survive
+        // a relaunch, so they can't be used as a migration marker.
         let raw = defaults.double(forKey: Keys.chunkSeconds)
-        self.chunkSeconds = raw >= 25.0 ? raw : 30.0
+        self.chunkSeconds = raw >= 15.0 ? raw : 30.0
         // Default 20s. `double(forKey:)` returns 0 for an unset key, and
         // 0 is also the legitimate "disable the floor" value — so use a
         // sentinel via object(forKey:) to tell "never set" (→ 20) apart
@@ -233,11 +235,23 @@ final class LiveAISettings: ObservableObject {
         self.backgroundMode = defaults.bool(forKey: Keys.backgroundMode)
         self.forceLiveAIOnLowEndHardware = defaults.bool(forKey: Keys.forceLowEnd)
         let sim = defaults.double(forKey: Keys.simThreshold)
-        // Migrate the old 0.75 default — too strict for wespeaker on
-        // 1-5s VAD utterances; same-speaker cosine sim at that length
-        // sits in 0.5-0.7, so 0.75 split every utterance into a new
-        // SPEAKER_NN. Treat values >= 0.7 as "old default, migrate".
-        self.speakerSimilarityThreshold = (sim > 0 && sim < 0.7) ? sim : 0.55
+        if defaults.bool(forKey: Keys.simThresholdMigrated) {
+            self.speakerSimilarityThreshold = sim > 0 ? sim : 0.55
+        } else {
+            // One-shot migration of the old 0.75 default — too strict for
+            // wespeaker on 1-5s VAD utterances; same-speaker cosine sim at
+            // that length sits in 0.5-0.7, so 0.75 split every utterance
+            // into a new SPEAKER_NN. Treat values >= 0.7 as "old default,
+            // migrate" — but only ONCE: the Settings slider legitimately
+            // offers up to 0.95, so re-running this on every launch would
+            // silently discard a user's chosen threshold. The flag (plus
+            // writing the migrated value back) makes later >= 0.7 values
+            // stick.
+            let migrated = (sim > 0 && sim < 0.7) ? sim : 0.55
+            self.speakerSimilarityThreshold = migrated
+            defaults.set(migrated, forKey: Keys.simThreshold)
+            defaults.set(true, forKey: Keys.simThresholdMigrated)
+        }
         self.prompt = defaults.string(forKey: Keys.prompt) ?? Self.defaultPrompt
         let langRaw = defaults.string(forKey: Keys.outputLanguage) ?? OutputLanguage.auto.rawValue
         self.outputLanguage = OutputLanguage(rawValue: langRaw) ?? .auto
@@ -324,6 +338,7 @@ the content.
         static let backgroundMode = "liveAI.backgroundMode"
         static let forceLowEnd = "liveAI.forceOnLowEndHardware"
         static let simThreshold = "liveAI.speakerSimilarityThreshold"
+        static let simThresholdMigrated = "liveAI.speakerSimilarityThreshold.migrated"
         static let prompt = "liveAI.prompt"
         static let outputLanguage = "liveAI.outputLanguage"
         static let summaryPrompt = "liveAI.summaryPrompt"

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -124,11 +124,13 @@ final class RecordingStore: ObservableObject {
         self.modelsDirectory = rootDirectory.appendingPathComponent("Models", isDirectory: true)
         self.storeURL = rootDirectory.appendingPathComponent("recordings.json")
         self.foldersURL = rootDirectory.appendingPathComponent("folders.json")
+        self.tombstonesURL = rootDirectory.appendingPathComponent("voicememo-tombstones.json")
 
         try? fileManager.createDirectory(at: defaultRecs, withIntermediateDirectories: true)
         try? fileManager.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         load()
         loadFolders()
+        loadTombstones()
     }
 
     /// Switch the recordings directory to `newDirectory`. Clears the
@@ -443,6 +445,15 @@ final class RecordingStore: ObservableObject {
         try? fileManager.removeItem(at: transcriptURL(for: recording))
         try? fileManager.removeItem(at: summaryURL(for: recording))
         try? fileManager.removeItem(at: subtitleURL(for: recording))
+        // Tombstone a deleted Voice-Memos import so the next sync doesn't
+        // resurrect it: the importer's dedup is keyed on the LIVE store, and
+        // the source memo still exists in the Voice Memos folder — deleting
+        // an imported memo silently never stuck before this. (Escape hatch:
+        // a manual File → Open import carries no memo ID and still works.)
+        if let memoID = recording.voiceMemoUniqueID {
+            voiceMemoTombstones.insert(memoID)
+            persistTombstones()
+        }
         persist()
     }
 
@@ -646,6 +657,33 @@ final class RecordingStore: ObservableObject {
             try data.write(to: storeURL, options: .atomic)
         } catch {
             print("RecordingStore persist error: \(error)")
+        }
+    }
+
+    // MARK: - Voice-memo tombstones
+
+    /// Voice-memo unique IDs the user permanently deleted from Mila. The
+    /// importer skips these on every sync — without the tombstone, a
+    /// deleted import re-imported (and re-transcribed) on the next FSEvents
+    /// fire or rescan, because the dedup set is built from the live store
+    /// and the source memo still exists in the Voice Memos folder.
+    /// Persisted at the original root (app state, not user content — it
+    /// deliberately does NOT travel with a relocated recordings folder).
+    private(set) var voiceMemoTombstones: Set<String> = []
+    private let tombstonesURL: URL
+
+    private func loadTombstones() {
+        guard let data = try? Data(contentsOf: tombstonesURL),
+              let ids = try? JSONDecoder().decode(Set<String>.self, from: data) else { return }
+        voiceMemoTombstones = ids
+    }
+
+    private func persistTombstones() {
+        do {
+            let data = try JSONEncoder().encode(voiceMemoTombstones)
+            try data.write(to: tombstonesURL, options: .atomic)
+        } catch {
+            print("RecordingStore tombstones persist error: \(error)")
         }
     }
 

--- a/Mila/Transcription/DiarizationBootstrap.swift
+++ b/Mila/Transcription/DiarizationBootstrap.swift
@@ -286,7 +286,11 @@ final class DiarizationBootstrap: ObservableObject {
             ]
             let stderr = Pipe()
             process.standardError = stderr
-            process.standardOutput = Pipe()
+            // Discard stdout via the null device — an assigned-but-never-read
+            // Pipe() is NOT a sink: it's a ~64 KB buffer, and pip's progress
+            // output can fill it, blocking pip on write() while we block in
+            // waitUntilExit() (the PR #15 deadlock class).
+            process.standardOutput = FileHandle.nullDevice
             try process.run()
             let stderrRead = Task.detached { stderr.fileHandleForReading.readDataToEndOfFile() }
             process.waitUntilExit()
@@ -319,7 +323,9 @@ final class DiarizationBootstrap: ObservableObject {
             ] + wheelPaths
             let stderr = Pipe()
             process.standardError = stderr
-            process.standardOutput = Pipe()  // discard
+            // Null device, not Pipe(): an unread Pipe deadlocks past ~64 KB
+            // of pip stdout (see runPipInstallSpec).
+            process.standardOutput = FileHandle.nullDevice
             try process.run()
             let stderrRead = Task.detached { stderr.fileHandleForReading.readDataToEndOfFile() }
             process.waitUntilExit()
@@ -359,8 +365,12 @@ final class DiarizationBootstrap: ObservableObject {
                 find \(pathList) \\( -name '*.so' -o -name '*.dylib' \\) -print0 \
                   | xargs -0 -n1 codesign -f -s - --timestamp=none
                 """]
-            process.standardError = Pipe()
-            process.standardOutput = Pipe()
+            // Null device, not Pipe(): nobody reads these, and codesign's
+            // per-dylib "replacing existing signature" chatter over hundreds
+            // of files can overflow an unread pipe's ~64 KB buffer — child
+            // blocks on write(), we block in waitUntilExit(), deadlock.
+            process.standardError = FileHandle.nullDevice
+            process.standardOutput = FileHandle.nullDevice
             try process.run()
             process.waitUntilExit()
             // Non-fatal: ad-hoc signing failures don't block functionality on

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -104,6 +104,10 @@ final class LiveSpeakerDiarizer: ObservableObject {
             diarLog.log("start skipped — daemon already running")
             return
         }
+        // Fresh launch: don't let a previous daemon's failure report leak
+        // into this session's diagnostics (failPending deliberately keeps
+        // the FIRST error it sees, so a stale one would win).
+        lastError = nil
         guard diarization.isConfigured else {
             lastError = "Diarization is not configured"
             diarLog.log("NOT starting — isConfigured=false (isEnabled=\(diarization.isEnabled, privacy: .public) hasBundledRuntime=\(diarization.hasBundledRuntime, privacy: .public) bootstrap.isReady=\(diarization.bootstrap.isReady, privacy: .public))")
@@ -374,13 +378,21 @@ final class LiveSpeakerDiarizer: ObservableObject {
             if data.isEmpty {
                 // EOF — daemon exited.
                 Task { @MainActor [weak self] in
-                    self?.failPending(error: "daemon exited")
+                    // Identity gate: a task enqueued just before stop()
+                    // detached this handler can land AFTER a new daemon
+                    // is up — it must not fail the NEW daemon's pending
+                    // queue.
+                    guard let self, self.stdoutHandle === fh else { return }
+                    self.failPending(error: "daemon exited")
                 }
                 fh.readabilityHandler = nil
                 return
             }
             Task { @MainActor [weak self] in
-                self?.consumeStdout(data)
+                // Same identity gate: stale bytes from a dying daemon must
+                // not be matched against the next daemon's pending queue.
+                guard let self, self.stdoutHandle === fh else { return }
+                self.consumeStdout(data)
             }
         }
     }

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -70,11 +70,36 @@ final class LiveSpeakerDiarizer: ObservableObject {
         let error: String?
     }
 
+    /// Monotonic counter pairing each recording's daemon start with the
+    /// stop() that follows it. The record-start path deliberately detaches
+    /// `start()` (pyannote cold-init must not block the state observer),
+    /// which used to leave a race: a fast start→stop recording could run
+    /// `stop()` (no-op, nothing launched yet) BEFORE the detached start
+    /// body executed — the ~1 GB torch daemon then booted *after* the
+    /// recording ended and idled until some future recording's stop.
+    /// Claiming a session synchronously at record-start and closing it in
+    /// stop() lets the late-running start body detect it was superseded.
+    private var session = 0
+
+    /// Claim a session token synchronously BEFORE detaching the async
+    /// `start(diarization:session:)` call.
+    func beginSession() -> Int {
+        session += 1
+        return session
+    }
+
     /// Boot the Python daemon. No-op if a daemon is already running, or
     /// if diarization is disabled / not configured. Throws nothing — any
     /// failure becomes a `lastError` so callers don't have to wrap try/
     /// catch around every recording start.
-    func start(diarization: DiarizationSettings) async {
+    ///
+    /// `session` (from `beginSession()`) ties this start to one recording;
+    /// pass nil only where start/stop can't race (tests).
+    func start(diarization: DiarizationSettings, session: Int? = nil) async {
+        if let session, session != self.session {
+            diarLog.log("start skipped — recording already stopped before the detached start ran")
+            return
+        }
         guard process == nil else {
             diarLog.log("start skipped — daemon already running")
             return
@@ -131,6 +156,13 @@ final class LiveSpeakerDiarizer: ObservableObject {
         // daemon emits `{"ready":true}` on stdout once the pipeline and
         // embedding inference are loaded.
         let ready = await waitForReady(timeoutSeconds: 30)
+        if let session, session != self.session {
+            // stop() ran while we waited for the handshake — it already
+            // terminated the daemon and reset the state; don't resurrect
+            // any of it for a recording that's over.
+            diarLog.log("start superseded during ready-wait — leaving stopped state alone")
+            return
+        }
         isReady = ready
         diarLog.log("daemon ready=\(ready, privacy: .public)")
         if !ready {
@@ -140,6 +172,9 @@ final class LiveSpeakerDiarizer: ObservableObject {
 
     /// Shut down the daemon. Idempotent. Called when a recording stops.
     func stop() {
+        // Close the current session so a start() that was detached for this
+        // recording but hasn't run (or is still in its ready-wait) aborts.
+        session += 1
         if let stdin = stdinPipe {
             let cmd = #"{"cmd":"shutdown"}\#n"#
             try? stdin.fileHandleForWriting.write(contentsOf: Data(cmd.utf8))
@@ -148,6 +183,11 @@ final class LiveSpeakerDiarizer: ObservableObject {
         process?.terminate()
         process = nil
         stdinPipe = nil
+        // Detach the readability handler BEFORE dropping the handle: bytes
+        // still buffered in the dying daemon's stdout pipe would otherwise
+        // keep arriving through the old handler and get matched against the
+        // NEXT daemon's `pending` queue.
+        stdoutHandle?.readabilityHandler = nil
         stdoutHandle = nil
         stderrHandle = nil
         stdoutBuffer.removeAll()
@@ -312,6 +352,13 @@ final class LiveSpeakerDiarizer: ObservableObject {
             // The stdout reader fills `stdoutBuffer` and dispatches lines
             // to pending continuations. If isReady is set elsewhere, exit.
             if isReady { return true }
+            // Daemon died before the handshake (missing dep, bad models
+            // path) or stop() ran mid-wait: bail now instead of spinning
+            // the full 30s. Whatever error line the daemon printed on its
+            // way down was captured into `lastError` by handleLine /
+            // failPending, so start()'s `lastError ??` fallback preserves
+            // the real diagnosis over the generic "did not become ready".
+            guard let process, process.isRunning else { return false }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
         return isReady
@@ -353,7 +400,18 @@ final class LiveSpeakerDiarizer: ObservableObject {
             isReady = true
             return
         }
-        guard !pending.isEmpty else { return }
+        guard !pending.isEmpty else {
+            // Pre-ready line with no waiter. The daemon reports startup
+            // failures as an {"error": ...} line right before exiting —
+            // dropping it here left only the generic "did not become
+            // ready" after a full timeout spin. Keep the real diagnosis.
+            if let resp = try? JSONDecoder().decode(EmbedResponse.self, from: data),
+               let error = resp.error {
+                lastError = error
+                diarLog.log("daemon pre-ready error: \(error, privacy: .public)")
+            }
+            return
+        }
         let cont = pending.removeFirst()
         if let resp = try? JSONDecoder().decode(EmbedResponse.self, from: data) {
             cont.resume(returning: resp)
@@ -368,6 +426,9 @@ final class LiveSpeakerDiarizer: ObservableObject {
         }
         pending.removeAll()
         isReady = false
+        // Keep an earlier, more specific report (e.g. the daemon's own
+        // {"error": ...} startup line) over this generic one.
+        lastError = lastError ?? error
     }
 
     private func startStderrReader() {

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -88,12 +88,15 @@ final class ModelManager: NSObject, ObservableObject {
     @Published private(set) var downloads: [String: Double] = [:]
     @Published var selectedModelName: String
 
-    /// Human-readable description of the most recent failed model download,
-    /// or nil. Every failure path of a multi-GB fetch used to end in a log
-    /// line only — the progress row just vanished and the user had no idea
-    /// whether the model installed or why it didn't. Cleared when a new
-    /// download for the same model starts (and dismissible from the UI).
-    @Published var lastDownloadError: String?
+    /// Human-readable descriptions of failed model downloads, keyed by
+    /// `WhisperModel.name`. Every failure path of a multi-GB fetch used to
+    /// end in a log line only — the progress row just vanished and the user
+    /// had no idea whether the model installed or why it didn't. Keyed per
+    /// model (not one flat slot) because the two default models auto-download
+    /// concurrently on first launch: starting B must not wipe A's report.
+    /// A new attempt for a model clears only that model's entry; also
+    /// dismissible from the UI.
+    @Published var lastDownloadErrors: [String: String] = [:]
 
     private let modelsDirectory: URL
     private lazy var session: URLSession = {
@@ -201,8 +204,9 @@ final class ModelManager: NSObject, ObservableObject {
     func download(_ model: WhisperModel) {
         guard downloads[model.name] == nil else { return }
         guard !didShutDownSession else { return }
-        // A fresh attempt supersedes the previous failure report.
-        lastDownloadError = nil
+        // A fresh attempt supersedes the previous failure report for THIS
+        // model only — a concurrent sibling download's error must survive.
+        lastDownloadErrors[model.name] = nil
         downloads[model.name] = 0
         let task = session.downloadTask(with: model.url)
         observers[task.taskIdentifier] = model
@@ -342,7 +346,7 @@ extension ModelManager: URLSessionDownloadDelegate {
             }
             if let moveErr {
                 modelLogger.error("Download \(model.name, privacy: .public): failed to capture URLSession temp file: \(moveErr.localizedDescription, privacy: .public)")
-                self.lastDownloadError = "\(model.displayName): download failed (\(moveErr.localizedDescription))"
+                self.lastDownloadErrors[model.name] = "\(model.displayName): download failed (\(moveErr.localizedDescription))"
                 return
             }
             // A 404/403 from HuggingFace delivers an HTML error page that
@@ -352,7 +356,7 @@ extension ModelManager: URLSessionDownloadDelegate {
                !(200..<300).contains(http.statusCode) {
                 try? FileManager.default.removeItem(at: tempCopy)
                 modelLogger.error("Download \(model.name, privacy: .public): server returned HTTP \(http.statusCode, privacy: .public)")
-                self.lastDownloadError = "\(model.displayName): server returned HTTP \(http.statusCode)"
+                self.lastDownloadErrors[model.name] = "\(model.displayName): server returned HTTP \(http.statusCode)"
                 return
             }
             // Hash off the main actor — for the 3 GB ivritLarge model this is
@@ -367,7 +371,7 @@ extension ModelManager: URLSessionDownloadDelegate {
             } catch {
                 try? FileManager.default.removeItem(at: tempCopy)
                 modelLogger.error("Download \(model.name, privacy: .public): integrity check failed: \(error.localizedDescription, privacy: .public)")
-                self.lastDownloadError = "\(model.displayName): downloaded file failed its integrity check — try again"
+                self.lastDownloadErrors[model.name] = "\(model.displayName): downloaded file failed its integrity check — try again"
                 return
             }
             let dest = self.url(for: model)
@@ -377,7 +381,7 @@ extension ModelManager: URLSessionDownloadDelegate {
                 modelLogger.notice("Download \(model.name, privacy: .public): installed at \(dest.path, privacy: .public)")
             } catch {
                 modelLogger.error("Download \(model.name, privacy: .public): final move failed: \(error.localizedDescription, privacy: .public)")
-                self.lastDownloadError = "\(model.displayName): could not install (\(error.localizedDescription))"
+                self.lastDownloadErrors[model.name] = "\(model.displayName): could not install (\(error.localizedDescription))"
             }
             self.refreshInstalled()
         }
@@ -392,7 +396,7 @@ extension ModelManager: URLSessionDownloadDelegate {
             if let model = self.observers.removeValue(forKey: id) {
                 self.downloads.removeValue(forKey: model.name)
                 modelLogger.error("Download \(model.name, privacy: .public): network/task failure: \(error.localizedDescription, privacy: .public)")
-                self.lastDownloadError = "\(model.displayName): download failed (\(error.localizedDescription))"
+                self.lastDownloadErrors[model.name] = "\(model.displayName): download failed (\(error.localizedDescription))"
             } else if let model = self.coreMLObservers.removeValue(forKey: id) {
                 self.coreMLDownloads.removeValue(forKey: model.name)
                 modelLogger.error("CoreML download \(model.name, privacy: .public): network/task failure: \(error.localizedDescription, privacy: .public)")

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -88,6 +88,13 @@ final class ModelManager: NSObject, ObservableObject {
     @Published private(set) var downloads: [String: Double] = [:]
     @Published var selectedModelName: String
 
+    /// Human-readable description of the most recent failed model download,
+    /// or nil. Every failure path of a multi-GB fetch used to end in a log
+    /// line only — the progress row just vanished and the user had no idea
+    /// whether the model installed or why it didn't. Cleared when a new
+    /// download for the same model starts (and dismissible from the UI).
+    @Published var lastDownloadError: String?
+
     private let modelsDirectory: URL
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
@@ -194,6 +201,8 @@ final class ModelManager: NSObject, ObservableObject {
     func download(_ model: WhisperModel) {
         guard downloads[model.name] == nil else { return }
         guard !didShutDownSession else { return }
+        // A fresh attempt supersedes the previous failure report.
+        lastDownloadError = nil
         downloads[model.name] = 0
         let task = session.downloadTask(with: model.url)
         observers[task.taskIdentifier] = model
@@ -333,6 +342,17 @@ extension ModelManager: URLSessionDownloadDelegate {
             }
             if let moveErr {
                 modelLogger.error("Download \(model.name, privacy: .public): failed to capture URLSession temp file: \(moveErr.localizedDescription, privacy: .public)")
+                self.lastDownloadError = "\(model.displayName): download failed (\(moveErr.localizedDescription))"
+                return
+            }
+            // A 404/403 from HuggingFace delivers an HTML error page that
+            // would only surface later as a baffling hash mismatch — report
+            // the HTTP failure directly instead.
+            if let http = downloadTask.response as? HTTPURLResponse,
+               !(200..<300).contains(http.statusCode) {
+                try? FileManager.default.removeItem(at: tempCopy)
+                modelLogger.error("Download \(model.name, privacy: .public): server returned HTTP \(http.statusCode, privacy: .public)")
+                self.lastDownloadError = "\(model.displayName): server returned HTTP \(http.statusCode)"
                 return
             }
             // Hash off the main actor — for the 3 GB ivritLarge model this is
@@ -347,6 +367,7 @@ extension ModelManager: URLSessionDownloadDelegate {
             } catch {
                 try? FileManager.default.removeItem(at: tempCopy)
                 modelLogger.error("Download \(model.name, privacy: .public): integrity check failed: \(error.localizedDescription, privacy: .public)")
+                self.lastDownloadError = "\(model.displayName): downloaded file failed its integrity check — try again"
                 return
             }
             let dest = self.url(for: model)
@@ -356,6 +377,7 @@ extension ModelManager: URLSessionDownloadDelegate {
                 modelLogger.notice("Download \(model.name, privacy: .public): installed at \(dest.path, privacy: .public)")
             } catch {
                 modelLogger.error("Download \(model.name, privacy: .public): final move failed: \(error.localizedDescription, privacy: .public)")
+                self.lastDownloadError = "\(model.displayName): could not install (\(error.localizedDescription))"
             }
             self.refreshInstalled()
         }
@@ -370,6 +392,7 @@ extension ModelManager: URLSessionDownloadDelegate {
             if let model = self.observers.removeValue(forKey: id) {
                 self.downloads.removeValue(forKey: model.name)
                 modelLogger.error("Download \(model.name, privacy: .public): network/task failure: \(error.localizedDescription, privacy: .public)")
+                self.lastDownloadError = "\(model.displayName): download failed (\(error.localizedDescription))"
             } else if let model = self.coreMLObservers.removeValue(forKey: id) {
                 self.coreMLDownloads.removeValue(forKey: model.name)
                 modelLogger.error("CoreML download \(model.name, privacy: .public): network/task failure: \(error.localizedDescription, privacy: .public)")

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -110,6 +110,14 @@ actor RemoteWhisperEngine: RemoteTranscribing {
         let boundary = "MilaBoundary-\(UUID().uuidString)"
         var request = URLRequest(url: config.endpoint.appendingPathComponent("audio/transcriptions"))
         request.httpMethod = "POST"
+        // The session's 120s request timeout is an INACTIVITY timer, and an
+        // OpenAI-compatible server sends zero bytes while it transcribes —
+        // after the upload finishes, a long recording routinely stays silent
+        // well past 120s of server-side processing, which failed the whole
+        // transcription with "The request timed out". Override per-request so
+        // only the 1-hour resource timeout bounds the wait; the short idle
+        // timeout still applies to everything else on this session.
+        request.timeoutInterval = 60 * 60
         request.setValue("multipart/form-data; boundary=\(boundary)",
                          forHTTPHeaderField: "Content-Type")
         if !config.apiKey.isEmpty {

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 struct SpeakerTurn: Codable {
     let start: Double
@@ -44,51 +45,74 @@ enum SpeakerDiarizer {
         }
     }
 
-    private struct PythonResult {
+    struct PythonResult {
         let stdout: Data
         let stderr: Data
         let exitCode: Int32
     }
 
-    private static func runPython(
+    /// Internal (not private) so tests can exercise the cancellation path
+    /// directly with a stub executable.
+    static func runPython(
         path: String,
         arguments: [String],
         environment: [String: String]? = nil
     ) async throws -> PythonResult {
-        try await Task.detached(priority: .userInitiated) {
-            guard FileManager.default.fileExists(atPath: path) else {
-                throw Error.pythonNotFound(path)
-            }
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw Error.pythonNotFound(path)
+        }
 
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: path)
-            process.arguments = arguments
-            var env = ProcessInfo.processInfo.environment
-            if let extra = environment { env.merge(extra) { _, new in new } }
-            process.environment = env
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        var env = ProcessInfo.processInfo.environment
+        if let extra = environment { env.merge(extra) { _, new in new } }
+        process.environment = env
 
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
 
-            try process.run()
+        // Task cancellation must reach the subprocess. Without this, a
+        // cancelled transcription (user hits Cancel / app shutdown) had no
+        // way to stop a running pyannote pass: `waitUntilExit()` blocked
+        // until the full diarization finished — minutes of CPU on a
+        // recording that may already be deleted, with the serial
+        // transcription queue stalled behind it the whole time.
+        let cancelled = OSAllocatedUnfairLock(initialState: false)
+        return try await withTaskCancellationHandler {
+            try await Task.detached(priority: .userInitiated) {
+                if cancelled.withLock({ $0 }) { throw CancellationError() }
+                try process.run()
+                // Close the narrow window where onCancel ran between the
+                // check above and `run()` — its terminate() hit a not-yet-
+                // launched process and was a no-op.
+                if cancelled.withLock({ $0 }) { process.terminate() }
 
-            // Drain both pipes in detached tasks to avoid deadlock.
-            // macOS pipe buffers are ~64 KB — if the subprocess
-            // fills stderr before we read it, it blocks on write()
-            // while we block on waitUntilExit().
-            let stdoutRead = Task.detached { stdout.fileHandleForReading.readDataToEndOfFile() }
-            let stderrRead = Task.detached { stderr.fileHandleForReading.readDataToEndOfFile() }
+                // Drain both pipes in detached tasks to avoid deadlock.
+                // macOS pipe buffers are ~64 KB — if the subprocess
+                // fills stderr before we read it, it blocks on write()
+                // while we block on waitUntilExit().
+                let stdoutRead = Task.detached { stdout.fileHandleForReading.readDataToEndOfFile() }
+                let stderrRead = Task.detached { stderr.fileHandleForReading.readDataToEndOfFile() }
 
-            process.waitUntilExit()
+                process.waitUntilExit()
 
-            return PythonResult(
-                stdout: await stdoutRead.value,
-                stderr: await stderrRead.value,
-                exitCode: process.terminationStatus
-            )
-        }.value
+                let result = PythonResult(
+                    stdout: await stdoutRead.value,
+                    stderr: await stderrRead.value,
+                    exitCode: process.terminationStatus
+                )
+                // A SIGTERM'd run must surface as cancellation, not as a
+                // "diarization failed (exit 15)" error banner.
+                if cancelled.withLock({ $0 }) { throw CancellationError() }
+                return result
+            }.value
+        } onCancel: {
+            cancelled.withLock { $0 = true }
+            if process.isRunning { process.terminate() }
+        }
     }
 
     // MARK: - Public API

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -99,13 +99,21 @@ enum SpeakerDiarizer {
 
                 process.waitUntilExit()
 
+                // A SIGTERM'd run surfaces as cancellation, not as a
+                // "diarization failed (exit 15)" error banner. Checked
+                // BEFORE awaiting the drains: the output is discarded
+                // anyway, and `readDataToEndOfFile` only returns at EOF —
+                // which any pipe-inheriting straggler of the killed python
+                // could postpone indefinitely. The abandoned readers exit
+                // on their own when the pipes finally close.
+                if cancelled.withLock({ $0 }) { throw CancellationError() }
+
                 let result = PythonResult(
                     stdout: await stdoutRead.value,
                     stderr: await stderrRead.value,
                     exitCode: process.terminationStatus
                 )
-                // A SIGTERM'd run must surface as cancellation, not as a
-                // "diarization failed (exit 15)" error banner.
+                // Cancellation that landed while draining still wins.
                 if cancelled.withLock({ $0 }) { throw CancellationError() }
                 return result
             }.value

--- a/Mila/Transcription/TranscriptExporter.swift
+++ b/Mila/Transcription/TranscriptExporter.swift
@@ -54,9 +54,18 @@ enum TranscriptExporter {
     }
 
     private static func formatSRTTime(_ seconds: Double) -> String {
-        let h = Int(seconds) / 3600
-        let m = (Int(seconds) % 3600) / 60
-        let s = seconds.truncatingRemainder(dividingBy: 60)
-        return String(format: "%02d:%02d:%06.3f", h, m, s).replacingOccurrences(of: ".", with: ",")
+        // Round to whole milliseconds FIRST, then decompose. The previous
+        // version truncated hours/minutes from the raw double but let
+        // `%06.3f` round the seconds field, so inputs within 0.5ms below a
+        // minute boundary printed an invalid :60 seconds field (59.9996 →
+        // "00:00:60,000" instead of "00:01:00,000"). Local whisper sits on
+        // a 10ms grid, but the remote path passes through the server's
+        // full-precision floats.
+        let totalMillis = Int((seconds * 1000).rounded())
+        let h = totalMillis / 3_600_000
+        let m = (totalMillis % 3_600_000) / 60_000
+        let s = (totalMillis % 60_000) / 1_000
+        let ms = totalMillis % 1_000
+        return String(format: "%02d:%02d:%02d,%03d", h, m, s, ms)
     }
 }

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -288,8 +288,14 @@ struct ContentView: View {
                 // tests can run on any CI machine regardless of how
                 // its `hw.model` is reported.
                 LiveAIRecordingView()
+            } else if !search.trimmingCharacters(in: .whitespaces).isEmpty {
+                // Home is a dashboard with no list to filter, so the
+                // toolbar search used to silently do nothing here. Route
+                // the query to the all-recordings list instead; clearing
+                // the field brings the dashboard back.
+                HistoryListView(category: .transcriptions, search: search, selection: $selection)
             } else {
-                HomeView(selection: $selection, search: search)
+                HomeView(selection: $selection)
             }
         case .queue:
             QueueView(selection: $selection)

--- a/Mila/Views/HistoryListView.swift
+++ b/Mila/Views/HistoryListView.swift
@@ -180,6 +180,11 @@ private struct HistoryRow: View {
     @State private var promptForNewFolder = false
     @State private var newFolderDraft = ""
     @State private var showingSendSheet = false
+    /// Confirmation gate before "Delete Permanently" actually removes the
+    /// files — unlike soft-delete there's no Trash to restore from, and
+    /// accidental loss of recordings was the #1 user complaint (same
+    /// rationale as the rename sheet's Discard confirm).
+    @State private var confirmingPermanentDelete = false
 
     var body: some View {
         let isSelected: Bool = {
@@ -275,6 +280,19 @@ private struct HistoryRow: View {
         .sheet(isPresented: $showingSendSheet) {
             SendToLLMSheet(recording: recording)
         }
+        .confirmationDialog("Delete “\(recording.title)” permanently?",
+                            isPresented: $confirmingPermanentDelete,
+                            titleVisibility: .visible) {
+            Button("Delete Permanently", role: .destructive) {
+                store.permanentlyDelete(recording)
+                if case .recording(let id) = selection, id == recording.id {
+                    selection = .home
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("The audio file and any transcript will be permanently deleted. This can't be undone.")
+        }
     }
 
     @ViewBuilder
@@ -283,10 +301,7 @@ private struct HistoryRow: View {
             Button("Restore") { store.restore(recording) }
             Divider()
             Button("Delete Permanently", role: .destructive) {
-                store.permanentlyDelete(recording)
-                if case .recording(let id) = selection, id == recording.id {
-                    selection = .home
-                }
+                confirmingPermanentDelete = true
             }
         } else {
             Button("Rename…") {
@@ -429,7 +444,13 @@ struct RenameSheet: View {
             Text("Rename Recording").font(.title3.weight(.semibold))
             TextField("Title", text: $draft)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit { onConfirm(draft) }
+                // Return must behave like the Save button below — without
+                // the guard it committed a blank title the disabled button
+                // was there to prevent.
+                .onSubmit {
+                    guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                    onConfirm(draft)
+                }
                 .accessibilityIdentifier("rename.title.field")
             HStack {
                 Spacer()

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -19,7 +19,6 @@ struct HomeView: View {
     @EnvironmentObject private var transcription: TranscriptionService
 
     @Binding var selection: SidebarSelection?
-    let search: String
 
     /// User's preference for capturing the system's audio mix. Defaults
     /// to ON because the main use case is meeting / content

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -229,14 +229,31 @@ struct LiveAIRecordingView: View {
     /// Split a rolling summary paragraph into one bullet per sentence.
     /// Falls back to the whole string as a single bullet when no
     /// sentence boundary is found — better than showing nothing.
+    ///
+    /// Uses Foundation's `.bySentences` tokenizer (same as
+    /// `AIOverviewSection.summaryAttributed`, so the live pane and the
+    /// detail pane split the same summary identically). The previous
+    /// naive split on every '.', '!', '?' character turned "Budget is
+    /// 3.5 million." into two bullets — and, despite its comment, never
+    /// actually included the Hebrew full stop in the separator set.
     static func bulletsFromSummary(_ s: String) -> [String] {
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
-        // Split on '. ', '! ', '? ' and the Hebrew full stop "׃ " plus
-        // line breaks. Filter empties.
-        let parts = trimmed
-            .split(whereSeparator: { ".!?\n".contains($0) })
-            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        let sourceLines: [String]
+        if trimmed.contains("\n") {
+            // Already has line structure (often the LLM's own bullets).
+            sourceLines = trimmed.components(separatedBy: "\n")
+        } else {
+            var sentences: [String] = []
+            trimmed.enumerateSubstrings(in: trimmed.startIndex..<trimmed.endIndex,
+                                        options: [.bySentences, .localized]) { sub, _, _, _ in
+                let sentence = (sub ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                if !sentence.isEmpty { sentences.append(sentence) }
+            }
+            sourceLines = sentences
+        }
+        let parts = sourceLines
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         return parts.isEmpty ? [trimmed] : parts
     }

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -238,6 +238,27 @@ struct RecordingDetailView: View {
         return modelManager.selectedModel()?.displayName ?? ""
     }
 
+    /// What the transcript area shows while a recording has no segments.
+    /// `nil` means no placeholder — the active-transcription progress view
+    /// owns that state.
+    enum EmptyTranscriptPlaceholder: Equatable {
+        /// Queued behind the active transcription — the Transcribe menu is
+        /// disabled (see `busy` in `actionButtons`), so pointing the user
+        /// at it would be a dead end.
+        case waitingInQueue
+        /// Idle: invite the user to start a transcription themselves.
+        case clickTranscribe
+    }
+
+    /// Decision for the empty-segments placeholder, split out as a pure
+    /// function so RecordingDetailPlaceholderTests can pin the queued
+    /// case without building the view.
+    static func emptyTranscriptPlaceholder(isActive: Bool,
+                                           isQueued: Bool) -> EmptyTranscriptPlaceholder? {
+        if isActive { return nil }
+        return isQueued ? .waitingInQueue : .clickTranscribe
+    }
+
     @ViewBuilder
     private var transcriptArea: some View {
         if transcription.activeRecordingID == recording.id {
@@ -261,11 +282,23 @@ struct RecordingDetailView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if recording.segments.isEmpty {
-            ContentUnavailableView(
-                "No transcript yet",
-                systemImage: "text.alignleft",
-                description: Text("Click \(Image(systemName: "text.badge.checkmark")) Transcribe to start.")
+            let placeholder = Self.emptyTranscriptPlaceholder(
+                isActive: transcription.activeRecordingID == recording.id,
+                isQueued: transcription.pendingIDs.contains(recording.id)
             )
+            if placeholder == .waitingInQueue {
+                ContentUnavailableView {
+                    Label("Waiting in queue", systemImage: "clock")
+                } description: {
+                    Text("Transcription will start when the recording ahead of it finishes.")
+                }
+            } else {
+                ContentUnavailableView(
+                    "No transcript yet",
+                    systemImage: "text.alignleft",
+                    description: Text("Click \(Image(systemName: "text.badge.checkmark")) Transcribe to start.")
+                )
+            }
         } else {
             VStack(spacing: 0) {
                 // Transcript-area copy button, on the right just below the
@@ -430,6 +463,14 @@ private struct PlayPauseButton: View {
             if player.timeControlStatus == .playing {
                 player.pause()
             } else {
+                // AVPlayer parks at end-of-item when playback finishes and
+                // a bare play() there is a no-op — the button looked dead
+                // after a memo played to the end until the user dragged the
+                // slider back. Rewind first in that case.
+                if let item = player.currentItem, item.duration.isNumeric,
+                   item.duration.seconds - player.currentTime().seconds <= 0.1 {
+                    player.seek(to: .zero)
+                }
                 player.play()
             }
         } label: {

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -504,20 +504,24 @@ private struct ModelsSettingsTab: View {
 
             // Failed downloads used to only leave an os_log line — the
             // progress bar vanished with zero explanation of whether the
-            // model installed or why it didn't.
-            if let error = manager.lastDownloadError {
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text(error)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Spacer()
-                    Button("Dismiss") { manager.lastDownloadError = nil }
-                        .buttonStyle(.borderless)
+            // model installed or why it didn't. One row per failed model:
+            // the defaults auto-download concurrently on first launch, so
+            // two reports can be live at once.
+            ForEach(manager.lastDownloadErrors.keys.sorted(), id: \.self) { name in
+                if let error = manager.lastDownloadErrors[name] {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text(error)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer()
+                        Button("Dismiss") { manager.lastDownloadErrors[name] = nil }
+                            .buttonStyle(.borderless)
+                    }
+                    .accessibilityIdentifier("models.download.error.\(name)")
                 }
-                .accessibilityIdentifier("models.download.error")
             }
         }
     }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -219,9 +219,26 @@ private struct HotkeysSettingsTab: View {
                 ForEach(HotkeyAction.allCases) { action in
                     HotkeyRow(action: action,
                               isRecording: recordingAction == action,
-                              onStartRecording: { recordingAction = action },
+                              // Live-registration warning: register() can fail
+                              // (another app owns the combo globally) and the
+                              // binding then LOOKS active while doing nothing.
+                              // Suppressed mid-capture — suspendAll() has
+                              // deliberately parked everything then.
+                              showsInactiveWarning: recordingAction == nil
+                                  && !HotkeyManager.shared.isRegistered(action),
+                              onStartRecording: {
+                                  recordingAction = action
+                                  // Park our own registrations so the pressed
+                                  // combo reaches the capture field's keyDown —
+                                  // Carbon otherwise consumes a currently-bound
+                                  // combo and STARTS DICTATION mid-capture.
+                                  HotkeyManager.shared.suspendAll()
+                              },
                               onCaptured: { applyCapture($0, for: action) },
-                              onCancel: { recordingAction = nil },
+                              onCancel: {
+                                  recordingAction = nil
+                                  HotkeyManager.shared.resumeAll()
+                              },
                               onReset: { resetToDefault(action) })
                 }
             }
@@ -235,10 +252,19 @@ private struct HotkeysSettingsTab: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onDisappear {
+            // Window closed mid-capture: don't leave the app's hotkeys
+            // parked forever.
+            if recordingAction != nil {
+                recordingAction = nil
+                HotkeyManager.shared.resumeAll()
+            }
+        }
     }
 
     private func applyCapture(_ binding: HotkeyBinding, for action: HotkeyAction) {
         recordingAction = nil
+        HotkeyManager.shared.resumeAll()
 
         // Reject empty / modifier-only combos: Carbon will accept them but
         // Apple shortcut conventions require at least one of ⌘ ⌃ ⌥.
@@ -258,6 +284,24 @@ private struct HotkeysSettingsTab: View {
             }
         }
 
+        // Re-capturing the combo the action already has: nothing to do
+        // (and the registrability probe below would false-positive against
+        // our own live registration).
+        guard binding != hotkeys.binding(for: action) else {
+            lastError = nil
+            return
+        }
+
+        // Validate registrability BEFORE persisting. The old flow persisted
+        // first and dropped the registration failure on the floor: Settings
+        // showed the new combo as active while no hotkey was registered at
+        // all (the previous combo had already been unregistered) — dictation
+        // went silently dead until a reset.
+        guard HotkeyManager.shared.canRegister(binding) else {
+            lastError = "\(binding.displayName) is already taken by another app or macOS — choose a different combo."
+            return
+        }
+
         lastError = nil
         hotkeys.setBinding(binding, for: action)
     }
@@ -273,6 +317,7 @@ private struct HotkeyRow: View {
 
     let action: HotkeyAction
     let isRecording: Bool
+    let showsInactiveWarning: Bool
     let onStartRecording: () -> Void
     let onCaptured: (HotkeyBinding) -> Void
     let onCancel: () -> Void
@@ -283,6 +328,13 @@ private struct HotkeyRow: View {
             Text(action.displayLabel)
                 .font(.body)
                 .frame(width: 160, alignment: .leading)
+
+            if showsInactiveWarning {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .help("This combo couldn't be registered — another app or macOS owns it globally. Pick a different one or hit Reset.")
+                    .accessibilityIdentifier("hotkeys.\(action.rawValue).inactive")
+            }
 
             Spacer()
 
@@ -449,6 +501,24 @@ private struct ModelsSettingsTab: View {
                     ModelRow(model: model)
                 }
             }
+
+            // Failed downloads used to only leave an os_log line — the
+            // progress bar vanished with zero explanation of whether the
+            // model installed or why it didn't.
+            if let error = manager.lastDownloadError {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(error)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button("Dismiss") { manager.lastDownloadError = nil }
+                        .buttonStyle(.borderless)
+                }
+                .accessibilityIdentifier("models.download.error")
+            }
         }
     }
 }
@@ -561,6 +631,12 @@ private struct ModelRow: View {
     @EnvironmentObject private var manager: ModelManager
     let model: WhisperModel
 
+    /// Confirmation gate before deleting an installed model — these are
+    /// multi-GB downloads, so an accidental click shouldn't cost the user
+    /// a re-download.
+    @State private var confirmingDelete = false
+    @State private var deleteError: String?
+
     var body: some View {
         let progress = manager.downloads[model.name]
         let installed = manager.isInstalled(model)
@@ -583,7 +659,7 @@ private struct ModelRow: View {
                     .foregroundStyle(.green)
                     .labelStyle(.iconOnly)
                 Button("Delete", role: .destructive) {
-                    try? manager.delete(model)
+                    confirmingDelete = true
                 }
                 .buttonStyle(.borderless)
             } else {
@@ -593,6 +669,29 @@ private struct ModelRow: View {
         }
         .padding(8)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .confirmationDialog("Delete \(model.displayName)?",
+                            isPresented: $confirmingDelete,
+                            titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                do {
+                    try manager.delete(model)
+                } catch {
+                    deleteError = error.localizedDescription
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Using this model again will require re-downloading it (\(byteCountString(model.sizeBytes))).")
+        }
+        .alert(
+            "Couldn't delete model",
+            isPresented: Binding(
+                get: { deleteError != nil },
+                set: { if !$0 { deleteError = nil } }
+            ),
+            actions: { Button("OK") { deleteError = nil } },
+            message: { Text(deleteError ?? "") }
+        )
     }
 
     private func byteCountString(_ bytes: Int64) -> String {

--- a/Mila/Views/SidebarView.swift
+++ b/Mila/Views/SidebarView.swift
@@ -40,6 +40,10 @@ struct SidebarView: View {
     @State private var newFolderName = ""
     @State private var renameTarget: String?
     @State private var renameDraft = ""
+    /// Inline error shown in the rename sheet when `store.renameFolder`
+    /// rejects the new name (collision). Kept here so the sheet can stay
+    /// open instead of silently no-op'ing and closing.
+    @State private var renameError: String?
 
     /// Whether the "All Transcriptions" section is expanded to show its
     /// recordings inline. Persisted so the user's choice survives app
@@ -100,6 +104,7 @@ struct SidebarView: View {
                     .contextMenu {
                         Button("Rename Folder…") {
                             renameDraft = name
+                            renameError = nil
                             renameTarget = name
                         }
                         Button("Delete Folder", role: .destructive) {
@@ -168,11 +173,17 @@ struct SidebarView: View {
                 title: "Rename Folder",
                 confirmLabel: "Rename",
                 name: $renameDraft,
+                errorText: $renameError,
                 onConfirm: {
-                    if let renamed = store.renameFolder(target.name, to: renameDraft) {
-                        if case .folder(let sel) = selection, sel == target.name {
-                            selection = .folder(renamed)
-                        }
+                    // nil = rejected (name collides with an existing
+                    // folder). Keep the sheet open with an inline error
+                    // instead of silently closing as if it worked.
+                    guard let renamed = store.renameFolder(target.name, to: renameDraft) else {
+                        renameError = "A folder with that name already exists."
+                        return
+                    }
+                    if case .folder(let sel) = selection, sel == target.name {
+                        selection = .folder(renamed)
                     }
                     renameTarget = nil
                 },
@@ -339,16 +350,50 @@ struct FolderNameSheet: View {
     let title: String
     let confirmLabel: String
     @Binding var name: String
+    /// Inline validation message (e.g. a rename collision). Owned by the
+    /// presenting view — its confirm handler sets it and keeps the sheet
+    /// open; the sheet clears it as soon as the user edits the name.
+    /// Defaults to a constant nil so the create-folder call sites (which
+    /// have no failure mode to surface) don't have to thread state through.
+    @Binding var errorText: String?
     let onConfirm: () -> Void
     let onCancel: () -> Void
+
+    init(title: String,
+         confirmLabel: String,
+         name: Binding<String>,
+         errorText: Binding<String?> = .constant(nil),
+         onConfirm: @escaping () -> Void,
+         onCancel: @escaping () -> Void) {
+        self.title = title
+        self.confirmLabel = confirmLabel
+        self._name = name
+        self._errorText = errorText
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text(title).font(.title3.weight(.semibold))
             TextField("Folder name", text: $name)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit { onConfirm() }
+                // Return must behave like the confirm button below — without
+                // the guard it fired onConfirm on a blank name the disabled
+                // button was there to prevent.
+                .onSubmit {
+                    guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                    onConfirm()
+                }
+                .onChange(of: name) { _, _ in errorText = nil }
                 .accessibilityIdentifier("folder.name.field")
+            if let errorText {
+                Text(errorText)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("folder.name.error")
+            }
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -130,6 +130,17 @@ final class VoiceMemosImporter: ObservableObject {
 
     private func sync() async {
         guard settings.isEnabled, settings.hasSelection else { return }
+        // Re-check on entry: `requestSync`'s guard runs when the request is
+        // made, but `isSyncing` only flips once this Task actually starts.
+        // Two requests landing in the same main-actor drain (e.g. "Rescan
+        // now" + an FSEvents hop) both saw false and spawned overlapping
+        // syncs — each snapshots `alreadyImported` before the other's
+        // `store.add` lands, so the same memo imported (and transcribed)
+        // twice.
+        guard !isSyncing else {
+            pendingResync = true
+            return
+        }
         isSyncing = true
         lastError = nil
         defer {
@@ -160,7 +171,12 @@ final class VoiceMemosImporter: ObservableObject {
             return
         }
 
+        // Live imports + tombstones of imports the user permanently
+        // deleted — without the tombstones, deleting an imported memo in
+        // Mila didn't stick (the source memo still exists in the Voice
+        // Memos folder and re-imported on the next sync).
         let alreadyImported = Set(store.recordings.compactMap { $0.voiceMemoUniqueID })
+            .union(store.voiceMemoTombstones)
         let fm = FileManager.default
 
         var imported = 0

--- a/MilaTests/AudioConvertTests.swift
+++ b/MilaTests/AudioConvertTests.swift
@@ -92,6 +92,52 @@ final class AudioConvertTests: XCTestCase {
         XCTAssertTrue(samples.isEmpty)
     }
 
+    // MARK: - StreamingWhisperConverter
+
+    /// Regression: sample-rate conversion is stateful. The old pattern —
+    /// a fresh `AVAudioConverter` per tap buffer (`toWhisperFormat` in a
+    /// loop) — restarts the resampler filter at every chunk edge, which
+    /// dips the output toward zero at each boundary (~every 85ms of every
+    /// recording from a 48kHz mic). A DC (constant 1.0) input makes those
+    /// dips easy to detect: through the session-scoped streaming converter
+    /// the settled output must stay flat across all chunk boundaries.
+    func test_streaming_converter_keeps_resampler_state_across_buffers() throws {
+        let inputFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                        sampleRate: 48_000,
+                                        channels: 1,
+                                        interleaved: false)!
+        let converter = try XCTUnwrap(StreamingWhisperConverter(inputFormat: inputFormat))
+
+        var output: [Float] = []
+        for _ in 0..<8 {
+            let chunk = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: 4096)!
+            chunk.frameLength = 4096
+            if let ptr = chunk.floatChannelData?[0] {
+                for i in 0..<4096 { ptr[i] = 1.0 }
+            }
+            let converted = try converter.convert(chunk)
+            output.append(contentsOf: AudioConvert.samples(from: converted))
+        }
+
+        // 8 × 4096 @ 48k → ~10.9k frames @ 16k (minus a little converter
+        // latency). Skip the legitimate initial filter ramp, then require
+        // the DC level to hold across every boundary.
+        XCTAssertGreaterThan(output.count, 8_000, "converter should emit most frames")
+        let settled = output.dropFirst(400)
+        let minValue = settled.min() ?? 0
+        XCTAssertGreaterThan(minValue, 0.95,
+                             "DC input must stay flat across buffer boundaries — a dip means the resampler state was reset mid-stream (min=\(minValue))")
+    }
+
+    func test_streaming_converter_passes_through_whisper_shaped_buffers() throws {
+        let converter = try XCTUnwrap(
+            StreamingWhisperConverter(inputFormat: WhisperAudioFormat.pcmFloat32))
+        let buffer = makeBuffer(format: WhisperAudioFormat.pcmFloat32, sineHz: 440, frames: 1600)
+        let converted = try converter.convert(buffer)
+        XCTAssertTrue(converted === buffer,
+                      "Pass-through must return the same instance (documented contract — callers copy before mutating)")
+    }
+
     // MARK: - Helpers
 
     private func makeBuffer(format: AVAudioFormat,

--- a/MilaTests/DiarizationSettingsTests.swift
+++ b/MilaTests/DiarizationSettingsTests.swift
@@ -80,6 +80,44 @@ final class DiarizationSettingsTests: XCTestCase {
                        "isConfigured must remain false until torch is installed, even after the init refresh.")
     }
 
+    // MARK: - Regression: enabling mid-session restores persisted verification
+
+    /// Regression: launching with diarization OFF but a persisted verified
+    /// setup, then flipping the toggle ON, showed "Setup needed" for a fully
+    /// verified setup. The `isEnabled` didSet deliberately skips `checkDeps()`
+    /// when `diarization.verified` is persisted — but nothing restored
+    /// `verificationStatus` either (`restoreVerifiedState()` only ran in
+    /// init, and only when the app launched already-enabled). `status` stayed
+    /// at "Setup needed" (and on the legacy no-bundled-runtime flow, where
+    /// `isConfigured` returns `status.isGood`, the whole feature stayed
+    /// gated) until the user manually re-verified.
+    func test_enabling_mid_session_restores_persisted_verified_state() throws {
+        // A real file on disk so `pythonFound` is deterministic.
+        let pythonStub = tempRoot.appendingPathComponent("python3")
+        try Data().write(to: pythonStub)
+
+        defaults.set(false, forKey: "diarization.enabled")
+        defaults.set(true, forKey: "diarization.verified")
+        defaults.set(pythonStub.path, forKey: "diarization.pythonPath")
+        defaults.set(pythonStub.path, forKey: "diarization.verifiedPythonPath")
+
+        // Inject a bootstrap that's already "ready" (fake bundled python +
+        // installed torch) so the didSet's fire-and-forget
+        // `bootstrapIfNeeded()` early-returns instead of downloading wheels
+        // from the network inside a unit test.
+        let bootstrap = DiarizationBootstrap(bundledPython: try makeFakeBundledPython().path,
+                                             sitePackages: try makeFakeTorchSitePackages())
+        let settings = DiarizationSettings(defaults: defaults, bootstrap: bootstrap)
+        XCTAssertEqual(settings.status, .disabled, "Sanity: launched disabled")
+
+        settings.isEnabled = true
+
+        XCTAssertEqual(settings.status, .verified,
+                       "Persisted verification must be restored when the user re-enables mid-session — not report 'Setup needed'")
+        XCTAssertTrue(settings.status.isGood,
+                      "status.isGood is what isConfigured returns on the legacy (no-bundled-runtime) flow — the restored verification must open that gate")
+    }
+
     // MARK: - Fixtures
 
     private func makeFakeBundledPython() throws -> URL {

--- a/MilaTests/DictationPasteboardTests.swift
+++ b/MilaTests/DictationPasteboardTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import AppKit
+@testable import Mila
+
+/// Regression coverage for dictation's clipboard save/restore.
+///
+/// The paste flow used to snapshot only `string(forType: .string)`: if the
+/// user had an image / file / rich content on the clipboard, dictating
+/// destroyed it permanently — `clearContents()` wiped the pasteboard and the
+/// restore step was skipped entirely because the string snapshot was nil.
+/// `snapshotPasteboard`/`restorePasteboard` capture every item with every
+/// type it carries. Tested against a private named pasteboard so the user's
+/// real clipboard is untouched.
+@MainActor
+final class DictationPasteboardTests: XCTestCase {
+
+    private var pasteboard: NSPasteboard!
+
+    override func setUp() {
+        super.setUp()
+        pasteboard = NSPasteboard(name: .init("MilaTests.pasteboard.\(UUID().uuidString)"))
+    }
+
+    override func tearDown() {
+        pasteboard.releaseGlobally()
+        pasteboard = nil
+        super.tearDown()
+    }
+
+    func test_non_string_content_survives_snapshot_clear_restore() {
+        let fakeImage = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])  // PNG-ish bytes
+        let item = NSPasteboardItem()
+        item.setData(fakeImage, forType: .png)
+        item.setString("caption", forType: .string)
+        pasteboard.clearContents()
+        pasteboard.writeObjects([item])
+
+        let snapshot = DictationController.snapshotPasteboard(pasteboard)
+        XCTAssertFalse(snapshot.isEmpty, "Snapshot must capture the existing item")
+
+        // What paste() does: clobber the clipboard with the transcript.
+        pasteboard.clearContents()
+        pasteboard.setString("the dictated text", forType: .string)
+        XCTAssertNil(pasteboard.pasteboardItems?.first?.data(forType: .png))
+
+        DictationController.restorePasteboard(pasteboard, from: snapshot)
+
+        XCTAssertEqual(pasteboard.pasteboardItems?.first?.data(forType: .png), fakeImage,
+                       "Non-string content must survive the dictation round trip")
+        XCTAssertEqual(pasteboard.pasteboardItems?.first?.string(forType: .string), "caption")
+    }
+
+    func test_multiple_items_round_trip() {
+        pasteboard.clearContents()
+        let a = NSPasteboardItem(); a.setString("first", forType: .string)
+        let b = NSPasteboardItem(); b.setString("second", forType: .string)
+        pasteboard.writeObjects([a, b])
+
+        let snapshot = DictationController.snapshotPasteboard(pasteboard)
+        pasteboard.clearContents()
+        pasteboard.setString("transcript", forType: .string)
+        DictationController.restorePasteboard(pasteboard, from: snapshot)
+
+        let strings = (pasteboard.pasteboardItems ?? []).compactMap { $0.string(forType: .string) }
+        XCTAssertEqual(strings.sorted(), ["first", "second"],
+                       "Every pasteboard item must be restored, not just the first")
+    }
+
+    func test_empty_pasteboard_snapshot_is_empty() {
+        pasteboard.clearContents()
+        XCTAssertTrue(DictationController.snapshotPasteboard(pasteboard).isEmpty)
+    }
+}

--- a/MilaTests/DictationPasteboardTests.swift
+++ b/MilaTests/DictationPasteboardTests.swift
@@ -62,8 +62,8 @@ final class DictationPasteboardTests: XCTestCase {
         DictationController.restorePasteboard(pasteboard, from: snapshot)
 
         let strings = (pasteboard.pasteboardItems ?? []).compactMap { $0.string(forType: .string) }
-        XCTAssertEqual(strings.sorted(), ["first", "second"],
-                       "Every pasteboard item must be restored, not just the first")
+        XCTAssertEqual(strings, ["first", "second"],
+                       "Every pasteboard item must be restored, in order, not just the first")
     }
 
     func test_empty_pasteboard_snapshot_is_empty() {

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -207,6 +207,45 @@ final class LLMRunnerTests: XCTestCase {
         }
     }
 
+    /// Regression: after a timeout-kill, the pipe drain used to be an
+    /// UNBOUNDED wait for EOF. A grandchild the CLI spawned (MCP server,
+    /// node helper) that inherited stdout/stderr and survived the parent's
+    /// SIGKILL kept the pipes open — `run` then never returned, leaving the
+    /// caller's in-flight slot (summarizer spinner, Live AI tick) stuck
+    /// permanently. The script models that: a background `sleep` inherits
+    /// stdout and outlives its killed parent. `run` must still return
+    /// `.timedOut` promptly instead of waiting out the grandchild.
+    func test_timeout_returns_even_when_grandchild_holds_pipes_open() async {
+        let script = makeScript("""
+            #!/bin/sh
+            sleep 60 &
+            sleep 60
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        let started = Date()
+        do {
+            _ = try await LLMRunner.run(tool: .claude,
+                                        prompt: "x",
+                                        transcript: "y",
+                                        executablePathOverride: script.path,
+                                        timeout: 1)
+            XCTFail("Expected timedOut error")
+        } catch let error as LLMRunnerError {
+            guard case .timedOut = error else {
+                XCTFail("Wrong error: \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Wrong error type: \(error)")
+        }
+        let elapsed = Date().timeIntervalSince(started)
+        // Generous CI bound (same flake class as the plain timeout test) —
+        // the point is "returns in seconds, not after the grandchild's 60s".
+        XCTAssertLessThan(elapsed, 40,
+                          "run() must not wait for the orphaned grandchild to release the pipes; took \(elapsed)s")
+    }
+
     // MARK: - Real-CLI smoke tests
     //
     // These hit the actual `claude` / `cursor-agent` binaries if installed.

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -216,12 +216,24 @@ final class LLMRunnerTests: XCTestCase {
     /// stdout and outlives its killed parent. `run` must still return
     /// `.timedOut` promptly instead of waiting out the grandchild.
     func test_timeout_returns_even_when_grandchild_holds_pipes_open() async {
+        // The grandchild's PID is parked in a file so the test can reap it
+        // on exit — otherwise every run leaves a stray `sleep 60` behind.
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-grandchild-\(UUID().uuidString).pid")
         let script = makeScript("""
             #!/bin/sh
             sleep 60 &
+            echo $! > "\(pidFile.path)"
             sleep 60
             """)
-        defer { try? FileManager.default.removeItem(at: script) }
+        defer {
+            if let pidText = try? String(contentsOf: pidFile, encoding: .utf8),
+               let pid = Int32(pidText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                kill(pid, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: pidFile)
+            try? FileManager.default.removeItem(at: script)
+        }
 
         let started = Date()
         do {

--- a/MilaTests/LiveAIBulletsTests.swift
+++ b/MilaTests/LiveAIBulletsTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Mila
+
+/// Tests for `LiveAIRecordingView.bulletsFromSummary` — the live Summary
+/// pane's sentence splitter.
+///
+/// Regression: the original implementation split on every '.', '!', '?'
+/// CHARACTER, so a summary containing a decimal ("the budget is 3.5
+/// million") shattered into nonsense bullets mid-number — while the detail
+/// pane (`AIOverviewSection.summaryAttributed`) already used Foundation's
+/// `.bySentences` tokenizer and rendered the same summary correctly. The two
+/// panes now share the same splitting behavior.
+@MainActor
+final class LiveAIBulletsTests: XCTestCase {
+
+    func test_decimal_numbers_stay_within_one_bullet() {
+        let bullets = LiveAIRecordingView.bulletsFromSummary(
+            "The budget is 3.5 million. Next review is scheduled.")
+        XCTAssertEqual(bullets.count, 2, "Two sentences → two bullets, got \(bullets)")
+        XCTAssertTrue(bullets[0].contains("3.5 million"),
+                      "The decimal must not be split mid-number: \(bullets)")
+    }
+
+    func test_plain_sentences_split_one_bullet_each() {
+        let bullets = LiveAIRecordingView.bulletsFromSummary(
+            "First point here. Second point there. Third one closes.")
+        XCTAssertEqual(bullets.count, 3, "got \(bullets)")
+    }
+
+    func test_newline_structured_summary_splits_per_line() {
+        let bullets = LiveAIRecordingView.bulletsFromSummary(
+            "- migration plan agreed\n- rollout starts Monday")
+        XCTAssertEqual(bullets.count, 2, "got \(bullets)")
+    }
+
+    func test_empty_and_whitespace_summaries_yield_no_bullets() {
+        XCTAssertEqual(LiveAIRecordingView.bulletsFromSummary(""), [])
+        XCTAssertEqual(LiveAIRecordingView.bulletsFromSummary("  \n "), [])
+    }
+
+    func test_no_boundary_falls_back_to_single_bullet() {
+        let bullets = LiveAIRecordingView.bulletsFromSummary("just one clause with no period")
+        XCTAssertEqual(bullets, ["just one clause with no period"])
+    }
+}

--- a/MilaTests/LiveAISettingsMigrationTests.swift
+++ b/MilaTests/LiveAISettingsMigrationTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Mila
+
+/// Regression tests for `LiveAISettings.init`'s persisted-value migrations.
+///
+/// Two init-time "migrate the old default" rules were written against value
+/// RANGES that the current Settings sliders legitimately offer, so they
+/// silently discarded the user's chosen value on every launch:
+///
+///  * `chunkSeconds`: the pre-1.6.1 migration treated anything below 25s as
+///    stale — but the tick-frequency slider offers 15–60s, so a chosen 15
+///    or 20 reverted to 30 on relaunch, forever.
+///  * `speakerSimilarityThreshold`: the "old 0.75 default" migration treated
+///    anything ≥ 0.7 as stale on EVERY launch — but the slider offers up to
+///    0.95, so a chosen 0.8 reverted to 0.55 on relaunch, forever. (Worse:
+///    `didSet` doesn't fire in init, so defaults kept the 0.8 while the app
+///    ran with 0.55 — UI and persisted state permanently disagreed.)
+@MainActor
+final class LiveAISettingsMigrationTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "LiveAISettingsMigrationTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    // MARK: - chunkSeconds
+
+    func test_chunkSeconds_slider_minimum_survives_relaunch() {
+        // 15s is the minimum the Settings slider (15...60) offers.
+        defaults.set(15.0, forKey: "liveAI.chunkSeconds")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.chunkSeconds, 15.0,
+                       "A value the slider offers must round-trip a relaunch, not be 'migrated' back to 30")
+    }
+
+    func test_chunkSeconds_20_survives_relaunch() {
+        defaults.set(20.0, forKey: "liveAI.chunkSeconds")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.chunkSeconds, 20.0)
+    }
+
+    func test_chunkSeconds_pre161_value_still_migrates_to_30() {
+        // The old default (5s) predates the 15s slider minimum — it must
+        // still be migrated.
+        defaults.set(5.0, forKey: "liveAI.chunkSeconds")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.chunkSeconds, 30.0)
+    }
+
+    func test_chunkSeconds_unset_defaults_to_30() {
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.chunkSeconds, 30.0)
+    }
+
+    // MARK: - speakerSimilarityThreshold
+
+    func test_simThreshold_user_choice_above_070_survives_relaunch() {
+        // First launch on this suite: runs the one-shot legacy migration
+        // (and records that it ran).
+        let first = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(first.speakerSimilarityThreshold, 0.55, accuracy: 0.0001)
+
+        // The user drags the slider (0.5...0.95) to 0.8; didSet persists it.
+        first.speakerSimilarityThreshold = 0.8
+
+        // Relaunch: the choice must stick.
+        let second = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(second.speakerSimilarityThreshold, 0.8, accuracy: 0.0001,
+                       "A slider value ≥ 0.7 chosen after the one-shot migration must survive a relaunch")
+    }
+
+    func test_simThreshold_legacy_075_default_migrates_once_to_055() {
+        // A pre-migration suite carrying the old 0.75 default.
+        defaults.set(0.75, forKey: "liveAI.speakerSimilarityThreshold")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.speakerSimilarityThreshold, 0.55, accuracy: 0.0001,
+                       "The legacy 0.75 default must still be migrated on first launch")
+        // And the migration is recorded + written back, so it never re-runs.
+        XCTAssertTrue(defaults.bool(forKey: "liveAI.speakerSimilarityThreshold.migrated"))
+        XCTAssertEqual(defaults.double(forKey: "liveAI.speakerSimilarityThreshold"), 0.55,
+                       accuracy: 0.0001)
+    }
+
+    func test_simThreshold_legacy_sub_070_value_is_preserved_by_migration() {
+        defaults.set(0.6, forKey: "liveAI.speakerSimilarityThreshold")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.speakerSimilarityThreshold, 0.6, accuracy: 0.0001)
+    }
+
+    func test_simThreshold_unset_defaults_to_055() {
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.speakerSimilarityThreshold, 0.55, accuracy: 0.0001)
+    }
+}

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -39,6 +39,45 @@ final class MicrophoneRecorderTests: XCTestCase {
         await mic.stop()
     }
 
+    /// Regression: the timeout must fire even when the bring-up stalls in an
+    /// await that is NOT cancellation-responsive — which is exactly what the
+    /// real path does (`realBringUp` awaits a detached task's `.value`, and
+    /// the CoreAudio calls inside it can wedge indefinitely).
+    ///
+    /// The old `withThrowingTaskGroup`-based race could not exit until ALL
+    /// children finished: the timeout child threw at the deadline, but the
+    /// group then blocked awaiting the stuck operation child, so `start()`
+    /// stayed suspended until (or forever, if) CoreAudio returned. The test
+    /// above didn't catch this because its override stalls in a cancellable
+    /// `Task.sleep`. This one mirrors the real path's non-cancellable
+    /// structure: with the group race it returns only after the full 3s
+    /// stall; with the first-wins race it returns at the 0.15s deadline.
+    func test_timeout_fires_even_when_bring_up_is_not_cancellation_responsive() async throws {
+        let mic = MicrophoneRecorder()
+        mic.bringUpTimeout = 0.15
+        mic.bringUpOverride = {
+            // A detached task's `.value` ignores the awaiter's cancellation,
+            // and Thread.sleep inside it models a wedged CoreAudio
+            // dispatch_sync (won't return early for anyone).
+            await Task.detached { Thread.sleep(forTimeInterval: 3.0) }.value
+        }
+
+        let started = Date()
+        do {
+            try await mic.start()
+            XCTFail("Expected MicrophoneError.bringUpTimedOut; start() returned successfully")
+        } catch let error as MicrophoneError {
+            XCTAssertEqual(error, .bringUpTimedOut)
+            let elapsed = Date().timeIntervalSince(started)
+            // Must return near the 0.15s deadline — NOT after the 3s stall.
+            // 2.0s bound = generous CI jitter margin while still strictly
+            // below the stall duration.
+            XCTAssertLessThan(elapsed, 2.0,
+                              "start() must throw at the timeout deadline, not wait out the stalled bring-up; took \(elapsed)s")
+        }
+        await mic.stop()
+    }
+
     /// The bug being prevented: even if the bring-up *thread* is wedged on
     /// CoreAudio for hundreds of milliseconds, the main thread / dispatch
     /// queue must remain free to service UI work. We assert this by parking

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -116,6 +116,54 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
                        "Replaced send must not surface its output")
     }
 
+    /// Regression: when a send is cancelled-and-replaced, the REPLACED
+    /// task's self-cleanup must not wipe the REPLACEMENT's handle. Before
+    /// the fix, the first task's unconditional `defer { sendTasks[id] = nil }`
+    /// ran when it unwound with `.cancelled` — `isSending` went false while
+    /// the replacement CLI was still running, and `cancelAndDiscard` could
+    /// no longer reach it (the CLI kept running against a recording that
+    /// was being permanently deleted).
+    func test_replaced_send_does_not_orphan_replacement_handle() async throws {
+        let first = makeScript("""
+            #!/bin/sh
+            sleep 5
+            printf 'FIRST'
+            """)
+        let second = makeScript("""
+            #!/bin/sh
+            sleep 20
+            printf 'SECOND'
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: first)
+            try? FileManager.default.removeItem(at: second)
+        }
+
+        let rec = addCompletedRecording(text: "transcript")
+        coordinator.present(rec)
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
+                              transcript: "transcript", summary: "",
+                              executableOverride: first.path)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        // Replace: cancels the first task (its CLI gets SIGTERM'd and it
+        // unwinds through its defer while the second is still running).
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
+                              transcript: "transcript", summary: "",
+                              executableOverride: second.path)
+        // Give the replaced task ample time to unwind and run its cleanup.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        XCTAssertTrue(coordinator.isSending(rec.id),
+                      "The replacement send is still in flight — the replaced task's cleanup must not have cleared its handle")
+
+        // And the handle still works: discard reaches the replacement.
+        coordinator.cancelAndDiscard()
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertFalse(coordinator.isSending(rec.id),
+                       "cancelAndDiscard must be able to cancel the replacement send")
+    }
+
     // MARK: - Discard cancels an in-flight send
 
     /// Discarding the recording (cancelAndDiscard) must cancel a pending

--- a/MilaTests/RecordingDetailPlaceholderTests.swift
+++ b/MilaTests/RecordingDetailPlaceholderTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Mila
+
+/// Pins the empty-transcript placeholder decision in `RecordingDetailView`.
+/// The regression this guards: a recording queued behind the active
+/// transcription used to show "Click … Transcribe to start" while that very
+/// menu was disabled (`busy` in `actionButtons`), sending the user to a
+/// dead-end control.
+final class RecordingDetailPlaceholderTests: XCTestCase {
+
+    func test_queued_recording_shows_waiting_not_click_transcribe() {
+        XCTAssertEqual(
+            RecordingDetailView.emptyTranscriptPlaceholder(isActive: false, isQueued: true),
+            .waitingInQueue,
+            "A queued recording's Transcribe menu is disabled — the placeholder must not tell the user to click it."
+        )
+    }
+
+    func test_idle_recording_invites_transcription() {
+        XCTAssertEqual(
+            RecordingDetailView.emptyTranscriptPlaceholder(isActive: false, isQueued: false),
+            .clickTranscribe,
+            "With nothing queued the Transcribe menu is enabled, so the click-to-start instruction is actionable."
+        )
+    }
+
+    func test_active_recording_has_no_placeholder() {
+        XCTAssertNil(
+            RecordingDetailView.emptyTranscriptPlaceholder(isActive: true, isQueued: false),
+            "While actively transcribing, the progress view owns the transcript area — no placeholder."
+        )
+    }
+
+    func test_active_wins_over_queued() {
+        XCTAssertNil(
+            RecordingDetailView.emptyTranscriptPlaceholder(isActive: true, isQueued: true),
+            "An id can transiently be both active and pending; the progress view must win."
+        )
+    }
+}

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -40,6 +40,39 @@ final class RecordingStoreTests: XCTestCase {
         XCTAssertTrue(third.recordings.isEmpty)
     }
 
+    /// Regression: deleting an imported Voice Memo never stuck — the
+    /// importer dedups against the live store, and the source memo still
+    /// exists in the Voice Memos folder, so the next sync re-imported (and
+    /// re-transcribed) it. Permanent deletion must leave a persistent
+    /// tombstone the importer's dedup set includes.
+    func test_permanently_deleting_voice_memo_import_leaves_persistent_tombstone() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Imported memo",
+                            source: .microphone,
+                            audioFileName: "memo.wav",
+                            voiceMemoUniqueID: "memo-unique-123")
+        store.add(rec)
+        XCTAssertTrue(store.voiceMemoTombstones.isEmpty)
+
+        store.permanentlyDelete(rec)
+        XCTAssertTrue(store.voiceMemoTombstones.contains("memo-unique-123"),
+                      "Deleting a voice-memo import must tombstone its unique ID")
+
+        // Survives a relaunch (the importer syncs on every launch).
+        let reloaded = RecordingStore(rootDirectory: tempRoot)
+        XCTAssertTrue(reloaded.voiceMemoTombstones.contains("memo-unique-123"),
+                      "Tombstones must persist across store instances")
+    }
+
+    func test_permanently_deleting_non_import_leaves_no_tombstone() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Mic recording", source: .microphone,
+                            audioFileName: "plain.wav")
+        store.add(rec)
+        store.permanentlyDelete(rec)
+        XCTAssertTrue(store.voiceMemoTombstones.isEmpty)
+    }
+
     func test_soft_delete_moves_to_recently_deleted_and_restore_returns_it() {
         let store = RecordingStore(rootDirectory: tempRoot)
         let rec = Recording(title: "X", source: .microphone, audioFileName: "x.wav")

--- a/MilaTests/SpeakerDiarizerCancelTests.swift
+++ b/MilaTests/SpeakerDiarizerCancelTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Mila
+
+/// Regression coverage for `SpeakerDiarizer.runPython` honoring Swift task
+/// cancellation.
+///
+/// Before the fix, `runPython` had no cancellation path at all: cancelling
+/// the transcription task (user hits Cancel in the rename sheet, app
+/// shutdown) left the pyannote subprocess running to completion —
+/// `waitUntilExit()` blocked for the full diarization pass (minutes on a
+/// long recording that may already be deleted), and the serial transcription
+/// queue stalled behind it the whole time.
+final class SpeakerDiarizerCancelTests: XCTestCase {
+
+    /// Cancelling the awaiting task must SIGTERM the subprocess and unwind
+    /// with `CancellationError` promptly — not after the subprocess decides
+    /// to finish on its own (30s here, "whole pyannote pass" in production).
+    func test_cancelling_runPython_terminates_the_subprocess_promptly() async throws {
+        let task = Task {
+            try await SpeakerDiarizer.runPython(
+                path: "/bin/sh",
+                arguments: ["-c", "sleep 30"]
+            )
+        }
+        // Let the subprocess actually start.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let cancelledAt = Date()
+        task.cancel()
+        let result = await task.result
+        let elapsed = Date().timeIntervalSince(cancelledAt)
+
+        switch result {
+        case .success(let r):
+            XCTFail("Expected CancellationError, got success (exit \(r.exitCode))")
+        case .failure(let error):
+            XCTAssertTrue(error is CancellationError,
+                          "A SIGTERM'd run must surface as CancellationError, not \(error)")
+        }
+        // Generous bound for CI VM jitter; the point is "returns in seconds,
+        // not when the 30s subprocess finishes".
+        XCTAssertLessThan(elapsed, 10.0,
+                          "Cancellation must terminate the subprocess promptly; took \(elapsed)s")
+    }
+
+    /// Sanity: an uncancelled run still completes and returns stdout/stderr
+    /// and the exit code (the drain-then-wait plumbing survived the
+    /// cancellation refactor).
+    func test_uncancelled_runPython_still_returns_output_and_exit_code() async throws {
+        let result = try await SpeakerDiarizer.runPython(
+            path: "/bin/sh",
+            arguments: ["-c", "printf OUT; printf ERR >&2; exit 3"]
+        )
+        XCTAssertEqual(String(data: result.stdout, encoding: .utf8), "OUT")
+        XCTAssertEqual(String(data: result.stderr, encoding: .utf8), "ERR")
+        XCTAssertEqual(result.exitCode, 3)
+    }
+}

--- a/MilaTests/TranscriptExporterTests.swift
+++ b/MilaTests/TranscriptExporterTests.swift
@@ -55,6 +55,23 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertFalse(body.contains("00:00:01.500"))
     }
 
+    /// Regression: timestamps within 0.5ms below a minute boundary used to
+    /// emit an invalid `:60` seconds field — hours/minutes were truncated
+    /// from the raw double while the seconds field was rounded by printf,
+    /// so 59.9996 printed as "00:00:60,000" instead of "00:01:00,000".
+    /// Local whisper sits on a 10ms grid, but the remote path passes
+    /// through the server's full-precision floats.
+    func test_srt_time_rounds_up_across_minute_boundary() {
+        let rec = makeRecording(segments: [
+            .init(start: 59.9996, end: 3599.9996, text: "Boundary")
+        ])
+        let body = TranscriptExporter.srtBody(for: rec)
+        XCTAssertTrue(body.contains("00:01:00,000 --> 01:00:00,000"),
+                      "Rounding must carry into minutes/hours; got: \(body)")
+        XCTAssertFalse(body.contains(":60,"),
+                       "An SRT seconds field can never be 60: \(body)")
+    }
+
     func test_srt_body_prefixes_speaker_labels_when_present() {
         var seg1 = TranscriptSegment(start: 0, end: 1, text: "Hello")
         seg1.speaker = "SPEAKER_00"

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WERCalculator.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WERCalculator.swift
@@ -28,7 +28,18 @@ public enum WERCalculator {
     }
 
     private static func tokenize(_ text: String) -> [String] {
-        let stripped = text.unicodeScalars.filter { char in
+        // Fold typographic apostrophes to ASCII before the punctuation
+        // strip. The filter below exempts only U+0027, so "don’t" (smart
+        // quote U+2019, what most editors auto-insert) tokenized to "dont"
+        // while "don't" stayed "don't" — every contraction counted as a
+        // substitution when reference and hypothesis disagreed on the
+        // apostrophe form. Same for Hebrew geresh (U+05F3, ג׳ון) and the
+        // modifier-letter apostrophe (U+02BC).
+        let folded = text
+            .replacingOccurrences(of: "\u{2019}", with: "'")
+            .replacingOccurrences(of: "\u{05F3}", with: "'")
+            .replacingOccurrences(of: "\u{02BC}", with: "'")
+        let stripped = folded.unicodeScalars.filter { char in
             !CharacterSet.punctuationCharacters.contains(char) || CharacterSet(charactersIn: "'").contains(char)
         }
         return String(stripped)

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
@@ -326,10 +326,11 @@ public actor WhisperEngine {
         }
         params.abort_callback_user_data = userPtr
 
-        let langCString = strdup(language)
+        let lang = Self.languageParams(for: language)
+        let langCString = strdup(lang.language)
         defer { free(langCString) }
         params.language = UnsafePointer(langCString)
-        params.detect_language = (language == "auto" || language.isEmpty)
+        params.detect_language = lang.detectLanguage
 
         let result: Int32 = samples.withUnsafeBufferPointer { ptr in
             whisper_full(ctx, params, ptr.baseAddress, Int32(ptr.count))
@@ -445,6 +446,22 @@ public actor WhisperEngine {
         // 750 — the "discrete safe subdivision of 1500" point that
         // whisper's encoder accepts (see fixture sweep above).
         return 750
+    }
+
+    /// The `(language, detect_language)` pair handed to `whisper_full`.
+    ///
+    /// whisper.cpp already auto-detects — and then TRANSCRIBES — when
+    /// `params.language` is `"auto"` (or NULL). `params.detect_language`
+    /// means something else entirely: "return right after language
+    /// detection, skip transcription" (whisper_full in the pinned v1.8.4:
+    /// `if (params.detect_language) { return 0; }`). Setting it for our
+    /// Auto-detect mode made every local transcription in "auto" succeed
+    /// with ZERO segments — an empty transcript and no error anywhere.
+    /// So: `detect_language` is always false, and an empty language string
+    /// (which whisper would reject in `whisper_lang_id`) normalizes to
+    /// `"auto"`.
+    static func languageParams(for language: String) -> (language: String, detectLanguage: Bool) {
+        (language: language.isEmpty ? "auto" : language, detectLanguage: false)
     }
 
     /// Classify whisper.cpp's init-time log lines into a `CoreMLStatus`.

--- a/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/LanguageParamsTests.swift
+++ b/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/LanguageParamsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import TranscriptionCore
+
+/// Tests for `WhisperEngine.languageParams(for:)` — the policy behind the
+/// `params.language` / `params.detect_language` pair passed to `whisper_full`.
+///
+/// Regression: the engine used to set `detect_language = true` whenever the
+/// language was "auto" (or empty). In whisper.cpp, `detect_language` does NOT
+/// mean "auto-detect then transcribe" — it means "return right after language
+/// detection, skip transcription" (`if (params.detect_language) return 0;`
+/// in whisper_full). Passing `language = "auto"` alone already triggers
+/// detect-and-transcribe. The result: every local transcription with the 🌐
+/// Auto-detect toolbar language completed "successfully" with ZERO segments —
+/// an empty transcript, no error anywhere. (The remote path was unaffected,
+/// which masked the bug for remote-backend users.)
+final class LanguageParamsTests: XCTestCase {
+
+    func test_auto_language_never_sets_detect_language() {
+        let p = WhisperEngine.languageParams(for: "auto")
+        XCTAssertEqual(p.language, "auto")
+        XCTAssertFalse(p.detectLanguage,
+                       "detect_language=true makes whisper_full return before transcribing — Auto-detect must rely on language=\"auto\" alone")
+    }
+
+    func test_empty_language_normalizes_to_auto_without_detect_flag() {
+        let p = WhisperEngine.languageParams(for: "")
+        XCTAssertEqual(p.language, "auto",
+                       "whisper_lang_id rejects an empty string; it must normalize to \"auto\"")
+        XCTAssertFalse(p.detectLanguage)
+    }
+
+    func test_explicit_languages_pass_through_unchanged() {
+        for lang in ["en", "he"] {
+            let p = WhisperEngine.languageParams(for: lang)
+            XCTAssertEqual(p.language, lang)
+            XCTAssertFalse(p.detectLanguage)
+        }
+    }
+}

--- a/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/WERCalculatorTests.swift
+++ b/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/WERCalculatorTests.swift
@@ -49,4 +49,27 @@ final class WERCalculatorTests: XCTestCase {
         let wer = WERCalculator.calculate(reference: "שלום עולם", hypothesis: "שלום עולם")
         XCTAssertEqual(wer, 0.0, accuracy: 0.001)
     }
+
+    // MARK: - Apostrophe folding
+
+    /// Regression: the tokenizer exempted only ASCII U+0027 from the
+    /// punctuation strip, so a smart-quote reference ("don’t" — what most
+    /// editors auto-insert) tokenized to "dont" while the hypothesis's
+    /// ASCII "don't" stayed "don't": every contraction counted as a
+    /// substitution purely because of the apostrophe form.
+    func test_typographic_apostrophe_matches_ascii_apostrophe() {
+        let wer = WERCalculator.calculate(reference: "don\u{2019}t stop",
+                                          hypothesis: "don't stop")
+        XCTAssertEqual(wer, 0.0, accuracy: 0.001,
+                       "U+2019 and U+0027 apostrophes must normalize identically")
+    }
+
+    /// Same defect class for Hebrew: geresh (U+05F3) vs ASCII apostrophe
+    /// in loanwords like ג׳ון / ג'ון.
+    func test_hebrew_geresh_matches_ascii_apostrophe() {
+        let wer = WERCalculator.calculate(reference: "ג\u{05F3}ון הלך",
+                                          hypothesis: "ג'ון הלך")
+        XCTAssertEqual(wer, 0.0, accuracy: 0.001,
+                       "Hebrew geresh and ASCII apostrophe must normalize identically")
+    }
 }


### PR DESCRIPTION
# Bug-hunt sweep: 29 fixes across engine, capture, subprocess handling, and UI — with regression tests

A systematic audit of the codebase (five parallel review passes over Audio, Transcription, Models/Actions, Views, and TranscriptionCore/VoiceMemos), followed by fixes for every confirmed finding. 24 new regression tests pin the behavior.

## Headline: Auto-detect language produced EMPTY transcripts on the local engine

`WhisperEngine` set `params.detect_language = true` for the "auto" language. In whisper.cpp that flag means *"return right after language detection — skip transcription"* (`whisper_full`: `if (params.detect_language) return 0;`), so every local transcription with the 🌐 Auto-detect toolbar option "succeeded" with zero segments: empty transcript, no error anywhere. `language = "auto"` alone already triggers detect-and-transcribe. Reproduced empirically (large-v3-turbo, `en_hello_world.wav`: `"en"` → " Hello world.", `"auto"` → 0 segments). The remote path never had the bug, which masked it for remote-backend users.
**Fix:** never set `detect_language`; normalize empty language to `"auto"`. Policy extracted to `WhisperEngine.languageParams(for:)` + `LanguageParamsTests`.

## Correctness fixes (each with a regression test)

| Fix | Where | Test |
|---|---|---|
| Auto-detect → empty transcripts | `WhisperEngine.swift` | `LanguageParamsTests` (3) |
| Live AI tick-frequency 15/20s silently reset to 30s on every launch (init migration discarded values the 15–60s slider legitimately offers) | `LiveAISettings.swift` | `LiveAISettingsMigrationTests` (4) |
| Speaker-similarity ≥ 0.7 silently reset to 0.55 on every launch (migration re-ran forever; now one-shot with a persisted flag + write-back) | `LiveAISettings.swift` | `LiveAISettingsMigrationTests` (4) |
| Mic bring-up timeout never fired on the real path: a `withThrowingTaskGroup` race can't exit while the non-cancellable CoreAudio child is stuck, so a wedged Bluetooth mic hung `start()` forever despite the 5s deadline | `MicrophoneRecorder.swift` — first-wins continuation race; a bring-up that completes after the timeout is torn down via `onAbandoned` instead of holding the mic hot | `MicrophoneRecorderTests` |
| Cancelling a transcription never reached the pyannote subprocess — the full diarization pass kept burning CPU on a possibly-deleted recording while the serial queue stalled behind it | `SpeakerDiarizer.runPython` — `withTaskCancellationHandler` + SIGTERM, cancelled runs surface as `CancellationError` | `SpeakerDiarizerCancelTests` (2) |
| Replacing an in-flight "Send to LLM" orphaned the replacement's task handle (`isSending` went false mid-flight; Discard couldn't cancel it and the CLI ran against a deleted recording) | `PostRecordingCoordinator.swift` | `PostRecordingCoordinatorSendTests` |
| SRT export emitted invalid `00:00:60,000` timestamps within 0.5 ms of a minute boundary (truncated h/m + printf-rounded seconds) | `TranscriptExporter.swift` | `TranscriptExporterTests` |
| WER counted every contraction as an error when reference/hypothesis disagreed on apostrophe form (U+2019 smart quote / U+05F3 Hebrew geresh stripped as punctuation, ASCII `'` kept) | `WERCalculator.swift` | `WERCalculatorTests` (2) |
| Live Summary pane split bullets on every `.` character — "the budget is 3.5 million" shattered mid-number; now shares the detail pane's `.bySentences` tokenizer | `LiveAIRecordingView.swift` | `LiveAIBulletsTests` (5) |
| Enabling diarization mid-session ignored the persisted verified state → "Setup needed" for a verified setup until manual re-verify | `DiarizationSettings.swift` | `DiarizationSettingsTests` |
| Fresh `AVAudioConverter` per tap buffer reset the resampler filter every ~85 ms — a waveform discontinuity at every buffer boundary of every recording from a non-16 kHz device (i.e. all mics). New session-scoped `StreamingWhisperConverter` keeps filter state across buffers (mic tap, SCK output, file re-encode) | `AudioUtilities.swift`, `MicrophoneRecorder.swift`, `SystemAudioRecorder.swift`, `FileTranscriber.swift` | `AudioConvertTests` (DC-continuity) |
| LLM CLI timeout could still hang forever: after SIGKILL the pipe drain was an unbounded wait, and a grandchild (MCP server/node helper) holding stdout/stderr kept it blocked — summarizer/Live-AI slots stuck permanently | `LLMRunner.swift` — chunked lock-boxed reads + bounded (3s) drain | `LLMRunnerTests` |
| Dictation destroyed non-text clipboard contents (only `string(forType:)` was snapshotted; copy a screenshot, dictate, screenshot gone forever) | `DictationController.swift` — full item/type snapshot & restore | `DictationPasteboardTests` (3) |
| Deleted Voice-Memos imports resurrected on the next sync (dedup keyed on the live store; the source memo still exists) — permanent deletes now leave persisted tombstones the importer skips | `RecordingStore.swift`, `VoiceMemosImporter.swift` | `RecordingStoreTests` (2) |
| Queued recording's detail pane told the user to click a disabled Transcribe button — now shows "Waiting in queue" | `RecordingDetailView.swift` | `RecordingDetailPlaceholderTests` (4) |

## Fixes without a practical unit-test seam

- **Remote transcription of long recordings died at 120s** — `timeoutIntervalForRequest` is an *inactivity* timer and OpenAI-compatible servers send zero bytes while transcribing; anything needing >2 min of server time failed with "The request timed out". Per-request override to the 1-hour resource bound (`RemoteWhisperEngine.swift`).
- **Failed meeting-mode start leaked a hot mic + open WAV forever** — `system.start()` throwing (Screen Recording permission) left the already-started mic capturing with `state == .idle`, so `cancelAll()` refused to clean up. Bring-up is now wrapped with full teardown on throw; stale `pendingSystem` audio is also cleared at start so the previous meeting's app audio can't bleed into the next recording (`RecordingSession.swift`).
- **SCK audio delivered on a concurrent queue + per-buffer unordered `Task` hops** — buffer order into the saved mix wasn't guaranteed under load. Now a private serial sample queue with a direct thread-safe `yield` (`SystemAudioRecorder.swift`).
- **SCK stream death mid-meeting was swallowed** — TCC revocation/display change flipped `isRunning` but leaked the dead `SCStream` (stop()'s guard early-returned) and nothing was recorded anywhere; now cleaned up + surfaced via `lastStreamError`.
- **`InputLevelMonitor.stop()` during a slow bring-up orphaned a running engine** (mic indicator pinned with no window open) — generation counter; superseded bring-ups tear their engine down.
- **`DiarizationBootstrap` wrote pip/codesign output into never-read `Pipe()`s** — a ~64 KB buffer, not a sink; the exact PR #15 deadlock class. Now `FileHandle.nullDevice`.
- **Fast start→stop leaked the ~1 GB live-diarization daemon** — the detached `start()` could run after `stop()` no-op'd; a session token claimed synchronously at record-start supersedes the stale start (`LiveSpeakerDiarizer.swift`, `MilaApp.swift`). Also: the 30s ready-wait now bails as soon as the daemon dies, and the daemon's own startup error line is preserved instead of the generic "did not become ready"; stale stdout `readabilityHandler` detached on stop so leftover bytes can't be matched against the next daemon's queue.
- **Voice-Memos double-import race** — two sync requests in one main-actor drain both passed the `isSyncing` guard; re-checked on entry (`VoiceMemosImporter.swift`).
- **Model download failures were invisible** — every failure path (network drop, SHA mismatch, HTTP error page, final move) just removed the progress row. Now published as `ModelManager.lastDownloadError`, shown in Settings with a Dismiss button; HTTP status is checked before hashing so a HF 404 reads as "server returned HTTP 404" instead of a baffling integrity failure.
- **Dictation hotkey double-press double-started the pipeline** — re-entrancy guard set synchronously before the permission/bring-up awaits (`DictationController.swift`).
- **Hotkey rebinding could silently kill dictation** — `RegisterEventHotKey` failure (combo owned by another app/macOS) was dropped after the old combo was already unregistered: Settings showed the new combo as active while nothing worked. New combos are now probe-validated before persisting (inline error on failure), live registrations are suspended during capture so pressing a currently-bound combo is captured instead of starting dictation, and rows with a dead registration show a ⚠️ warning (`HotkeyManager.swift`, `SettingsView.swift`).
- **Diagnostic reports omitted the recording language** — the settings whitelist prefix `"recordingLanguage"` never matched the real key `recording.language` (`DiagnosticReporter.swift`).
- **Play button dead after playback reached the end** — rewinds to zero before playing (`RecordingDetailView.swift`).

## UX fixes

- "Delete Permanently" now asks for confirmation (destructive, no undo — same rationale as the Discard confirm).
- The toolbar search field now works on Home: routes to the all-recordings list filtered by the query.
- Renaming a folder to an existing name keeps the sheet open with an inline error instead of silently doing nothing.
- Whisper-model Delete asks for confirmation (multi-GB re-download) and surfaces deletion errors instead of `try?`-swallowing them.
- Return no longer bypasses disabled Save/Create buttons in the rename/folder sheets.

## Verification

- `swift test` (TranscriptionCore): all green, including the new `LanguageParamsTests` and WER apostrophe tests.
- Full `xcodebuild build-for-testing` clean; all new/extended test classes run green locally, plus every existing test class covering the modified files (`RemoteTranscriptionSettingsTests`, `RemoteWhisperEngineParsingTests`, `TranscriptionServiceTests`, `RecordingSummarizer*`, `LiveAI*`, `SystemCapabilitiesTests`, `VoiceMemos*`, `QuickActionsControllerTests`, `MeetingStopPromptTests`, `DiagnosticReporterTests`).
- UI-facing changes (placeholders, dialogs, search routing, hotkey capture flow) compile and are covered by logic-level tests where a seam exists, but have **not** been visually click-verified — reviewer eyes appreciated on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Settings hotkey capture with clearer inactive/combo-failed warnings, validation, and reliable park/resume behavior.
  * Surfaced model download failures directly in the Models UI, and improved live AI summary bullet splitting.

* **Bug Fixes**
  * Improved transcription reliability (safer timeouts, stream handling, and smoother audio resampling) and prevented stale subprocess output from impacting later recordings.
  * Fixed dictation pasteboard full-fidelity restore, prevented re-import of permanently deleted voice memos, corrected SRT time rounding, and refined search/queue/placeholder/play-pause behaviors.
  * Improved apostrophe matching and “auto” language handling for transcription/WER.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->