### PR TITLE
Let users stop and remove stuck Queue items

### DIFF
--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -421,6 +421,28 @@ final class RecordingStore: ObservableObject {
         }
     }
 
+    /// Mark a queued/in-progress recording as no longer transcribing after the
+    /// user cancelled it from the Queue. We land it in `.failed` — the existing
+    /// terminal state — rather than adding a dedicated `.cancelled` case: the
+    /// Queue only keeps `.pending`/`.running` rows, so a cancelled item drops
+    /// out of the Queue either way, and every status-rendering site (list rows,
+    /// detail view) already handles `.failed`. The recording + its audio stay on
+    /// disk so the user can still re-transcribe it later; use
+    /// `permanentlyDelete` when they want it gone.
+    ///
+    /// Paired with `TranscriptionService.cancel(recordingID:)`, which trips the
+    /// engine's abort flag so the in-flight whisper pass unwinds. That path
+    /// deliberately leaves the store status alone (the discard coordinator owns
+    /// the delete), so a Queue-level cancel must flip the status itself —
+    /// otherwise a `.running` item would sit in the Queue forever. No-op if the
+    /// recording is already in a terminal state.
+    func cancelTranscription(_ recording: Recording) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recording.id }) else { return }
+        guard recordings[idx].status == .pending || recordings[idx].status == .running else { return }
+        recordings[idx].status = .failed
+        persist()
+    }
+
     /// Move to "Recently Deleted". The audio file stays on disk until permanent delete.
     func softDelete(_ recording: Recording) {
         guard let idx = recordings.firstIndex(where: { $0.id == recording.id }) else { return }

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -548,7 +548,7 @@ private struct QueueView: View {
                 } else {
                     VStack(spacing: 8) {
                         ForEach(Array(queue.enumerated()), id: \.element.id) { index, rec in
-                            QueueRow(recording: rec, position: index)
+                            QueueRow(recording: rec, position: index, selection: $selection)
                                 .contentShape(Rectangle())
                                 .onTapGesture { selection = .recording(rec.id) }
                         }
@@ -566,7 +566,14 @@ private struct QueueRow: View {
     let recording: Recording
     /// 0 = currently transcribing, 1+ = number of jobs ahead in the queue
     let position: Int
+    @Binding var selection: SidebarSelection?
+    @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var transcription: TranscriptionService
+
+    /// Gate before "Remove" wipes the audio + any transcript — there's no
+    /// Trash to restore from (same rationale as the context menu's permanent
+    /// delete), so a stray click can't silently discard a recording.
+    @State private var confirmingRemove = false
 
     private var isActive: Bool {
         transcription.activeRecordingID == recording.id
@@ -606,10 +613,61 @@ private struct QueueRow: View {
                     }
                 }
             }
+
+            // Stop (cancel the run/queue slot, keep the recording) + Remove
+            // (cancel and delete it outright). Both trip the engine abort flag
+            // first so a `.running` item stops burning CPU immediately.
+            Button {
+                cancel()
+            } label: {
+                Image(systemName: "stop.circle")
+            }
+            .buttonStyle(.borderless)
+            .help("Stop transcribing — keeps the recording so you can re-transcribe later")
+            .accessibilityIdentifier("queue.row.stop.\(recording.title)")
+
+            Button(role: .destructive) {
+                confirmingRemove = true
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove from queue and delete the recording")
+            .accessibilityIdentifier("queue.row.remove.\(recording.title)")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .confirmationDialog("Remove “\(recording.title)” from the queue?",
+                            isPresented: $confirmingRemove,
+                            titleVisibility: .visible) {
+            Button("Remove", role: .destructive) { remove() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Transcription stops and the audio file is permanently deleted. This can't be undone.")
+        }
+    }
+
+    /// Stop the transcription but keep the recording. Trip the engine abort
+    /// flag (unwinds `whisper_full` in ~100ms / drops it from the pending
+    /// queue) AND flip the store status out of `.pending`/`.running` — the
+    /// service's cancel path intentionally leaves the status alone, so without
+    /// this the row would stay stuck in the Queue.
+    private func cancel() {
+        transcription.cancel(recordingID: recording.id)
+        store.cancelTranscription(recording)
+    }
+
+    /// Stop AND delete: abort the run, then remove the recording and its audio
+    /// + sidecars via the same `permanentlyDelete` the context menu uses. Move
+    /// the selection home if this row was selected so we don't leave a dangling
+    /// detail pane.
+    private func remove() {
+        transcription.cancel(recordingID: recording.id)
+        store.permanentlyDelete(recording)
+        if case .recording(let id) = selection, id == recording.id {
+            selection = .home
+        }
     }
 
     private var statusLabel: String {

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -624,7 +624,7 @@ private struct QueueRow: View {
             }
             .buttonStyle(.borderless)
             .help("Stop transcribing — keeps the recording so you can re-transcribe later")
-            .accessibilityIdentifier("queue.row.stop.\(recording.title)")
+            .accessibilityIdentifier("queue.row.stop.\(recording.id)")
 
             Button(role: .destructive) {
                 confirmingRemove = true
@@ -633,7 +633,7 @@ private struct QueueRow: View {
             }
             .buttonStyle(.borderless)
             .help("Remove from queue and delete the recording")
-            .accessibilityIdentifier("queue.row.remove.\(recording.title)")
+            .accessibilityIdentifier("queue.row.remove.\(recording.id)")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -406,6 +406,68 @@ final class RecordingStoreTests: XCTestCase {
                        "Whitespace-only summary must be treated as empty")
     }
 
+    // MARK: - Cancelling a queued/running transcription
+
+    /// Stopping a `.running` recording from the Queue must move it to a
+    /// terminal state (`.failed`) so it drops out of the Queue instead of
+    /// sitting there forever showing "Transcribing".
+    func test_cancel_transcription_marks_running_recording_failed() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        var rec = Recording(title: "In progress", source: .microphone, audioFileName: "r.wav")
+        rec.status = .running
+        store.add(rec)
+
+        store.cancelTranscription(rec)
+
+        let stored = store.recordings.first { $0.id == rec.id }
+        XCTAssertEqual(stored?.status, .failed)
+    }
+
+    /// Same for a `.pending` item still waiting its turn.
+    func test_cancel_transcription_marks_pending_recording_failed() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Waiting", source: .microphone,
+                            audioFileName: "p.wav", status: .pending)
+        store.add(rec)
+
+        store.cancelTranscription(rec)
+
+        XCTAssertEqual(store.recordings.first { $0.id == rec.id }?.status, .failed)
+    }
+
+    /// Cancelling an already-completed recording is a no-op — we must not
+    /// clobber a finished transcript's status back to `.failed` if the row is
+    /// stale (e.g. the run finished between the user clicking Stop and the
+    /// mutation landing).
+    func test_cancel_transcription_is_noop_for_completed_recording() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Done", source: .microphone,
+                            audioFileName: "d.wav", status: .completed,
+                            fullText: "hello")
+        store.add(rec)
+
+        store.cancelTranscription(rec)
+
+        XCTAssertEqual(store.recordings.first { $0.id == rec.id }?.status, .completed)
+    }
+
+    /// Removing from the Queue reuses `permanentlyDelete`, so both the metadata
+    /// and the on-disk audio go away.
+    func test_permanently_delete_removes_queued_recording_and_audio() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let audioURL = store.freshAudioURL(suggestedName: "Queued")
+        try Data(repeating: 0, count: 1024).write(to: audioURL)
+        let rec = Recording(title: "Queued", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent, status: .running)
+        store.add(rec)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+
+        store.permanentlyDelete(rec)
+
+        XCTAssertNil(store.recordings.first { $0.id == rec.id })
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
     func test_load_seeds_folders_from_recordings_when_folders_file_missing() throws {
         // Simulates a recordings.json that already references a folder name
         // (e.g. after restoring from backup, or hand-editing the JSON).

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -489,6 +489,34 @@ final class TranscriptionServiceTests: XCTestCase {
                           "User-cancelled recordings must not surface as engine failures")
     }
 
