### PR TITLE
feat(recordings): auto-drop accidental short + empty recordings (#61)

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1339,7 +1339,7 @@ struct MilaApp: App {
             }
         }
         store.updateAll(statusChanged)          // single persist for the whole sweep
-        toEnqueue.forEach(transcription.enqueue)
+        toEnqueue.forEach { transcription.enqueue($0) }
 
         // 2. Auto-enqueue recovered orphans.
         let ids = store.consumePendingRecoveryIDs()

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -421,6 +421,15 @@ struct MilaApp: App {
                 summarizer?.summarizeIfNeeded(rec)
             }
         }
+        // Auto-drop accidental short+empty captures (issue #61). A recording
+        // that finishes transcription with no text AND under the user's
+        // minimum-duration threshold (Settings ▸ Storage, default 5s, 0 = keep
+        // all) is a hotkey misfire / silence clip — permanently drop it so it
+        // never spams the list. Reads the live threshold each time so a
+        // Settings change takes effect on the next recording without relaunch.
+        svc.shouldAutoDropShortEmpty = { [weak storage] duration, transcript in
+            storage?.shouldAutoDrop(duration: duration, transcript: transcript) ?? false
+        }
         // Late-bind the live-AI dependencies onto `actions` so it can
         // attach summary/items to the saved Recording and skip the
         // rename sheet when Live AI was running.

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1339,7 +1339,12 @@ struct MilaApp: App {
             }
         }
         store.updateAll(statusChanged)          // single persist for the whole sweep
-        toEnqueue.forEach { transcription.enqueue($0) }
+        // Recovered rows are re-runs of transcriptions that were already
+        // in flight before the app quit — never a fresh capture. Mark them
+        // as re-transcriptions so the issue-#61 auto-drop gate can't delete
+        // one (e.g. a mid-retranscribe of an empty-transcript recording that
+        // crashed) just because the recovered rerun comes back short + empty.
+        toEnqueue.forEach { transcription.enqueue($0, isRetranscription: true) }
 
         // 2. Auto-enqueue recovered orphans.
         let ids = store.consumePendingRecoveryIDs()

