### PR TITLE
Fix Stop button lag: drop cancelled item from the Queue immediately

### DIFF
--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -506,8 +506,16 @@ private struct QueueView: View {
     private var queue: [Recording] {
         var seen = Set<UUID>()
         var ordered: [Recording] = []
+        // Only surface the engine's active recording while it's still in a
+        // queue state. When the user hits Stop, `cancelTranscription` flips the
+        // store status to `.failed` immediately, but the engine's
+        // `activeRecordingID` only clears ~100ms later once `whisper_full`
+        // unwinds. Without this status guard the cancelled row lingers as
+        // "Transcribing" in that window, so Stop looks unresponsive and the
+        // user clicks it repeatedly.
         if let activeID = transcription.activeRecordingID,
-           let active = store.recordings.first(where: { $0.id == activeID }) {
+           let active = store.recordings.first(where: { $0.id == activeID }),
+           active.status == .running || active.status == .pending {
             ordered.append(active)
             seen.insert(activeID)
         }


### PR DESCRIPTION
## Problem

Reported after #71 shipped: pressing **Stop** on an actively-transcribing Queue item "didn't react right away — I had to click it multiple times."

## Cause

The Queue's row list always includes `transcription.activeRecordingID`, regardless of the recording's store status:

```swift
if let activeID = transcription.activeRecordingID,
   let active = store.recordings.first(where: { $0.id == activeID }) {
    ordered.append(active)   // included even after cancellation
```

Stop calls `RecordingStore.cancelTranscription`, which flips the store status to `.failed` **immediately** — but the engine's `activeRecordingID` only clears ~100 ms later, once whisper.cpp's `abort_callback` trips and `whisper_full` unwinds. In that window the cancelled row keeps rendering as "Transcribing", so Stop looks broken and the user clicks again. (Pending items leave instantly — only the actively-transcribing one lingered.)

## Fix

Guard the active-item branch on a live queue status, so a just-cancelled recording drops out of the Queue the instant Stop is pressed:

```swift
if let activeID = transcription.activeRecordingID,
   let active = store.recordings.first(where: { $0.id == activeID }),
   active.status == .running || active.status == .pending {
```

The engine still finishes aborting in the background; this only stops the UI from showing a cancelled row as active.

## Testing

- `make build` succeeds.
- No behavior change for normal transcription (active item is `.running`, so it still shows); only cancelled/terminal items are excluded.

Follow-up to #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled recordings are now removed from the active queue promptly.
  * Recordings that are failed, completed, or otherwise no longer active no longer remain temporarily visible in the queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->