### PR TITLE
feat: color transcript speaker labels distinctly when multiple speakers detected

### DIFF
--- a/Mila/Transcription/SpeakerColor.swift
+++ b/Mila/Transcription/SpeakerColor.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Stable per-speaker color for the transcript UI. When diarization finds
+/// more than one speaker, each raw `SPEAKER_NN` ID gets its own color so a
+/// multi-speaker conversation is scannable at a glance instead of relying
+/// solely on the "Speaker A" / "Speaker B" text label.
+///
+/// The index is parsed directly from the raw diarizer ID (not hashed from
+/// the label) so the same speaker keeps the same color across every
+/// render of a recording, live or post-processed.
+private let speakerColorPalette: [Color] = [
+    .blue, .green, .orange, .purple, .pink, .teal, .indigo, .brown
+]
+
+extension String {
+    var speakerColor: Color {
+        let index: Int
+        if hasPrefix("SPEAKER_"), let n = Int(dropFirst("SPEAKER_".count)), n >= 0 {
+            index = n
+        } else {
+            index = abs(hashValue)
+        }
+        return speakerColorPalette[index % speakerColorPalette.count]
+    }
+}

--- a/Mila/Transcription/SpeakerColor.swift
+++ b/Mila/Transcription/SpeakerColor.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TranscriptionCore
 
 /// Stable per-speaker color for the transcript UI. When diarization finds
 /// more than one speaker, each raw `SPEAKER_NN` ID gets its own color so a
