### PR TITLE
make-dmg: preserve entitlements and stable signing identity so TCC grants survive DMG installs

### DIFF
--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -53,6 +53,7 @@ make dmg VERSION="$VERSION"
 ## Verifying the signature
 
 A correct local build is signed with the Mila Local Dev cert (or ad-hoc if that cert was never created) and carries the app entitlements:
+
 ```bash
 codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature|Authority"
 # Identifier=io.island.whisper.IslandWhisper
@@ -81,9 +82,13 @@ Ad-hoc-signed apps copied (not downloaded) have no quarantine flag, so they laun
 
 ```bash
 SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
-      ~/Library/Keychains/login.keychain-db | awk '/SHA-1 hash/ {print $NF}' | head -1)
-codesign --force --sign "$SHA" \
-  --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+      ~/Library/Keychains/login.keychain-db 2>/dev/null | awk '/SHA-1 hash/ {print $NF}' | head -1)
+if [ -z "$SHA" ]; then
+  echo "no 'Mila Local Dev' cert — run scripts/install-debug.sh once to create it" >&2
+else
+  codesign --force --sign "$SHA" \
+    --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+fi
 ```
 
 If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it (or accept ad-hoc + per-install re-prompts).
@@ -93,5 +98,5 @@ If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it 
 - **Running `make dmg` without `VERSION=`** → the `MARKETING_VERSION: command not found` failure above. Always pass it.
 - **Editing `Mila.xcodeproj` directly** → overwritten on next `make project`. Edit `project.yml` instead.
 - **Hardcoding a version in `Info.plist`** → it must stay `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`; bump versions only in `project.yml`.
-- **Expecting a Developer-ID / notarized build** → not available locally; this repo only ad-hoc signs.
+- **Expecting a Developer-ID / notarized build** → not available locally; local builds sign with the Mila Local Dev cert or ad-hoc. (`CODESIGN_IDENTITY=- make dmg` forces ad-hoc, e.g. to test the Gatekeeper first-launch prompt.)
 - **`rm`-ing an old `/Applications/Mila.app`** → use `trash` so it's recoverable.

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -7,7 +7,7 @@ description: Use when building, compiling, or running the Mila app locally from 
 
 ## Overview
 
-Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are **ad-hoc signed** ("Sign to Run Locally") — that is the only "self-signed" path this repo supports. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
+Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are signed with the persistent self-signed **"Mila Local Dev"** cert when it exists in the login keychain (created on first run of `scripts/install-debug.sh`), falling back to **ad-hoc** ("Sign to Run Locally") otherwise. The stable cert matters: macOS TCC keys mic/screen-recording grants on the signing identity, so ad-hoc builds re-prompt for recording permission after every install. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
 
 All build commands run from the repo root (wherever your checkout lives).
 
@@ -19,7 +19,7 @@ All build commands run from the repo root (wherever your checkout lives).
 | Debug build | `make build` | `build/Build/Products/Debug/Mila.app` |
 | Build **and launch** | `make run` | builds Debug, then `open`s it |
 | Release build | `make release-build` | `build-release/Build/Products/Release/Mila.app` |
-| Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (ad-hoc signed) |
+| Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (Mila Local Dev cert if present, else ad-hoc) |
 | Run tests | `make test` | XCTest run |
 | Clean | `make clean` | removes `Mila.xcodeproj`, `build`, `build-release`, `*.dmg` |
 
@@ -52,11 +52,13 @@ make dmg VERSION="$VERSION"
 
 ## Verifying the signature
 
-A correct local build is ad-hoc signed:
+A correct local build is signed with the Mila Local Dev cert (or ad-hoc if that cert was never created) and carries the app entitlements:
 ```bash
-codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature"
+codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature|Authority"
 # Identifier=io.island.whisper.IslandWhisper
-# Signature=adhoc
+# Authority=Mila Local Dev        (or Signature=adhoc as fallback)
+codesign -d --entitlements - /Applications/Mila.app 2>/dev/null | grep audio-input
+# must list com.apple.security.device.audio-input — if missing, re-sign (below)
 ```
 
 ## Installing a local build into /Applications
@@ -74,6 +76,17 @@ open -a /Applications/Mila.app    # verify it launches
 ```
 
 Ad-hoc-signed apps copied (not downloaded) have no quarantine flag, so they launch without the Gatekeeper right-click dance. If the app WAS downloaded, Gatekeeper shows a "right-click → Open" prompt on first launch.