+    /// The Queue's "Stop" button flow: abort the active run via the service AND
+    /// flip the store status (the service leaves it alone). The recording must
+    /// end in a terminal state so it drops out of the Queue instead of showing
+    /// "Transcribing" forever, but the audio + row must survive for a later
+    /// re-transcribe.
+    func test_stop_from_queue_leaves_recording_terminal_and_kept() async throws {
+        let target = try TestRecordingFixture.make(in: store, title: "Stop me")
+        await stub.setDefaultDelay(0.4)
+
+        service.enqueue(target.recording)
+        let deadline = Date().addingTimeInterval(2)
+        while service.activeRecordingID != target.recording.id && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(service.activeRecordingID, target.recording.id)
+
+        // Mirror QueueRow.cancel(): trip the abort flag + mark it cancelled.
+        service.cancel(recordingID: target.recording.id)
+        store.cancelTranscription(target.recording)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == target.recording.id })
+        XCTAssertEqual(stored.status, .failed,
+                       "A stopped recording must leave the running/pending Queue state")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.audioURL.path),
+                      "Stop keeps the audio so the user can re-transcribe")
+    }
+
     // MARK: - Re-transcribe with the other language
 
     /// Drives the right-click "Re-transcribe in [other language]" path: the


### PR DESCRIPTION
## Problem

