### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audio-loopback-e2e.yml
+++ b/.github/workflows/audio-loopback-e2e.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install xcodegen

--- a/.github/workflows/audio-loopback-e2e.yml
+++ b/.github/workflows/audio-loopback-e2e.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Cache diarization bundle
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Cache whisper models (full + tiny)
         id: whisper-models-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/Library/Application Support/Mila/Models
@@ -191,7 +191,7 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit 0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: e2e-results

--- a/.github/workflows/build-speaches-image.yml
+++ b/.github/workflows/build-speaches-image.yml
@@ -46,6 +46,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Lowercase image name
         id: img

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Show toolchain
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Show toolchain
         run: |
@@ -38,7 +38,7 @@ jobs:
       # services both workflows.
       - name: Cache diarization bundle
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -53,7 +53,7 @@ jobs:
       # cold-path-only cost.
       - name: Cache whisper tiny + CoreML encoder
         id: tiny-coreml-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/whisper-coreml-test
           key: whisper-tiny-coreml-v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install xcodegen
         run: brew install xcodegen
@@ -43,7 +43,7 @@ jobs:
       # Initialize BEFORE the build so CodeQL's tracer observes Swift
       # compilation (manual build mode — autobuild can't drive XcodeGen).
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           languages: swift
           build-mode: manual
@@ -72,6 +72,6 @@ jobs:
             | cat
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           category: "/language:swift"

--- a/.github/workflows/debug-mac-runner.yml
+++ b/.github/workflows/debug-mac-runner.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Cache diarization bundle
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache whisper models
         id: whisper-models-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # Mila's default ModelManager location. `make models`
           # populates this directory.
@@ -99,7 +99,7 @@ jobs:
         # limit-access-to-actor=false because we connect from a shell
         # that doesn't necessarily have a GH OAuth token; the random
         # URL is the access control.
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
         with:
           limit-access-to-actor: false
           detached: false

--- a/.github/workflows/debug-mac-runner.yml
+++ b/.github/workflows/debug-mac-runner.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Show toolchain + runner info

--- a/.github/workflows/e2e-diarization.yml
+++ b/.github/workflows/e2e-diarization.yml
@@ -19,11 +19,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -36,7 +36,7 @@ jobs:
       - name: Cache pyannote venv
         if: steps.changes.outputs.relevant == 'true'
         id: venv-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/diar-venv
           key: diar-venv-${{ runner.os }}-py3.11-${{ env.VENV_VERSION }}

--- a/.github/workflows/e2e-diarization.yml
+++ b/.github/workflows/e2e-diarization.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3

--- a/.github/workflows/e2e-hebrew-remote.yml
+++ b/.github/workflows/e2e-hebrew-remote.yml
@@ -76,6 +76,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -199,6 +201,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/.github/workflows/e2e-remote-transcription.yml
+++ b/.github/workflows/e2e-remote-transcription.yml
@@ -24,9 +24,9 @@ jobs:
     env:
       MOCK_PORT: "8123"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -55,7 +55,7 @@ jobs:
       - name: Cache diarization bundle
         if: steps.changes.outputs.relevant == 'true'
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}

--- a/.github/workflows/e2e-remote-transcription.yml
+++ b/.github/workflows/e2e-remote-transcription.yml
@@ -25,6 +25,8 @@ jobs:
       MOCK_PORT: "8123"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes

--- a/.github/workflows/e2e-transcription.yml
+++ b/.github/workflows/e2e-transcription.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache whisper.cpp build
         if: steps.changes.outputs.relevant == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: whisper-build-cache
         with:
           path: |
@@ -77,13 +77,13 @@ jobs:
 
       - name: Install Swift
         if: steps.changes.outputs.relevant == 'true'
-        uses: swift-actions/setup-swift@v2
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:
           swift-version: '5.10'
 
       - name: Cache whisper model
         if: steps.changes.outputs.relevant == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/whisper-models
           key: whisper-model-ggml-tiny-v1

--- a/.github/workflows/e2e-transcription.yml
+++ b/.github/workflows/e2e-transcription.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
@@ -29,7 +29,7 @@ jobs:
       # restores are seconds.
       - name: Cache diarization bundle
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: xcresult
           path: build/Logs/Test/*.xcresult

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install xcodegen

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -39,7 +39,7 @@ jobs:
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -67,7 +67,7 @@ jobs:
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
@@ -90,10 +90,10 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
           filters: |
@@ -115,7 +115,7 @@ jobs:
       - name: Cache diarization bundle
         if: steps.changes.outputs.relevant == 'true'
         id: diar-bundle-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: Mila/Resources/PythonRuntime
           key: diar-bundle-${{ runner.os }}-${{ hashFiles('scripts/build-diarization-bundle.sh') }}
@@ -140,13 +140,13 @@ jobs:
             -only-testing:MilaUITests/DetailLayoutUITests \
             -derivedDataPath build-uitests \
             CODE_SIGNING_ALLOWED=NO || (echo "UI tests failed — vision check skipped" && exit 1)
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.changes.outputs.relevant == 'true' && (always())
         with:
           name: ui-screenshots
           path: /tmp/mila-ui-screenshots/
           if-no-files-found: warn
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -29,6 +29,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
@@ -57,6 +59,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes
         with:
@@ -92,6 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: changes


### PR DESCRIPTION
Pins every remaining GitHub Actions reference to a full commit SHA (with a version
comment), finishing the SHA-pinning already applied in `build-speaches-image.yml`
and `e2e-hebrew-remote.yml`.

Pure pinning, no upgrades: each action stays on the same version it already used
(latest patch of its current major), so there is no behavior change. For `checkout`,
`cache`, and `upload-artifact` this reuses the exact SHAs the repo already pins
elsewhere.

Mutable tags like `@v4`/`@v3` can be force-moved by a compromised or hijacked action;
a commit SHA cannot. A companion Dependabot config keeps these pins current.

Actions pinned: `actions/checkout` v4.3.1, `actions/cache` v4.3.0,
`actions/upload-artifact` v4.6.2, `actions/setup-python` v5.6.0,
`dorny/paths-filter` v3.0.3, `github/codeql-action` v3.37.0,
`mxschmitt/action-tmate` v3.24, `swift-actions/setup-swift` v2.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs across CI, end-to-end testing (including transcription/diarization), security analysis, and platform test workflows.
  * Improved workflow reproducibility and supply-chain stability without changing test commands, build steps, or job logic.
  * Updated certain checkout steps to disable credential persistence (`persist-credentials: false`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->