### PR TITLE
ci: add Dependabot for GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot — keep GitHub Actions and the Docker base image current.
+#
+# Scope: this repo pins actions by SHA (see the workflows); Dependabot keeps those
+# pinned SHAs current with a PR + changelog. Swift/SPM deps are declared in
+# project.yml (XcodeGen), which Dependabot does not parse, and the whisper.cpp
+# submodule is governed by .github/whisper-cpp-pin.txt — both are intentionally
+# left out here to avoid fighting those mechanisms.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/docker/speaches-hebrew"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"


### PR DESCRIPTION
Adds a Dependabot config so GitHub Actions and the `speaches-hebrew` Docker base
image get automated update PRs (weekly, 7-day cooldown, grouped). The workflows
SHA-pin their actions; Dependabot keeps those pinned SHAs current with a PR and
changelog.

Scoped to `github-actions` + `docker` only. Swift/SPM dependencies are declared in
`project.yml` (XcodeGen), which Dependabot does not parse, and the whisper.cpp
submodule is governed by `.github/whisper-cpp-pin.txt` - both are intentionally left
out to avoid conflicting with those mechanisms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for GitHub Actions and Docker configurations.
  * Updates are grouped where possible and limited to a manageable number of open update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->