--- a/Mila/Models/RecordingStorageSettings.swift
+++ b/Mila/Models/RecordingStorageSettings.swift
@@ -34,9 +34,15 @@ import Combine
 final class RecordingStorageSettings: ObservableObject {
     static let bookmarkKey = "storage.recordingsDirectoryBookmark"
     static let limitBytesKey = "storage.limitBytes"
+    static let minDurationKey = "recordings.minDuration"
     /// 5 GiB — generous for compressed (m4a) recordings (~20–30 MB/hour),
     /// so this is roughly 150+ hours before the cap bites.
     static let defaultLimitBytes: Int64 = 5 * 1024 * 1024 * 1024
+    /// Auto-drop threshold (seconds). Recordings that finish transcription
+    /// with no text AND shorter than this are discarded as accidental
+    /// captures (hotkey misfires, silence). `0` disables the gate — keep
+    /// everything. See issue #61 / `shouldAutoDrop`.
+    static let defaultMinDuration: Double = 5.0
 
     /// Hard cap on the recordings library size. New recordings are
     /// blocked once usage reaches this; existing/in-progress recordings
@@ -53,6 +59,40 @@ final class RecordingStorageSettings: ObservableObject {
     var limitGigabytes: Double {
         get { Double(limitBytes) / 1_073_741_824.0 }
         set { limitBytes = max(1, Int64((newValue * 1_073_741_824.0).rounded())) }
+    }
+
+    /// Minimum-duration gate for auto-dropping accidental captures (issue
+    /// #61). A recording that finishes transcription with an empty transcript
+    /// AND a duration below this many seconds is a hotkey misfire / silence
+    /// clip — Mila discards it so it never spams the list. `0` disables the
+    /// gate (keep everything). Persisted so the choice sticks across launches.
+    @Published var minDuration: Double {
+        didSet {
+            // Clamp defensively (the Settings stepper is already bounded);
+            // the reassignment re-enters didSet and persists the clamped value.
+            if minDuration < 0 { minDuration = 0; return }
+            guard minDuration != oldValue else { return }
+            defaults.set(minDuration, forKey: Self.minDurationKey)
+        }
+    }
+
+    /// Auto-drop gate for accidental short recordings (issue #61). Returns
+    /// true when a just-finished recording should be dropped: it is BOTH
+    /// shorter than `threshold` AND its transcript is empty/whitespace-only.
+    ///
+    /// A `threshold` of 0 disables the gate entirely (keep everything). A
+    /// short clip that DID produce text is kept ("short but has content"),
+    /// as is any clip at or over the threshold — length alone never drops a
+    /// recording that captured real speech.
+    static func shouldAutoDrop(duration: Double, transcript: String, threshold: Double) -> Bool {
+        guard threshold > 0, duration < threshold else { return false }
+        return transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Convenience over the static gate using the user's persisted
+    /// `minDuration` threshold.
+    func shouldAutoDrop(duration: Double, transcript: String) -> Bool {
+        Self.shouldAutoDrop(duration: duration, transcript: transcript, threshold: minDuration)
     }
 
     /// The currently-active user-selected recordings directory, or nil when
@@ -81,6 +121,11 @@ final class RecordingStorageSettings: ObservableObject {
             self.limitBytes = Int64(stored)
         } else {
             self.limitBytes = Self.defaultLimitBytes
+        }
+        if let stored = defaults.object(forKey: Self.minDurationKey) as? Double {
+            self.minDuration = max(0, stored)
+        } else {
+            self.minDuration = Self.defaultMinDuration
         }
         resolveAndStartAccessing()
     }

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -606,7 +606,7 @@ final class TranscriptionService: ObservableObject {
                 // we persist the .failed row: a sub-threshold clip with no
                 // transcribable audio is pure list spam. A long-but-silent clip
                 // is over the threshold, so the gate keeps it as .failed.
-                if autoDropIfShortAndEmpty(working, transcript: "") { return }
+                if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: "") { return }
                 store.update(working)
                 return
             }
@@ -715,7 +715,7 @@ final class TranscriptionService: ObservableObject {
             // it instead of leaving a .failed row cluttering the list. The gate
             // keeps any clip that produced text (even a short one) and anything
             // at/over the threshold, so this only ever removes worthless rows.
-            if autoDropIfShortAndEmpty(working, transcript: text) { return }
+            if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: text) { return }
             store.update(working)
 
             if working.status == .completed {
@@ -786,9 +786,18 @@ final class TranscriptionService: ObservableObject {
     /// them through Recently Deleted would just leave orphaned audio on disk
     /// for the grace period. No-op when the gate isn't wired (tests) or the
     /// recording has real content / is long enough to keep.
-    private func autoDropIfShortAndEmpty(_ recording: Recording, transcript: String) -> Bool {
-        guard shouldAutoDropShortEmpty?(recording.duration, transcript) == true else { return false }
-        print("Transcribe: auto-dropping \(recording.title) [\(recording.id.uuidString.prefix(8))] — \(recording.duration)s + empty transcript (issue #61)")
+    private func autoDropIfShortAndEmpty(_ recording: Recording, duration: Double, transcript: String) -> Bool {
+        // Only auto-drop accidental *local mic captures* (mic recordings +
+        // dictation hotkey misfires — both `.microphone`). Never Voice Memos,
+        // imported files (`.systemAudio`), or meeting captures: those aren't
+        // accidental and/or their source audio wasn't captured in Mila, so
+        // permanently deleting them would be data loss (issue #61 review).
+        guard recording.source == .microphone else { return false }
+        // Use the freshly-decoded audio duration, NOT `recording.duration`,
+        // which can be stale (crash-recovered rows are seeded with 0) and
+        // would let a long-but-silent clip slip under the threshold.
+        guard shouldAutoDropShortEmpty?(duration, transcript) == true else { return false }
+        print("Transcribe: auto-dropping \(recording.title) [\(recording.id.uuidString.prefix(8))] — \(duration)s + empty transcript (issue #61)")
         store.permanentlyDelete(recording)
         return true
     }

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -208,12 +208,22 @@ final class TranscriptionService: ObservableObject {
 
     // MARK: - Public API
 
+    /// IDs enqueued as a manual re-transcribe. Consumed by `process` to make
+    /// the issue-#61 auto-drop gate an *explicit* first-transcription check
+    /// rather than one inferred from an empty transcript — a recording that
+    /// previously failed empty also has empty `fullText`, so inference alone
+    /// could hard-delete it (plus its audio) on a deliberate retry.
+    private var retranscriptionIDs: Set<UUID> = []
+
     /// Enqueue a recording for transcription. Returns immediately.
     /// Calls don't overlap — the queue drains FIFO on a single background task.
     /// Idempotent: re-enqueuing the active or already-queued recording is a no-op.
-    func enqueue(_ recording: Recording) {
+    /// `isRetranscription` marks a deliberate re-run of an existing recording so
+    /// the auto-drop gate never discards it (see `retranscriptionIDs`).
+    func enqueue(_ recording: Recording, isRetranscription: Bool = false) {
         if activeRecordingID == recording.id { return }
         if queue.contains(where: { $0.id == recording.id }) { return }
+        if isRetranscription { retranscriptionIDs.insert(recording.id) }
         queue.append(recording)
         publishPending()
         startWorkerIfNeeded()
@@ -484,13 +494,17 @@ final class TranscriptionService: ObservableObject {
         // the wrong model for the language actually transcribed.
         // (The recording may also have been edited or soft-deleted in the gap.)
         var working = store.recordings.first(where: { $0.id == recording.id }) ?? recording
-        // Whether this is the recording's FIRST transcription. A manual
-        // re-transcribe keeps the prior transcript on the row, so a non-empty
-        // `fullText` here means "already has content" — we must NOT auto-drop
-        // such a recording if the retry comes back empty (that would delete an
-        // existing recording + its audio). Captured before `fullText` is
-        // overwritten below. See issue #61 review.
-        let isFirstTranscription = working.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        // Whether this is the recording's FIRST transcription — the only case
+        // the issue-#61 auto-drop gate may discard a recording. A manual
+        // re-transcribe must NEVER be dropped even if it comes back empty
+        // (that would delete an existing recording + its audio). Use the
+        // explicit `enqueue(isRetranscription:)` flag (consumed here), AND
+        // require an empty prior `fullText`, so neither a UI retry of a
+        // previously-failed-empty recording nor a recovered re-run is dropped.
+        // Captured before `fullText` is overwritten below. See issue #61 review.
+        let wasRetranscribeEnqueue = retranscriptionIDs.remove(recording.id) != nil
+        let isFirstTranscription = !wasRetranscribeEnqueue
+            && working.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         if working.isTrashed {
             print("Transcribe skipped: \(working.title) was deleted before processing")
             return

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -85,6 +85,17 @@ final class TranscriptionService: ObservableObject {
     /// exists). For first-time transcription it's `false`.
     var onTranscriptionCompleted: ((Recording, _ wasRetranscription: Bool) -> Void)?
 
+    /// Auto-drop gate for accidental short+empty captures (issue #61). Wired
+    /// by `MilaApp` to the user's `recordings.minDuration` threshold. Given a
+    /// just-finished recording's duration + transcript, returns `true` when
+    /// the clip should be dropped — i.e. it's BOTH shorter than the threshold
+    /// AND has no transcript (a hotkey misfire / silence). Short clips that
+    /// DID produce text, and anything at/over the threshold, return `false`
+    /// (kept). `nil` — the default, used by every test that doesn't opt in —
+    /// means "never drop", so transcription behaviour is unchanged unless the
+    /// app explicitly wires the gate.
+    var shouldAutoDropShortEmpty: ((_ duration: Double, _ transcript: String) -> Bool)?
+
     private var queue: [Recording] = []
     private var worker: Task<Void, Never>?
 
@@ -591,6 +602,11 @@ final class TranscriptionService: ObservableObject {
                 working.status = .failed
                 working.fullText = ""
                 working.segments = []
+                // Auto-drop accidental short+empty captures (issue #61) before
+                // we persist the .failed row: a sub-threshold clip with no
+                // transcribable audio is pure list spam. A long-but-silent clip
+                // is over the threshold, so the gate keeps it as .failed.
+                if autoDropIfShortAndEmpty(working, transcript: "") { return }
                 store.update(working)
                 return
             }
@@ -693,6 +709,13 @@ final class TranscriptionService: ObservableObject {
                 working.duration = lastEnd
             }
             working.status = text.isEmpty ? .failed : .completed
+            // Auto-drop accidental short+empty captures (issue #61): a clip
+            // that came back with NO transcript AND is under the user's
+            // minimum-duration threshold is a hotkey misfire / silence — drop
+            // it instead of leaving a .failed row cluttering the list. The gate
+            // keeps any clip that produced text (even a short one) and anything
+            // at/over the threshold, so this only ever removes worthless rows.
+            if autoDropIfShortAndEmpty(working, transcript: text) { return }
             store.update(working)
 
             if working.status == .completed {
@@ -753,6 +776,21 @@ final class TranscriptionService: ObservableObject {
             working.status = .failed
             store.update(working)
         }
+    }
+
+    /// Permanently delete `recording` when the auto-drop gate flags it as an
+    /// accidental short+empty capture (issue #61). Returns `true` if it
+    /// dropped it (the caller should then early-return without persisting a
+    /// `.failed`/`.completed` row). We hard-delete rather than soft-delete:
+    /// these clips have no transcript and no audio worth keeping, so routing
+    /// them through Recently Deleted would just leave orphaned audio on disk
+    /// for the grace period. No-op when the gate isn't wired (tests) or the
+    /// recording has real content / is long enough to keep.
+    private func autoDropIfShortAndEmpty(_ recording: Recording, transcript: String) -> Bool {
+        guard shouldAutoDropShortEmpty?(recording.duration, transcript) == true else { return false }
+        print("Transcribe: auto-dropping \(recording.title) [\(recording.id.uuidString.prefix(8))] — \(recording.duration)s + empty transcript (issue #61)")
+        store.permanentlyDelete(recording)
+        return true
     }
 }
 

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -484,6 +484,13 @@ final class TranscriptionService: ObservableObject {
         // the wrong model for the language actually transcribed.
         // (The recording may also have been edited or soft-deleted in the gap.)
         var working = store.recordings.first(where: { $0.id == recording.id }) ?? recording
+        // Whether this is the recording's FIRST transcription. A manual
+        // re-transcribe keeps the prior transcript on the row, so a non-empty
+        // `fullText` here means "already has content" — we must NOT auto-drop
+        // such a recording if the retry comes back empty (that would delete an
+        // existing recording + its audio). Captured before `fullText` is
+        // overwritten below. See issue #61 review.
+        let isFirstTranscription = working.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         if working.isTrashed {
             print("Transcribe skipped: \(working.title) was deleted before processing")
             return
@@ -606,7 +613,7 @@ final class TranscriptionService: ObservableObject {
                 // we persist the .failed row: a sub-threshold clip with no
                 // transcribable audio is pure list spam. A long-but-silent clip
                 // is over the threshold, so the gate keeps it as .failed.
-                if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: "") { return }
+                if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: "", isFirstTranscription: isFirstTranscription) { return }
                 store.update(working)
                 return
             }
@@ -715,7 +722,7 @@ final class TranscriptionService: ObservableObject {
             // it instead of leaving a .failed row cluttering the list. The gate
             // keeps any clip that produced text (even a short one) and anything
             // at/over the threshold, so this only ever removes worthless rows.
-            if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: text) { return }
+            if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: text, isFirstTranscription: isFirstTranscription) { return }
             store.update(working)
 
             if working.status == .completed {
@@ -786,7 +793,11 @@ final class TranscriptionService: ObservableObject {
     /// them through Recently Deleted would just leave orphaned audio on disk
     /// for the grace period. No-op when the gate isn't wired (tests) or the
     /// recording has real content / is long enough to keep.
-    private func autoDropIfShortAndEmpty(_ recording: Recording, duration: Double, transcript: String) -> Bool {
+    private func autoDropIfShortAndEmpty(_ recording: Recording, duration: Double, transcript: String, isFirstTranscription: Bool) -> Bool {
+        // Only auto-drop a recording's FIRST transcription. A manual
+        // re-transcribe of an existing recording that comes back empty must
+        // NOT be deleted — that would destroy content the user already had.
+        guard isFirstTranscription else { return false }
         // Only auto-drop accidental *local mic captures* (mic recordings +
         // dictation hotkey misfires — both `.microphone`). Never Voice Memos,
         // imported files (`.systemAudio`), or meeting captures: those aren't

--- a/Mila/Views/RecordingContextMenu.swift
+++ b/Mila/Views/RecordingContextMenu.swift
@@ -135,7 +135,7 @@ private struct RecordingContextMenu: ViewModifier {
                 guard !isBusy,
                       let prepared = store.prepareForRetranscription(id: recording.id)
                 else { return }
-                transcription.enqueue(prepared)
+                transcription.enqueue(prepared, isRetranscription: true)
             }
             .disabled(isBusy)
             Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
@@ -183,7 +183,7 @@ private struct RecordingContextMenu: ViewModifier {
         guard let prepared = store.prepareForRetranscription(id: recording.id,
                                                              language: language.rawValue)
         else { return }
-        transcription.enqueue(prepared)
+        transcription.enqueue(prepared, isRetranscription: true)
     }
 
     /// Save the recording's SRT to a user-chosen location. NSSavePanel lets

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -142,7 +142,7 @@ struct RecordingDetailView: View {
                     // stays consistent and we never enqueue a stale snapshot
                     // whose `.wav` a since-run compression already deleted.
                     guard let prepared = store.prepareForRetranscription(id: recording.id) else { return }
-                    transcription.enqueue(prepared)
+                    transcription.enqueue(prepared, isRetranscription: true)
                 } label: {
                     Label("\(currentLang.flagEmoji) \(currentLang.displayName) (current)",
                           systemImage: "arrow.clockwise")
@@ -208,7 +208,7 @@ struct RecordingDetailView: View {
         guard let prepared = store.prepareForRetranscription(id: recording.id,
                                                              language: language.rawValue)
         else { return }
-        transcription.enqueue(prepared)
+        transcription.enqueue(prepared, isRetranscription: true)
     }
 
 

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -34,6 +34,7 @@ struct StorageSettingsTab: View {
             header
             currentLocationCard
             storageLimitCard
+            autoDropCard
             if storage.lastResolutionWasStale {
                 staleBookmarkNotice
             }
@@ -150,6 +151,41 @@ struct StorageSettingsTab: View {
         }
         .padding(12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// Auto-drop threshold: a stepper for the minimum-duration gate that
+    /// discards accidental short + empty captures (hotkey misfires, silence)
+    /// right after transcription. 0 disables it (keep everything). See
+    /// issue #61 / `RecordingStorageSettings.minDuration`.
+    private var autoDropCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: "scissors")
+                    .foregroundStyle(.tint)
+                Text("Discard accidental recordings")
+                    .font(.callout.weight(.semibold))
+                Spacer()
+            }
+            Stepper(value: Binding(get: { storage.minDuration },
+                                   set: { storage.minDuration = $0 }),
+                    in: 0...60, step: 1) {
+                Text(autoDropSummary)
+                    .font(.callout)
+            }
+            .accessibilityIdentifier("storage.minDuration.stepper")
+            Text("When a recording finishes with no transcript and is shorter than this, Mila deletes it automatically — those are almost always hotkey misfires or silence. Short recordings that did capture speech are always kept. Set to 0 seconds to keep everything.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var autoDropSummary: String {
+        let s = Int(storage.minDuration.rounded())
+        if s == 0 { return "Keep all recordings (auto-discard off)" }
+        return "Discard empty recordings under \(s) second\(s == 1 ? "" : "s")"
     }
 
     private var reclaimSummary: String {

--- a/MilaTests/RecordingStorageSettingsTests.swift
+++ b/MilaTests/RecordingStorageSettingsTests.swift
@@ -79,6 +79,70 @@ final class RecordingStorageSettingsTests: XCTestCase {
                      "Stale bookmarks pointing at deleted folders must surface as nil so the store falls back to default")
     }
 
+    // MARK: - Auto-drop gate (issue #61)
+
+    func test_minDuration_defaults_to_five_seconds() {
+        let settings = RecordingStorageSettings(defaults: defaults)
+        XCTAssertEqual(settings.minDuration, 5.0)
+    }
+
+    func test_minDuration_persists_across_instances() {
+        let first = RecordingStorageSettings(defaults: defaults)
+        first.minDuration = 8
+        let second = RecordingStorageSettings(defaults: defaults)
+        XCTAssertEqual(second.minDuration, 8)
+    }
+
+    func test_minDuration_clamps_negative_to_zero() {
+        let settings = RecordingStorageSettings(defaults: defaults)
+        settings.minDuration = -3
+        XCTAssertEqual(settings.minDuration, 0)
+    }
+
+    func test_gate_drops_short_and_empty() {
+        // The core case: a sub-threshold clip with no transcript is dropped.
+        XCTAssertTrue(RecordingStorageSettings.shouldAutoDrop(
+            duration: 2, transcript: "", threshold: 5))
+    }
+
+    func test_gate_treats_whitespace_only_transcript_as_empty() {
+        XCTAssertTrue(RecordingStorageSettings.shouldAutoDrop(
+            duration: 2, transcript: "   \n\t ", threshold: 5))
+    }
+
+    func test_gate_keeps_short_but_non_empty() {
+        // "Short but has content" — the explicit edge case from the issue. A
+        // brief clip that DID capture speech must never be dropped.
+        XCTAssertFalse(RecordingStorageSettings.shouldAutoDrop(
+            duration: 2, transcript: "hi there", threshold: 5))
+    }
+
+    func test_gate_keeps_long_recordings() {
+        // At/over the threshold is kept regardless of transcript (a long
+        // silent recording is a deliberate capture, not list spam).
+        XCTAssertFalse(RecordingStorageSettings.shouldAutoDrop(
+            duration: 30, transcript: "", threshold: 5))
+        XCTAssertFalse(RecordingStorageSettings.shouldAutoDrop(
+            duration: 5, transcript: "", threshold: 5),
+            "Exactly at the threshold is kept (strict less-than)")
+    }
+
+    func test_gate_disabled_at_threshold_zero_keeps_everything() {
+        XCTAssertFalse(RecordingStorageSettings.shouldAutoDrop(
+            duration: 0.1, transcript: "", threshold: 0),
+            "Threshold 0 disables the gate — even a 0.1s empty clip is kept")
+    }
+
+    func test_gate_instance_method_uses_persisted_threshold() {
+        let settings = RecordingStorageSettings(defaults: defaults)
+        settings.minDuration = 3
+        XCTAssertTrue(settings.shouldAutoDrop(duration: 1, transcript: ""))
+        XCTAssertFalse(settings.shouldAutoDrop(duration: 4, transcript: ""))
+        settings.minDuration = 0
+        XCTAssertFalse(settings.shouldAutoDrop(duration: 1, transcript: ""),
+                       "minDuration 0 must keep everything")
+    }
+
     // MARK: - RecordingStore.relocateRecordings
 
     func test_store_relocate_routes_new_recordings_to_new_directory() throws {

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -378,6 +378,48 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(stored.status, .failed)
     }
 
+    /// The gate targets accidental *local mic* captures only. A short, empty
+    /// Voice Memos import must NOT be permanently deleted — it has its own
+    /// handling, and deleting it would tombstone the source memo (issue #61
+    /// review: scope the gate away from imports).
+    func test_voice_memo_short_empty_is_not_auto_dropped() async throws {
+        enableAutoDrop()
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "Imported memo",
+                                                    durationSeconds: 1.0,
+                                                    source: .voiceMemo)
+        await stub.setDefaultCanned([])
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id },
+                                   "A Voice Memo import must not be auto-dropped by the mic-capture gate")
+        XCTAssertEqual(stored.status, .failed)
+    }
+
+    /// Regression: the gate must use the DECODED audio duration, not
+    /// `recording.duration`, which crash-recovered rows seed with a stale `0`.
+    /// A long-but-empty clip whose stored duration is `0` must stay `.failed`,
+    /// not be deleted as if it were short (issue #61 review).
+    func test_long_empty_recording_is_kept_despite_stale_zero_duration() async throws {
+        enableAutoDrop()
+        let audioURL = store.freshAudioURL(suggestedName: "Long silent")
+        try TestSupport.writeSineWav(at: audioURL, durationSeconds: 6.0)  // > 5s threshold
+        let rec = Recording(title: "Long silent", duration: 0,  // stale — real audio is 6s
+                            source: .microphone, audioFileName: audioURL.lastPathComponent,
+                            language: "he")
+        store.add(rec)
+        await stub.setDefaultCanned([])
+
+        service.enqueue(rec)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == rec.id },
+                                   "A 6s clip must not be dropped just because recording.duration was a stale 0")
+        XCTAssertEqual(stored.status, .failed)
+    }
+
     /// The silence guard rejects the clip before whisper runs; the auto-drop
     /// gate must still remove it (short + empty), so accidental sub-0.3s /
     /// silent captures never even reach the list.

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -420,6 +420,28 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(stored.status, .failed)
     }
 
+    /// A manual re-transcribe of an EXISTING recording that comes back empty
+    /// must not be auto-dropped — the recording already had content, and
+    /// deleting it would destroy the user's data. Only first-time captures are
+    /// eligible for auto-drop (issue #61 review).
+    func test_short_empty_retranscribe_of_existing_recording_is_kept() async throws {
+        enableAutoDrop()
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "Existing note",
+                                                    durationSeconds: 1.0)
+        var rec = fixture.recording
+        rec.status = .completed
+        rec.fullText = "the note I already transcribed"
+        store.update(rec)                 // now it has prior content
+        await stub.setDefaultCanned([])   // the retry produces nothing
+
+        service.enqueue(rec)
+        await service.waitForIdle()
+
+        XCTAssertNotNil(store.recordings.first { $0.id == rec.id },
+                        "Re-transcribing an existing recording to an empty result must not delete it")
+    }
+
     /// The silence guard rejects the clip before whisper runs; the auto-drop
     /// gate must still remove it (short + empty), so accidental sub-0.3s /
     /// silent captures never even reach the list.

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -297,6 +297,110 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(stored.fullText, "")
     }
 
+    // MARK: - Auto-drop short + empty recordings (issue #61)
+
+    /// Wire the real gate onto the service so these tests exercise the exact
+    /// production path (`RecordingStorageSettings.shouldAutoDrop` +
+    /// `TranscriptionService.process`), not a test-only shortcut.
+    private func enableAutoDrop(threshold: Double = 5) {
+        service.shouldAutoDropShortEmpty = { duration, transcript in
+            RecordingStorageSettings.shouldAutoDrop(
+                duration: duration, transcript: transcript, threshold: threshold)
+        }
+    }
+
+    func test_short_empty_recording_is_auto_dropped_after_transcription() async throws {
+        enableAutoDrop()
+        // Audible + long enough to reach whisper (passes the silence guard),
+        // but the engine returns no segments → empty transcript, under 5s.
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "Hotkey misfire",
+                                                    durationSeconds: 1.0)
+        await stub.setDefaultCanned([])
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        XCTAssertNil(store.recordings.first { $0.id == fixture.recording.id },
+                     "A short recording with an empty transcript must be dropped from the store")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.audioURL.path),
+                       "The dropped recording's audio file must be removed (no orphan)")
+        let calls = await stub.transcribeCalls
+        XCTAssertEqual(calls.count, 1, "Drop happens AFTER transcription resolves")
+    }
+
+    func test_short_but_transcribed_recording_is_kept() async throws {
+        // The explicit edge case from the issue: short, but it produced text.
+        enableAutoDrop()
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "Short but real",
+                                                    durationSeconds: 1.0)
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "quick note to self")
+        ])
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.fullText, "quick note to self")
+    }
+
+    func test_short_empty_recording_is_kept_when_gate_disabled() async throws {
+        // Threshold 0 disables the gate: the short+empty clip stays as .failed
+        // (the pre-#61 behaviour), it is NOT dropped.
+        enableAutoDrop(threshold: 0)
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "Kept because gate off",
+                                                    durationSeconds: 1.0)
+        await stub.setDefaultCanned([])
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.status, .failed)
+    }
+
+    func test_short_empty_recording_is_kept_when_no_hook_wired() async throws {
+        // Default: no gate wired at all (every existing caller/test). Behaviour
+        // is unchanged — the short+empty recording lands .failed and stays.
+        let fixture = try TestRecordingFixture.make(in: store,
+                                                    title: "No hook",
+                                                    durationSeconds: 1.0)
+        await stub.setDefaultCanned([])
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.status, .failed)
+    }
+
+    /// The silence guard rejects the clip before whisper runs; the auto-drop
+    /// gate must still remove it (short + empty), so accidental sub-0.3s /
+    /// silent captures never even reach the list.
+    func test_silence_rejected_recording_is_auto_dropped_when_short() async throws {
+        enableAutoDrop()
+        let url = store.freshAudioURL(suggestedName: "Silent misfire")
+        try TestSupport.writeSineWav(at: url, durationSeconds: 0.06, amplitude: 0.0001)
+        let recording = Recording(title: "Silent misfire",
+                                  duration: 0.06,
+                                  source: .microphone,
+                                  audioFileName: url.lastPathComponent,
+                                  language: "he")
+        store.add(recording)
+
+        service.enqueue(recording)
+        await service.waitForIdle()
+
+        XCTAssertNil(store.recordings.first { $0.id == recording.id },
+                     "A silence-rejected short clip must be auto-dropped")
+        let calls = await stub.transcribeCalls
+        XCTAssertTrue(calls.isEmpty, "Silence guard still short-circuits before whisper")
+    }
+
     // MARK: - User-reported "every empty recording shows the same transcript"
 
     /// REGRESSION: When the second/third Voice Memo captures almost no audio


