### PR TITLE
Voice Memos: import modern .qta recordings + always-on start-date cutoff

### DIFF
--- a/Mila/Audio/FileTranscriber.swift
+++ b/Mila/Audio/FileTranscriber.swift
@@ -95,7 +95,7 @@ enum FileTranscriber {
     static let allowedExtensions: [String] = [
         "wav", "aif", "aiff", "caf",
         "m4a", "mp3", "aac",
-        "mp4", "mov", "m4v", "mkv",
+        "mp4", "mov", "m4v", "mkv", "qta",
         "webm", "ogg", "flac"
     ]
 }

--- a/Mila/Models/VoiceMemosSettings.swift
+++ b/Mila/Models/VoiceMemosSettings.swift
@@ -16,7 +16,15 @@ final class VoiceMemosSettings: ObservableObject {
     /// Master switch. Off by default: Voice Memos sync reads another app's
     /// data and kicks off bulk transcription, so it's strictly opt-in.
     @Published var isEnabled: Bool {
-        didSet { defaults.set(isEnabled, forKey: Keys.enabled) }
+        didSet {
+            defaults.set(isEnabled, forKey: Keys.enabled)
+            // Turning sync on starts the cutoff at today so a large existing
+            // library doesn't backfill years of memos into the queue. The user
+            // moves the date earlier in Settings to pull older recordings in.
+            if isEnabled, oldValue == false {
+                startDate = Calendar.current.startOfDay(for: Date())
+            }
+        }
     }
 
     /// `ZUUID`s of the Voice Memos folders the user chose to watch.
@@ -31,12 +39,22 @@ final class VoiceMemosSettings: ObservableObject {
         didSet { defaults.set(includeUnfiled, forKey: Keys.includeUnfiled) }
     }
 
+    /// Only import memos recorded on or after this date. Older memos are
+    /// skipped so enabling sync on a large existing library doesn't flood the
+    /// queue with years of backfill. Defaults to the start of today (set when
+    /// sync is turned on); the always-visible picker in Settings lets the user
+    /// move it earlier to backfill retroactively. Persisted as a plist `Date`.
+    @Published var startDate: Date {
+        didSet { defaults.set(startDate, forKey: Keys.startDate) }
+    }
+
     private let defaults: UserDefaults
 
     private enum Keys {
         static let enabled = "voiceMemos.enabled"
         static let folderUUIDs = "voiceMemos.folderUUIDs"
         static let includeUnfiled = "voiceMemos.includeUnfiled"
+        static let startDate = "voiceMemos.startDate"
     }
 
     /// Skip accidental sub-`minDurationSeconds` taps during bulk import. Voice
@@ -50,6 +68,16 @@ final class VoiceMemosSettings: ObservableObject {
         let stored = defaults.stringArray(forKey: Keys.folderUUIDs) ?? []
         self.selectedFolderUUIDs = Set(stored)
         self.includeUnfiled = defaults.bool(forKey: Keys.includeUnfiled)
+        if let stored = defaults.object(forKey: Keys.startDate) as? Date {
+            self.startDate = stored
+        } else {
+            // Pin to the start of today on first run so the value doesn't
+            // drift forward each launch — an unpinned "today" default would
+            // keep moving the cutoff and silently hold back yesterday's memos.
+            let today = Calendar.current.startOfDay(for: Date())
+            self.startDate = today
+            defaults.set(today, forKey: Keys.startDate)
+        }
     }
 
     /// True when the user has actually picked something to watch — gates the

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -30,6 +30,7 @@ struct VoiceMemosSettingsTab: View {
             case .available:
                 if settings.isEnabled {
                     folderPicker
+                    startDatePicker
                     statusFooter
                 }
             case .databaseMissing:
@@ -155,23 +156,73 @@ struct VoiceMemosSettingsTab: View {
         }
     }
 
+    /// Retroactive start-date cutoff. Always visible; defaults to today when
+    /// sync is turned on (see `VoiceMemosSettings`) so enabling on a large
+    /// library doesn't backfill years of memos. The user moves the date
+    /// earlier to pull in older recordings.
+    private var startDatePicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text("Transcribe memos recorded after")
+                DatePicker(
+                    "Start date",
+                    selection: $settings.startDate,
+                    in: ...Date(),
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.field)
+                .labelsHidden()
+                .fixedSize()
+            }
+            Text("Memos recorded before this date aren't imported. Move it earlier to backfill older recordings.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     private var statusFooter: some View {
-        HStack(spacing: 6) {
-            if importer.isSyncing {
-                ProgressView().controlSize(.small)
-                Text("Syncing…").foregroundStyle(.secondary)
-            } else if let error = importer.lastError {
-                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
-                Text(error).foregroundStyle(.secondary)
-            } else if let date = importer.lastSyncDate {
-                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-                Text("Last synced \(date.formatted(date: .abbreviated, time: .shortened)) — "
-                     + "\(importer.totalImported) imported this session")
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                if importer.isSyncing {
+                    ProgressView().controlSize(.small)
+                    Text("Syncing…").foregroundStyle(.secondary)
+                } else if let error = importer.lastError {
+                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                    Text(error).foregroundStyle(.secondary)
+                } else if let date = importer.lastSyncDate {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                    Text("Last synced \(date.formatted(date: .abbreviated, time: .shortened)) — "
+                         + "\(importer.totalImported) imported this session")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            // Explain why the last scan imported less than the folder count —
+            // otherwise "0 imported" with memos present looks broken (before
+            // the start-date cutoff, not downloaded yet, failed to decode…).
+            if !importer.isSyncing, importer.lastError == nil, let detail = lastScanDetail {
+                Text(detail)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.leading, 20)
             }
         }
         .font(.caption)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One-line "why were some skipped" summary of the most recent scan, or
+    /// nil when nothing was skipped.
+    private var lastScanDetail: String? {
+        let s = importer.lastSummary
+        var parts: [String] = []
+        if s.failedImport > 0 { parts.append("\(s.failedImport) failed to import") }
+        if s.skippedOlder > 0 { parts.append("\(s.skippedOlder) before start date") }
+        if s.skippedMissing > 0 { parts.append("\(s.skippedMissing) not downloaded from iCloud yet") }
+        if s.skippedShort > 0 { parts.append("\(s.skippedShort) too short") }
+        if s.skippedComposition > 0 { parts.append("\(s.skippedComposition) multi-take") }
+        guard !parts.isEmpty else { return nil }
+        return "Last scan held back " + parts.joined(separator: ", ") + "."
     }
 
     private func binding(for folder: VoiceMemosLibrary.Folder) -> Binding<Bool> {

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -12,8 +12,10 @@ import OSLog
 ///  - **Dedup:** every imported recording carries its `ZUNIQUEID` in
 ///    `Recording.voiceMemoUniqueID`; a rescan skips anything already present,
 ///    so restarts / repeated FSEvents bursts never re-import a memo.
-///  - **Filtering:** short pocket recordings, `.qta` (unsupported format) and
-///    `.composition` (multi-take) bundles are skipped, with counts surfaced.
+///  - **Filtering:** short pocket recordings, memos before the start-date
+///    cutoff, and `.composition` (multi-take) bundles are skipped, with counts
+///    surfaced. Modern `.qta` (QuickTime-container) memos import normally —
+///    `AVAudioFile`/`reencode` decodes their standard audio track.
 ///
 /// Imports reuse `FileTranscriber.importFile`, which re-encodes into the
 /// library and enqueues exactly like a drag-and-drop import — no new
@@ -28,12 +30,30 @@ final class VoiceMemosImporter: ObservableObject {
 
     private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceMemos")
 
+    /// Per-run tally the Settings status line reads to explain what the last
+    /// sync did — especially *why* it imported less than the folder count
+    /// (before the start-date cutoff, not downloaded yet, failed to decode…).
+    struct SyncSummary: Equatable {
+        var imported = 0
+        var failedImport = 0        // attempted but errored (couldn't decode/re-encode)
+        var skippedOlder = 0        // recorded before the start-date cutoff
+        var skippedShort = 0        // sub-minDurationSeconds pocket taps
+        var skippedComposition = 0  // multi-take .composition bundles
+        var skippedMissing = 0      // not downloaded from iCloud yet
+
+        var totalHeldBack: Int {
+            failedImport + skippedOlder + skippedShort + skippedComposition + skippedMissing
+        }
+    }
+
     /// Last successful sync timestamp, for the Settings status line.
     @Published private(set) var lastSyncDate: Date?
     /// Recordings enqueued by the most recent sync.
     @Published private(set) var lastImportedCount = 0
     /// Cumulative recordings imported this session.
     @Published private(set) var totalImported = 0
+    /// Breakdown of the most recent sync run (imported + why others skipped).
+    @Published private(set) var lastSummary = SyncSummary()
     @Published private(set) var isSyncing = false
     @Published private(set) var lastError: String?
 
@@ -157,6 +177,7 @@ final class VoiceMemosImporter: ObservableObject {
 
         let folderUUIDs = settings.selectedFolderUUIDs
         let includeUnfiled = settings.includeUnfiled
+        let startDate = settings.startDate
 
         // Read the (private, WAL-mode) DB off the main actor.
         let lib = library
@@ -179,17 +200,18 @@ final class VoiceMemosImporter: ObservableObject {
             .union(store.voiceMemoTombstones)
         let fm = FileManager.default
 
-        var imported = 0
-        var skippedShort = 0, skippedFormat = 0, skippedComposition = 0, skippedMissing = 0
+        var summary = SyncSummary()
 
         for memo in memos where !alreadyImported.contains(memo.uniqueID) {
-            if memo.isComposition { skippedComposition += 1; continue }
-            if memo.isUnsupportedFormat { skippedFormat += 1; continue }
-            if memo.duration < VoiceMemosSettings.minDurationSeconds { skippedShort += 1; continue }
+            // Start-date cutoff first, so the "before cutoff" count reflects
+            // everything the user's date choice held back.
+            if memo.date < startDate { summary.skippedOlder += 1; continue }
+            if memo.isComposition { summary.skippedComposition += 1; continue }
+            if memo.duration < VoiceMemosSettings.minDurationSeconds { summary.skippedShort += 1; continue }
             guard fm.fileExists(atPath: memo.fileURL.path) else {
                 // Not downloaded from iCloud yet (or evicted); a later
                 // FSEvents fire will catch it once it lands.
-                skippedMissing += 1
+                summary.skippedMissing += 1
                 continue
             }
 
@@ -204,15 +226,17 @@ final class VoiceMemosImporter: ObservableObject {
                     voiceMemoUniqueID: memo.uniqueID
                 )
                 transcription.enqueue(recording)
-                imported += 1
+                summary.imported += 1
             } catch {
+                summary.failedImport += 1
                 log.error("VoiceMemos import failed for \(memo.fileURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
 
-        lastImportedCount = imported
-        totalImported += imported
+        lastImportedCount = summary.imported
+        totalImported += summary.imported
+        lastSummary = summary
         lastSyncDate = Date()
-        log.log("VoiceMemos sync: imported \(imported), skipped short=\(skippedShort) format=\(skippedFormat) composition=\(skippedComposition) missing=\(skippedMissing)")
+        log.log("VoiceMemos sync: imported \(summary.imported), failed=\(summary.failedImport) older=\(summary.skippedOlder) short=\(summary.skippedShort) composition=\(summary.skippedComposition) missing=\(summary.skippedMissing)")
     }
 }

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -132,13 +132,6 @@ struct VoiceMemosLibrary {
         var isComposition: Bool {
             fileURL.pathExtension.lowercased() == "composition"
         }
-
-        /// `.qta` is the newer (2025+) Voice Memos container that whisper /
-        /// AVAudioFile can't open directly — flagged so the importer can
-        /// skip it until a conversion step exists.
-        var isUnsupportedFormat: Bool {
-            fileURL.pathExtension.lowercased() == "qta"
-        }
     }
 
     enum LibraryError: LocalizedError, Equatable {

--- a/MilaTests/VoiceMemosLibraryTests.swift
+++ b/MilaTests/VoiceMemosLibraryTests.swift
@@ -147,10 +147,12 @@ final class VoiceMemosLibraryTests: XCTestCase {
         XCTAssertEqual(rec1.duration, 12.0, accuracy: 0.001)
         XCTAssertEqual(rec1.date, Date(timeIntervalSinceReferenceDate: 700000000.0))
         XCTAssertEqual(rec1.fileURL, tempRoot.appendingPathComponent("file1.m4a"))
-        XCTAssertFalse(rec1.isUnsupportedFormat)
         XCTAssertFalse(rec1.isComposition)
 
-        XCTAssertTrue(try XCTUnwrap(byID["rec-6"]).isUnsupportedFormat)  // .qta
-        XCTAssertTrue(try XCTUnwrap(byID["rec-7"]).isComposition)        // .composition
+        // `.qta` (the modern QuickTime-container Voice Memo) is a flat audio
+        // file the import path decodes normally — it must NOT be treated as a
+        // `.composition` bundle and skipped.
+        XCTAssertFalse(try XCTUnwrap(byID["rec-6"]).isComposition)  // .qta imports normally
+        XCTAssertTrue(try XCTUnwrap(byID["rec-7"]).isComposition)   // .composition
     }
 }


### PR DESCRIPTION
## Problem

Voice Memos sync **silently imports nothing** for anyone recording on a current iPhone.

Modern iOS (18+) Voice Memos save as **`.qta`** — a QuickTime container holding a standard AAC audio track alongside an Apple Positional Audio Codec (APAC / spatial) track. Mila skipped every `.qta` on its *file extension*, based on a code comment claiming "whisper / AVAudioFile can't open directly."

That assumption is false on macOS 26. I verified with Mila's exact decode call:

```
AVAudioFile(forReading: <a real .qta>)  →  opens OK
  processingFormat: 2 ch, 48000 Hz, Float32
  frames: 1290240   duration: 26.88 sec
  peak amplitude: 0.4370  → real audio (reads the AAC track, ignores the spatial one)
```

`afconvert -f WAVE -d LEI16@16000 -c 1 file.qta out.wav` also produces a clean 16 kHz mono WAV. So `.qta` was always transcribable — the blanket skip just refused it. On a test library of 13 unfiled memos, **12 were `.qta`** and every sync logged `imported 0, skipped format=12`.

## What this changes

- **Import `.qta`.** Stop pre-skipping on the extension; let the existing `reencode()` path handle it. `AVAudioFile`/ExtAudioFile sniffs file *content* (not extension) and already accepts `.mov`/`.mp4`/AAC. `.qta` is also added to the manual Open-file panel's allowed extensions.
- **Real failure accounting.** The old pre-emptive "unsupported format" skip is replaced by a `failedImport` counter incremented only when an import *actually throws* — so a genuinely-undecodable file is surfaced, not silently dropped.
- **Start-date cutoff.** New `VoiceMemosSettings.startDate` defaults to the start of *today* when sync is turned on, so enabling on a large library doesn't backfill years of memos into the queue. The date picker is **always visible**; move it earlier to backfill older recordings.
- **Honest status line.** Settings now shows a per-scan breakdown (imported / failed / before start date / not downloaded yet / too short / multi-take), so a low import count is never an unexplained "0 imported" mystery.

## Testing

- `make build` succeeds.
- Verified end-to-end on a real synced library: after the fix, the 12 previously-skipped `.qta` memos import and transcribe.
- Updated `VoiceMemosLibraryTests` (a `.qta` fixture is no longer flagged unsupported; `.composition` still is).

Relates to #56, #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing QTA audio files.
  * Added a start-date setting to skip older voice memos during import.
  * Added clearer scan summaries showing imported, skipped, failed, and unavailable recordings.
* **Bug Fixes**
  * Improved handling and reporting of unsupported or incomplete recordings.
  * Automatically initializes the import start date when voice memo syncing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->