### PR TITLE
Fix stuck-in-Queue recordings: re-enqueue stale .pending at launch

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1298,6 +1298,12 @@ struct MilaApp: App {
         //    own. `enqueue` is idempotent, so a row also re-attached as a
         //    recovered orphan in step 2 is still enqueued at most once.
         let fm = FileManager.default
+        // Collect the status changes and re-enqueues, then persist once at the
+        // end. `store.update(_:)` rewrites the whole recordings file per call,
+        // so a large synced library (dozens of stale `.pending` rows) would
+        // otherwise fire a burst of synchronous full-file writes on launch.
+        var statusChanged: [Recording] = []
+        var toEnqueue: [Recording] = []
         for recording in store.recordings
         where recording.status == .running || recording.status == .pending {
             let wavURL = store.audioURL(for: recording)
@@ -1311,18 +1317,20 @@ struct MilaApp: App {
                 // `.pending` row is re-enqueued as-is.
                 if fixed.status != .pending {
                     fixed.status = .pending
-                    store.update(fixed)
+                    statusChanged.append(fixed)
                 }
                 print("MilaApp: re-enqueuing stale \(recording.status.rawValue) recording \(recording.audioFileName)")
-                transcription.enqueue(fixed)
+                toEnqueue.append(fixed)
             case .markFailed:
                 fixed.status = .failed
-                store.update(fixed)
+                statusChanged.append(fixed)
                 print("MilaApp: reset stale \(recording.status.rawValue) recording \(recording.audioFileName) to .failed (WAV missing)")
             case .leaveAlone:
                 break  // unreachable given the `where` filter above
             }
         }
+        store.updateAll(statusChanged)          // single persist for the whole sweep
+        toEnqueue.forEach(transcription.enqueue)
 
         // 2. Auto-enqueue recovered orphans.
         let ids = store.consumePendingRecoveryIDs()

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1246,17 +1246,41 @@ struct MilaApp: App {
         }
     }
 
+    /// Recovery decision for one recording left over from a previous
+    /// session, factored out of `enqueueRecoveredRecordings` so the launch
+    /// sweep is unit-testable without the App/SwiftUI lifecycle.
+    enum RecoveryAction: Equatable {
+        case reenqueue    // hand back to the transcription worker
+        case markFailed   // audio is gone — stop the row from retrying
+        case leaveAlone   // terminal / already settled
+    }
+
+    /// `.running` (died mid-transcription) and `.pending` (queued but never
+    /// started) are both mid-flight leftovers the fresh worker won't resume
+    /// on its own: re-enqueue when the `.wav` survives, else `.failed`.
+    /// `.completed` / `.failed` are terminal and left untouched.
+    static func recoveryAction(status: TranscriptionStatus, wavExists: Bool) -> RecoveryAction {
+        switch status {
+        case .running, .pending:
+            return wavExists ? .reenqueue : .markFailed
+        case .completed, .failed:
+            return .leaveAlone
+        }
+    }
+
     /// Crash-recovery sweep + stale-status cleanup. Two things happen
     /// here at launch:
-    ///   1. Any recording left in `.running` from a previous session
-    ///      (the app died while whisper was mid-transcription OR while
-    ///      the stop-time live-drain in `QuickActionsController` was
-    ///      still in flight) is reset to `.pending` and re-enqueued for
-    ///      transcription — provided its `.wav` is still on disk.
-    ///      Without re-enqueue, the row would sit in `.running` forever
-    ///      (the worker never publishes it on the new process) and the
-    ///      Queue view's "still-pending fallback" keeps showing it.
-    ///      If the WAV is gone we fall back to `.failed` so the row
+    ///   1. Any recording left mid-flight from a previous session is
+    ///      re-enqueued — both `.running` (the app died while whisper was
+    ///      mid-transcription OR the stop-time live-drain in
+    ///      `QuickActionsController` was still in flight) and `.pending`
+    ///      (queued but never started before the app quit). The worker on
+    ///      this fresh process boots with an empty queue and won't touch
+    ///      either unless we hand it back, so a `.pending` row would
+    ///      otherwise sit in the Queue forever showing "Queued" and a
+    ///      `.running` row would never advance. `.running` is first reset to
+    ///      `.pending`; both are re-enqueued provided the `.wav` is still on
+    ///      disk. If the WAV is gone we fall back to `.failed` so the row
     ///      doesn't loop forever trying to read a missing file.
     ///   2. Orphan .wav files re-attached by RecordingStore as
     ///      `.pending` are enqueued for transcription so the user
