### PR TITLE
Clarify Full Disk Access copy for the granted-but-still-denied case (#56)

### DIFF
--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -79,8 +79,10 @@ struct VoiceMemosSettingsTab: View {
             Image(systemName: "lock.shield")
                 .foregroundStyle(.orange)
             VStack(alignment: .leading, spacing: 8) {
-                Text("Mila can't read your Voice Memos library. macOS needs you to grant "
-                     + "Mila Full Disk Access, then reopen this tab.")
+                Text("Mila can't read your Voice Memos library. Open Full Disk Access below "
+                     + "and enable Mila. If Mila already appears enabled there, toggle it off "
+                     + "and back on — updating Mila can invalidate the grant — then quit and "
+                     + "reopen Mila.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -153,7 +153,9 @@ struct VoiceMemosLibrary {
                 return "No Voice Memos library was found on this Mac."
             case .accessDenied:
                 return "Mila can't read your Voice Memos library. Grant Mila Full Disk Access in "
-                    + "System Settings → Privacy & Security → Full Disk Access, then reopen this tab."
+                    + "System Settings → Privacy & Security → Full Disk Access. If Mila already "
+                    + "appears enabled there, toggle it off and back on (updating Mila can "
+                    + "invalidate the grant), then quit and reopen Mila."
             case .openFailed(let msg):
                 return "Could not open the Voice Memos database: \(msg)"
             case .schemaUnsupported:


### PR DESCRIPTION
## Problem

Issue #56: the Voice Memos tab shows *"Mila can't read your Voice Memos library — grant Full Disk Access, then reopen this tab"* **even when Full Disk Access is already granted** (toggle ON in System Settings). The guidance is misleading and the user is stuck.

## Root cause

macOS keys Full Disk Access on the app's **code signature**. When Mila updates, the binary's code hash changes, which can **silently invalidate the existing grant**: the System Settings toggle still reads **ON**, but reads are denied until the entry is toggled **off and back on**, and the refreshed grant only takes effect after a **full relaunch** (not just switching tabs).

I hit this repeatedly while testing — every rebuilt/reinstalled Mila lost the grant while the toggle stayed on, reproducing #56's exact symptom.

## Change

Copy-only fix to both surfaces that render the denial:
- The Settings-tab `accessDeniedNotice`.
- `VoiceMemosLibrary.LibraryError.accessDenied`'s description.

Both now tell the user: if Mila **already appears enabled** in Full Disk Access, **toggle it off and back on** (a Mila update can invalidate the grant), then **quit and reopen Mila**.

No behavior change — text only.

## Testing

- `make build` succeeds.

Relates to #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Full Disk Access guidance when Mila can’t read the Voice Memos library.
  * Added steps to toggle access off and back on after updates, then quit and reopen Mila.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->