### PR TITLE
Voice Memos folder-sync UX: un-select cleanup, folder preview, stable status, dedicated folder

### DIFF
--- a/Mila/Audio/FileTranscriber.swift
+++ b/Mila/Audio/FileTranscriber.swift
@@ -14,7 +14,9 @@ enum FileTranscriber {
                            source: RecordingSource = .systemAudio,
                            title titleOverride: String? = nil,
                            createdAt: Date? = nil,
-                           voiceMemoUniqueID: String? = nil) async throws -> Recording {
+                           voiceMemoUniqueID: String? = nil,
+                           voiceMemoFolderUUID: String? = nil,
+                           folder: String? = nil) async throws -> Recording {
         let didStart = sourceURL.startAccessingSecurityScopedResource()
         defer { if didStart { sourceURL.stopAccessingSecurityScopedResource() } }
 
@@ -30,6 +32,13 @@ enum FileTranscriber {
 
         let duration = try await reencode(source: sourceURL, destination: destURL)
 
+        // Ensure the destination folder exists in the sidebar list before the
+        // recording references it — `createFolder` is idempotent, so a shared
+        // folder like "Voice Memos" is only created once. Without this the
+        // folder wouldn't appear in the sidebar until the next launch (it's
+        // otherwise only seeded from persisted recordings at load).
+        if let folder { store.createFolder(folder) }
+
         let recording = Recording(
             title: title,
             createdAt: createdAt ?? Date(),
@@ -37,7 +46,9 @@ enum FileTranscriber {
             source: source,
             audioFileName: destURL.lastPathComponent,
             language: language.rawValue,
-            voiceMemoUniqueID: voiceMemoUniqueID
+            folder: folder,
+            voiceMemoUniqueID: voiceMemoUniqueID,
+            voiceMemoFolderUUID: voiceMemoFolderUUID
         )
         store.add(recording)
         return recording

--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -81,6 +81,25 @@ struct Recording: Identifiable, Codable, Hashable {
     /// non-Voice-Memo recording.
     var voiceMemoUniqueID: String?
 
+    /// The Voice Memos folder this memo was imported from, keyed by the
+    /// stable `ZFOLDER.ZUUID`, or `Recording.voiceMemoUnfiledFolderID` for
+    /// the unfiled bucket. Set only on `source == .voiceMemo` imports. Lets
+    /// "un-selecting a folder removes its recordings" (issue #57) find every
+    /// recording that came from a given folder without guessing.
+    ///
+    /// nil means "origin not recorded" — either a non-Voice-Memo recording or
+    /// a memo imported before this field existed. Legacy nil is deliberately
+    /// treated as unknown and never swept up by the un-select cleanup, so an
+    /// upgrade can't mass-delete a user's older imports.
+    var voiceMemoFolderUUID: String?
+
+    /// Sentinel stored in `voiceMemoFolderUUID` for memos imported from the
+    /// Voice Memos "Unfiled" bucket, which has no real folder UUID. Keeps
+    /// "imported from Unfiled" distinguishable from a legacy import whose
+    /// origin was never recorded (nil) — the former is cleaned up when the
+    /// user turns Unfiled off, the latter is left alone.
+    static let voiceMemoUnfiledFolderID = "__voicememos.unfiled__"
+
     init(id: UUID = UUID(),
          title: String,
          createdAt: Date = Date(),
@@ -97,7 +116,8 @@ struct Recording: Identifiable, Codable, Hashable {
          appName: String? = nil,
          summary: String? = nil,
          actionItems: [ActionItem]? = nil,
-         voiceMemoUniqueID: String? = nil) {
+         voiceMemoUniqueID: String? = nil,
+         voiceMemoFolderUUID: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -115,6 +135,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.summary = summary
         self.actionItems = actionItems
         self.voiceMemoUniqueID = voiceMemoUniqueID
+        self.voiceMemoFolderUUID = voiceMemoFolderUUID
     }
 
     var isTrashed: Bool { deletedAt != nil }
@@ -149,7 +170,7 @@ struct Recording: Identifiable, Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,
-             summary, actionItems, voiceMemoUniqueID
+             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID
         // `fullText` deliberately excluded — lives in a sidecar .txt file.
         // Legacy records that had it inline are decoded via the custom init.
         case fullText
@@ -173,6 +194,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.summary = try c.decodeIfPresent(String.self, forKey: .summary)
         self.actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
         self.voiceMemoUniqueID = try c.decodeIfPresent(String.self, forKey: .voiceMemoUniqueID)
+        self.voiceMemoFolderUUID = try c.decodeIfPresent(String.self, forKey: .voiceMemoFolderUUID)
         // Legacy records still have fullText inline; new records leave it
         // empty here and RecordingStore loads it from the sidecar .txt.
         self.fullText = try c.decodeIfPresent(String.self, forKey: .fullText) ?? ""
@@ -196,6 +218,7 @@ struct Recording: Identifiable, Codable, Hashable {
         try c.encodeIfPresent(summary, forKey: .summary)
         try c.encodeIfPresent(actionItems, forKey: .actionItems)
         try c.encodeIfPresent(voiceMemoUniqueID, forKey: .voiceMemoUniqueID)
+        try c.encodeIfPresent(voiceMemoFolderUUID, forKey: .voiceMemoFolderUUID)
         // fullText intentionally omitted — sidecar .txt is the source of truth.
     }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -524,6 +524,41 @@ final class RecordingStore: ObservableObject {
         recordings.filter { !$0.isTrashed && $0.folder == folderName }
     }
 
+    /// Live (non-trashed) Voice-Memo imports that originated from the Voice
+    /// Memos folder `folderID` (a `ZFOLDER.ZUUID`, or
+    /// `Recording.voiceMemoUnfiledFolderID` for the unfiled bucket). Only
+    /// `.voiceMemo` recordings with a matching recorded origin are returned —
+    /// legacy imports (nil origin) and the user's own recordings are excluded,
+    /// so the un-select cleanup can never sweep up something it didn't import.
+    func voiceMemoRecordings(fromFolderID folderID: String) -> [Recording] {
+        recordings.filter {
+            !$0.isTrashed
+                && $0.source == .voiceMemo
+                && $0.voiceMemoFolderUUID == folderID
+        }
+    }
+
+    /// Un-select cleanup (issue #57): move every live Voice-Memo import that
+    /// came from `folderID` to Recently Deleted. Soft-delete (not permanent)
+    /// so the user can restore them, and — crucially — so no tombstone is
+    /// written: the recordings stay in the store, so re-selecting the folder
+    /// won't re-import duplicates, and the source memos remain untouched in
+    /// Voice Memos. Returns the number moved to the trash.
+    @discardableResult
+    func softDeleteVoiceMemos(fromFolderID folderID: String) -> Int {
+        let now = Date()
+        var count = 0
+        for idx in recordings.indices where
+            !recordings[idx].isTrashed
+            && recordings[idx].source == .voiceMemo
+            && recordings[idx].voiceMemoFolderUUID == folderID {
+            recordings[idx].deletedAt = now
+            count += 1
+        }
+        if count > 0 { persist() }
+        return count
+    }
+
     /// Non-trashed recordings that haven't been filed anywhere yet. These
     /// surface in the sidebar's "Default" view. Replaces the old
     /// Transcriptions/Meetings/Dictations category split — we now have one

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -23,6 +23,14 @@ struct VoiceMemosSettingsTab: View {
     @State private var previews: [String: [VoiceMemosLibrary.Memo]] = [:]
     /// Folder ids with a preview load in flight (drives the row's spinner).
     @State private var loadingPreviews: Set<String> = []
+    /// Folder ids whose last preview load FAILED. Tracked separately from
+    /// `previews` so a read error isn't cached as an empty folder (which would
+    /// suppress retries and show a false "No recordings"); re-expanding retries.
+    @State private var previewErrors: Set<String> = []
+    /// Bumped on every `loadFolders` (rescan / settings change). Async folder
+    /// and preview loads capture the current value and drop their results if a
+    /// newer load has started since, so a stale `Task` can't clobber fresh state.
+    @State private var loadGeneration = 0
     /// Set when de-selecting a folder that still has imported recordings, to
     /// drive the "remove its recordings?" confirmation (issue #57, part 1).
     @State private var pendingCleanup: PendingCleanup?
@@ -277,6 +285,11 @@ struct VoiceMemosSettingsTab: View {
                 Text("Loading…").font(.caption).foregroundStyle(.secondary)
             }
             .padding(.leading, 26)
+        } else if previewErrors.contains(id) {
+            Text("Couldn't load recordings — collapse and expand to retry.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 26)
         } else if let memos = previews[id] {
             if memos.isEmpty {
                 Text("No recordings in this folder.")
@@ -335,10 +348,12 @@ struct VoiceMemosSettingsTab: View {
     private func loadPreview(id: String, isUnfiled: Bool) {
         guard previews[id] == nil, !loadingPreviews.contains(id) else { return }
         loadingPreviews.insert(id)
+        previewErrors.remove(id)
         let lib = library
         let limit = previewLimit
+        let gen = loadGeneration
         Task {
-            let loaded: [VoiceMemosLibrary.Memo]
+            let loaded: [VoiceMemosLibrary.Memo]?
             do {
                 loaded = try await Task.detached(priority: .userInitiated) {
                     let memos = try lib.recordings(
@@ -347,10 +362,18 @@ struct VoiceMemosSettingsTab: View {
                     return Array(memos.sorted { $0.date > $1.date }.prefix(limit))
                 }.value
             } catch {
-                loaded = []
+                loaded = nil
             }
-            previews[id] = loaded
+            // Drop stale results: a rescan/settings change started a newer load.
+            guard gen == loadGeneration else { return }
             loadingPreviews.remove(id)
+            if let loaded {
+                previews[id] = loaded
+            } else {
+                // Don't cache the failure as an empty folder — flag it so the
+                // row shows a retryable error instead of a false "No recordings".
+                previewErrors.insert(id)
+            }
         }
     }
 
@@ -458,23 +481,32 @@ struct VoiceMemosSettingsTab: View {
     }
 
     private func loadFolders() async {
+        loadGeneration &+= 1
+        let gen = loadGeneration
         isLoading = true
         loadError = nil
         // Drop cached previews so a rescan reflects the current library; keep
         // the user's expansion choices and re-load previews for what's open.
+        // Also clear in-flight/error preview state so a rescan can re-load a
+        // folder that was previously loading or had failed.
         previews.removeAll()
-        defer { isLoading = false }
+        loadingPreviews.removeAll()
+        previewErrors.removeAll()
+        defer { if gen == loadGeneration { isLoading = false } }
         let lib = library
         do {
             let loaded = try await Task.detached(priority: .userInitiated) {
                 (folders: try lib.folders(), unfiled: try lib.unfiledCount())
             }.value
+            // A newer load started while this one was in flight — drop stale results.
+            guard gen == loadGeneration else { return }
             folders = loaded.folders
             unfiledCount = loaded.unfiled
             for id in expandedFolderIDs {
                 loadPreview(id: id, isUnfiled: id == unfiledPreviewID)
             }
         } catch {
+            guard gen == loadGeneration else { return }
             // Drop stale data so a failed refresh can't leave the user
             // interacting with folder choices that no longer reflect the DB.
             folders = []

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -8,11 +8,40 @@ import AppKit
 struct VoiceMemosSettingsTab: View {
     @EnvironmentObject private var settings: VoiceMemosSettings
     @EnvironmentObject private var importer: VoiceMemosImporter
+    @EnvironmentObject private var store: RecordingStore
 
     @State private var folders: [VoiceMemosLibrary.Folder] = []
     @State private var unfiledCount = 0
     @State private var loadError: String?
     @State private var isLoading = false
+
+    /// Folder ids (a `ZFOLDER.ZUUID`, or `unfiledPreviewID` for the unfiled
+    /// bucket) the user expanded to preview contents (issue #57, part 2).
+    @State private var expandedFolderIDs: Set<String> = []
+    /// Cached preview memos per folder id — the first `previewLimit` titles,
+    /// loaded lazily on expand so the user can review a folder WITHOUT syncing.
+    @State private var previews: [String: [VoiceMemosLibrary.Memo]] = [:]
+    /// Folder ids with a preview load in flight (drives the row's spinner).
+    @State private var loadingPreviews: Set<String> = []
+    /// Set when de-selecting a folder that still has imported recordings, to
+    /// drive the "remove its recordings?" confirmation (issue #57, part 1).
+    @State private var pendingCleanup: PendingCleanup?
+
+    /// Stable key for the unfiled bucket in the preview/expansion dictionaries
+    /// (it has no real folder UUID). Reuses the same sentinel the importer
+    /// stamps onto unfiled imports so the two never disagree.
+    private var unfiledPreviewID: String { Recording.voiceMemoUnfiledFolderID }
+
+    /// Cap on how many memo titles a preview loads/shows — enough to review a
+    /// folder without reading/rendering thousands of rows.
+    private let previewLimit = 50
+
+    private struct PendingCleanup: Identifiable {
+        let folderID: String
+        let name: String
+        let count: Int
+        var id: String { folderID }
+    }
 
     /// Reader over the folder the user granted (falling back to the standard
     /// location, which is what a legacy Full-Disk-Access user already sees).
@@ -51,6 +80,24 @@ struct VoiceMemosSettingsTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .task(id: "\(settings.isEnabled)-\(settings.grantedFolderURL?.path ?? "")") {
             if settings.isEnabled { await loadFolders() }
+        }
+        .confirmationDialog(
+            "Remove imported recordings?",
+            isPresented: Binding(
+                get: { pendingCleanup != nil },
+                set: { if !$0 { pendingCleanup = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingCleanup
+        ) { cleanup in
+            Button("Move \(cleanup.count) to Recently Deleted", role: .destructive) {
+                store.softDeleteVoiceMemos(fromFolderID: cleanup.folderID)
+                pendingCleanup = nil
+            }
+            Button("Keep Recordings", role: .cancel) { pendingCleanup = nil }
+        } message: { cleanup in
+            Text("Move the \(cleanup.count) recording\(cleanup.count == 1 ? "" : "s") imported from “\(cleanup.name)” to Recently Deleted? "
+                 + "You can restore them there, and re-syncing this folder later won't create duplicates.")
         }
     }
 
@@ -153,13 +200,17 @@ struct VoiceMemosSettingsTab: View {
             }
 
             List {
-                Toggle(isOn: $settings.includeUnfiled) {
-                    folderRow(name: "Unfiled", count: unfiledCount, systemImage: "tray")
-                }
+                folderGroup(id: unfiledPreviewID,
+                            name: "Unfiled",
+                            count: unfiledCount,
+                            systemImage: "tray",
+                            isUnfiled: true)
                 ForEach(folders) { folder in
-                    Toggle(isOn: binding(for: folder)) {
-                        folderRow(name: folder.name, count: folder.count, systemImage: "folder")
-                    }
+                    folderGroup(id: folder.uuid,
+                                name: folder.name,
+                                count: folder.count,
+                                systemImage: "folder",
+                                isUnfiled: false)
                 }
             }
             .frame(height: 220)
@@ -171,9 +222,87 @@ struct VoiceMemosSettingsTab: View {
             }
 
             if !settings.hasSelection {
-                Text("Choose at least one folder to start syncing.")
+                Text("Choose at least one folder to start syncing. Tap the arrow to preview a folder's recordings before turning it on.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// One folder in the picker: a selection toggle with a leading disclosure
+    /// arrow that expands an inline, non-importing preview of the folder's
+    /// recordings (issue #57, part 2).
+    @ViewBuilder
+    private func folderGroup(id: String,
+                             name: String,
+                             count: Int,
+                             systemImage: String,
+                             isUnfiled: Bool) -> some View {
+        HStack(spacing: 6) {
+            Button {
+                toggleExpand(id: id, isUnfiled: isUnfiled)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(expandedFolderIDs.contains(id) ? 90 : 0))
+                    .frame(width: 12, height: 12)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            // An empty folder has nothing to preview; keep the space so the
+            // toggles stay aligned.
+            .disabled(count == 0)
+            .opacity(count == 0 ? 0 : 1)
+            .help(expandedFolderIDs.contains(id) ? "Hide recordings" : "Preview recordings")
+
+            Toggle(isOn: selectionBinding(folderID: id, isUnfiled: isUnfiled, displayName: name)) {
+                folderRow(name: name, count: count, systemImage: systemImage)
+            }
+        }
+
+        if expandedFolderIDs.contains(id) {
+            previewRows(for: id, total: count)
+        }
+    }
+
+    /// Inline preview rows shown under an expanded folder — a loading spinner,
+    /// an empty note, or the memo titles + a "…and N more" overflow line.
+    @ViewBuilder
+    private func previewRows(for id: String, total: Int) -> some View {
+        if loadingPreviews.contains(id) {
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Loading…").font(.caption).foregroundStyle(.secondary)
+            }
+            .padding(.leading, 26)
+        } else if let memos = previews[id] {
+            if memos.isEmpty {
+                Text("No recordings in this folder.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 26)
+            } else {
+                ForEach(memos) { memo in
+                    HStack {
+                        Text(memo.title)
+                            .font(.caption)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(memo.date, format: .dateTime.month().day().year())
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 26)
+                }
+                if total > memos.count {
+                    Text("…and \(total - memos.count) more")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, 26)
+                }
             }
         }
     }
@@ -187,6 +316,41 @@ struct VoiceMemosSettingsTab: View {
             Text("\(count)")
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Toggle a folder's inline preview, lazily loading its memo titles the
+    /// first time it's expanded.
+    private func toggleExpand(id: String, isUnfiled: Bool) {
+        if expandedFolderIDs.contains(id) {
+            expandedFolderIDs.remove(id)
+        } else {
+            expandedFolderIDs.insert(id)
+            loadPreview(id: id, isUnfiled: isUnfiled)
+        }
+    }
+
+    /// Read a folder's memo titles off the main actor and cache them. Reuses
+    /// the read-only library reader — no import, no queueing.
+    private func loadPreview(id: String, isUnfiled: Bool) {
+        guard previews[id] == nil, !loadingPreviews.contains(id) else { return }
+        loadingPreviews.insert(id)
+        let lib = library
+        let limit = previewLimit
+        Task {
+            let loaded: [VoiceMemosLibrary.Memo]
+            do {
+                loaded = try await Task.detached(priority: .userInitiated) {
+                    let memos = try lib.recordings(
+                        folderUUIDs: isUnfiled ? [] : [id],
+                        includeUnfiled: isUnfiled)
+                    return Array(memos.sorted { $0.date > $1.date }.prefix(limit))
+                }.value
+            } catch {
+                loaded = []
+            }
+            previews[id] = loaded
+            loadingPreviews.remove(id)
         }
     }
 
@@ -259,16 +423,46 @@ struct VoiceMemosSettingsTab: View {
         return "Last scan held back " + parts.joined(separator: ", ") + "."
     }
 
-    private func binding(for folder: VoiceMemosLibrary.Folder) -> Binding<Bool> {
+    /// Selection toggle for a folder (or the unfiled bucket). Turning it OFF
+    /// stops future imports immediately, then — if that folder already
+    /// imported recordings — arms the cleanup confirmation so de-selecting can
+    /// actually reverse the sync (issue #57, part 1).
+    private func selectionBinding(folderID: String,
+                                  isUnfiled: Bool,
+                                  displayName: String) -> Binding<Bool> {
         Binding(
-            get: { settings.selectedFolderUUIDs.contains(folder.uuid) },
-            set: { settings.setFolder(folder.uuid, selected: $0) }
+            get: {
+                isUnfiled ? settings.includeUnfiled : settings.selectedFolderUUIDs.contains(folderID)
+            },
+            set: { newValue in
+                if newValue {
+                    if isUnfiled { settings.includeUnfiled = true }
+                    else { settings.setFolder(folderID, selected: true) }
+                    return
+                }
+                // De-selecting: stop future imports right away.
+                if isUnfiled { settings.includeUnfiled = false }
+                else { settings.setFolder(folderID, selected: false) }
+                // Then offer to remove what this folder already imported. The
+                // cleanup keys on the recorded origin (a real ZUUID, or the
+                // unfiled sentinel), independent of this display name.
+                let cleanupID = isUnfiled ? Recording.voiceMemoUnfiledFolderID : folderID
+                let matches = store.voiceMemoRecordings(fromFolderID: cleanupID).count
+                if matches > 0 {
+                    pendingCleanup = PendingCleanup(folderID: cleanupID,
+                                                    name: displayName,
+                                                    count: matches)
+                }
+            }
         )
     }
 
     private func loadFolders() async {
         isLoading = true
         loadError = nil
+        // Drop cached previews so a rescan reflects the current library; keep
+        // the user's expansion choices and re-load previews for what's open.
+        previews.removeAll()
         defer { isLoading = false }
         let lib = library
         do {
@@ -277,6 +471,9 @@ struct VoiceMemosSettingsTab: View {
             }.value
             folders = loaded.folders
             unfiledCount = loaded.unfiled
+            for id in expandedFolderIDs {
+                loadPreview(id: id, isUnfiled: id == unfiledPreviewID)
+            }
         } catch {
             // Drop stale data so a failed refresh can't leave the user
             // interacting with folder choices that no longer reflect the DB.

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -346,7 +346,11 @@ struct VoiceMemosSettingsTab: View {
     /// Read a folder's memo titles off the main actor and cache them. Reuses
     /// the read-only library reader — no import, no queueing.
     private func loadPreview(id: String, isUnfiled: Bool) {
-        guard previews[id] == nil, !loadingPreviews.contains(id) else { return }
+        // Don't start a preview while a folder refresh is in flight — it would
+        // capture the refresh's generation and cache a snapshot the refresh's
+        // own end-of-load pass would then suppress. `loadFolders` re-loads
+        // previews for expanded folders once the refresh finishes.
+        guard !isLoading, previews[id] == nil, !loadingPreviews.contains(id) else { return }
         loadingPreviews.insert(id)
         previewErrors.remove(id)
         let lib = library
@@ -492,16 +496,21 @@ struct VoiceMemosSettingsTab: View {
         previews.removeAll()
         loadingPreviews.removeAll()
         previewErrors.removeAll()
-        defer { if gen == loadGeneration { isLoading = false } }
         let lib = library
         do {
             let loaded = try await Task.detached(priority: .userInitiated) {
                 (folders: try lib.folders(), unfiled: try lib.unfiledCount())
             }.value
-            // A newer load started while this one was in flight — drop stale results.
+            // A newer load started while this one was in flight — drop stale
+            // results and let that newer load own `isLoading`.
             guard gen == loadGeneration else { return }
             folders = loaded.folders
             unfiledCount = loaded.unfiled
+            // Clear `isLoading` BEFORE kicking off preview loads: `loadPreview`
+            // refuses to start while a refresh is in flight (so a user expand
+            // mid-refresh can't cache a snapshot the refresh would then suppress),
+            // and this end-of-refresh pass is what loads previews for open folders.
+            isLoading = false
             for id in expandedFolderIDs {
                 loadPreview(id: id, isUnfiled: id == unfiledPreviewID)
             }
@@ -512,6 +521,7 @@ struct VoiceMemosSettingsTab: View {
             folders = []
             unfiledCount = 0
             loadError = error.localizedDescription
+            isLoading = false
         }
     }
 }

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -37,6 +37,12 @@ final class VoiceMemosImporter: ObservableObject {
 
     private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceMemos")
 
+    /// Mila folder that synced Voice Memos are filed into so they're grouped
+    /// together in the sidebar instead of mixed into All Transcripts
+    /// (issue #57, part 4). One shared folder — simple and predictable; the
+    /// per-source origin is tracked separately on `Recording.voiceMemoFolderUUID`.
+    static let syncedFolderName = "Voice Memos"
+
     /// Per-run tally the Settings status line reads to explain what the last
     /// sync did — especially *why* it imported less than the folder count
     /// (before the start-date cutoff, not downloaded yet, failed to decode…).
@@ -51,6 +57,43 @@ final class VoiceMemosImporter: ObservableObject {
         var totalHeldBack: Int {
             failedImport + skippedOlder + skippedShort + skippedComposition + skippedMissing
         }
+    }
+
+    /// Pure classification of a scan: which not-yet-imported memos are eligible
+    /// to import, plus the tally of why the rest were held back. Split out of
+    /// `sync()` so the "is there real work?" decision — the one that gates the
+    /// visible "Syncing…" state — is testable without a database or filesystem,
+    /// and so an idle rescan that imports nothing never flips the UI (issue #57,
+    /// the "Last synced" flicker).
+    struct ImportPlan: Equatable {
+        var toImport: [VoiceMemosLibrary.Memo] = []
+        var summary = SyncSummary()
+
+        /// True only when the scan will actually import something — the sole
+        /// case that should surface a "Syncing…" spinner to the user.
+        var hasVisibleWork: Bool { !toImport.isEmpty }
+    }
+
+    /// Decide what a scan would do, given the memos read from the library and
+    /// the dedup/cutoff inputs. Pure (no I/O beyond the injected `fileExists`
+    /// probe) so it's unit-testable. Mirrors the eligibility order the old
+    /// inline loop used: start-date cutoff first (so its count reflects the
+    /// user's date choice), then composition, then too-short, then not-yet-
+    /// downloaded.
+    static func plan(memos: [VoiceMemosLibrary.Memo],
+                     alreadyImported: Set<String>,
+                     startDate: Date,
+                     minDuration: Double,
+                     fileExists: (URL) -> Bool) -> ImportPlan {
+        var plan = ImportPlan()
+        for memo in memos where !alreadyImported.contains(memo.uniqueID) {
+            if memo.date < startDate { plan.summary.skippedOlder += 1; continue }
+            if memo.isComposition { plan.summary.skippedComposition += 1; continue }
+            if memo.duration < minDuration { plan.summary.skippedShort += 1; continue }
+            guard fileExists(memo.fileURL) else { plan.summary.skippedMissing += 1; continue }
+            plan.toImport.append(memo)
+        }
+        return plan
     }
 
     /// Last successful sync timestamp, for the Settings status line.
@@ -69,6 +112,12 @@ final class VoiceMemosImporter: ObservableObject {
     private var started = false
     /// Coalesces FSEvents bursts and overlapping triggers into one run.
     private var pendingResync = false
+    /// A scan is running. Distinct from the *published* `isSyncing`, which now
+    /// only reflects user-visible import work (issue #57): a scan that imports
+    /// nothing runs with `scanInFlight == true` but never flips `isSyncing`, so
+    /// the status line stays steady. This is the flag the coalescing guard
+    /// keys on so two scans never overlap.
+    private var scanInFlight = false
 
     init(store: RecordingStore,
          transcription: TranscriptionService,
@@ -146,7 +195,11 @@ final class VoiceMemosImporter: ObservableObject {
 
     /// Run a sync, coalescing requests so two never overlap.
     private func requestSync() {
-        guard !isSyncing else {
+        // Guard on `scanInFlight` (set synchronously at the top of `sync()`),
+        // NOT the published `isSyncing` — the latter now only tracks visible
+        // import work, so an idle scan leaves it false and two requests would
+        // otherwise both spawn overlapping syncs.
+        guard !scanInFlight else {
             pendingResync = true
             return
         }
@@ -156,24 +209,23 @@ final class VoiceMemosImporter: ObservableObject {
     private func sync() async {
         guard settings.isEnabled, settings.hasSelection else { return }
         // Re-check on entry: `requestSync`'s guard runs when the request is
-        // made, but `isSyncing` only flips once this Task actually starts.
-        // Two requests landing in the same main-actor drain (e.g. "Rescan
-        // now" + an FSEvents hop) both saw false and spawned overlapping
-        // syncs — each snapshots `alreadyImported` before the other's
-        // `store.add` lands, so the same memo imported (and transcribed)
-        // twice.
-        guard !isSyncing else {
+        // made, but the flag only flips once this Task actually starts. Two
+        // requests landing in the same main-actor drain (e.g. "Rescan now" +
+        // an FSEvents hop) both saw false and spawned overlapping syncs — each
+        // snapshots `alreadyImported` before the other's `store.add` lands, so
+        // the same memo imported (and transcribed) twice. `scanInFlight` is set
+        // synchronously below before the first `await`, closing that window.
+        guard !scanInFlight else {
             pendingResync = true
             return
         }
-        isSyncing = true
-        lastError = nil
+        scanInFlight = true
         defer {
-            isSyncing = false
+            scanInFlight = false
             // A folder change / FSEvents burst that arrived mid-sync set
-            // `pendingResync`; kick the next pass now that `isSyncing` is
-            // clear (doing this before clearing it would just re-set the flag
-            // and the second pass would never run).
+            // `pendingResync`; kick the next pass now that the flag is clear
+            // (doing this before clearing it would just re-set the flag and
+            // the second pass would never run).
             if pendingResync {
                 pendingResync = false
                 requestSync()
@@ -192,7 +244,7 @@ final class VoiceMemosImporter: ObservableObject {
                 try lib.recordings(folderUUIDs: folderUUIDs, includeUnfiled: includeUnfiled)
             }.value
         } catch {
-            lastError = error.localizedDescription
+            setError(error.localizedDescription)
             log.error("VoiceMemos sync failed reading DB: \(error.localizedDescription, privacy: .public)")
             return
         }
@@ -204,22 +256,29 @@ final class VoiceMemosImporter: ObservableObject {
         let alreadyImported = Set(store.recordings.compactMap { $0.voiceMemoUniqueID })
             .union(store.voiceMemoTombstones)
         let fm = FileManager.default
+        let plan = Self.plan(memos: memos,
+                             alreadyImported: alreadyImported,
+                             startDate: startDate,
+                             minDuration: VoiceMemosSettings.minDurationSeconds,
+                             fileExists: { fm.fileExists(atPath: $0.path) })
 
-        var summary = SyncSummary()
+        // Nothing to import: publish the (stable) summary WITHOUT ever flipping
+        // `isSyncing`. This is the fix for the "Last synced" flicker (issue
+        // #57) — the FSEvents watcher fires ~once/second as voicememod touches
+        // the WAL, and every one of those idle rescans used to flash the
+        // spinner and re-stamp the timestamp. `publishOutcome` also skips any
+        // no-op writes, so an idle rescan leaves the status line untouched.
+        guard plan.hasVisibleWork else {
+            publishOutcome(summary: plan.summary, imported: 0)
+            return
+        }
 
-        for memo in memos where !alreadyImported.contains(memo.uniqueID) {
-            // Start-date cutoff first, so the "before cutoff" count reflects
-            // everything the user's date choice held back.
-            if memo.date < startDate { summary.skippedOlder += 1; continue }
-            if memo.isComposition { summary.skippedComposition += 1; continue }
-            if memo.duration < VoiceMemosSettings.minDurationSeconds { summary.skippedShort += 1; continue }
-            guard fm.fileExists(atPath: memo.fileURL.path) else {
-                // Not downloaded from iCloud yet (or evicted); a later
-                // FSEvents fire will catch it once it lands.
-                summary.skippedMissing += 1
-                continue
-            }
+        // Real work — surface the spinner only for the actual import loop.
+        isSyncing = true
+        defer { isSyncing = false }
 
+        var summary = plan.summary
+        for memo in plan.toImport {
             do {
                 let recording = try await FileTranscriber.importFile(
                     at: memo.fileURL,
@@ -228,7 +287,13 @@ final class VoiceMemosImporter: ObservableObject {
                     source: .voiceMemo,
                     title: memo.title,
                     createdAt: memo.date,
-                    voiceMemoUniqueID: memo.uniqueID
+                    voiceMemoUniqueID: memo.uniqueID,
+                    // Record the origin folder so "un-select removes its
+                    // recordings" (issue #57) can find them later. Unfiled
+                    // memos carry the sentinel so they stay distinct from a
+                    // legacy import whose origin was never stored.
+                    voiceMemoFolderUUID: memo.folderUUID ?? Recording.voiceMemoUnfiledFolderID,
+                    folder: Self.syncedFolderName
                 )
                 transcription.enqueue(recording)
                 summary.imported += 1
@@ -238,10 +303,33 @@ final class VoiceMemosImporter: ObservableObject {
             }
         }
 
-        lastImportedCount = summary.imported
-        totalImported += summary.imported
-        lastSummary = summary
-        lastSyncDate = Date()
+        publishOutcome(summary: summary, imported: summary.imported)
         log.log("VoiceMemos sync: imported \(summary.imported), failed=\(summary.failedImport) older=\(summary.skippedOlder) short=\(summary.skippedShort) composition=\(summary.skippedComposition) missing=\(summary.skippedMissing)")
+    }
+
+    /// Publish a scan's results, mutating only the `@Published` state that
+    /// actually changed. An idle rescan that imports nothing and finds the same
+    /// held-back set as last time leaves every published property untouched, so
+    /// the status line doesn't re-render — the crux of the anti-flicker fix
+    /// (issue #57). Clearing a stale error only happens on a successful scan.
+    private func publishOutcome(summary: SyncSummary, imported: Int) {
+        if lastError != nil { lastError = nil }
+        if imported > 0 {
+            lastImportedCount = imported
+            totalImported += imported
+        }
+        if summary != lastSummary { lastSummary = summary }
+        // Bump the timestamp on real imports, and once on the first successful
+        // scan so the user still gets an initial "Last synced …". Idle rescans
+        // leave it alone, so it reads as a steady last-activity time rather
+        // than a once-a-second churn.
+        if imported > 0 || lastSyncDate == nil { lastSyncDate = Date() }
+    }
+
+    /// Set `lastError` only when it changes, so a failure that recurs on every
+    /// idle rescan (e.g. a transient DB read error) doesn't re-render the
+    /// status line each time.
+    private func setError(_ message: String?) {
+        if lastError != message { lastError = message }
     }
 }

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -483,4 +483,74 @@ final class RecordingStoreTests: XCTestCase {
         let reloaded = RecordingStore(rootDirectory: tempRoot)
         XCTAssertEqual(reloaded.folders, ["Imported"])
     }
+
+    // MARK: - Voice Memos un-select cleanup (issue #57, part 1)
+
+    /// Build a Voice-Memo import stub with a recorded source folder.
+    private func voiceMemoImport(_ id: String,
+                                 fromFolderID folderID: String?) -> Recording {
+        Recording(title: "Memo \(id)",
+                  source: .voiceMemo,
+                  audioFileName: "\(id).wav",
+                  voiceMemoUniqueID: "unique-\(id)",
+                  voiceMemoFolderUUID: folderID)
+    }
+
+    func test_voiceMemoRecordings_fromFolderID_selectsOnlyMatchingOrigin() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
+        store.add(voiceMemoImport("b", fromFolderID: "FOLDER-1"))
+        store.add(voiceMemoImport("c", fromFolderID: "FOLDER-2"))
+        store.add(voiceMemoImport("d", fromFolderID: Recording.voiceMemoUnfiledFolderID))
+        // Legacy import (origin never recorded) + a plain mic recording must
+        // never be selected.
+        store.add(voiceMemoImport("legacy", fromFolderID: nil))
+        store.add(Recording(title: "Mic", source: .microphone, audioFileName: "mic.wav"))
+
+        XCTAssertEqual(Set(store.voiceMemoRecordings(fromFolderID: "FOLDER-1").map(\.voiceMemoUniqueID)),
+                       ["unique-a", "unique-b"])
+        XCTAssertEqual(store.voiceMemoRecordings(fromFolderID: "FOLDER-2").map(\.voiceMemoUniqueID),
+                       ["unique-c"])
+        XCTAssertEqual(store.voiceMemoRecordings(fromFolderID: Recording.voiceMemoUnfiledFolderID).map(\.voiceMemoUniqueID),
+                       ["unique-d"])
+    }
+
+    func test_softDeleteVoiceMemos_movesMatchingToTrash_leavesOthers() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
+        store.add(voiceMemoImport("b", fromFolderID: "FOLDER-1"))
+        store.add(voiceMemoImport("c", fromFolderID: "FOLDER-2"))
+        store.add(voiceMemoImport("legacy", fromFolderID: nil))
+
+        let removed = store.softDeleteVoiceMemos(fromFolderID: "FOLDER-1")
+        XCTAssertEqual(removed, 2)
+
+        // The two FOLDER-1 imports are trashed but still present (restorable).
+        let trashedIDs = Set(store.recordings.filter { $0.isTrashed }.map(\.voiceMemoUniqueID))
+        XCTAssertEqual(trashedIDs, ["unique-a", "unique-b"])
+        // FOLDER-2 and the legacy nil-origin import are untouched.
+        XCTAssertEqual(Set(store.recordings.filter { !$0.isTrashed }.map(\.voiceMemoUniqueID)),
+                       ["unique-c", "unique-legacy"])
+    }
+
+    /// Soft-delete (not permanent) so no tombstone is written — the recordings
+    /// stay in the store, so re-selecting the folder can't create duplicates,
+    /// and the source memos in Voice Memos are never touched.
+    func test_softDeleteVoiceMemos_doesNotTombstone() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
+
+        store.softDeleteVoiceMemos(fromFolderID: "FOLDER-1")
+        XCTAssertTrue(store.voiceMemoTombstones.isEmpty,
+                      "Un-select cleanup must not tombstone — it's a recoverable soft-delete")
+        XCTAssertEqual(store.recordings.count, 1, "The recording stays in the store")
+        XCTAssertTrue(store.recordings.first?.isTrashed ?? false)
+    }
+
+    func test_softDeleteVoiceMemos_noMatches_returnsZero() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
+        XCTAssertEqual(store.softDeleteVoiceMemos(fromFolderID: "FOLDER-UNKNOWN"), 0)
+        XCTAssertFalse(store.recordings.first?.isTrashed ?? true)
+    }
 }

--- a/MilaTests/RecordingTests.swift
+++ b/MilaTests/RecordingTests.swift
@@ -146,4 +146,41 @@ final class RecordingTests: XCTestCase {
         XCTAssertEqual(formatDuration(3_600), "1:00:00")
         XCTAssertEqual(formatDuration(3_661), "1:01:01")
     }
+
+    /// The Voice-Memo source-folder field (issue #57) round-trips, and a legacy
+    /// record without the key decodes to nil rather than throwing — so an
+    /// upgrade never crashes on existing imports, and legacy-nil origins are
+    /// left out of the un-select cleanup.
+    func test_voiceMemoFolderUUID_round_trips_and_legacy_decodes_nil() throws {
+        let original = Recording(
+            title: "Imported memo",
+            source: .voiceMemo,
+            audioFileName: "memo.wav",
+            voiceMemoUniqueID: "unique-1",
+            voiceMemoFolderUUID: "FOLDER-42"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Recording.self, from: try encoder.encode(original))
+        XCTAssertEqual(decoded.voiceMemoFolderUUID, "FOLDER-42")
+
+        let legacy = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Legacy import",
+          "createdAt": "2025-01-01T00:00:00Z",
+          "duration": 1.0,
+          "source": "voiceMemo",
+          "audioFileName": "Legacy.wav",
+          "status": "completed",
+          "language": "en",
+          "segments": [],
+          "voiceMemoUniqueID": "unique-legacy"
+        }
+        """.data(using: .utf8)!
+        let decodedLegacy = try decoder.decode(Recording.self, from: legacy)
+        XCTAssertNil(decodedLegacy.voiceMemoFolderUUID)
+    }
 }

--- a/MilaTests/VoiceMemosImporterPlanTests.swift
+++ b/MilaTests/VoiceMemosImporterPlanTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import Mila
+
+/// Unit tests for `VoiceMemosImporter.plan` — the pure scan classifier that
+/// gates the visible "Syncing…" state (issue #57, the "Last synced" flicker).
+/// The importer only flips `isSyncing` / re-stamps "Last synced" when
+/// `plan.hasVisibleWork` is true, so proving an all-already-imported scan
+/// yields no visible work is proving the flicker fix at the logic level —
+/// without needing FSEvents or a live database.
+@MainActor
+final class VoiceMemosImporterPlanTests: XCTestCase {
+
+    private let cutoff = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    private func memo(_ id: String,
+                      folderUUID: String? = "FOLDER-1",
+                      duration: Double = 30,
+                      date: Date? = nil,
+                      ext: String = "m4a") -> VoiceMemosLibrary.Memo {
+        VoiceMemosLibrary.Memo(
+            uniqueID: id,
+            fileURL: URL(fileURLWithPath: "/tmp/\(id).\(ext)"),
+            folderUUID: folderUUID,
+            title: "Memo \(id)",
+            duration: duration,
+            date: date ?? cutoff.addingTimeInterval(1_000)
+        )
+    }
+
+    /// Every candidate is already imported → nothing to do, and crucially no
+    /// visible work, so an idle rescan never flips the UI.
+    func test_plan_allAlreadyImported_hasNoVisibleWork() {
+        let memos = [memo("a"), memo("b")]
+        let plan = VoiceMemosImporter.plan(
+            memos: memos,
+            alreadyImported: ["a", "b"],
+            startDate: cutoff,
+            minDuration: 3.0,
+            fileExists: { _ in true })
+
+        XCTAssertFalse(plan.hasVisibleWork)
+        XCTAssertTrue(plan.toImport.isEmpty)
+        XCTAssertEqual(plan.summary, VoiceMemosImporter.SyncSummary())
+    }
+
+    /// A fresh eligible memo is real work → visible.
+    func test_plan_eligibleMemo_hasVisibleWork() {
+        let plan = VoiceMemosImporter.plan(
+            memos: [memo("a")],
+            alreadyImported: [],
+            startDate: cutoff,
+            minDuration: 3.0,
+            fileExists: { _ in true })
+
+        XCTAssertTrue(plan.hasVisibleWork)
+        XCTAssertEqual(plan.toImport.map(\.uniqueID), ["a"])
+    }
+
+    /// Each held-back reason is tallied under the right bucket, and none of
+    /// them count as visible work.
+    func test_plan_classifiesEachSkipReason() {
+        let memos = [
+            memo("old", date: cutoff.addingTimeInterval(-1)),        // before cutoff
+            memo("comp", ext: "composition"),                        // multi-take
+            memo("short", duration: 1.0),                            // too short
+            memo("missing"),                                         // not downloaded
+            memo("ok")                                               // eligible
+        ]
+        let plan = VoiceMemosImporter.plan(
+            memos: memos,
+            alreadyImported: [],
+            startDate: cutoff,
+            minDuration: 3.0,
+            fileExists: { $0.lastPathComponent != "missing.m4a" })
+
+        XCTAssertEqual(plan.summary.skippedOlder, 1)
+        XCTAssertEqual(plan.summary.skippedComposition, 1)
+        XCTAssertEqual(plan.summary.skippedShort, 1)
+        XCTAssertEqual(plan.summary.skippedMissing, 1)
+        XCTAssertEqual(plan.toImport.map(\.uniqueID), ["ok"])
+        XCTAssertTrue(plan.hasVisibleWork)
+    }
+
+    /// The start-date cutoff is checked first, so an old memo that is also too
+    /// short is counted as "before start date" (matching the status line's
+    /// intent that the cutoff count reflects the user's date choice).
+    func test_plan_startDateCutoffTakesPrecedenceOverDuration() {
+        let plan = VoiceMemosImporter.plan(
+            memos: [memo("old-and-short", duration: 1.0, date: cutoff.addingTimeInterval(-1))],
+            alreadyImported: [],
+            startDate: cutoff,
+            minDuration: 3.0,
+            fileExists: { _ in true })
+
+        XCTAssertEqual(plan.summary.skippedOlder, 1)
+        XCTAssertEqual(plan.summary.skippedShort, 0)
+        XCTAssertFalse(plan.hasVisibleWork)
+    }
+}


### PR DESCRIPTION
Fixes #57.

Implements all four Voice Memos folder-sync UX enhancements from the issue. These are UX-only — the underlying sync (from PRs #69–#73) is unchanged, and the read-only `VoiceMemosLibrary` reader is untouched.

## 1. Un-selecting a folder removes its recordings
Imports now record **which** Voice Memos folder they came from, so de-selecting can actually reverse the sync.

- New `Recording.voiceMemoFolderUUID` — set on `.voiceMemo` imports to the source `ZFOLDER.ZUUID`, or `Recording.voiceMemoUnfiledFolderID` (a sentinel) for the unfiled bucket. Populated in the import path (`VoiceMemosImporter` → `FileTranscriber.importFile`).
- `RecordingStore.voiceMemoRecordings(fromFolderID:)` + `softDeleteVoiceMemos(fromFolderID:)`.
- In Settings, turning a folder (or Unfiled) **off** stops future imports immediately, then — if that folder already imported recordings — pops a confirmation to **Move N to Recently Deleted** (or Keep).
- **Soft-delete, not permanent:** recordings stay restorable, and no tombstone is written, so re-selecting the folder won't create duplicates and the source memos are never touched.
- **Migration-safe:** legacy imports with no recorded origin (`nil`) are deliberately excluded, so an upgrade can't mass-delete a user's older imports.

## 2. Preview a folder's recordings before selecting
Each folder in the picker gets a disclosure arrow that lazily loads and shows its memo titles + dates (via the existing read-only reader, off the main actor) — **no import, no queueing**. Capped at 50 with an "…and N more" line.

## 3. Fixed the "Last synced" flicker
The FSEvents watcher fires ~once/second as `voicememod` touches the WAL; every idle rescan used to flash the spinner and re-stamp the timestamp.

- Scan classification is now a pure, testable `VoiceMemosImporter.plan(...)` → `ImportPlan`.
- The published `isSyncing` only flips for **real import work** (a separate private `scanInFlight` drives coalescing).
- `publishOutcome` skips no-op writes and only bumps "Last synced" on actual imports (or the first scan), so an idle rescan leaves the status line completely untouched. Real "imported N" / "held back N" updates still land.

## 4. Dedicated folder for synced recordings
Voice Memo imports are filed into a shared **"Voice Memos"** folder (created idempotently, shows in the sidebar) instead of being mixed into All Transcripts. Per-source-folder was deemed not worth the flat-namespace/rename fragility; the per-source origin is still tracked separately on `voiceMemoFolderUUID` for part 1.

## Tests
- `RecordingStoreTests`: source-folder selection, soft-delete cleanup selects the right recordings, leaves legacy/other-folder/non-VM alone, and writes no tombstone.
- `RecordingTests`: new field codable round-trip + legacy record decodes to nil.
- `VoiceMemosImporterPlanTests` (new): the scan classifier's `hasVisibleWork` (all-already-imported → no visible work = the flicker fix at the logic level) and skip tallies.

## Verification
`make build` → **BUILD SUCCEEDED**. Unit-test target compiles (`build-for-testing` → TEST BUILD SUCCEEDED). Per repo guidance, XCUITests were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice Memo imports now store and utilize their source folder UUID (including “Unfiled”).
  * Folder controls gained expandable, inline memo previews with loading/error handling.
  * Deselecting a folder now asks to move matching imported recordings to Recently Deleted (after confirmation).
* **Bug Fixes**
  * Prevented overlapping Voice Memo sync scans from importing duplicates.
  * Reduced “last synced”/sync-status flicker during idle rescans.
  * Kept backward compatibility for older saved recordings without the new origin field.
* **Tests**
  * Added coverage for folder filtering, soft-delete behavior, and importer planning/JSON round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->