### PR TITLE
Opt-in beta update channel (Settings → Updates)

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -35,6 +35,10 @@ final class UpdaterViewModel: NSObject, ObservableObject,
     private(set) var controller: SPUStandardUpdaterController!
     @Published var canCheckForUpdates = false
 
+    /// UserDefaults key for the "Enable beta version" opt-in. Read live by
+    /// `allowedChannels(for:)` and written by the toggle in Settings → Updates.
+    static let betaChannelDefaultsKey = "updates.betaChannel"
+
     /// The update we want the custom popup to show. Non-nil iff a scheduled
     /// poll found a newer version we haven't already shown the user.
     /// `ContentView` binds a `.sheet(item:)` to this.
@@ -116,6 +120,16 @@ final class UpdaterViewModel: NSObject, ObservableObject,
     }
 
     // MARK: - SPUUpdaterDelegate
+
+    /// Which appcast channels this app is willing to update to. Sparkle always
+    /// includes the default (stable) channel; returning `["beta"]` additionally
+    /// opts the user into items tagged `<sparkle:channel>beta</sparkle:channel>`.
+    /// So stable users never see beta releases, while users who enable the beta
+    /// toggle get betas AND stable. Read live from defaults so flipping the
+    /// toggle takes effect on the next check — no relaunch needed.
+    nonisolated func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        UserDefaults.standard.bool(forKey: Self.betaChannelDefaultsKey) ? ["beta"] : []
+    }
 
     /// Sparkle found a newer valid version. Capture its release notes for the
     /// custom popup. This fires for both scheduled and user-initiated checks;

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import AppKit
 import Carbon.HIToolbox
 
 enum SettingsTab: Int, Hashable {
-    case hotkeys, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage
+    case hotkeys, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage, updates
 }
 
 @Observable
@@ -45,6 +45,9 @@ struct SettingsView: View {
             StorageSettingsTab()
                 .tabItem { Label("Storage", systemImage: "externaldrive") }
                 .tag(SettingsTab.storage)
+            UpdatesSettingsTab()
+                .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
+                .tag(SettingsTab.updates)
         }
         .frame(width: 560, height: 560)
         .padding(20)
@@ -54,6 +57,55 @@ struct SettingsView: View {
                 SettingsNavigation.shared.pendingTab = nil
             }
         }
+    }
+}
+
+// MARK: - Updates
+
+/// Settings → Updates. Shows the current version and the opt-in beta channel.
+/// The toggle writes `UpdaterViewModel.betaChannelDefaultsKey`, which the
+/// Sparkle updater delegate (`allowedChannels(for:)`) reads to decide whether
+/// to offer `<sparkle:channel>beta</sparkle:channel>` appcast items.
+private struct UpdatesSettingsTab: View {
+    @AppStorage(UpdaterViewModel.betaChannelDefaultsKey) private var betaChannel = false
+
+    private var versionString: String {
+        let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(v) (\(b))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Updates")
+                .font(.title3.weight(.semibold))
+            Text("Mila checks for updates automatically and installs them with your approval. You're on version \(versionString).")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+
+            Toggle(isOn: $betaChannel) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Enable beta version of Mila")
+                    Text("Receive pre-release builds with the newest features before they ship to everyone. Betas can be less stable. Turn this off to stay on stable releases — you'll move back to stable the next time a stable version ships.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toggleStyle(.switch)
+            .accessibilityIdentifier("updates.beta.toggle")
+
+            Text("After enabling, choose “Check for Updates…” from the Mila menu to fetch the latest beta right away.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 


### PR DESCRIPTION
## What

Adds an **"Enable beta version of Mila"** toggle in a new **Settings → Updates** tab, so users can opt into pre-release (beta) builds via Sparkle's channel support.

## How

- `UpdaterViewModel.allowedChannels(for:)` (Sparkle `SPUUpdaterDelegate`) returns `["beta"]` when the toggle is on, else `[]`. Sparkle always includes the default (stable) channel, so:
  - **Stable users** (toggle off) never see items tagged `<sparkle:channel>beta</sparkle:channel>`.
  - **Beta users** (toggle on) get beta **and** stable items — so they roll onto the next stable release automatically.
- The toggle writes `UpdaterViewModel.betaChannelDefaultsKey` (`updates.betaChannel`); the delegate reads it **live**, so flipping it takes effect on the next check with no relaunch.
- New **Updates** tab also shows the current version; help text points users to "Check for Updates…" to fetch a beta immediately.

## Appcast side

This is the app-side half. Beta releases are tagged with `<sparkle:channel>beta</sparkle:channel>` in the published appcast (done at release time), which is what this toggle gates on. No behavior change for anyone until a channel-tagged item exists.

## Testing

- `make build` succeeds.
- Default off → `allowedChannels` returns `[]` (stable only), so existing users are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Updates** section to Settings.
  * Added the app’s current version and build information.
  * Added an optional **Enable beta version** setting for receiving beta updates.

* **Bug Fixes**
  * Beta update preferences are now applied when checking for available updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->