### PR DESCRIPTION
## Summary

Very short accidental captures (~0–5s: hotkey misfires, start/stop before speaking, a moment of silence) pile up and spam the recordings/sidebar list. This adds a configurable **minimum-duration gate** that permanently drops a recording when — **after** transcription resolves — it is **both shorter than the threshold AND has an empty/whitespace-only transcript**.

The explicit edge case from the issue is honored: a **short clip that produced real text is always kept** ("short but has content"), and any clip **at/over the threshold** is kept regardless of transcript. Only newly-finished recordings are affected — the existing library is never retroactively swept.

Fixes #61

## What changed

- **`RecordingStorageSettings.minDuration`** — new `recordings.minDuration` setting (default **5s**, **0 = keep all**), UserDefaults-backed and persisted. Added to the existing storage settings object to avoid new `@StateObject`/`.environmentObject` wiring.
- **Pure gate `RecordingStorageSettings.shouldAutoDrop(duration:transcript:threshold:)`** — the testable decision, used verbatim by the app and the tests.
- **`TranscriptionService.shouldAutoDropShortEmpty` hook** — wired in `MilaApp` to the live threshold (reads it each time, so a Settings change takes effect on the next recording without relaunch). `nil` by default, so every existing test/caller sees **unchanged** transcription behaviour unless the gate is explicitly wired. Applied in **both** post-transcription exit points in `process(_:)`:
  - the normal completion path (whisper returned an empty transcript), and
  - the pre-whisper silence/too-short guard (sub-0.3s or near-silent clips).
