### PR TITLE
Voice Memos: replace Full Disk Access with a scoped folder grant

### DIFF
--- a/Mila/Models/VoiceMemosSettings.swift
+++ b/Mila/Models/VoiceMemosSettings.swift
@@ -48,6 +48,19 @@ final class VoiceMemosSettings: ObservableObject {
         didSet { defaults.set(startDate, forKey: Keys.startDate) }
     }
 
+    /// The Voice Memos Recordings folder the user granted Mila access to,
+    /// resolved from a persisted security-scoped bookmark. `nil` until the
+    /// user grants it (or if the grant was lost). Reading another app's
+    /// group container needs an explicit grant; this scoped, single-folder
+    /// grant replaces the old Full Disk Access requirement. Mirrors the
+    /// bookmark pattern in `RecordingStorageSettings`.
+    @Published private(set) var grantedFolderURL: URL?
+
+    /// The URL we currently hold `startAccessingSecurityScopedResource` on,
+    /// paired with a `stop` before re-resolving. Unsandboxed builds don't
+    /// strictly need this, but it's the correct pattern (and sandbox-ready).
+    private var accessingURL: URL?
+
     private let defaults: UserDefaults
 
     private enum Keys {
@@ -55,7 +68,13 @@ final class VoiceMemosSettings: ObservableObject {
         static let folderUUIDs = "voiceMemos.folderUUIDs"
         static let includeUnfiled = "voiceMemos.includeUnfiled"
         static let startDate = "voiceMemos.startDate"
+        static let folderBookmark = "voiceMemos.folderBookmark"
     }
+
+    /// The standard on-disk location of the synced Voice Memos library —
+    /// what the "Grant Access" open panel points at so the user only has to
+    /// confirm, not navigate into hidden `~/Library`.
+    static var suggestedFolder: URL { VoiceMemosLibrary.defaultRecordingsDirectory }
 
     /// Skip accidental sub-`minDurationSeconds` taps during bulk import. Voice
     /// Memos libraries are full of 1–2s pocket recordings; transcribing them
@@ -77,6 +96,76 @@ final class VoiceMemosSettings: ObservableObject {
             let today = Calendar.current.startOfDay(for: Date())
             self.startDate = today
             defaults.set(today, forKey: Keys.startDate)
+        }
+        resolveFolderAccess()
+    }
+
+    // MARK: - Scoped folder access (replaces Full Disk Access)
+
+    /// True once Mila holds a working grant to the Voice Memos folder.
+    var hasFolderAccess: Bool { grantedFolderURL != nil }
+
+    /// Resolve the persisted bookmark and start accessing it. Idempotent —
+    /// safe to call again after `grantFolder`. Mirrors
+    /// `RecordingStorageSettings.resolveAndStartAccessing`.
+    func resolveFolderAccess() {
+        if let url = accessingURL {
+            url.stopAccessingSecurityScopedResource()
+            accessingURL = nil
+        }
+        grantedFolderURL = nil
+
+        guard let data = defaults.data(forKey: Keys.folderBookmark) else { return }
+        var isStale = false
+        let resolved: URL
+        do {
+            resolved = try URL(resolvingBookmarkData: data,
+                               options: [.withSecurityScope],
+                               relativeTo: nil,
+                               bookmarkDataIsStale: &isStale)
+        } catch {
+            // Unreadable blob — drop it so we don't fail on every launch.
+            print("VoiceMemosSettings: failed to resolve folder bookmark: \(error)")
+            defaults.removeObject(forKey: Keys.folderBookmark)
+            return
+        }
+        if isStale {
+            if let refreshed = try? resolved.bookmarkData(options: [.withSecurityScope],
+                                                          includingResourceValuesForKeys: nil,
+                                                          relativeTo: nil) {
+                defaults.set(refreshed, forKey: Keys.folderBookmark)
+            } else {
+                defaults.removeObject(forKey: Keys.folderBookmark)
+                return
+            }
+        }
+        let started = resolved.startAccessingSecurityScopedResource()
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: resolved.path, isDirectory: &isDir)
+        if !exists || !isDir.boolValue {
+            if started { resolved.stopAccessingSecurityScopedResource() }
+            defaults.removeObject(forKey: Keys.folderBookmark)
+            return
+        }
+        accessingURL = resolved
+        grantedFolderURL = resolved
+    }
+
+    /// Persist a freshly-picked folder (from the "Grant Access" open panel)
+    /// as a security-scoped bookmark and start accessing it. Returns true on
+    /// success. Mirrors `RecordingStorageSettings.setDirectory`.
+    @discardableResult
+    func grantFolder(_ url: URL) -> Bool {
+        do {
+            let data = try url.bookmarkData(options: [.withSecurityScope],
+                                            includingResourceValuesForKeys: nil,
+                                            relativeTo: nil)
+            defaults.set(data, forKey: Keys.folderBookmark)
+            resolveFolderAccess()
+            return grantedFolderURL != nil
+        } catch {
+            print("VoiceMemosSettings: failed to mint folder bookmark for \(url.path): \(error)")
+            return false
         }
     }
 

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -96,6 +96,15 @@ struct VoiceMemosSettingsTab: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 Button("Grant Access…") { grantAccess() }
+                // A failed grant leaves availability at `.accessDenied`, so this
+                // card (not `folderPicker`) stays on screen — surface the error
+                // here or the user gets no feedback.
+                if let loadError {
+                    Text(loadError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
         .padding(12)

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -14,7 +14,12 @@ struct VoiceMemosSettingsTab: View {
     @State private var loadError: String?
     @State private var isLoading = false
 
-    private let library = VoiceMemosLibrary()
+    /// Reader over the folder the user granted (falling back to the standard
+    /// location, which is what a legacy Full-Disk-Access user already sees).
+    private var library: VoiceMemosLibrary {
+        VoiceMemosLibrary(recordingsDirectory: settings.grantedFolderURL
+                          ?? VoiceMemosLibrary.defaultRecordingsDirectory)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -26,22 +31,25 @@ struct VoiceMemosSettingsTab: View {
             Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
                 .toggleStyle(.switch)
 
-            switch library.availability {
-            case .available:
-                if settings.isEnabled {
+            if settings.isEnabled {
+                switch library.availability {
+                case .available:
                     folderPicker
                     startDatePicker
                     statusFooter
+                case .databaseMissing:
+                    // We can read the folder (grant or legacy FDA in place)
+                    // but there's no library there — iCloud sync off, or the
+                    // user granted the wrong folder.
+                    unavailableNotice
+                case .accessDenied:
+                    grantAccessNotice
                 }
-            case .databaseMissing:
-                unavailableNotice
-            case .accessDenied:
-                accessDeniedNotice
             }
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .task(id: settings.isEnabled) {
+        .task(id: "\(settings.isEnabled)-\(settings.grantedFolderURL?.path ?? "")") {
             if settings.isEnabled { await loadFolders() }
         }
     }
@@ -72,30 +80,45 @@ struct VoiceMemosSettingsTab: View {
         .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
     }
 
-    /// Shown when the Voice Memos DB exists but macOS blocked access. Mila is
-    /// not sandboxed, so reading the Voice Memos group container needs Full
-    /// Disk Access — point the user straight at the right pane (issue #45).
-    private var accessDeniedNotice: some View {
+    /// Shown until Mila holds a scoped grant to the Voice Memos folder. Mila
+    /// is not sandboxed, so reading another app's group container needs the
+    /// user's consent — but a one-folder grant is all it takes, no Full Disk
+    /// Access. The panel is pre-pointed at the folder so the user just
+    /// confirms rather than navigating hidden `~/Library`.
+    private var grantAccessNotice: some View {
         HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "lock.shield")
+            Image(systemName: "folder.badge.questionmark")
                 .foregroundStyle(.orange)
             VStack(alignment: .leading, spacing: 8) {
-                Text("Mila can't read your Voice Memos library. Open Full Disk Access below "
-                     + "and enable Mila. If Mila already appears enabled there, toggle it off "
-                     + "and back on — updating Mila can invalidate the grant — then quit and "
-                     + "reopen Mila.")
+                Text("Mila needs your permission to read the Voice Memos folder. Click below "
+                     + "and confirm — Mila gets access to just that one folder, not your whole disk.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                Button("Open Full Disk Access Settings…") {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
+                Button("Grant Access…") { grantAccess() }
             }
         }
         .padding(12)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.08)))
+    }
+
+    /// Run the folder-grant open panel, pre-pointed at the standard Voice
+    /// Memos location, and persist the resulting security-scoped bookmark.
+    private func grantAccess() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = VoiceMemosSettings.suggestedFolder
+        panel.message = "Grant Mila access to your iPhone Voice Memos recordings folder."
+        panel.prompt = "Grant Access"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        if settings.grantFolder(url) {
+            Task { await loadFolders() }
+            importer.rescan()
+        } else {
+            loadError = "Couldn't save access to that folder. Please try again."
+        }
     }
 
     private var folderPicker: some View {

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -26,7 +26,14 @@ final class VoiceMemosImporter: ObservableObject {
     private let transcription: TranscriptionService
     private let settings: VoiceMemosSettings
     private let languageSettings: RecordingLanguageSettings
-    private let library: VoiceMemosLibrary
+
+    /// Reader over the folder the user granted access to (falling back to the
+    /// standard location, which is what a Full-Disk-Access user already sees).
+    /// Rebuilt each access so it always reflects the current grant.
+    private var library: VoiceMemosLibrary {
+        VoiceMemosLibrary(recordingsDirectory: settings.grantedFolderURL
+                          ?? VoiceMemosLibrary.defaultRecordingsDirectory)
+    }
 
     private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceMemos")
 
@@ -66,13 +73,11 @@ final class VoiceMemosImporter: ObservableObject {
     init(store: RecordingStore,
          transcription: TranscriptionService,
          settings: VoiceMemosSettings,
-         languageSettings: RecordingLanguageSettings,
-         library: VoiceMemosLibrary = VoiceMemosLibrary()) {
+         languageSettings: RecordingLanguageSettings) {
         self.store = store
         self.transcription = transcription
         self.settings = settings
         self.languageSettings = languageSettings
-        self.library = library
     }
 
     /// Wire up settings observation + the watcher, and run an initial sync.
@@ -105,9 +110,9 @@ final class VoiceMemosImporter: ObservableObject {
             return
         }
         // Sync is on and folders are chosen, but the library may still be
-        // unreadable. Log *why* rather than silently bailing — a TCC / Full
-        // Disk Access denial is the one failure that otherwise leaves no
-        // trace in the logs at all (issue #45).
+        // unreadable. Log *why* rather than silently bailing — a TCC denial
+        // is the one failure that otherwise leaves no trace in the logs at
+        // all (issue #45).
         switch library.availability {
         case .available:
             break
@@ -116,7 +121,7 @@ final class VoiceMemosImporter: ObservableObject {
             stop()
             return
         case .accessDenied(let reason):
-            log.error("VoiceMemos sync is enabled but macOS denied access to \(self.library.databaseDisplayPath, privacy: .public) (\(reason, privacy: .public)). Grant Mila Full Disk Access in System Settings → Privacy & Security → Full Disk Access.")
+            log.error("VoiceMemos sync is enabled but macOS denied access to \(self.library.databaseDisplayPath, privacy: .public) (\(reason, privacy: .public)). Grant access to the Voice Memos folder from Settings → Voice Memos.")
             lastError = VoiceMemosLibrary.LibraryError.accessDenied(reason).localizedDescription
             stop()
             return

--- a/Mila/VoiceMemos/VoiceMemosLibrary.swift
+++ b/Mila/VoiceMemos/VoiceMemosLibrary.swift
@@ -145,10 +145,8 @@ struct VoiceMemosLibrary {
             case .databaseMissing:
                 return "No Voice Memos library was found on this Mac."
             case .accessDenied:
-                return "Mila can't read your Voice Memos library. Grant Mila Full Disk Access in "
-                    + "System Settings → Privacy & Security → Full Disk Access. If Mila already "
-                    + "appears enabled there, toggle it off and back on (updating Mila can "
-                    + "invalidate the grant), then quit and reopen Mila."
+                return "Mila can't read your Voice Memos library. Open Settings → Voice Memos "
+                    + "and click Grant Access to give Mila permission to that folder."
             case .openFailed(let msg):
                 return "Could not open the Voice Memos database: \(msg)"
             case .schemaUnsupported:


### PR DESCRIPTION
## Why

Reading the synced Voice Memos library required **Full Disk Access** — a heavy, trust-eroding permission for what is really a single-folder feature. It's also the root of #56's "granted but still denied" confusion: FDA is keyed on the app's code signature, so an update can silently invalidate the grant while the toggle still reads ON.

## It doesn't actually need FDA

The library lives in another app's group container (`~/Library/Group Containers/group.com.apple.VoiceMemos.shared/`), which TCC gates. But a **user-selected folder grant** via `NSOpenPanel` + a persisted **security-scoped bookmark** is sufficient, and it's scoped to just that one folder.

Verified end-to-end with an isolated probe app that has **zero Full Disk Access**:

```
[baseline raw read]      DENIED ❌  Operation not permitted     ← no FDA
[grant folder via panel] saved security-scoped bookmark
[same-session read]      SUCCESS ✅  "SQLite format 3"
--- relaunch (fresh process, still no FDA) ---
[baseline raw read]      SUCCESS ✅  ← grant persisted across relaunch
[resolve bookmark+read]  SUCCESS ✅
```

And then verified in Mila itself (no FDA): clicking **Grant Access** makes the folder list + memos appear and the watcher start, with no Full Disk Access anywhere.

This is the **same bookmark pattern the app already ships** for the custom-recordings-directory setting (`RecordingStorageSettings`), so it's already proven under the notarized/hardened-runtime build.

## Changes

- **`VoiceMemosSettings`** persists a security-scoped bookmark to the granted folder, resolves + starts accessing it at launch (`resolveFolderAccess`), and mints one from a user-picked URL (`grantFolder`) — mirroring `RecordingStorageSettings`.
- **`VoiceMemosSettingsTab`** replaces the Full Disk Access instructions with a **"Grant Access…"** card whose open panel is pre-pointed at the Voice Memos folder (the user just confirms — no navigating hidden `~/Library`). "Access to just that one folder, not your whole disk."
- **`VoiceMemosImporter`** reads through the granted folder.
- **Legacy Full Disk Access still works** — if the default path is already readable, no grant is requested — so existing users aren't disrupted.

## Testing

- `make build` succeeds.
- Isolated no-FDA probe (above): scoped grant reads the DB and persists across relaunch.
- In-app (no FDA): Grant Access → library reads, watcher starts, sync runs (`imported 0 … older=1`, no denial).

Relates to #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder-specific permission management for Voice Memos using security-scoped access.
  * Users can grant access by selecting their Voice Memos folder via Settings → Voice Memos → Grant Access.
  * Granted folder access is remembered for future sessions.
  * Voice Memos automatically refreshes after access is granted.
* **Bug Fixes**
  * Replaced Full Disk Access guidance with clearer folder-access instructions.
  * Improved handling of invalid, stale, or unavailable folder permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->