### PR TITLE
Fix #62: restore right-click context menu on sidebar transcript rows

### DIFF
--- a/Mila/Views/HistoryListView.swift
+++ b/Mila/Views/HistoryListView.swift
@@ -1,6 +1,4 @@
 import SwiftUI
-import AppKit
-import UniformTypeIdentifiers
 
 struct HistoryListView: View {
     let category: HistoryCategory
@@ -171,20 +169,9 @@ private struct HistoryRow: View {
     let recording: Recording
     @Binding var selection: SidebarSelection?
 
-    @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var transcription: TranscriptionService
-    @EnvironmentObject private var llm: LLMSettings
 
     @State private var hovering = false
-    @State private var renameRequest: String?
-    @State private var promptForNewFolder = false
-    @State private var newFolderDraft = ""
-    @State private var showingSendSheet = false
-    /// Confirmation gate before "Delete Permanently" actually removes the
-    /// files — unlike soft-delete there's no Trash to restore from, and
-    /// accidental loss of recordings was the #1 user complaint (same
-    /// rationale as the rename sheet's Discard confirm).
-    @State private var confirmingPermanentDelete = false
 
     var body: some View {
         let isSelected: Bool = {
@@ -247,167 +234,9 @@ private struct HistoryRow: View {
         .draggable(recording.isTrashed
                    ? RecordingDragPayload(id: UUID())   // unused — won't be matched
                    : RecordingDragPayload(id: recording.id))
-        .contextMenu { contextMenu }
+        .recordingContextMenu(recording: recording, selection: $selection)
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("history.row.\(recording.title)")
-        .sheet(item: Binding(
-            get: { renameRequest.map(RenameDraft.init) },
-            set: { if $0 == nil { renameRequest = nil } }
-        )) { draft in
-            RenameSheet(
-                initialTitle: draft.title,
-                onConfirm: { newTitle in
-                    store.rename(recording, to: newTitle)
-                    renameRequest = nil
-                },
-                onCancel: { renameRequest = nil }
-            )
-        }
-        .sheet(isPresented: $promptForNewFolder) {
-            FolderNameSheet(
-                title: "New Folder",
-                confirmLabel: "Create",
-                name: $newFolderDraft,
-                onConfirm: {
-                    if let created = store.createFolder(newFolderDraft) {
-                        store.assign(recording, toFolder: created)
-                    }
-                    promptForNewFolder = false
-                },
-                onCancel: { promptForNewFolder = false }
-            )
-        }
-        .sheet(isPresented: $showingSendSheet) {
-            SendToLLMSheet(recording: recording)
-        }
-        .confirmationDialog("Delete “\(recording.title)” permanently?",
-                            isPresented: $confirmingPermanentDelete,
-                            titleVisibility: .visible) {
-            Button("Delete Permanently", role: .destructive) {
-                store.permanentlyDelete(recording)
-                if case .recording(let id) = selection, id == recording.id {
-                    selection = .home
-                }
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            Text("The audio file and any transcript will be permanently deleted. This can't be undone.")
-        }
-    }
-
-    @ViewBuilder
-    private var contextMenu: some View {
-        if recording.isTrashed {
-            Button("Restore") { store.restore(recording) }
-            Divider()
-            Button("Delete Permanently", role: .destructive) {
-                confirmingPermanentDelete = true
-            }
-        } else {
-            Button("Rename…") {
-                renameRequest = recording.title
-            }
-            Menu("Move to Folder") {
-                Button(recording.folder == nil ? "✓ None" : "None") {
-                    store.assign(recording, toFolder: nil)
-                }
-                if !store.folders.isEmpty {
-                    Divider()
-                    ForEach(store.folders, id: \.self) { folder in
-                        Button(recording.folder == folder ? "✓ \(folder)" : folder) {
-                            store.assign(recording, toFolder: folder)
-                        }
-                    }
-                }
-                Divider()
-                Button("New Folder…") {
-                    newFolderDraft = ""
-                    promptForNewFolder = true
-                }
-            }
-            Divider()
-            let currentLang = RecordingLanguage.fromCode(recording.language)
-            // Busy = this recording is already transcribing or queued. We gate
-            // BEFORE mutating the store: `enqueue` drops active/queued ids, but
-            // `prepareForRetranscription` persists `.pending`/language first, so
-            // without this guard a re-transcribe on a busy row would clobber its
-            // status even though the enqueue itself no-ops.
-            let isBusy = transcription.activeRecordingID == recording.id
-                || transcription.pendingIDs.contains(recording.id)
-            Button("Re-transcribe (\(currentLang.flagEmoji) \(currentLang.displayName))") {
-                // Route through the live-store chokepoint (same as the
-                // language-switch action) so we never enqueue a stale snapshot
-                // whose `.wav` a since-run compression already deleted.
-                guard !isBusy,
-                      let prepared = store.prepareForRetranscription(id: recording.id)
-                else { return }
-                transcription.enqueue(prepared)
-            }
-            .disabled(isBusy)
-            Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
-                retranscribe(recording, in: currentLang.other)
-            }
-            .disabled(isBusy)
-            if llm.isConfigured {
-                Divider()
-                Button("Send to \(llm.tool.displayName)…") {
-                    showingSendSheet = true
-                }
-                .disabled(recording.fullText.isEmpty && recording.segments.isEmpty)
-            }
-            Divider()
-            Button("Export Subtitles (.srt)…") {
-                exportSRT()
-            }
-            .disabled(recording.segments.isEmpty)
-            Button("Reveal in Finder") {
-                NSWorkspace.shared.activateFileViewerSelecting([store.audioURL(for: recording)])
-            }
-            Divider()
-            Button("Delete", role: .destructive) {
-                store.softDelete(recording)
-                if case .recording(let id) = selection, id == recording.id {
-                    selection = .home
-                }
-            }
-        }
-    }
-
-    /// Switch the recording's stored language and re-enqueue it. The
-    /// `TranscriptionService` reads `recording.language` to pick the right
-    /// model (ivrit.ai for Hebrew, OpenAI for English), so updating the
-    /// store before enqueueing is enough to re-run with the other model.
-    private func retranscribe(_ recording: Recording, in language: RecordingLanguage) {
-        // Gate before mutating the store: a busy (active/queued) recording must
-        // not have its status/language flipped under an in-flight pass, because
-        // `enqueue` would then no-op the re-run while the store mutation stuck.
-        guard transcription.activeRecordingID != recording.id,
-              !transcription.pendingIDs.contains(recording.id)
-        else { return }
-        // Mutate only language+status on the LIVE record so we don't clobber a
-        // since-compressed `.m4a` audioFileName back to a deleted `.wav`.
-        guard let prepared = store.prepareForRetranscription(id: recording.id,
-                                                             language: language.rawValue)
-        else { return }
-        transcription.enqueue(prepared)
-    }
-
-    /// Save the recording's SRT to a user-chosen location. NSSavePanel lets
-    /// the user place subtitles next to the original video file (the main
-    /// "video → SRT" use case) or anywhere else they like. We use the
-    /// title as the suggested filename so dragging a video produces
-    /// `MyVideo.srt` next to `MyVideo.mp4` by default.
-    private func exportSRT() {
-        let panel = NSSavePanel()
-        panel.title = "Export Subtitles"
-        panel.allowedContentTypes = [.init(filenameExtension: "srt") ?? .data]
-        panel.nameFieldStringValue = recording.title + ".srt"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        do {
-            try TranscriptExporter.writeSRT(for: recording, to: url)
-        } catch {
-            NSAlert(error: error).runModal()
-        }
     }
 
     private var preview: String {
@@ -416,11 +245,6 @@ private struct HistoryRow: View {
         let end = t.index(t.startIndex, offsetBy: 140)
         return String(t[..<end]) + "…"
     }
-}
-
-private struct RenameDraft: Identifiable {
-    let title: String
-    var id: String { title }
 }
 
 struct RenameSheet: View {

--- a/Mila/Views/RecordingContextMenu.swift
+++ b/Mila/Views/RecordingContextMenu.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+import AppKit
+
+/// The per-recording context menu (Rename / Move to Folder / Re-transcribe /
+/// Send to LLM / Export / Reveal / Delete) shared by the "All Transcripts"
+/// list rows (`HistoryListView`'s `HistoryRow`) and the sidebar's inline
+/// recording sub-rows (`SidebarView`'s `RecordingSubRow`).
+///
+/// Extracted into a single modifier so the two lists can't drift: the sidebar
+/// sub-rows previously carried no context menu at all (issue #62 — a
+/// right-click regression), which was only possible because each list built
+/// its own menu independently. Both now call
+/// `.recordingContextMenu(recording:selection:)`.
+///
+/// The modifier owns the sheet/dialog state each row needs (rename, new
+/// folder, send-to-LLM, permanent-delete confirmation), so callers only pass
+/// the recording and the shared `selection` binding (used to navigate away
+/// when the currently-selected recording is deleted).
+extension View {
+    func recordingContextMenu(recording: Recording,
+                              selection: Binding<SidebarSelection?>) -> some View {
+        modifier(RecordingContextMenu(recording: recording, selection: selection))
+    }
+}
+
+private struct RecordingContextMenu: ViewModifier {
+    let recording: Recording
+    @Binding var selection: SidebarSelection?
+
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var transcription: TranscriptionService
+    @EnvironmentObject private var llm: LLMSettings
+
+    @State private var renameRequest: String?
+    @State private var promptForNewFolder = false
+    @State private var newFolderDraft = ""
+    @State private var showingSendSheet = false
+    /// Confirmation gate before "Delete Permanently" actually removes the
+    /// files — unlike soft-delete there's no Trash to restore from, and
+    /// accidental loss of recordings was the #1 user complaint (same
+    /// rationale as the rename sheet's Discard confirm).
+    @State private var confirmingPermanentDelete = false
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu { menuItems }
+            .sheet(item: Binding(
+                get: { renameRequest.map(RenameDraft.init) },
+                set: { if $0 == nil { renameRequest = nil } }
+            )) { draft in
+                RenameSheet(
+                    initialTitle: draft.title,
+                    onConfirm: { newTitle in
+                        store.rename(recording, to: newTitle)
+                        renameRequest = nil
+                    },
+                    onCancel: { renameRequest = nil }
+                )
+            }
+            .sheet(isPresented: $promptForNewFolder) {
+                FolderNameSheet(
+                    title: "New Folder",
+                    confirmLabel: "Create",
+                    name: $newFolderDraft,
+                    onConfirm: {
+                        if let created = store.createFolder(newFolderDraft) {
+                            store.assign(recording, toFolder: created)
+                        }
+                        promptForNewFolder = false
+                    },
+                    onCancel: { promptForNewFolder = false }
+                )
+            }
+            .sheet(isPresented: $showingSendSheet) {
+                SendToLLMSheet(recording: recording)
+            }
+            .confirmationDialog("Delete “\(recording.title)” permanently?",
+                                isPresented: $confirmingPermanentDelete,
+                                titleVisibility: .visible) {
+                Button("Delete Permanently", role: .destructive) {
+                    store.permanentlyDelete(recording)
+                    if case .recording(let id) = selection, id == recording.id {
+                        selection = .home
+                    }
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("The audio file and any transcript will be permanently deleted. This can't be undone.")
+            }
+    }
+
+    @ViewBuilder
+    private var menuItems: some View {
+        if recording.isTrashed {
+            Button("Restore") { store.restore(recording) }
+            Divider()
+            Button("Delete Permanently", role: .destructive) {
+                confirmingPermanentDelete = true
+            }
+        } else {
+            Button("Rename…") {
+                renameRequest = recording.title
+            }
+            Menu("Move to Folder") {
+                Button(recording.folder == nil ? "✓ None" : "None") {
+                    store.assign(recording, toFolder: nil)
+                }
+                if !store.folders.isEmpty {
+                    Divider()
+                    ForEach(store.folders, id: \.self) { folder in
+                        Button(recording.folder == folder ? "✓ \(folder)" : folder) {
+                            store.assign(recording, toFolder: folder)
+                        }
+                    }
+                }
+                Divider()
+                Button("New Folder…") {
+                    newFolderDraft = ""
+                    promptForNewFolder = true
+                }
+            }
+            Divider()
+            let currentLang = RecordingLanguage.fromCode(recording.language)
+            // Busy = this recording is already transcribing or queued. We gate
+            // BEFORE mutating the store: `enqueue` drops active/queued ids, but
+            // `prepareForRetranscription` persists `.pending`/language first, so
+            // without this guard a re-transcribe on a busy row would clobber its
+            // status even though the enqueue itself no-ops.
+            let isBusy = transcription.activeRecordingID == recording.id
+                || transcription.pendingIDs.contains(recording.id)
+            Button("Re-transcribe (\(currentLang.flagEmoji) \(currentLang.displayName))") {
+                // Route through the live-store chokepoint (same as the
+                // language-switch action) so we never enqueue a stale snapshot
+                // whose `.wav` a since-run compression already deleted.
+                guard !isBusy,
+                      let prepared = store.prepareForRetranscription(id: recording.id)
+                else { return }
+                transcription.enqueue(prepared)
+            }
+            .disabled(isBusy)
+            Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
+                retranscribe(recording, in: currentLang.other)
+            }
+            .disabled(isBusy)
+            if llm.isConfigured {
+                Divider()
+                Button("Send to \(llm.tool.displayName)…") {
+                    showingSendSheet = true
+                }
+                .disabled(recording.fullText.isEmpty && recording.segments.isEmpty)
+            }
+            Divider()
+            Button("Export Subtitles (.srt)…") {
+                exportSRT()
+            }
+            .disabled(recording.segments.isEmpty)
+            Button("Reveal in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([store.audioURL(for: recording)])
+            }
+            Divider()
+            Button("Delete", role: .destructive) {
+                store.softDelete(recording)
+                if case .recording(let id) = selection, id == recording.id {
+                    selection = .home
+                }
+            }
+        }
+    }
+
+    /// Switch the recording's stored language and re-enqueue it. The
+    /// `TranscriptionService` reads `recording.language` to pick the right
+    /// model (ivrit.ai for Hebrew, OpenAI for English), so updating the
+    /// store before enqueueing is enough to re-run with the other model.
+    private func retranscribe(_ recording: Recording, in language: RecordingLanguage) {
+        // Gate before mutating the store: a busy (active/queued) recording must
+        // not have its status/language flipped under an in-flight pass, because
+        // `enqueue` would then no-op the re-run while the store mutation stuck.
+        guard transcription.activeRecordingID != recording.id,
+              !transcription.pendingIDs.contains(recording.id)
+        else { return }
+        // Mutate only language+status on the LIVE record so we don't clobber a
+        // since-compressed `.m4a` audioFileName back to a deleted `.wav`.
+        guard let prepared = store.prepareForRetranscription(id: recording.id,
+                                                             language: language.rawValue)
+        else { return }
+        transcription.enqueue(prepared)
+    }
+
+    /// Save the recording's SRT to a user-chosen location. NSSavePanel lets
+    /// the user place subtitles next to the original video file (the main
+    /// "video → SRT" use case) or anywhere else they like. We use the
+    /// title as the suggested filename so dragging a video produces
+    /// `MyVideo.srt` next to `MyVideo.mp4` by default.
+    private func exportSRT() {
+        let panel = NSSavePanel()
+        panel.title = "Export Subtitles"
+        panel.allowedContentTypes = [.init(filenameExtension: "srt") ?? .data]
+        panel.nameFieldStringValue = recording.title + ".srt"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try TranscriptExporter.writeSRT(for: recording, to: url)
+        } catch {
+            NSAlert(error: error).runModal()
+        }
+    }
+}
+
+private struct RenameDraft: Identifiable {
+    let title: String
+    var id: String { title }
+}

--- a/Mila/Views/SidebarView.swift
+++ b/Mila/Views/SidebarView.swift
@@ -87,7 +87,7 @@ struct SidebarView: View {
 
                 if allTranscriptionsExpanded {
                     ForEach(unfiled) { rec in
-                        RecordingSubRow(recording: rec)
+                        RecordingSubRow(recording: rec, selection: $selection)
                     }
                 }
 
@@ -318,8 +318,14 @@ private struct AllTranscriptionsRow: View {
 /// beneath it. Tagged `.recording(id)` so List selection drives navigation
 /// straight to the transcript page, and `.draggable` so it can still be
 /// filed into a folder by dragging — same payload the history rows use.
+///
+/// Carries the same per-recording `.recordingContextMenu` as the
+/// All Transcripts list so right-click works here too (issue #62): the menu
+/// needs the shared `selection` binding to navigate away if the currently
+/// open recording is deleted from the row.
 private struct RecordingSubRow: View {
     let recording: Recording
+    @Binding var selection: SidebarSelection?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -338,6 +344,7 @@ private struct RecordingSubRow: View {
         .contentShape(Rectangle())
         .tag(SidebarSelection.recording(recording.id))
         .draggable(RecordingDragPayload(id: recording.id))
+        .recordingContextMenu(recording: recording, selection: $selection)
         .accessibilityIdentifier("sidebar.recording.\(recording.title)")
     }
 }

--- a/MilaUITests/OrganizationUITests.swift
+++ b/MilaUITests/OrganizationUITests.swift
@@ -82,6 +82,34 @@ final class OrganizationUITests: XCTestCase {
                       "Renamed recording did not appear in the list")
     }
 
+    /// Regression test for issue #62: right-clicking a transcript sub-row in
+    /// the expanded "All Transcriptions" sidebar section must surface the same
+    /// per-recording context menu as the All Transcripts list. The bug was
+    /// that `RecordingSubRow` had no `.contextMenu` attached at all, so
+    /// right-click did nothing. Both lists now share `.recordingContextMenu`.
+    func test_sidebar_transcript_subrow_shows_context_menu() {
+        let app = launchApp()
+
+        // `--ui-test-seed-recording` pins the "All Transcriptions" section
+        // open (see `MilaApp.init`), so the seeded recording is reachable as
+        // an inline sidebar sub-row without having to drive the disclosure
+        // triangle.
+        let subRow = app.descendants(matching: .any)
+            .matching(identifier: "sidebar.recording.Seed Recording")
+            .firstMatch
+        XCTAssertTrue(subRow.waitForExistence(timeout: 10),
+                      "Seeded recording sub-row not visible in the sidebar")
+
+        // Right-click must open the per-recording context menu. Before the
+        // fix, `RecordingSubRow` had no `.contextMenu`, so nothing appeared.
+        // "Move to Folder" is unique to this menu, so its presence proves the
+        // menu opened rather than a stray match from elsewhere.
+        subRow.rightClick()
+        let menuItem = app.menuItems["Move to Folder"].firstMatch
+        XCTAssertTrue(menuItem.waitForExistence(timeout: 5),
+                      "Context menu did not appear on sidebar transcript sub-row (issue #62)")
+    }
+
     func test_create_folder_from_sidebar_and_navigate_to_empty_folder() {
         let app = launchApp()
 


### PR DESCRIPTION
## Summary

Fixes #62 — right-clicking a transcript in the sidebar (under an expanded **All Transcriptions**) did nothing: no context menu, so you couldn't Rename / Move to Folder / Re-transcribe / Delete from the sidebar. The **All Transcripts** page still worked, which is what made this read as a regression in the sidebar list specifically.

## Root cause

The sidebar sub-rows (`RecordingSubRow` in `SidebarView.swift`) and the All Transcripts rows (`HistoryRow` in `HistoryListView.swift`) are two different views that each built their own menu. `RecordingSubRow` had **no `.contextMenu`** attached at all — the two lists drifted.

## Fix

Extract the per-recording context menu — along with its sheets (rename, new folder, send-to-LLM), the permanent-delete confirmation dialog, and the `retranscribe`/`exportSRT` helpers — into a single shared view modifier `recordingContextMenu(recording:selection:)` in a new `RecordingContextMenu.swift`.

Both `HistoryRow` and `RecordingSubRow` now apply the **same** modifier, so:
- right-click works on the sidebar sub-rows again (issue #62), and
- the two lists can't silently drift apart in the future (the concern raised in the issue).

`RecordingSubRow` now takes the shared `selection` binding so the menu can navigate away when the currently-open recording is deleted. Net change is `-178 / +37` lines in the two view files (the menu code moved, not duplicated).

## Testing

- `make build` and `xcodebuild build-for-testing` succeed (app + unit + UI test targets compile).
- Verified manually against a seeded debug build: right-clicking the sidebar sub-row now shows the full per-recording menu.
- Added a regression test `OrganizationUITests.test_sidebar_transcript_subrow_shows_context_menu` that right-clicks the seeded sidebar sub-row and asserts the context menu appears. (UI tests run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared right-click menu for recording rows, with actions like rename, move, re-transcribe, send, export subtitles, reveal in Finder, and delete.
  * Recording rows in the sidebar now support the same context menu as other transcript lists.

* **Bug Fixes**
  * Fixed transcript sub-rows so the context menu opens reliably from the sidebar.
  * Improved delete behavior so selection updates correctly when the current recording is removed.

* **Tests**
  * Added UI coverage for the sidebar transcript sub-row context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->