### PR TITLE
Fix detached black border around the dictation pill

### DIFF
--- a/Mila/Views/DictationOverlayWindow.swift
+++ b/Mila/Views/DictationOverlayWindow.swift
@@ -78,7 +78,11 @@ final class DictationOverlayWindow {
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.hasShadow = true
+        // No window shadow: the pill fills only a small part of this
+        // transparent 320×64 panel, so AppKit's window shadow floats around
+        // the panel silhouette as a detached black rounded border rather than
+        // hugging the pill. The pill draws its own SwiftUI `.shadow` instead.
+        panel.hasShadow = false
         panel.isMovable = false
         panel.ignoresMouseEvents = true
         panel.contentView = NSHostingView(


### PR DESCRIPTION
## Problem

Fixes #75 — when the dictation hotkey is active, a black rounded border floats around the dictation pill, detached from it (a slightly larger rounded rectangle, not hugging the blue pill).

## Cause

`DictationOverlayWindow`'s `NSPanel` sets `hasShadow = true`, but the pill occupies only ~150×36 of the transparent 320×64 panel. AppKit computes the *window* shadow around the panel silhouette rather than the pill, so it renders as a detached rounded border. (The sibling `MeetingPromptOverlay` gets away with `hasShadow = true` because its card fills the panel.) The pill already draws its own SwiftUI `.shadow`, so the window shadow is redundant.

## Fix

Set `hasShadow = false` on the dictation panel; the pill keeps its own SwiftUI drop shadow.

## Testing

- `make build` succeeds.
- Verified on a local install: triggering the dictation hotkey no longer shows the detached border — just the pill's own soft shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate window shadow from the dictation overlay for a cleaner, more consistent pill appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->