### PR TITLE
Add mid-recording SRT export button to the live transcript pane

### DIFF
--- a/Mila/Transcription/TranscriptExporter.swift
+++ b/Mila/Transcription/TranscriptExporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TranscriptionCore
 
 enum TranscriptExporter {
 
@@ -27,7 +28,15 @@ enum TranscriptExporter {
     /// history context menu so users can drop subtitles next to a source
     /// video file. Throws so the caller can surface failures via NSAlert.
     static func writeSRT(for recording: Recording, to url: URL) throws {
-        let body = srtBody(for: recording)
+        try writeSRT(segments: recording.segments, to: url)
+    }
+
+    /// Raw-segments variant: write an SRT for a segment list that isn't
+    /// (yet) attached to a saved `Recording`. Used by the mid-recording
+    /// "Export SRT…" button in the live transcript pane, which snapshots
+    /// `LiveTranscriber.segments` while the recording is still running.
+    static func writeSRT(segments: [TranscriptSegment], to url: URL) throws {
+        let body = srtBody(for: segments)
         guard !body.isEmpty else {
             throw NSError(domain: "TranscriptExporter", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "No transcript segments to export."])
@@ -38,7 +47,13 @@ enum TranscriptExporter {
     /// Format the SRT content for `recording`. Returns empty string when
     /// there's nothing to write (no segments, or every segment is blank).
     static func srtBody(for recording: Recording) -> String {
-        let segments = recording.segments
+        srtBody(for: recording.segments)
+    }
+
+    /// Format SRT content for a raw segment list. Returns empty string
+    /// when there's nothing to write (no segments, or every segment is
+    /// blank).
+    static func srtBody(for segments: [TranscriptSegment]) -> String {
         guard !segments.isEmpty else { return "" }
 
         var entries: [String] = []

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+import AppKit
 import OSLog
+import TranscriptionCore
 
 /// Replaces the Home view while a recording is active AND Live AI mode is
 /// configured + enabled. Two stacked panes (top: action items, bottom:
@@ -306,6 +308,21 @@ struct LiveAIRecordingView: View {
                 if transcriber.isTranscribing {
                     ProgressView().controlSize(.small)
                 }
+                // Mid-recording SRT export (issue #65): save whatever the
+                // live transcript has accumulated so far, without stopping
+                // the recording. The finished recording still gets its
+                // authoritative .srt sidecar on Stop as before.
+                Button {
+                    exportLiveSRT()
+                } label: {
+                    Label("Export SRT…", systemImage: "square.and.arrow.up")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(transcriber.segments.isEmpty ? Color.secondary : Color.accentColor)
+                .disabled(transcriber.segments.isEmpty)
+                .help("Save the transcript so far as an .srt subtitles file — recording keeps going.")
+                .accessibilityIdentifier("liveAI.exportSRT")
             }
             .padding(.horizontal, 18)
             .padding(.top, 14)
@@ -369,6 +386,35 @@ struct LiveAIRecordingView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color.primary.opacity(0.02))
+    }
+
+    /// Save the accumulated live transcript as an SRT to a user-chosen
+    /// location — mid-recording, without stopping (issue #65). The
+    /// segment list is snapshotted BEFORE the modal save panel runs, so
+    /// the exported file reflects the transcript as of the button press
+    /// even though the live loop keeps appending while the panel is up.
+    /// Mirrors `RecordingContextMenu.exportSRT` (NSSavePanel + NSAlert on
+    /// failure); the suggested filename matches the date-stamped default
+    /// title a stopped recording would get.
+    private func exportLiveSRT() {
+        let snapshot = transcriber.segments.map { ls in
+            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
+                              text: ls.text, speaker: ls.speaker)
+        }
+        guard !snapshot.isEmpty else { return }
+        let panel = NSSavePanel()
+        panel.title = "Export Subtitles"
+        panel.allowedContentTypes = [.init(filenameExtension: "srt") ?? .data]
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        panel.nameFieldStringValue = "Recording · \(f.string(from: Date())).srt"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try TranscriptExporter.writeSRT(segments: snapshot, to: url)
+        } catch {
+            NSAlert(error: error).runModal()
+        }
     }
 }
 

--- a/MilaTests/TranscriptExporterTests.swift
+++ b/MilaTests/TranscriptExporterTests.swift
@@ -111,6 +111,41 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertTrue(written.contains("Line two"))
     }
 