@@ -18,8 +19,40 @@ extension String {
         if hasPrefix("SPEAKER_"), let n = Int(dropFirst("SPEAKER_".count)), n >= 0 {
             index = n
         } else {
-            index = abs(hashValue)
+            // Real diarizer IDs are always `SPEAKER_NN`; this only covers
+            // non-standard IDs. `hashValue` is randomized per process, so it
+            // can't be used here without breaking the "stable color" promise
+            // across app relaunches — sum unicode scalars instead.
+            index = abs(unicodeScalars.reduce(0) { $0 &+ Int($1.value) })
         }
         return speakerColorPalette[index % speakerColorPalette.count]
+    }
+}
+
+/// Segment types that carry a diarizer speaker ID — `TranscriptSegment`
+/// (post-recording transcript) and `LiveSegment` (live transcript).
+protocol SpeakerBearingSegment {
+    var speaker: String? { get }
+}
+
+extension TranscriptSegment: SpeakerBearingSegment {}
+extension LiveSegment: SpeakerBearingSegment {}
+
+extension Sequence where Element: SpeakerBearingSegment {
+    /// True once at least two distinct speaker IDs have been seen. Short-
+    /// circuits as soon as a second distinct speaker turns up rather than
+    /// building a full `Set` of every speaker ID — matters for the live
+    /// transcript, which re-evaluates this on every growing-segment render.
+    var hasMultipleSpeakers: Bool {
+        var firstSpeaker: String?
+        for segment in self {
+            guard let speaker = segment.speaker else { continue }
+            if let firstSpeaker {
+                if speaker != firstSpeaker { return true }
+            } else {
+                firstSpeaker = speaker
+            }
+        }
+        return false
     }
 }

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -331,7 +331,7 @@ struct LiveAIRecordingView: View {
                             // than one distinct speaker to tell apart — a
                             // single-speaker recording keeps the plain
                             // tint color.
-                            let hasMultipleSpeakers = Set(transcriber.segments.compactMap(\.speaker)).count > 1
+                            let hasMultipleSpeakers = transcriber.segments.hasMultipleSpeakers
                             ForEach(transcriber.segments) { seg in
                                 TranscriptLineView(segment: seg, language: language, useSpeakerColor: hasMultipleSpeakers)
                                     .frame(maxWidth: .infinity, alignment: textAlignment)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -327,8 +327,13 @@ struct LiveAIRecordingView: View {
                                 .frame(maxWidth: .infinity, alignment: textAlignment)
                                 .accessibilityIdentifier("liveTranscript.listening")
                         } else {
+                            // Only color speaker labels once there's more
+                            // than one distinct speaker to tell apart — a
+                            // single-speaker recording keeps the plain
+                            // tint color.
+                            let hasMultipleSpeakers = Set(transcriber.segments.compactMap(\.speaker)).count > 1
                             ForEach(transcriber.segments) { seg in
-                                TranscriptLineView(segment: seg, language: language)
+                                TranscriptLineView(segment: seg, language: language, useSpeakerColor: hasMultipleSpeakers)
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
                                 // inside TranscriptLineView (where SwiftUI
@@ -474,6 +479,10 @@ private struct RecordingElapsedLabel: View {
 private struct TranscriptLineView: View {
     let segment: LiveSegment
     let language: String
+    /// Whether to color the speaker label per-speaker rather than the
+    /// default tint — set by the caller once it's seen more than one
+    /// distinct speaker across the live transcript.
+    var useSpeakerColor: Bool = false
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -488,7 +497,7 @@ private struct TranscriptLineView: View {
             if let sp = segment.speaker {
                 Text(sp.friendlySpeakerLabel(language: language))
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(useSpeakerColor ? sp.speakerColor : .tint)
                     .frame(minWidth: 96, alignment: .leading)
             } else {
                 Color.clear.frame(width: 96, height: 1)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -497,7 +497,7 @@ private struct TranscriptLineView: View {
             if let sp = segment.speaker {
                 Text(sp.friendlySpeakerLabel(language: language))
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? sp.speakerColor : .tint)
+                    .foregroundStyle(useSpeakerColor ? sp.speakerColor : Color.accentColor)
                     .frame(minWidth: 96, alignment: .leading)
             } else {
                 Color.clear.frame(width: 96, height: 1)

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -580,7 +580,7 @@ private struct SegmentRow: View {
             if showSpeaker, let raw = segment.speaker, !raw.isEmpty {
                 Text(raw.friendlySpeakerLabel(language: language) + ":")
                     .font(.body.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? raw.speakerColor : .tint)
+                    .foregroundStyle(useSpeakerColor ? raw.speakerColor : Color.accentColor)
                     .fixedSize(horizontal: true, vertical: false)
             }
             Text(segment.text)

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -329,10 +329,15 @@ struct RecordingDetailView: View {
                         // "Speaker A" so the user gets feedback that the
                         // detection ran (vs. silently failing to detect).
                         let hasSpeakers = recording.segments.contains { $0.speaker != nil }
+                        // Only color speaker labels once there's more than
+                        // one distinct speaker to tell apart — a single-
+                        // speaker recording keeps the plain tint color.
+                        let hasMultipleSpeakers = Set(recording.segments.compactMap(\.speaker)).count > 1
                         ForEach(recording.segments) { seg in
                             SegmentRow(segment: seg,
                                        isActive: currentTime >= seg.start && currentTime < seg.end,
                                        showSpeaker: hasSpeakers,
+                                       useSpeakerColor: hasMultipleSpeakers,
                                        language: recording.language,
                                        onTap: { seek(to: seg.start) })
                         }
@@ -555,6 +560,10 @@ private struct SegmentRow: View {
     let segment: TranscriptSegment
     let isActive: Bool
     let showSpeaker: Bool
+    /// Whether to color the speaker label per-speaker rather than the
+    /// default tint — set by the caller once it's seen more than one
+    /// distinct speaker across the recording.
+    let useSpeakerColor: Bool
     /// Recording's language so we can render the raw `SPEAKER_00`
     /// label from pyannote as `Speaker A` / `דובר א׳` in the user's
     /// language — matching the labels the live view + post-recording
@@ -571,7 +580,7 @@ private struct SegmentRow: View {
             if showSpeaker, let raw = segment.speaker, !raw.isEmpty {
                 Text(raw.friendlySpeakerLabel(language: language) + ":")
                     .font(.body.weight(.semibold))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(useSpeakerColor ? raw.speakerColor : .tint)
                     .fixedSize(horizontal: true, vertical: false)
             }
             Text(segment.text)

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -332,7 +332,7 @@ struct RecordingDetailView: View {
                         // Only color speaker labels once there's more than
                         // one distinct speaker to tell apart — a single-
                         // speaker recording keeps the plain tint color.
-                        let hasMultipleSpeakers = Set(recording.segments.compactMap(\.speaker)).count > 1
+                        let hasMultipleSpeakers = recording.segments.hasMultipleSpeakers
                         ForEach(recording.segments) { seg in
                             SegmentRow(segment: seg,
                                        isActive: currentTime >= seg.start && currentTime < seg.end,

--- a/MilaTests/SpeakerColorTests.swift
+++ b/MilaTests/SpeakerColorTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import SwiftUI
+@testable import Mila
+
+final class SpeakerColorTests: XCTestCase {
+
+    func test_same_speaker_id_always_gets_the_same_color() {
+        XCTAssertEqual("SPEAKER_00".speakerColor, "SPEAKER_00".speakerColor)
+        XCTAssertEqual("SPEAKER_03".speakerColor, "SPEAKER_03".speakerColor)
+    }
+
+    func test_different_speakers_get_different_colors() {
+        XCTAssertNotEqual("SPEAKER_00".speakerColor, "SPEAKER_01".speakerColor)
+        XCTAssertNotEqual("SPEAKER_00".speakerColor, "SPEAKER_02".speakerColor)
+        XCTAssertNotEqual("SPEAKER_01".speakerColor, "SPEAKER_02".speakerColor)
+    }
+
+    func test_color_wraps_around_the_palette_beyond_its_size() {
+        // Whatever the palette size N is, speaker N should reuse speaker 0's
+        // color rather than crash or silently default to one color.
+        var index = 0
+        var color = "SPEAKER_00".speakerColor
+        while true {
+            index += 1
+            let next = "SPEAKER_\(String(format: "%02d", index))".speakerColor
+            if next == color { break }
+            color = next
+            XCTAssertLessThan(index, 64, "Palette should wrap well before 64 distinct speakers.")
+        }
+    }
+
+    func test_non_standard_speaker_ids_still_resolve_to_a_stable_color() {
+        XCTAssertEqual("host".speakerColor, "host".speakerColor)
+        XCTAssertEqual("Alice".speakerColor, "Alice".speakerColor)
+    }
+}

--- a/MilaTests/SpeakerColorTests.swift
+++ b/MilaTests/SpeakerColorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftUI
+import TranscriptionCore
 @testable import Mila
 
 final class SpeakerColorTests: XCTestCase {
@@ -28,5 +29,35 @@ final class SpeakerColorTests: XCTestCase {
     func test_non_standard_speaker_ids_still_resolve_to_a_stable_color() {
         XCTAssertEqual("host".speakerColor, "host".speakerColor)
         XCTAssertEqual("Alice".speakerColor, "Alice".speakerColor)
+    }
+
+    // MARK: - hasMultipleSpeakers
+
+    private func transcriptSegment(speaker: String?) -> TranscriptSegment {
+        TranscriptSegment(start: 0, end: 1, text: "", speaker: speaker)
+    }
+
+    private func liveSegment(speaker: String?) -> LiveSegment {
+        LiveSegment(id: UUID(), startSeconds: 0, endSeconds: 1, text: "", speaker: speaker, stable: true)
+    }
+
+    func test_hasMultipleSpeakers_false_when_zero_or_one_distinct_speaker() {
+        XCTAssertFalse([TranscriptSegment]().hasMultipleSpeakers)
+        XCTAssertFalse([transcriptSegment(speaker: nil), transcriptSegment(speaker: nil)].hasMultipleSpeakers)
+        XCTAssertFalse([transcriptSegment(speaker: "SPEAKER_00"), transcriptSegment(speaker: "SPEAKER_00")].hasMultipleSpeakers)
+    }
+
+    func test_hasMultipleSpeakers_true_once_a_second_distinct_speaker_appears() {
+        let segments = [
+            transcriptSegment(speaker: "SPEAKER_00"),
+            transcriptSegment(speaker: nil),
+            transcriptSegment(speaker: "SPEAKER_01"),
+        ]
+        XCTAssertTrue(segments.hasMultipleSpeakers)
+    }
+
+    func test_hasMultipleSpeakers_works_for_live_segments_too() {
+        XCTAssertFalse([liveSegment(speaker: "SPEAKER_00")].hasMultipleSpeakers)
+        XCTAssertTrue([liveSegment(speaker: "SPEAKER_00"), liveSegment(speaker: "SPEAKER_01")].hasMultipleSpeakers)
     }
 }

--- a/MilaTests/SpeakerColorTests.swift
+++ b/MilaTests/SpeakerColorTests.swift
@@ -18,15 +18,11 @@ final class SpeakerColorTests: XCTestCase {
     func test_color_wraps_around_the_palette_beyond_its_size() {
         // Whatever the palette size N is, speaker N should reuse speaker 0's
         // color rather than crash or silently default to one color.
-        var index = 0
-        var color = "SPEAKER_00".speakerColor
-        while true {
-            index += 1
-            let next = "SPEAKER_\(String(format: "%02d", index))".speakerColor
-            if next == color { break }
-            color = next
-            XCTAssertLessThan(index, 64, "Palette should wrap well before 64 distinct speakers.")
+        let first = "SPEAKER_00".speakerColor
+        let wrapped = (1..<64).contains { index in
+            "SPEAKER_\(String(format: "%02d", index))".speakerColor == first
         }
+        XCTAssertTrue(wrapped, "Palette should wrap back to speaker 0's color well before 64 distinct speakers.")
     }
 
     func test_non_standard_speaker_ids_still_resolve_to_a_stable_color() {


### PR DESCRIPTION
## Summary
- When diarization detects more than one speaker in a recording, each speaker's label ("Speaker A", "Speaker B", ...) is now rendered in a distinct, stable color instead of the single default tint — in both the post-recording transcript (`SegmentRow`) and the live transcript pane (`TranscriptLineView`).
- Color is derived directly from the raw `SPEAKER_NN` diarizer ID via a small fixed palette (`Mila/Transcription/SpeakerColor.swift`), so the same speaker keeps the same color across renders. Single-speaker recordings are unaffected (still use `Color.accentColor`, matching the prior `.tint` look).

## Test plan
- [x] Added `MilaTests/SpeakerColorTests.swift` covering stability, distinctness, palette wraparound, and non-standard speaker IDs.
- [x] `make test` (full Xcode) caught two real bugs during local verification, both fixed here: a `foregroundStyle` ternary mixing `Color` and `.tint` that failed to build, and an infinite loop in the wraparound test. A full local test run was interrupted before completion after those fixes landed — worth a CI run / one more local `make test` before merge to confirm everything is green end-to-end.
- [ ] Manually verify in a multi-speaker recording that speaker labels show distinct colors in both the transcript and live views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript speaker labels now switch to consistent per-speaker coloring when multiple distinct speakers are detected (live and saved recordings).
  * Speaker color selection is deterministic from the speaker identifier.
* **Bug Fixes**
  * Speaker colors remain stable across app relaunches by avoiding non-deterministic hashing.
  * Supports non-standard speaker IDs with predictable color mapping.
* **Tests**
  * Added tests validating deterministic colors, palette wrapping, and multi-speaker detection across both transcript and live segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->