+
+**TCC / recording-permission survival — re-sign if needed.** macOS keys mic and screen-recording grants on the app's signing identity + entitlements. `make dmg` already signs with the "Mila Local Dev" cert and `Mila/Resources/Mila.entitlements` when the cert exists in the login keychain, so a fresh DMG installs cleanly over a `scripts/install-debug.sh` install without re-prompting. But if the installed app is ad-hoc signed or missing entitlements (older DMG, cert created after the DMG was built — symptom: macOS asks for recording permission on every use), re-sign it in place:
+
+```bash
+SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+      ~/Library/Keychains/login.keychain-db | awk '/SHA-1 hash/ {print $NF}' | head -1)
+codesign --force --sign "$SHA" \
+  --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+```
+
+If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it (or accept ad-hoc + per-install re-prompts).
 
 ## Common Mistakes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,13 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
   literals there.
 - Tags are `v`-prefixed: `v1.2.8`. `CURRENT_PROJECT_VERSION` (the build
   number) must increase monotonically — Sparkle keys updates on it.
-- A local DMG for testing: `make dmg`. It signs with the persistent
+- A local DMG for testing: `make dmg VERSION=<x.y.z>` (the explicit
+  `VERSION=` is required — see the build skill). It signs with the persistent
   "Mila Local Dev" cert when that cert exists in the login keychain (created
   by `scripts/install-debug.sh`; keeps TCC mic/recording grants across
   installs) and falls back to ad-hoc otherwise. To force an ad-hoc build —
   e.g. to test the Gatekeeper right-click → Open first-launch prompt — run
-  `CODESIGN_IDENTITY=- make dmg`.
+  `CODESIGN_IDENTITY=- make dmg VERSION=<x.y.z>`.
 - Notarized, signed release builds and Sparkle appcast publishing are produced
   by a separate, private signing pipeline maintained by the original authors;
   that toolchain is not part of this repository. Forks that want notarized

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,12 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
   literals there.
 - Tags are `v`-prefixed: `v1.2.8`. `CURRENT_PROJECT_VERSION` (the build
   number) must increase monotonically — Sparkle keys updates on it.
-- A local, unsigned DMG for testing: `make dmg` (ad-hoc signed; Gatekeeper
-  shows the right-click → Open prompt on first launch).
+- A local DMG for testing: `make dmg`. It signs with the persistent
+  "Mila Local Dev" cert when that cert exists in the login keychain (created
+  by `scripts/install-debug.sh`; keeps TCC mic/recording grants across
+  installs) and falls back to ad-hoc otherwise. To force an ad-hoc build —
+  e.g. to test the Gatekeeper right-click → Open first-launch prompt — run
+  `CODESIGN_IDENTITY=- make dmg`.
 - Notarized, signed release builds and Sparkle appcast publishing are produced
   by a separate, private signing pipeline maintained by the original authors;
   that toolchain is not part of this repository. Forks that want notarized

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -9,8 +9,9 @@
 # login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
 # grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper
 # right-click → Open prompt on first launch and lose TCC grants on every
-# reinstall. Re-sign with `codesign -s "Developer ID Application: ..."` before
-# distributing externally.
+# reinstall; pass CODESIGN_IDENTITY=- to force ad-hoc (e.g. to test that
+# Gatekeeper first-launch path). Re-sign with
+# `codesign -s "Developer ID Application: ..."` before distributing externally.
 
 set -euo pipefail
 
@@ -47,9 +48,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENTITLEMENTS="$SCRIPT_DIR/../Mila/Resources/Mila.entitlements"
 
 if [[ -z "${CODESIGN_IDENTITY:-}" ]]; then