A recording could get stuck in the transcription **Queue** (`.pending` or `.running`) with no way to cancel or delete it. The Queue rows were display-only: if a transcription wedged, or the user simply changed their mind, the item sat there showing "Transcribing" (or "Queued") indefinitely with no escape hatch in the UI.

## Solution

Add two per-row affordances to `QueueView`/`QueueRow`:

- **Stop** (`stop.circle`) — trips the engine abort flag so the active whisper pass unwinds in ~100ms (via the existing `abort_callback`) / drops a pending item from the queue, **and** flips the store status out of `.pending`/`.running` so the row actually leaves the Queue. The recording + its audio are kept, so the user can re-transcribe later from the context menu.
- **Remove** (`trash`) — aborts the run, then permanently deletes the recording and its audio + sidecars via the existing `RecordingStore.permanentlyDelete` (the same path the recording context menu uses), behind a confirmation dialog (there's no Trash to restore a Queue removal from).

### How a `.running` item is actually interrupted

The interrupt reuses `TranscriptionService.cancel(recordingID:)`, which already exists and cooperatively aborts the active whisper.cpp pass through the `CancellationFlag` the engine polls. That path deliberately leaves the store status untouched (its original caller, the discard coordinator, owned the subsequent delete). So Stop pairs it with a new `RecordingStore.cancelTranscription(_:)` that moves the item to a terminal state — otherwise a `.running` row would stay stuck in the Queue after the engine aborted.

### Terminal state tradeoff

`cancelTranscription` lands the item in `.failed` rather than introducing a new `.cancelled` case. The Queue only renders `.pending`/`.running`, so a cancelled item drops out of the Queue regardless of the label, and every existing status-rendering site (list rows, detail view, `Codable`) already handles `.failed`. A dedicated `.cancelled` case would touch all of those for no user-visible gain. The mutation is a no-op if the recording already reached a terminal state (guards a stale click racing a just-finished run).

## Tests

- `RecordingStoreTests`: `cancelTranscription` marks running/pending → failed, is a no-op for completed, and `permanentlyDelete` removes a queued row + its on-disk audio.
- `TranscriptionServiceTests`: integration test mirroring the Stop flow — abort the active run via the service + `cancelTranscription`, assert the recording ends terminal and its audio survives for re-transcribe.

## Verification

`make build` → **BUILD SUCCEEDED**. Unit-test target compiled via `xcodebuild build-for-testing` → **TEST BUILD SUCCEEDED** (not run locally — per repo guidance XCUITests are left to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Stop” controls for active or pending queued transcriptions, preserving the recording for later re-transcription.
  * Added “Remove” actions for queued recordings with confirmation, including permanent deletion of the saved audio.
  * Automatically returns to the home view when deleting the currently selected recording.
* **Bug Fixes**
  * Ensures cancellation affects only queued/running jobs and leaves completed recordings unchanged.
  * Prevents deleted recordings from leaving an empty detail view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->