### PR TITLE
Live recording: copy-transcript button next to the SRT export

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -598,11 +598,7 @@ final class QuickActionsController: ObservableObject {
         // live pane. Now the dialog pops up instantly; the
         // background drain below updates the Recording (and thus
         // the sheet, which observes the store) as more data lands.
-        let initialSegments = liveTranscriber?.segments ?? []
-        let initialTranscriptSegments: [TranscriptSegment] = initialSegments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
+        let initialTranscriptSegments = liveTranscriber?.transcriptSegments ?? []
         let initialSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let initialItems = liveAISession?.actionItems ?? []
@@ -613,7 +609,7 @@ final class QuickActionsController: ObservableObject {
         // the drain task. Mirrors `useLiveTranscript` below: both VAD
         // and chunk modes produce live segments we want to preserve,
         // so the initial-status gate is segment-presence, not mode.
-        let initialStatus: TranscriptionStatus = initialSegments.isEmpty ? .pending : .running
+        let initialStatus: TranscriptionStatus = initialTranscriptSegments.isEmpty ? .pending : .running
         let recording = Recording(
             title: title,
             duration: duration,
@@ -705,7 +701,7 @@ final class QuickActionsController: ObservableObject {
         // Snapshot final state. Safe to read now because `.idle`
         // handler is skipping its `transcriber.stop()` /
         // `diarizer.stop()` while `isFinalizingRecording` is true.
-        let finalLiveSegments = liveTranscriber?.segments ?? []
+        let finalTranscriptSegments = liveTranscriber?.transcriptSegments ?? []
         let finalSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let finalItems = liveAISession?.actionItems ?? []
@@ -751,12 +747,8 @@ final class QuickActionsController: ObservableObject {
         //
         // `vadActive` here is whatever was passed in by the caller —
         // typically `liveAISettings.useVAD && liveAISettings.enabled`.
-        let hasLiveSegments = !finalLiveSegments.isEmpty
+        let hasLiveSegments = !finalTranscriptSegments.isEmpty
         let liveTranscriptIsAuthoritative = hasLiveSegments && vadActive
-        let finalTranscriptSegments: [TranscriptSegment] = finalLiveSegments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
         let finalFullText = finalTranscriptSegments.map(\.text).joined(separator: " ")
 
         guard var updated = store.recordings.first(where: { $0.id == recording.id }) else {

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -286,6 +286,28 @@ final class LiveTranscriber: ObservableObject {
         }.joined(separator: "\n")
     }
 
+    /// The live segments as `TranscriptSegment`s — the shape the
+    /// formatter/exporter share with finished recordings, so copy and
+    /// SRT export mid-recording produce the same output the detail view
+    /// would for the same content.
+    var transcriptSegments: [TranscriptSegment] {
+        segments.map {
+            TranscriptSegment(start: $0.startSeconds, end: $0.endSeconds,
+                              text: $0.text, speaker: $0.speaker)
+        }
+    }
+
+    /// Clipboard rendering of the in-progress transcript — same format
+    /// as the detail view's "Copy transcript" (speaker-prefixed turns
+    /// once live diarization has labelled anyone, plain joined text
+    /// otherwise), so copying mid-recording and copying after the fact
+    /// produce the same text.
+    var clipboardText: String {
+        TranscriptFormatter.plainText(segments: transcriptSegments,
+                                      fallback: fullText,
+                                      names: speakerNames)
+    }
+
     /// VAD path: enqueue a transcribe for a complete utterance. New
     /// utterances chain on top of the previous task so whisper runs
     /// strictly serially (the engine actor enforces this anyway, but

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -323,6 +323,10 @@ struct LiveAIRecordingView: View {
                 .buttonStyle(.borderless)
                 .disabled(transcriber.segments.isEmpty)
                 .help("Copy transcript")
+                // Icon-only button: `help` is the hover tooltip and the
+                // identifier is test-only — VoiceOver needs its own
+                // user-facing name.
+                .accessibilityLabel("Copy transcript")
                 .accessibilityIdentifier("liveTranscript.copy")
                 // Mid-recording SRT export (issue #65): save whatever the
                 // live transcript has accumulated so far, without stopping

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -309,6 +309,21 @@ struct LiveAIRecordingView: View {
                 if transcriber.isTranscribing {
                     ProgressView().controlSize(.small)
                 }
+                // Mid-recording clipboard copy: same format as the
+                // detail view's transcript copy (speaker-prefixed turns
+                // once live diarization has labelled anyone) so the two
+                // read as one feature.
+                Button {
+                    let text = transcriber.clipboardText
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .disabled(transcriber.segments.isEmpty)
+                .help("Copy transcript")
+                .accessibilityIdentifier("liveTranscript.copy")
                 // Mid-recording SRT export (issue #65): save whatever the
                 // live transcript has accumulated so far, without stopping
                 // the recording. The finished recording still gets its
@@ -413,10 +428,7 @@ struct LiveAIRecordingView: View {
     /// failure); the suggested filename matches the date-stamped default
     /// title a stopped recording would get.
     private func exportLiveSRT() {
-        let snapshot = transcriber.segments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
+        let snapshot = transcriber.transcriptSegments
         guard !snapshot.isEmpty else { return }
         let panel = NSSavePanel()
         panel.title = "Export Subtitles"

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -61,6 +61,31 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    /// Mid-recording copy button: `clipboardText` must match the detail
+    /// view's copy format — the plain fullText join while nobody is
+    /// labelled, speaker-prefixed turns once live diarization kicks in.
+    func test_clipboardText_matches_detail_copy_format() async {
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "hello"),
+            TranscriptSegment(start: 2, end: 3, text: "hi there")
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+
+        // No speakers yet -> plain joined text, no prefixes.
+        XCTAssertEqual(transcriber.clipboardText, "hello hi there")
+
+        transcriber.applySpeakerLabels([
+            (start: 0, end: 1, speaker: "SPEAKER_00"),
+            (start: 2, end: 3, speaker: "SPEAKER_01")
+        ])
+        XCTAssertEqual(transcriber.clipboardText,
+                       "SPEAKER_00: hello\nSPEAKER_01: hi there")
+        _ = transcriber.stop()
+    }
+
     func test_successive_ticks_dedup_overlap_by_time() async {
         // Two ticks. Each whisper call sees the window starting at the
         // same absolute time (0s in this test because the buffer is


### PR DESCRIPTION
## Summary

Rebased onto current `main` per review: the AGC half of this PR landed separately via island-io/mila#101 (tracked by island-io/mila#100) and its commits are dropped here, leaving only the copy-transcript button.

### Copy the transcript without stopping the recording
A copy button in the live transcript pane header, next to the existing "Export SRT…" button, enabled once the first segment lands. Clipboard text comes from the same `TranscriptFormatter` the detail view's copy uses: speaker-prefixed turns once live diarization has labelled anyone — with assigned speaker names applied (`names: speakerNames`), matching the detail-view copy and SRT export since #88 — plain joined text otherwise. So copying mid-recording and copying after the fact produce identical output.

Plumbing: `LiveTranscriber.transcriptSegments` (LiveSegment → TranscriptSegment) is now shared by `clipboardText`, `exportLiveSRT`, and both of `stopRecording`'s snapshots — those previously duplicated the same mapping inline. Rebased over the #87 `stopRecording` rework.

## Test plan
- New unit test: clipboard-format parity with the detail view (plain join with no speakers, speaker-prefixed turns after labels land).
- Full `MilaTests` unit suite passes on the rebased branch (463 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