-    LOCAL_DEV_SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+    LOCAL_DEV_SHAS=$(security find-certificate -c "Mila Local Dev" -a -Z \
         "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
-        | awk '/SHA-1 hash/ {print $NF}' | head -1 || true)
+        | awk '/SHA-1 hash/ {print $NF}' || true)
+    if [[ $(grep -c . <<<"$LOCAL_DEV_SHAS") -gt 1 ]]; then
+        echo "warning: multiple 'Mila Local Dev' certs in login keychain; using the first —" >&2
+        echo "         if TCC still re-prompts, delete the stale duplicates and re-sign." >&2
+    fi
+    LOCAL_DEV_SHA=$(head -1 <<<"$LOCAL_DEV_SHAS")
     if [[ -n "$LOCAL_DEV_SHA" ]]; then
         echo "signing with Mila Local Dev cert ($LOCAL_DEV_SHA)" >&2
         CODESIGN_IDENTITY="$LOCAL_DEV_SHA"

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -3,8 +3,11 @@
 #
 # Usage: scripts/make-dmg.sh path/to/Mila.app Mila-1.0.0.dmg 1.0.0
 #
-# Output: $DMG_PATH (relative or absolute) ready to upload as a GitHub release
-# asset. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
+# Output: $DMG_PATH (relative or absolute), a LOCAL TEST artifact. Published
+# releases are produced by the private signing pipeline, which notarizes and
+# runs the release-notes gate (scripts/check-release-notes.sh) before building;
+# this script deliberately skips that gate so local test DMGs don't require
+# release notes. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
 # else the persistent "Mila Local Dev" self-signed cert if present in the
 # login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
 # grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -4,9 +4,12 @@
 # Usage: scripts/make-dmg.sh path/to/Mila.app Mila-1.0.0.dmg 1.0.0
 #
 # Output: $DMG_PATH (relative or absolute) ready to upload as a GitHub release
-# asset. The app is ad-hoc signed (no Apple Developer ID required) so on first
-# launch macOS will Gatekeeper-prompt the user; right-click → Open works around
-# it. Re-sign with `codesign -s "Developer ID Application: ..."` before
+# asset. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
+# else the persistent "Mila Local Dev" self-signed cert if present in the
+# login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
+# grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper
+# right-click → Open prompt on first launch and lose TCC grants on every
+# reinstall. Re-sign with `codesign -s "Developer ID Application: ..."` before
 # distributing externally.
 
 set -euo pipefail
@@ -29,14 +32,42 @@ cp -R "$APP_PATH" "$STAGE/"
 ln -s /Applications "$STAGE/Applications"
 
 # Re-sign the bundle to make sure the embedded `whisper.framework` and the
-# wrapping app stay in sync after the cp -R above. Honors `CODESIGN_IDENTITY`
-# so CI can sign with our self-signed Developer-ID-equivalent cert (its
-# SHA1 fingerprint is the trust anchor for TCC permissions across releases —
-# every build signed with the SAME cert keeps the user's previously-granted
-# Accessibility / mic permissions). Defaults to ad-hoc ("-") for local
-# builds where the cert isn't in keychain.
-CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
-codesign --force --deep --sign "$CODESIGN_IDENTITY" "$STAGE/$(basename "$APP_PATH")"
+# wrapping app stay in sync after the cp -R above. Identity resolution:
+#   1. $CODESIGN_IDENTITY — CI / the private signing pipeline sets this (its
+#      SHA1 fingerprint is the trust anchor for TCC permissions across
+#      releases — every build signed with the SAME cert keeps the user's
+#      previously-granted Accessibility / mic permissions).
+#   2. The persistent "Mila Local Dev" self-signed cert (created by
+#      scripts/install-debug.sh) if it exists in the login keychain, signed
+#      by SHA-1 since self-signed certs never become "trusted identities" —
+#      same stability property for local installs.
+#   3. Ad-hoc ("-") as a last resort; macOS treats every ad-hoc rebuild as a
+#      new app, so TCC re-prompts for mic/recording after each install.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="$SCRIPT_DIR/../Mila/Resources/Mila.entitlements"
+
+if [[ -z "${CODESIGN_IDENTITY:-}" ]]; then
+    LOCAL_DEV_SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+        "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
+        | awk '/SHA-1 hash/ {print $NF}' | head -1 || true)
+    if [[ -n "$LOCAL_DEV_SHA" ]]; then
+        echo "signing with Mila Local Dev cert ($LOCAL_DEV_SHA)" >&2
+        CODESIGN_IDENTITY="$LOCAL_DEV_SHA"
+    else
+        echo "warning: no CODESIGN_IDENTITY and no 'Mila Local Dev' cert in login keychain;" >&2
+        echo "         ad-hoc signing — TCC will re-prompt for mic/recording after install." >&2
+        echo "         Run scripts/install-debug.sh once to create the persistent cert." >&2
+        CODESIGN_IDENTITY="-"
+    fi
+fi
+
+STAGED_APP="$STAGE/$(basename "$APP_PATH")"
+# Deep-sign nested code first, then re-sign the outer bundle with the app
+# entitlements (mic access, disable-library-validation, …) — a --deep sign
+# with --entitlements would stamp the app's entitlements onto every nested
+# framework, so entitlements go on the outer signature only.
+codesign --force --deep --sign "$CODESIGN_IDENTITY" "$STAGED_APP"
+codesign --force --sign "$CODESIGN_IDENTITY" --entitlements "$ENTITLEMENTS" "$STAGED_APP"
 
 VOLNAME="Mila $VERSION"
 TMP_DMG="$(mktemp -t MilaDMG.XXXXXX).dmg"


