### PR TITLE
Queue Stop moves the recording to Recently Deleted, not "Failed"

### DIFF
--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -453,10 +453,22 @@ final class RecordingStore: ObservableObject {
     /// the delete), so a Queue-level cancel must flip the status itself —
     /// otherwise a `.running` item would sit in the Queue forever. No-op if the
     /// recording is already in a terminal state.
-    func cancelTranscription(_ recording: Recording) {
+    /// Stop a queued/active transcription from the Queue and move the
+    /// recording to "Recently Deleted" rather than leaving a `.failed` row
+    /// cluttering the list. The status also flips to a terminal `.failed` so
+    /// the launch crash-recovery sweep and the Queue don't resurrect it. The
+    /// audio stays on disk (recoverable via Restore), so this is safe for mic
+    /// recordings and re-transcriptions of already-completed recordings — the
+    /// user gets their content back from the trash if they hit Stop by
+    /// mistake. No-op if the recording is already terminal (guards a stale
+    /// click racing a just-finished run). Paired with
+    /// `TranscriptionService.cancel(recordingID:)`, which trips the engine's
+    /// abort flag so the in-flight whisper pass unwinds.
+    func stopTranscription(_ recording: Recording) {
         guard let idx = recordings.firstIndex(where: { $0.id == recording.id }) else { return }
         guard recordings[idx].status == .pending || recordings[idx].status == .running else { return }
         recordings[idx].status = .failed
+        recordings[idx].deletedAt = Date()
         persist()
     }
 

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -507,14 +507,15 @@ private struct QueueView: View {
         var seen = Set<UUID>()
         var ordered: [Recording] = []
         // Only surface the engine's active recording while it's still in a
-        // queue state. When the user hits Stop, `cancelTranscription` flips the
-        // store status to `.failed` immediately, but the engine's
-        // `activeRecordingID` only clears ~100ms later once `whisper_full`
-        // unwinds. Without this status guard the cancelled row lingers as
-        // "Transcribing" in that window, so Stop looks unresponsive and the
-        // user clicks it repeatedly.
+        // queue state and not trashed. When the user hits Stop,
+        // `stopTranscription` flips the store status to `.failed` and moves it
+        // to Recently Deleted immediately, but the engine's `activeRecordingID`
+        // only clears ~100ms later once `whisper_full` unwinds. Without this
+        // guard the cancelled row lingers as "Transcribing" in that window, so
+        // Stop looks unresponsive and the user clicks it repeatedly.
         if let activeID = transcription.activeRecordingID,
            let active = store.recordings.first(where: { $0.id == activeID }),
+           !active.isTrashed,
            active.status == .running || active.status == .pending {
             ordered.append(active)
             seen.insert(activeID)
@@ -622,16 +623,16 @@ private struct QueueRow: View {
                 }
             }
 
-            // Stop (cancel the run/queue slot, keep the recording) + Remove
-            // (cancel and delete it outright). Both trip the engine abort flag
-            // first so a `.running` item stops burning CPU immediately.
+            // Stop (cancel + move to Recently Deleted) + Remove (cancel +
+            // permanently delete). Both trip the engine abort flag first so a
+            // `.running` item stops burning CPU immediately.
             Button {
                 cancel()
             } label: {
                 Image(systemName: "stop.circle")
             }
             .buttonStyle(.borderless)
-            .help("Stop transcribing — keeps the recording so you can re-transcribe later")
+            .help("Stop transcribing and move to Recently Deleted (restorable)")
             .accessibilityIdentifier("queue.row.stop.\(recording.id)")
 
             Button(role: .destructive) {
@@ -656,14 +657,15 @@ private struct QueueRow: View {
         }
     }
 
-    /// Stop the transcription but keep the recording. Trip the engine abort
-    /// flag (unwinds `whisper_full` in ~100ms / drops it from the pending
-    /// queue) AND flip the store status out of `.pending`/`.running` — the
-    /// service's cancel path intentionally leaves the status alone, so without
-    /// this the row would stay stuck in the Queue.
+    /// Stop the transcription and move the recording to Recently Deleted so it
+    /// leaves the list instead of lingering as a "Failed" row. Trip the engine
+    /// abort flag (unwinds `whisper_full` in ~100ms / drops it from the pending
+    /// queue), then `stopTranscription` flips the status terminal and soft-
+    /// deletes it — the audio survives in the trash, restorable if this was a
+    /// misclick (or a re-transcription of an already-completed recording).
     private func cancel() {
         transcription.cancel(recordingID: recording.id)
-        store.cancelTranscription(recording)
+        store.stopTranscription(recording)
     }
 
     /// Stop AND delete: abort the run, then remove the recording and its audio

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -406,49 +406,54 @@ final class RecordingStoreTests: XCTestCase {
                        "Whitespace-only summary must be treated as empty")
     }
 
-    // MARK: - Cancelling a queued/running transcription
+    // MARK: - Stopping a queued/running transcription
 
-    /// Stopping a `.running` recording from the Queue must move it to a
-    /// terminal state (`.failed`) so it drops out of the Queue instead of
-    /// sitting there forever showing "Transcribing".
-    func test_cancel_transcription_marks_running_recording_failed() {
+    /// Stopping a `.running` recording from the Queue moves it to Recently
+    /// Deleted (soft-delete) and marks it terminal, so it drops out of the
+    /// Queue and the main list instead of lingering as a "Failed" row — while
+    /// the audio stays recoverable via Restore.
+    func test_stop_transcription_trashes_running_recording() {
         let store = RecordingStore(rootDirectory: tempRoot)
         var rec = Recording(title: "In progress", source: .microphone, audioFileName: "r.wav")
         rec.status = .running
         store.add(rec)
 
-        store.cancelTranscription(rec)
+        store.stopTranscription(rec)
 
         let stored = store.recordings.first { $0.id == rec.id }
         XCTAssertEqual(stored?.status, .failed)
+        XCTAssertTrue(stored?.isTrashed == true, "Stopped recording should move to Recently Deleted")
     }
 
     /// Same for a `.pending` item still waiting its turn.
-    func test_cancel_transcription_marks_pending_recording_failed() {
+    func test_stop_transcription_trashes_pending_recording() {
         let store = RecordingStore(rootDirectory: tempRoot)
         let rec = Recording(title: "Waiting", source: .microphone,
                             audioFileName: "p.wav", status: .pending)
         store.add(rec)
 
-        store.cancelTranscription(rec)
+        store.stopTranscription(rec)
 
-        XCTAssertEqual(store.recordings.first { $0.id == rec.id }?.status, .failed)
+        let stored = store.recordings.first { $0.id == rec.id }
+        XCTAssertEqual(stored?.status, .failed)
+        XCTAssertTrue(stored?.isTrashed == true)
     }
 
-    /// Cancelling an already-completed recording is a no-op — we must not
-    /// clobber a finished transcript's status back to `.failed` if the row is
-    /// stale (e.g. the run finished between the user clicking Stop and the
-    /// mutation landing).
-    func test_cancel_transcription_is_noop_for_completed_recording() {
+    /// Stopping an already-completed recording is a no-op — we must not trash a
+    /// finished recording or clobber its status if the row is stale (e.g. the
+    /// run finished between the user clicking Stop and the mutation landing).
+    func test_stop_transcription_is_noop_for_completed_recording() {
         let store = RecordingStore(rootDirectory: tempRoot)
         let rec = Recording(title: "Done", source: .microphone,
                             audioFileName: "d.wav", status: .completed,
                             fullText: "hello")
         store.add(rec)
 
-        store.cancelTranscription(rec)
+        store.stopTranscription(rec)
 
-        XCTAssertEqual(store.recordings.first { $0.id == rec.id }?.status, .completed)
+        let stored = store.recordings.first { $0.id == rec.id }
+        XCTAssertEqual(stored?.status, .completed)
+        XCTAssertFalse(stored?.isTrashed == true, "A completed recording must not be trashed by a stale Stop")
     }
 
     /// Removing from the Queue reuses `permanentlyDelete`, so both the metadata

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -505,16 +505,18 @@ final class TranscriptionServiceTests: XCTestCase {
         }
         XCTAssertEqual(service.activeRecordingID, target.recording.id)
 
-        // Mirror QueueRow.cancel(): trip the abort flag + mark it cancelled.
+        // Mirror QueueRow.cancel(): trip the abort flag + stop (move to trash).
         service.cancel(recordingID: target.recording.id)
-        store.cancelTranscription(target.recording)
+        store.stopTranscription(target.recording)
         await service.waitForIdle()
 
         let stored = try XCTUnwrap(store.recordings.first { $0.id == target.recording.id })
         XCTAssertEqual(stored.status, .failed,
                        "A stopped recording must leave the running/pending Queue state")
+        XCTAssertTrue(stored.isTrashed,
+                      "Stop moves the recording to Recently Deleted so it leaves the list")
         XCTAssertTrue(FileManager.default.fileExists(atPath: target.audioURL.path),
-                      "Stop keeps the audio so the user can re-transcribe")
+                      "Stop keeps the audio (in the trash) so the user can restore / re-transcribe")
     }
 
     // MARK: - Re-transcribe with the other language


### PR DESCRIPTION
## Problem

Reported in testing: pressing **Stop** on a Queue item left it in the list as a **"Failed"** row. That reads like an error even though the user deliberately stopped it — clutter, not signal.

## Fix

Stop now moves the recording to **Recently Deleted** (soft-delete) instead of marking it `.failed` in place. `RecordingStore.cancelTranscription` is renamed to `stopTranscription` and now:

- flips the status terminal (`.failed`) so the launch crash-recovery sweep and the Queue don't resurrect it, **and**
- soft-deletes it (`deletedAt`) so it leaves the main list.

The audio stays on disk and is **restorable** from Recently Deleted. That makes it safe for cases where a hard delete would lose data — a mic recording being transcribed, or a re-transcription of an already-completed recording — so a misclick is undoable rather than destructive.

This also gives the two Queue buttons a clean split:
- **Stop** → soft (Recently Deleted, restorable, no confirmation)
- **Remove** → permanent delete (with confirmation)

## Testing

- `make build` succeeds.
- `RecordingStoreTests`: Stop trashes a running/pending recording (status `.failed` + `isTrashed`); no-op for a completed recording (not trashed).
- `TranscriptionServiceTests`: the end-to-end Stop flow leaves the recording terminal, trashed, and with its audio intact.

Follow-up to #71 / #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stopping an active or queued transcription now moves the recording to Recently Deleted for recovery.
  * The Stop action clearly indicates that the recording can be restored from Recently Deleted.
  * Active transcriptions in the queue are hidden when their recordings are trashed.

* **Bug Fixes**
  * Stopped transcriptions now remain in a terminal failed state and retain their audio files.
  * Completed recordings are unaffected when users attempt to stop transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->