@@ -1267,26 +1291,36 @@ struct MilaApp: App {
     /// `.failed` in the list so empty orphans don't nag the user at
     /// launch.
     private func enqueueRecoveredRecordings() {
-        // 1. Reset stale .running recordings. The current process
-        //    hasn't started its worker loop yet — anything still
-        //    flagged .running must be a leftover.
+        // 1. Resurrect stale mid-flight recordings. The current process
+        //    hasn't started its worker loop yet, so anything still flagged
+        //    `.running` (died mid-transcription) or `.pending` (queued but
+        //    never started) is a leftover the new worker won't resume on its
+        //    own. `enqueue` is idempotent, so a row also re-attached as a
+        //    recovered orphan in step 2 is still enqueued at most once.
         let fm = FileManager.default
-        for recording in store.recordings where recording.status == .running {
+        for recording in store.recordings
+        where recording.status == .running || recording.status == .pending {
             let wavURL = store.audioURL(for: recording)
             var fixed = recording
-            if fm.fileExists(atPath: wavURL.path) {
-                // Stop-time drain or batch worker died mid-transcription;
-                // the audio is still on disk, so re-queue for a fresh
-                // batch run instead of stranding the row at `.failed`
-                // (which has no recovery path the user can self-serve).
-                fixed.status = .pending
-                store.update(fixed)
-                print("MilaApp: re-enqueuing stale .running recording \(recording.audioFileName)")
+            switch Self.recoveryAction(status: recording.status,
+                                       wavExists: fm.fileExists(atPath: wavURL.path)) {
+            case .reenqueue:
+                // Audio still on disk: re-queue for a fresh batch run rather
+                // than stranding the row at `.failed` (no self-serve recovery
+                // path). `.running` is reset to `.pending`; an already
+                // `.pending` row is re-enqueued as-is.
+                if fixed.status != .pending {
+                    fixed.status = .pending
+                    store.update(fixed)
+                }
+                print("MilaApp: re-enqueuing stale \(recording.status.rawValue) recording \(recording.audioFileName)")
                 transcription.enqueue(fixed)
-            } else {
+            case .markFailed:
                 fixed.status = .failed
                 store.update(fixed)
-                print("MilaApp: reset stale .running recording \(recording.audioFileName) to .failed (WAV missing)")
+                print("MilaApp: reset stale \(recording.status.rawValue) recording \(recording.audioFileName) to .failed (WAV missing)")
+            case .leaveAlone:
+                break  // unreachable given the `where` filter above
             }
         }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -322,6 +322,23 @@ final class RecordingStore: ObservableObject {
         persist()
     }
 
+    /// Replace several stored records in one pass with a SINGLE persist, vs.
+    /// `update(_:)`'s one full-file rewrite per call. Used by the launch
+    /// crash-recovery sweep, which can flip many stale rows at once (a large
+    /// synced library can leave dozens of `.pending` rows). This is a
+    /// status/metadata bulk update — transcript/summary sidecars are left
+    /// as-is (recovery doesn't change their content). Unknown ids are skipped;
+    /// persists only if something actually changed.
+    func updateAll(_ updated: [Recording]) {
+        var touched = false
+        for recording in updated {
+            guard let idx = recordings.firstIndex(where: { $0.id == recording.id }) else { continue }
+            recordings[idx] = recording
+            touched = true
+        }
+        if touched { persist() }
+    }
+
     /// Flip a recording into `.pending` (optionally switching its transcription
     /// `language`) and return the CURRENT store record, ready to hand to
     /// `TranscriptionService.enqueue`.

--- a/MilaTests/LaunchRecoveryTests.swift
+++ b/MilaTests/LaunchRecoveryTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Mila
+
+/// Unit tests for the launch crash-recovery decision (`MilaApp.recoveryAction`),
+/// the pure core of `enqueueRecoveredRecordings`.
+///
+/// REGRESSION: the sweep used to only resurrect `.running` recordings, so a
+/// recording persisted as `.pending` (queued but never started before the app
+/// quit) was never re-enqueued on the next launch — it sat in the Queue forever
+/// showing "Queued". `.pending` must be recovered exactly like `.running`.
+final class LaunchRecoveryTests: XCTestCase {
+
+    // MARK: - .pending is recovered (the regression)
+
+    func test_pending_with_audio_is_reenqueued() {
+        XCTAssertEqual(
+            MilaApp.recoveryAction(status: .pending, wavExists: true),
+            .reenqueue,
+            "A .pending recording whose WAV survives must be re-enqueued at launch, not stranded in the Queue."
+        )
+    }
+
+    func test_pending_without_audio_is_failed() {
+        XCTAssertEqual(
+            MilaApp.recoveryAction(status: .pending, wavExists: false),
+            .markFailed,
+            "A .pending recording whose WAV is gone can't be recovered — mark it .failed so it stops retrying."
+        )
+    }
+
+    // MARK: - .running keeps its existing behavior
+
+    func test_running_with_audio_is_reenqueued() {
+        XCTAssertEqual(MilaApp.recoveryAction(status: .running, wavExists: true), .reenqueue)
+    }
+
+    func test_running_without_audio_is_failed() {
+        XCTAssertEqual(MilaApp.recoveryAction(status: .running, wavExists: false), .markFailed)
+    }
+
+    // MARK: - Terminal states are never touched
+
+    func test_completed_is_left_alone_regardless_of_audio() {
+        XCTAssertEqual(MilaApp.recoveryAction(status: .completed, wavExists: true), .leaveAlone)
+        XCTAssertEqual(MilaApp.recoveryAction(status: .completed, wavExists: false), .leaveAlone)
+    }
+
+    func test_failed_is_left_alone_regardless_of_audio() {
+        XCTAssertEqual(MilaApp.recoveryAction(status: .failed, wavExists: true), .leaveAlone)
+        XCTAssertEqual(MilaApp.recoveryAction(status: .failed, wavExists: false), .leaveAlone)
+    }
+}


### PR DESCRIPTION
## Problem

A recording can get **stuck in the Queue forever showing "Queued"** and never transcribe.

The launch crash-recovery sweep (`enqueueRecoveredRecordings`) only resurrected `.running` recordings. A recording persisted as **`.pending`** — queued but never started before the app quit — was never re-enqueued on the next launch. The fresh process boots its transcription worker with an empty queue and never touches an existing `.pending` row, so it stays stuck indefinitely (the Queue view's still-pending fallback keeps showing it).

## Fix

Recover `.pending` exactly like `.running`:
- Re-enqueue when the `.wav` still exists, else mark `.failed` so the row doesn't loop forever trying to read a missing file.
- `.running` is first reset to `.pending` (unchanged behaviour); an already-`.pending` row is re-enqueued as-is.
- `enqueue` is idempotent, so a row also re-attached as a recovered orphan is enqueued at most once.

The per-recording decision is factored into a pure, side-effect-free `MilaApp.recoveryAction(status:wavExists:)`, unit-tested by `LaunchRecoveryTests` without needing the App/SwiftUI lifecycle.

## Testing

- `make build` succeeds.
- `LaunchRecoveryTests` covers: `.pending`/`.running` + WAV → re-enqueue; `.pending`/`.running` without WAV → failed; `.completed`/`.failed` → left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch-time recovery for interrupted transcription jobs.
  * Pending and in-progress recordings are now handled consistently: they’re re-queued when audio exists, and marked failed when audio is missing.
  * Completed and previously failed recordings remain unchanged during recovery.

* **Tests**
  * Added unit tests covering the recovery decision logic to prevent regressions across all relevant statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->