+    // MARK: - Raw-segments variant (mid-recording export, issue #65)
+
+    func test_srt_body_for_raw_segments_matches_recording_variant() {
+        let segments: [TranscriptSegment] = [
+            .init(start: 0.0, end: 1.2, text: "Hello", speaker: "SPEAKER_00"),
+            .init(start: 1.2, end: 2.4, text: " "),       // blank — must be skipped
+            .init(start: 2.4, end: 3.6, text: "World")
+        ]
+        let body = TranscriptExporter.srtBody(for: segments)
+        // The recording-based variant delegates here — both must agree.
+        XCTAssertEqual(body, TranscriptExporter.srtBody(for: makeRecording(segments: segments)))
+        XCTAssertTrue(body.contains("1\n00:00:00,000 --> 00:00:01,200\nSPEAKER_00: Hello"))
+        XCTAssertTrue(body.contains("2\n00:00:02,400 --> 00:00:03,600\nWorld"))
+    }
+
+    func test_writeSRT_raw_segments_writes_file_to_explicit_destination() throws {
+        let segments: [TranscriptSegment] = [
+            .init(start: 0.0, end: 1.0, text: "Live line one"),
+            .init(start: 1.0, end: 2.0, text: "Live line two")
+        ]
+        let dest = tempRoot.appendingPathComponent("live.srt")
+        try TranscriptExporter.writeSRT(segments: segments, to: dest)
+
+        let written = try String(contentsOf: dest, encoding: .utf8)
+        XCTAssertTrue(written.contains("Live line one"))
+        XCTAssertTrue(written.contains("Live line two"))
+    }
+
+    func test_writeSRT_raw_segments_throws_when_empty() {
+        let url = tempRoot.appendingPathComponent("empty-live.srt")
+        XCTAssertThrowsError(try TranscriptExporter.writeSRT(segments: [], to: url))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path),
+                       "No file should be created when there's nothing to write")
+    }
+
     func test_sidecar_writeSRT_removes_stale_file_for_empty_segments() throws {
         // Mimic the "re-transcription came back empty" path: there's an old
         // sidecar from a prior successful run, the new run produced no


### PR DESCRIPTION
Fixes island-io/mila#65

## What

Adds an **Export SRT…** button to the live transcript pane header so users can save the transcript captured so far as an `.srt` subtitles file **while the recording keeps running**. Previously the only path to an SRT was stopping the recording and using the history context menu / sidecar.

## How

- **`TranscriptExporter`**: new `writeSRT(segments:to:)` and `srtBody(for: [TranscriptSegment])` variants that operate on a raw segment list not yet attached to a saved `Recording`; the existing `Recording`-based functions now delegate to them (no behavior change for the sidecar or context-menu export).
- **`LiveAIRecordingView`**: button in the "Live transcript" pane header. It snapshots `transcriber.segments` **before** the modal `NSSavePanel` runs, so the exported file reflects the transcript as of the button press even though the live loop keeps appending while the panel is up. Disabled until the first segment lands. The suggested filename matches the date-stamped default title a stopped recording would get. Mirrors the existing `RecordingContextMenu.exportSRT` idiom (NSSavePanel + NSAlert on failure).

## Testing

- 3 new unit tests in `TranscriptExporterTests`: raw-segments output parity with the `Recording` variant, file write to an explicit destination, and empty-list error without file creation. All 11 exporter tests pass.
- Verified end-to-end in the running app (seeded live view): button renders in the pane header, save panel opens with the date-stamped name, and the exported file is valid SRT — sequential numbering, `HH:MM:SS,mmm` timestamps, and correct segment text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now export the live transcript as an `.srt` file while recording is still in progress.
  * A new save flow lets you choose where to store the subtitle file without stopping the recording.

* **Bug Fixes**
  * Export behavior now consistently handles empty transcripts and blank segments.
  * SRT output formatting remains unchanged, with the same speaker labeling and segment filtering as before.

* **Tests**
  * Added coverage for exporting from transcript segments and for empty-export failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->