- **Settings ▸ Storage** — a stepper (`0…60s`) with a "0 = keep all recordings" affordance and explanatory copy.
- **Tests** — pure gate coverage in `RecordingStorageSettingsTests` (short+empty → drop; short+non-empty → keep; long → keep; whitespace-only → drop; threshold 0 → keep all; persistence; negative clamp) plus end-to-end coverage in `TranscriptionServiceTests` driving the real gate through `process(_:)` (dropped-from-store + audio file removed; short-but-transcribed kept; gate-disabled kept; no-hook-wired unchanged; silence-rejected short clip dropped).

## Key decisions

- **Hook location:** the post-transcription completion path (per the issue's "transcribe-then-evaluate", since you need the transcript to know it's empty), covering both the empty-result and silence-guard exits so accidental captures never linger as `.failed` rows.
- **Drop vs. trash:** `permanentlyDelete` (truly gone), not `softDelete`. These clips have no transcript and no audio worth keeping, so Recently Deleted would only leave orphaned audio on disk for the grace period. Tradeoff: a dropped clip is not recoverable — acceptable since it's empty by definition and the gate is user-tunable/disable-able.
- **Setting location:** added to `RecordingStorageSettings` (already a `@StateObject` injected on both scenes) rather than a new settings object, per `CLAUDE.md` guidance.
- **Scope:** Voice Memos imports keep their own separate `VoiceMemosSettings.minDurationSeconds` skip — untouched.

## Verification

- `make build` → **BUILD SUCCEEDED**
- `xcodebuild build-for-testing` → **TEST BUILD SUCCEEDED** (app + test targets compile; tests not run locally per repo convention — CI runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Discard accidental recordings” setting with a 0–60s minimum duration control (default: 5s), persisted across launches.
- **Bug Fixes**
  - Automatically discards short microphone recordings with empty/whitespace transcripts when below the configured threshold.
  - Setting the threshold to 0 disables discarding; clips at/above the threshold are kept.
  - Re-transcriptions are no longer at risk of being auto-discarded.
- **Tests**
  - Added regression coverage for auto-discard behavior, including re-transcription and threshold edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->