### PR TITLE
Don't block the Record button on the final summary call

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,21 @@
+# Pull Requests
+
+## Every fix PR must be linked to a GitHub issue
+
+When opening a PR that fixes a bug or changes reported behavior, it MUST be
+connected to a GitHub issue:
+
+1. **Create the issue first** if one doesn't already exist. Describe the
+   problem, the root cause, and the intended fix — a repro helps.
+2. **Link the PR to the issue** in the PR description with a closing keyword —
+   `Closes #<n>` (or `Fixes #<n>`) — so merging the PR auto-closes the issue and
+   the two stay permanently cross-referenced.
+
+**Why:** the issue is the durable, searchable record of *what was wrong and
+why*; the PR is *how it was fixed*. Linking them keeps that history navigable
+(release notes, regression hunts, "why did we change this?" archaeology)
+instead of scattering the context across commit messages that are easy to lose.
+
+This applies to bug fixes and behavior changes. Trivial chores (typo fix,
+comment tweak, dependency bump) don't need an issue, but anything a user could
+file a bug about does.

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -688,22 +688,18 @@ final class QuickActionsController: ObservableObject {
         if let diar = liveDiarizer {
             liveTranscriber?.applySpeakerLabels(diar.intervals)
         }
-        // Push one final feed with the post-drain transcript so the
-        // LLM tail covers up to stop. Mirrors `.idle` handler's
-        // behavior; we skip the .idle drain here so we have to do
-        // the feed ourselves. `awaitFinalTick` then drains both the
-        // tick this feed kicks off AND any in-flight tick.
-        if liveAISettings?.enabled == true,
-           llmSettings?.isConfigured == true,
-           let transcriber = liveTranscriber {
-            let text = transcriber.formattedTranscript
-            if !text.isEmpty {
-                // Stop-time flush — bypass the min-interval floor so the
-                // final tick covers up to stop (awaitFinalTick drains it).
-                liveAISession?.feed(transcript: text, immediate: true)
-            }
-        }
-        await liveAISession?.awaitFinalTick()
+        // The final Live-AI summary tick is deliberately NOT awaited here.
+        // It used to run inline (feed the post-drain transcript, then
+        // `awaitFinalTick()` the resulting `claude` call), which held the
+        // Record button on "Finalizing…" for the whole summary subprocess —
+        // several seconds on a real conversation — even though the transcript
+        // was already complete and on screen. We now snapshot whatever the
+        // rolling live summary / action items are RIGHT NOW (for instant
+        // display in the post-record sheet), free the button below the
+        // instant the transcript is saved, and let `finalizeTail` regenerate
+        // the summary from the full transcript in the background. The saved
+        // summary upgrades in place a few seconds later, queue-style.
+        // See island-io/mila#86.
 
         // Snapshot final state. Safe to read now because `.idle`
         // handler is skipping its `transcriber.stop()` /
@@ -881,11 +877,24 @@ final class QuickActionsController: ObservableObject {
                         }
                     }
                 }
-                // Write the SRT sidecar + trigger the summarizer ourselves (the
-                // enqueue path normally runs both via its onTranscriptionCompleted
-                // hook).
+                // Write the SRT sidecar, then produce the summary in the
+                // background — the record button is already free while this
+                // runs. `stopRecording` no longer awaits the final Live-AI
+                // summary tick inline (island-io/mila#86), so the rolling
+                // summary snapshotted onto the recording can be a
+                // throttle-interval stale (missing the tail of the
+                // conversation). For a Live-AI recording, regenerate from the
+                // FULL transcript here so the saved summary is complete — this
+                // faithfully replaces the removed inline tick, under the same
+                // enabled + configured conditions. `summarizeIfNeeded` covers
+                // the Live-AI-off case under the normal auto-summary gate.
                 TranscriptExporter.writeSRT(for: updated, in: self.store.recordingsDirectory)
-                self.summarizer?.summarizeIfNeeded(updated)
+                if self.liveAISettings?.enabled == true,
+                   self.llmSettings?.isConfigured == true {
+                    self.summarizer?.regenerate(updated)
+                } else {
+                    self.summarizer?.summarizeIfNeeded(updated)
+                }
                 // Shrink storage: the live transcript is authoritative and the
                 // rediarize above is done reading the WAV, so transcode it to
                 // m4a in the background. (The batch path does this via its own

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -296,6 +296,74 @@ final class QuickActionsControllerTests: XCTestCase {
                        "the heavy finalize tail must run with the record button free")
     }
 