### PR DESCRIPTION
## Problem

`scripts/make-dmg.sh` re-signs the staged app with `codesign --force --deep --sign "${CODESIGN_IDENTITY:--}"` but never passes `--entitlements`, so a DMG-built app loses all 7 entitlements from `Mila/Resources/Mila.entitlements` — including `com.apple.security.device.audio-input` and `com.apple.security.cs.disable-library-validation`. It also defaults to ad-hoc signing.

macOS TCC keys mic/screen-recording grants on the app's designated requirement. `scripts/install-debug.sh` deliberately signs with a persistent self-signed "Mila Local Dev" cert so grants survive rebuilds — but installing a DMG build over that changes the designated requirement (ad-hoc + no entitlements), so macOS re-prompts for recording permission on every use. This bit a real user: a DMG-installed build kept re-prompting until manually re-signed with the cert + entitlements.

## Fix

- **`scripts/make-dmg.sh`**
  - After the existing `--deep` re-sign (which keeps nested `whisper.framework` in sync), a second **non-deep** pass signs the outer bundle with `Mila/Resources/Mila.entitlements`. Two passes deliberately: `--deep` + `--entitlements` would stamp the app's entitlements onto every nested framework.
  - When `CODESIGN_IDENTITY` is unset, the script now reuses the **"Mila Local Dev"** cert from the login keychain (looked up by CN via `security find-certificate -c ... -a -Z`, signed by SHA-1 — same approach as `install-debug.sh`) instead of ad-hoc, keeping the designated requirement stable across installs. Falls back to ad-hoc with a warning pointing at `install-debug.sh` to create the cert.
  - `CODESIGN_IDENTITY` still takes precedence, so CI / the private signing pipeline is unaffected.
- **`.claude/skills/build-mila-locally/SKILL.md`**: documents the new signing behavior, adds an entitlements check to signature verification, and adds a "TCC / recording-permission survival" section with the manual re-sign command for already-installed apps that keep re-prompting.

## Verification

Built a dummy `Mila.app`, ran `make-dmg.sh` on it, mounted the resulting DMG:

- all 7 entitlements present on the app inside the DMG (`codesign -d --entitlements -`), including `device.audio-input` and `cs.disable-library-validation`
- `codesign --verify --verbose` passes: valid on disk, satisfies its designated requirement
- the identity-resolution path correctly finds and selects the "Mila Local Dev" cert by SHA-1 when present, and takes `CODESIGN_IDENTITY` verbatim when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local macOS DMG/app signing now resolves the signing identity in order: explicit `CODESIGN_IDENTITY`, then the persistent **“Mila Local Dev”** certificate (from the login keychain) when available, otherwise ad-hoc.
  * DMG signing now applies entitlements to the outer app signature, improving first-run/reinstall permission consistency.

* **Documentation**
  * Updated local build/DMG instructions to verify both signature authority and entitlements, and added steps to restore mic/screen-recording permissions when macOS prompts reappear.
  * Release process docs now include a **`CODESIGN_IDENTITY=-`** example for testing Gatekeeper first-launch prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->