+    /// island-io/mila#86: `stopRecording` no longer blocks the Record button
+    /// on the final Live-AI summary tick. Instead, for an authoritative
+    /// Live-AI recording, `finalizeTail` regenerates the summary from the FULL
+    /// transcript in the BACKGROUND — so a rolling summary that was a
+    /// throttle-interval stale at stop time (missing the tail of the
+    /// conversation) gets refreshed with the finalize flag already clear.
+    func test_finalize_tail_regenerates_live_ai_summary_in_background() async throws {
+        // Live AI on + claude configured, on isolated suites.
+        let llmSuite = "QuickActionsControllerTests.llm.regen"
+        let liveSuite = "QuickActionsControllerTests.live.regen"
+        UserDefaults().removePersistentDomain(forName: llmSuite)
+        UserDefaults().removePersistentDomain(forName: liveSuite)
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: llmSuite)!)
+        llm.tool = .claude
+        let liveAI = LiveAISettings(defaults: UserDefaults(suiteName: liveSuite)!)
+        liveAI.enabled = true
+        liveAI.model = ""
+        defer {
+            UserDefaults().removePersistentDomain(forName: llmSuite)
+            UserDefaults().removePersistentDomain(forName: liveSuite)
+        }
+
+        // Stubbed summarizer standing in for the real full-transcript claude
+        // call — echoes the transcript so the assertion can prove the summary
+        // was regenerated from the WHOLE transcript, not the stale rolling one.
+        let summarizer = RecordingSummarizer(store: store,
+                                             llmSettings: llm,
+                                             liveAISettings: liveAI,
+                                             runLLM: { _, _, transcript, _, _, _, _ in
+            "COMPLETE: \(transcript)"
+        })
+        controller.llmSettings = llm
+        controller.liveAISettings = liveAI
+        controller.summarizer = summarizer
+
+        // A freshly-stopped Live-AI recording: authoritative live segments
+        // covering the whole conversation, but a STALE rolling summary.
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        let url = store.recordingsDirectory.appendingPathComponent("regen.wav")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        var recording = Recording(
+            title: "regen-recording",
+            duration: 0.6,
+            source: .microphone,
+            audioFileName: url.lastPathComponent,
+            status: .completed,
+            language: languageSettings.current.rawValue,
+            segments: [TranscriptSegment(start: 0, end: 0.6,
+                                         text: "the whole conversation including the tail")],
+            fullText: "the whole conversation including the tail"
+        )
+        recording.summary = "stale rolling summary"
+        store.add(recording)
+
+        // The button is already free by the time the tail runs.
+        controller.isFinalizingRecording = false
+        controller.finalizeTail(for: recording, liveTranscriptIsAuthoritative: true)
+        await controller.awaitFinalizeTails()
+        await summarizer.awaitInFlight(recording.id)
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == recording.id })
+        XCTAssertEqual(stored.summary, "COMPLETE: the whole conversation including the tail",
+                       "finalizeTail must regenerate the Live-AI summary from the full transcript in the background")
+        XCTAssertFalse(controller.isFinalizingRecording,
+                       "summary regeneration must run with the record button free")
+    }
+
     // MARK: - Re-diarize gate (skip when the live pass found few speakers)
 
     /// The offline re-diarize only fixes the online diarizer's


### PR DESCRIPTION
## Problem

After stopping a recording, the main Record button showed **"Finalizing…"** and stayed disabled for several seconds — blocking a new recording — even when the transcript was already complete on screen.

Fixes #86.

## Root cause

`stopRecording()` holds `isFinalizingRecording = true` (which disables the Record button) across an inline drain that awaits three things before freeing the button:

1. `liveTranscriber.transcribeNow()` — transcribe the final utterance (fast)
2. `liveDiarizer.awaitPending()` — streaming diarizer (no-op when diarization is off)
3. `liveAISession.awaitFinalTick()` — **a final `claude` summary/action-items subprocess** ← the slow one

The heavy *offline* tail (re-diarize / transcode) was already backgrounded in `finalizeTail`. Only the summary tick was left on the blocking path.

## Fix

Drop the inline final tick:

- Snapshot the rolling summary/action items for instant display in the post-record sheet, then **free the button the moment the transcript is saved**.
- `finalizeTail` regenerates the summary from the **full transcript** in the background via the existing `RecordingSummarizer` (decoupled from the live singletons, re-fetches by id). The saved summary upgrades in place a few seconds later — the "process it in a queue" behavior.
- Action items keep the rolling snapshot, consistent with how every other background path (re-transcribe `regenerate`, backfill) already treats them — action items are a live-only artifact.

**Net effect:** Record frees in well under a second after Stop; the summary lands in the background.

### Why this doesn't introduce a store race

`RecordingSummarizer.runSummary` (whole-struct `store.update`) and `compressRecordingAudio` (in-place `audioFileName` mutation) now run concurrently in the authoritative branch. Each writer's read-modify-write is atomic on the main actor (no `await` between the re-fetch and the store write), so neither can interleave inside the other and clobber it. This mirrors the pre-existing non-live path, which already ran `summarizeIfNeeded` + compress concurrently.

## Tests

- New unit test `test_finalize_tail_regenerates_live_ai_summary_in_background` pins that the authoritative Live-AI tail regenerates the summary from the full transcript with `isFinalizingRecording` already clear.
- The existing record-while-finalizing E2E (`AudioLoopbackUITests`) still holds — the button frees *earlier* now, and the transcript snapshot + live-singleton teardown still happen inside the guard.
- `make build` + `build-for-testing` green; new test passes locally.

## Also

Adds `.claude/rules/pull-requests.md`: fix PRs must be linked to a GitHub issue via a closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live-AI recordings now finish stopping more quickly without waiting for final summary generation.
  * Recording summaries are regenerated from the complete transcript in the background, improving accuracy when the live summary is outdated.
  * The rename experience remains available promptly while final processing continues.

* **Documentation**
  * Added contribution guidance requiring reported fixes to reference a pre-existing issue and automatically close it when merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->