### PR TITLE
Speaker renaming with a persistent, searchable name directory

### DIFF
--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -316,7 +316,8 @@ final class PostRecordingCoordinator: ObservableObject {
             }
             if rec.status != .pending && rec.status != .running {
                 let text = TranscriptFormatter.plainText(segments: rec.segments,
-                                                         fallback: rec.fullText)
+                                                         fallback: rec.fullText,
+                                                         names: rec.speakerNames)
                 return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ? nil
                     : text

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -625,7 +625,8 @@ final class QuickActionsController: ObservableObject {
             fullText: initialTranscriptSegments.map(\.text).joined(separator: " "),
             appName: appName,
             summary: initialSummary.isEmpty ? nil : initialSummary,
-            actionItems: initialItems.isEmpty ? nil : initialItems
+            actionItems: initialItems.isEmpty ? nil : initialItems,
+            speakerNames: liveTranscriber?.speakerNames ?? [:]
         )
         store.add(recording)
         activeJob = .none
@@ -769,6 +770,11 @@ final class QuickActionsController: ObservableObject {
             return
         }
         updated.segments = finalTranscriptSegments
+        // Mid-recording speaker renames from the live pane. Snapshotted
+        // here (before `liveTranscriber?.stop()` below) alongside the
+        // segments they label; `finalizeTail` remaps them if the offline
+        // re-diarize pass re-keys the speaker IDs.
+        updated.speakerNames = liveTranscriber?.speakerNames ?? [:]
         // Always preserve fullText when we have live segments — the
         // sheet should show what the user just saw on screen, even
         // for chunk mode while the batch diarization pass is still
@@ -869,9 +875,19 @@ final class QuickActionsController: ObservableObject {
                         wavURL: self.store.audioURL(for: updated),
                         segments: updated.segments,
                         recordingID: id) {
+                        let preRediarize = updated.segments
                         updated.segments = rediarized
                         if var current = self.store.recordings.first(where: { $0.id == id }) {
                             current.segments = rediarized
+                            // The offline pass re-keyed every SPEAKER_NN, so
+                            // names assigned mid-recording (or in the detail
+                            // view while this pass ran — hence the re-fetched
+                            // row's map, not the snapshot's) must follow the
+                            // utterances they labeled onto the new IDs.
+                            current.speakerNames = SpeakerNameRemapper.remap(
+                                names: current.speakerNames,
+                                from: preRediarize,
+                                to: rediarized)
                             self.store.update(current)
                             updated = current
                         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -249,6 +249,9 @@ struct MilaApp: App {
     @StateObject private var recordingSummarizer: RecordingSummarizer
     @StateObject private var voiceMemosSettings: VoiceMemosSettings
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
+    /// Persistent, app-wide list of speaker names — the pick-list behind
+    /// the transcript's speaker rename popover.
+    @StateObject private var speakerDirectory = SpeakerDirectory()
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -545,6 +548,7 @@ struct MilaApp: App {
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
+                .environmentObject(speakerDirectory)
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -598,6 +602,7 @@ struct MilaApp: App {
                 .environmentObject(liveAISettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
+                .environmentObject(speakerDirectory)
         }
     }
 

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -251,7 +251,7 @@ struct MilaApp: App {
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
     /// Persistent, app-wide list of speaker names — the pick-list behind
     /// the transcript's speaker rename popover.
-    @StateObject private var speakerDirectory = SpeakerDirectory()
+    @StateObject private var speakerDirectory: SpeakerDirectory
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -497,6 +497,7 @@ struct MilaApp: App {
                                             languageSettings: langSettings)
         _voiceMemosSettings = StateObject(wrappedValue: vmSettings)
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
+        _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -61,6 +61,12 @@ final class LiveTranscriber: ObservableObject {
     /// flat string (e.g. the LLM feed via `formattedTranscript`).
     @Published private(set) var segments: [LiveSegment] = []
 
+    /// User-assigned display names for live speakers (raw `SPEAKER_NN`
+    /// → name), set from the live pane's rename popover mid-recording.
+    /// Copied into the saved `Recording` at stop (QuickActionsController),
+    /// where the post-stop re-diarize remaps them onto the re-keyed IDs.
+    @Published var speakerNames: [String: String] = [:]
+
     var chunkSeconds: Double = 30.0
     var windowSeconds: Double = 30.0
     /// When true, route incoming audio through `UtteranceDetector` and
@@ -135,6 +141,7 @@ final class LiveTranscriber: ObservableObject {
         self.samplesDropped = 0
         self.fullText = ""
         self.segments = []
+        self.speakerNames = [:]
         self.lastError = nil
         self.epoch &+= 1
         liveLog.log("LiveTranscriber.start lang=\(language, privacy: .public) chunk=\(self.chunkSeconds, privacy: .public)s window=\(self.windowSeconds, privacy: .public)s useVAD=\(self.useVAD, privacy: .public) epoch=\(self.epoch, privacy: .public)")

--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -93,6 +93,13 @@ struct Recording: Identifiable, Codable, Hashable {
     /// upgrade can't mass-delete a user's older imports.
     var voiceMemoFolderUUID: String?
 
+    /// User-assigned display names for diarized speakers, keyed by the raw
+    /// diarizer ID (`SPEAKER_00` → "Daniel"). Segments keep their raw IDs —
+    /// this map is a display overlay resolved at render/export time, so
+    /// re-clustering tooling and the color palette stay keyed on stable IDs.
+    /// Empty for recordings whose speakers were never renamed.
+    var speakerNames: [String: String]
+
     /// Sentinel stored in `voiceMemoFolderUUID` for memos imported from the
     /// Voice Memos "Unfiled" bucket, which has no real folder UUID. Keeps
     /// "imported from Unfiled" distinguishable from a legacy import whose
@@ -117,7 +124,8 @@ struct Recording: Identifiable, Codable, Hashable {
          summary: String? = nil,
          actionItems: [ActionItem]? = nil,
          voiceMemoUniqueID: String? = nil,
-         voiceMemoFolderUUID: String? = nil) {
+         voiceMemoFolderUUID: String? = nil,
+         speakerNames: [String: String] = [:]) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -136,6 +144,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.actionItems = actionItems
         self.voiceMemoUniqueID = voiceMemoUniqueID
         self.voiceMemoFolderUUID = voiceMemoFolderUUID
+        self.speakerNames = speakerNames
     }
 
     var isTrashed: Bool { deletedAt != nil }
@@ -170,7 +179,8 @@ struct Recording: Identifiable, Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,
-             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID
+             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID,
+             speakerNames
         // `fullText` deliberately excluded — lives in a sidecar .txt file.
         // Legacy records that had it inline are decoded via the custom init.
         case fullText
@@ -195,6 +205,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
         self.voiceMemoUniqueID = try c.decodeIfPresent(String.self, forKey: .voiceMemoUniqueID)
         self.voiceMemoFolderUUID = try c.decodeIfPresent(String.self, forKey: .voiceMemoFolderUUID)
+        self.speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
         // Legacy records still have fullText inline; new records leave it
         // empty here and RecordingStore loads it from the sidecar .txt.
         self.fullText = try c.decodeIfPresent(String.self, forKey: .fullText) ?? ""
@@ -219,6 +230,9 @@ struct Recording: Identifiable, Codable, Hashable {
         try c.encodeIfPresent(actionItems, forKey: .actionItems)
         try c.encodeIfPresent(voiceMemoUniqueID, forKey: .voiceMemoUniqueID)
         try c.encodeIfPresent(voiceMemoFolderUUID, forKey: .voiceMemoFolderUUID)
+        if !speakerNames.isEmpty {
+            try c.encode(speakerNames, forKey: .speakerNames)
+        }
         // fullText intentionally omitted — sidecar .txt is the source of truth.
     }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -374,6 +374,27 @@ final class RecordingStore: ObservableObject {
         persist()
     }
 
+    /// Assign (or clear, with nil/empty) a display name for one raw
+    /// diarizer speaker ID on a recording. Segments keep their raw
+    /// `SPEAKER_NN` IDs — the name is a display overlay resolved at
+    /// render/export time. Regenerates the `.srt` sidecar for completed
+    /// recordings so the on-disk export matches what the UI shows.
+    func setSpeakerName(_ name: String?, forSpeaker rawID: String, recordingID: UUID) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recordingID }) else { return }
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, !trimmed.isEmpty {
+            guard recordings[idx].speakerNames[rawID] != trimmed else { return }
+            recordings[idx].speakerNames[rawID] = trimmed
+        } else {
+            guard recordings[idx].speakerNames[rawID] != nil else { return }
+            recordings[idx].speakerNames.removeValue(forKey: rawID)
+        }
+        persist()
+        if recordings[idx].status == .completed {
+            TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
+        }
+    }
+
     /// Move a recording into a folder (or unfile it with nil). Auto-creates
     /// the folder so callers can drag into a brand-new name without a
     /// separate `createFolder` round-trip. Dedup is case-insensitive — if

--- a/Mila/Models/SpeakerDirectory.swift
+++ b/Mila/Models/SpeakerDirectory.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// App-wide directory of speaker names the user has assigned across
+/// recordings — the pick-list behind the speaker rename popover. Most
+/// people recur across meetings, so the list persists to
+/// `speaker-names.json` at the Application Support/Mila root. Like the
+/// voice-memo tombstones (and unlike `folders.json`), it deliberately
+/// does NOT travel with a relocated recordings folder: it's app state,
+/// not per-folder content.
+///
+/// Per-recording assignments live in `Recording.speakerNames` as plain
+/// string copies — removing a name here never touches recordings it was
+/// already assigned to.
+@MainActor
+final class SpeakerDirectory: ObservableObject {
+
+    @Published private(set) var names: [String] = []
+
+    private let fileURL: URL
+
+    /// `directory` is the folder that holds `speaker-names.json`.
+    /// Injectable so tests can point at a temp directory.
+    init(directory: URL) {
+        self.fileURL = directory.appendingPathComponent("speaker-names.json")
+        load()
+    }
+
+    /// Production init: same Application Support/Mila root the
+    /// RecordingStore resolves.
+    convenience init() {
+        // Mirror RecordingStore: UI tests must never read or write the
+        // user's real directory.
+        if CommandLine.arguments.contains("--ui-test-clean-store") {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("Mila-UITest-Speakers-\(UUID())", isDirectory: true)
+            self.init(directory: tmp)
+            return
+        }
+        let appSupport = try! FileManager.default.url(for: .applicationSupportDirectory,
+                                                      in: .userDomainMask,
+                                                      appropriateFor: nil,
+                                                      create: true)
+        self.init(directory: appSupport.appendingPathComponent("Mila", isDirectory: true))
+    }
+
+    /// Add a name to the directory. Trims whitespace, rejects empty input,
+    /// and dedupes case-insensitively — adding "daniel" when "Daniel"
+    /// exists returns the existing canonical spelling instead of a
+    /// duplicate. Returns the canonical name that's now in the list, or
+    /// nil when the input was blank.
+    @discardableResult
+    func add(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let existing = names.first(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return existing
+        }
+        names.append(trimmed)
+        names.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        persist()
+        return trimmed
+    }
+
+    func remove(_ name: String) {
+        let before = names.count
+        names.removeAll { $0.caseInsensitiveCompare(name) == .orderedSame }
+        if names.count != before { persist() }
+    }
+
+    /// Names matching a type-to-filter query (case-insensitive contains).
+    /// An empty/whitespace query returns the full list.
+    func matches(for query: String) -> [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return names }
+        return names.filter { $0.localizedCaseInsensitiveContains(trimmed) }
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else { return }
+        names = decoded.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func persist() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(names)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("SpeakerDirectory persist error: \(error)")
+        }
+    }
+}

--- a/Mila/Models/SpeakerDirectory.swift
+++ b/Mila/Models/SpeakerDirectory.swift
@@ -36,10 +36,12 @@ final class SpeakerDirectory: ObservableObject {
             self.init(directory: tmp)
             return
         }
-        let appSupport = try! FileManager.default.url(for: .applicationSupportDirectory,
-                                                      in: .userDomainMask,
-                                                      appropriateFor: nil,
-                                                      create: true)
+        // Non-throwing lookup + temp-dir fallback: a missing Application
+        // Support directory shouldn't crash the app at launch — worst case
+        // the directory just doesn't persist across reboots.
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
         self.init(directory: appSupport.appendingPathComponent("Mila", isDirectory: true))
     }
 

--- a/Mila/Transcription/SpeakerColor.swift
+++ b/Mila/Transcription/SpeakerColor.swift
@@ -27,6 +27,19 @@ extension String {
         }
         return speakerColorPalette[index % speakerColorPalette.count]
     }
+
+    /// Speaker color that honors user-assigned names: when two raw IDs
+    /// share the same assigned name (the user's fix for an over-split
+    /// speaker), both take the color of the lowest raw ID carrying that
+    /// name so they read as one person. Unnamed IDs keep their own color.
+    func speakerColor(names: [String: String]) -> Color {
+        guard let name = names[self] else { return speakerColor }
+        let canonical = names
+            .filter { $0.value == name }
+            .keys
+            .min() ?? self
+        return canonical.speakerColor
+    }
 }
 
 /// Segment types that carry a diarizer speaker ID — `TranscriptSegment`

--- a/Mila/Transcription/SpeakerLabel.swift
+++ b/Mila/Transcription/SpeakerLabel.swift
@@ -4,13 +4,27 @@ import Foundation
 /// identifiers into a label the user actually wants to see — `Speaker A`
 /// in English, `דובר א׳` in Hebrew.
 ///
-/// The raw labels stay in the internal data model (segment metadata,
-/// SRT exports, post-recording sidecar text) because they're stable
-/// across runs and tooling outside Mila (pyannote, third-party
-/// re-clustering scripts) expects them. The conversion only happens
-/// at display time and when feeding text to the LLM, so the LLM sees
-/// the same labels the user sees and emits them back the same way.
+/// The raw labels stay in the internal data model (segment metadata)
+/// because they're stable across runs and tooling outside Mila
+/// (pyannote, third-party re-clustering scripts) expects them. The
+/// conversion happens at display/export time and when feeding text to
+/// the LLM, so the LLM sees the same labels the user sees and emits
+/// them back the same way. When the user has assigned a real name to a
+/// speaker (`Recording.speakerNames`), that name wins everywhere —
+/// UI, clipboard, `.srt` sidecar, LLM feed — via
+/// `displaySpeakerName(names:language:)`.
 extension String {
+    /// The label to show/export for this raw speaker ID: the
+    /// user-assigned name when one exists, otherwise the friendly
+    /// "Speaker A" / "דובר א׳" fallback.
+    func displaySpeakerName(names: [String: String], language: String) -> String {
+        if let name = names[self]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return name
+        }
+        return friendlySpeakerLabel(language: language)
+    }
+
     func friendlySpeakerLabel(language: String) -> String {
         guard self.hasPrefix("SPEAKER_") else { return self }
         let suffix = self.dropFirst("SPEAKER_".count)

--- a/Mila/Transcription/SpeakerNameRemapper.swift
+++ b/Mila/Transcription/SpeakerNameRemapper.swift
@@ -1,0 +1,50 @@
+import Foundation
+import TranscriptionCore
+
+/// Carries user-assigned speaker names across the post-stop offline
+/// re-diarization, which re-keys every `SPEAKER_NN` label (global
+/// clustering assigns IDs by first-speaking order, unrelated to the
+/// live diarizer's IDs). Without the remap, a name assigned to live
+/// `SPEAKER_03` could silently land on — or vanish from — a different
+/// person in the finalized recording.
+///
+/// Works because `TranscriptionService.rediarizeSegments` only
+/// reassigns `.speaker` on the SAME segment array: `old[i]` and
+/// `new[i]` are the same utterance, so per-index pairs tell us which
+/// old speaker each new speaker was.
+enum SpeakerNameRemapper {
+
+    /// For each new speaker ID, find the old ID that dominates it by
+    /// summed segment duration and carry that old ID's name over.
+    /// Handles the offline pass merging over-segmented live speakers
+    /// (dominant name wins) and splitting one live speaker into two
+    /// (the name propagates to both halves).
+    static func remap(names: [String: String],
+                      from old: [TranscriptSegment],
+                      to new: [TranscriptSegment]) -> [String: String] {
+        guard !names.isEmpty else { return [:] }
+
+        // votes[newID][oldID] = summed duration of segments where the
+        // utterance carried oldID before and newID after. The small
+        // floor keeps zero-duration segments counted (degrades to a
+        // per-segment vote instead of dropping them).
+        var votes: [String: [String: Double]] = [:]
+        for (o, n) in zip(old, new) {
+            guard let oldID = o.speaker, let newID = n.speaker else { continue }
+            let duration = max(n.end - n.start, 0.001)
+            votes[newID, default: [:]][oldID, default: 0] += duration
+        }
+
+        var remapped: [String: String] = [:]
+        for (newID, tally) in votes {
+            let dominant = tally.max { a, b in
+                if a.value != b.value { return a.value < b.value }
+                return a.key > b.key  // deterministic tie-break: lower old ID wins
+            }?.key
+            if let dominant, let name = names[dominant] {
+                remapped[newID] = name
+            }
+        }
+        return remapped
+    }
+}

--- a/Mila/Transcription/TranscriptExporter.swift
+++ b/Mila/Transcription/TranscriptExporter.swift
@@ -28,15 +28,16 @@ enum TranscriptExporter {
     /// history context menu so users can drop subtitles next to a source
     /// video file. Throws so the caller can surface failures via NSAlert.
     static func writeSRT(for recording: Recording, to url: URL) throws {
-        try writeSRT(segments: recording.segments, to: url)
+        try writeSRT(segments: recording.segments, to: url, names: recording.speakerNames)
     }
 
     /// Raw-segments variant: write an SRT for a segment list that isn't
     /// (yet) attached to a saved `Recording`. Used by the mid-recording
     /// "Export SRT…" button in the live transcript pane, which snapshots
     /// `LiveTranscriber.segments` while the recording is still running.
-    static func writeSRT(segments: [TranscriptSegment], to url: URL) throws {
-        let body = srtBody(for: segments)
+    static func writeSRT(segments: [TranscriptSegment], to url: URL,
+                         names: [String: String] = [:]) throws {
+        let body = srtBody(for: segments, names: names)
         guard !body.isEmpty else {
             throw NSError(domain: "TranscriptExporter", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "No transcript segments to export."])
@@ -47,13 +48,15 @@ enum TranscriptExporter {
     /// Format the SRT content for `recording`. Returns empty string when
     /// there's nothing to write (no segments, or every segment is blank).
     static func srtBody(for recording: Recording) -> String {
-        srtBody(for: recording.segments)
+        srtBody(for: recording.segments, names: recording.speakerNames)
     }
 
     /// Format SRT content for a raw segment list. Returns empty string
     /// when there's nothing to write (no segments, or every segment is
-    /// blank).
-    static func srtBody(for segments: [TranscriptSegment]) -> String {
+    /// blank). `names` substitutes user-assigned speaker names for raw
+    /// diarizer IDs in the cue prefix; unnamed speakers keep the raw ID.
+    static func srtBody(for segments: [TranscriptSegment],
+                        names: [String: String] = [:]) -> String {
         guard !segments.isEmpty else { return "" }
 
         var entries: [String] = []
@@ -62,7 +65,7 @@ enum TranscriptExporter {
             guard !text.isEmpty else { continue }
 
             let seqNum = entries.count + 1
-            let prefix = seg.speaker.map { $0 + ": " } ?? ""
+            let prefix = seg.speaker.map { (names[$0] ?? $0) + ": " } ?? ""
             entries.append("\(seqNum)\n\(formatSRTTime(seg.start)) --> \(formatSRTTime(seg.end))\n\(prefix)\(text)")
         }
         return entries.isEmpty ? "" : entries.joined(separator: "\n\n") + "\n\n"

--- a/Mila/Transcription/TranscriptFormatter.swift
+++ b/Mila/Transcription/TranscriptFormatter.swift
@@ -5,14 +5,20 @@ enum TranscriptFormatter {
 
     /// Plain-text rendering of `segments` suitable for the clipboard or for
     /// piping into an LLM prompt. When any segment carries a speaker label
-    /// (diarization ran), each turn is prefixed `SPEAKER_XX: ` and
+    /// (diarization ran), each turn is prefixed with the speaker's label and
     /// consecutive segments from the same speaker collapse into one
     /// paragraph. When no segment has a speaker, falls back to `fallback`
     /// — the trimmed full-text join the rest of the app stores.
     ///
+    /// `names` maps raw diarizer IDs (`SPEAKER_00`) to user-assigned names;
+    /// unnamed speakers keep the raw ID. Turns collapse on the RESOLVED
+    /// label, so two raw IDs the user named identically (their fix for an
+    /// over-split speaker) merge into one paragraph.
+    ///
     /// Matches the SRT exporter's prefix format so the clipboard text and
     /// the on-disk `.srt` use the same speaker labels.
-    static func plainText(segments: [TranscriptSegment], fallback: String) -> String {
+    static func plainText(segments: [TranscriptSegment], fallback: String,
+                          names: [String: String] = [:]) -> String {
         guard segments.contains(where: { $0.speaker != nil }) else { return fallback }
 
         var lines: [String] = []
@@ -22,7 +28,7 @@ enum TranscriptFormatter {
         for seg in segments {
             let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { continue }
-            let speaker = seg.speaker
+            let speaker = seg.speaker.map { names[$0] ?? $0 }
 
             if currentSpeaker == .none {
                 currentSpeaker = .some(speaker)

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -725,6 +725,12 @@ final class TranscriptionService: ObservableObject {
             print("Transcribe done: \(working.title) -> \(enrichedSegments.count) segments, \(text.count) chars")
 
             working.segments = enrichedSegments
+            // The batch pass minted fresh speaker IDs (new clustering, new
+            // segment boundaries) with no alignment to the old ones, so any
+            // user-assigned names are now keyed to meaningless IDs — clear
+            // them rather than mislabel a different voice. Only explicit
+            // re-transcribes of a renamed recording hit this in practice.
+            working.speakerNames = [:]
             working.fullText = text
             if let lastEnd = enrichedSegments.last?.end, lastEnd > 0 {
                 working.duration = lastEnd

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -205,7 +205,8 @@ struct LiveAIRecordingView: View {
             sectionHeader(icon: "checklist", title: "Action items", isRTL: isRTL)
             VStack(alignment: isRTL ? .trailing : .leading, spacing: 4) {
                 ForEach(aiSession.actionItems) { item in
-                    ActionItemRow(item: item, language: language, isRTL: isRTL)
+                    ActionItemRow(item: item, language: language, isRTL: isRTL,
+                                  speakerNames: transcriber.speakerNames)
                 }
             }
         }
@@ -350,7 +351,16 @@ struct LiveAIRecordingView: View {
                             // tint color.
                             let hasMultipleSpeakers = transcriber.segments.hasMultipleSpeakers
                             ForEach(transcriber.segments) { seg in
-                                TranscriptLineView(segment: seg, language: language, useSpeakerColor: hasMultipleSpeakers)
+                                TranscriptLineView(segment: seg, language: language,
+                                                   useSpeakerColor: hasMultipleSpeakers,
+                                                   speakerNames: transcriber.speakerNames,
+                                                   onAssignName: { raw, name in
+                                                       if let name {
+                                                           transcriber.speakerNames[raw] = name
+                                                       } else {
+                                                           transcriber.speakerNames.removeValue(forKey: raw)
+                                                       }
+                                                   })
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
                                 // inside TranscriptLineView (where SwiftUI
@@ -411,7 +421,8 @@ struct LiveAIRecordingView: View {
         panel.nameFieldStringValue = "Recording · \(f.string(from: Date())).srt"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
-            try TranscriptExporter.writeSRT(segments: snapshot, to: url)
+            try TranscriptExporter.writeSRT(segments: snapshot, to: url,
+                                            names: transcriber.speakerNames)
         } catch {
             NSAlert(error: error).runModal()
         }
@@ -451,6 +462,9 @@ private struct ActionItemRow: View {
     /// / open sidebar and shoved Hebrew action items to the left, which
     /// is the bug this replaces.
     var isRTL: Bool = false
+    /// Live speaker names so the metadata line shows the same label the
+    /// transcript pane does after a mid-recording rename.
+    var speakerNames: [String: String] = [:]
 
     var body: some View {
         let align: Alignment = isRTL ? .trailing : .leading
@@ -478,7 +492,7 @@ private struct ActionItemRow: View {
     @ViewBuilder private var metadataRow: some View {
         HStack(spacing: 8) {
             if let speaker = item.speaker {
-                Text(speaker.friendlySpeakerLabel(language: language))
+                Text(speaker.displaySpeakerName(names: speakerNames, language: language))
                     .font(.caption2.monospaced())
                     .foregroundStyle(.secondary)
             }
@@ -529,6 +543,11 @@ private struct TranscriptLineView: View {
     /// default tint — set by the caller once it's seen more than one
     /// distinct speaker across the live transcript.
     var useSpeakerColor: Bool = false
+    /// User-assigned live speaker names (raw ID → name).
+    var speakerNames: [String: String] = [:]
+    /// Persists a rename picked from the label's popover mid-recording:
+    /// (raw speaker ID, chosen name or nil-to-reset).
+    var onAssignName: (String, String?) -> Void = { _, _ in }
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -541,10 +560,15 @@ private struct TranscriptLineView: View {
         let lineRTL = segment.text.isPredominantlyHebrew || language == "he"
         HStack(alignment: .top, spacing: 8) {
             if let sp = segment.speaker {
-                Text(sp.friendlySpeakerLabel(language: language))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? sp.speakerColor : Color.accentColor)
-                    .frame(minWidth: 96, alignment: .leading)
+                SpeakerLabelButton(
+                    rawID: sp,
+                    names: speakerNames,
+                    language: language,
+                    color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
+                    font: .caption.weight(.semibold),
+                    onAssign: { name in onAssignName(sp, name) }
+                )
+                .frame(minWidth: 96, alignment: .leading)
             } else {
                 Color.clear.frame(width: 96, height: 1)
             }

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -339,7 +339,12 @@ struct RecordingDetailView: View {
                                        showSpeaker: hasSpeakers,
                                        useSpeakerColor: hasMultipleSpeakers,
                                        language: recording.language,
-                                       onTap: { seek(to: seg.start) })
+                                       speakerNames: recording.speakerNames,
+                                       onTap: { seek(to: seg.start) },
+                                       onAssignName: { raw, name in
+                                           store.setSpeakerName(name, forSpeaker: raw,
+                                                                recordingID: recording.id)
+                                       })
                         }
                     }
                     .padding()
@@ -411,7 +416,8 @@ struct RecordingDetailView: View {
 
     private func copyTranscript() {
         let text = TranscriptFormatter.plainText(segments: recording.segments,
-                                                 fallback: recording.fullText)
+                                                 fallback: recording.fullText,
+                                                 names: recording.speakerNames)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }
@@ -569,7 +575,12 @@ private struct SegmentRow: View {
     /// language — matching the labels the live view + post-recording
     /// action items already show.
     let language: String
+    /// User-assigned speaker names for this recording (raw ID → name).
+    let speakerNames: [String: String]
     let onTap: () -> Void
+    /// Persists a rename picked from the label's popover:
+    /// (raw speaker ID, chosen name or nil-to-reset).
+    let onAssignName: (String, String?) -> Void
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -578,10 +589,15 @@ private struct SegmentRow: View {
             // label "Speaker A" / "דובר א׳" and the actual content.
             // `fixedSize` keeps the label at its natural width.
             if showSpeaker, let raw = segment.speaker, !raw.isEmpty {
-                Text(raw.friendlySpeakerLabel(language: language) + ":")
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? raw.speakerColor : Color.accentColor)
-                    .fixedSize(horizontal: true, vertical: false)
+                SpeakerLabelButton(
+                    rawID: raw,
+                    names: speakerNames,
+                    language: language,
+                    color: useSpeakerColor ? raw.speakerColor(names: speakerNames) : Color.accentColor,
+                    suffix: ":",
+                    onAssign: { name in onAssignName(raw, name) }
+                )
+                .fixedSize(horizontal: true, vertical: false)
             }
             Text(segment.text)
                 .font(.body)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -53,7 +53,8 @@ struct RenameRecordingSheet: View {
     /// join when no segments carry speaker info.
     private var transcript: String {
         TranscriptFormatter.plainText(segments: liveRecording.segments,
-                                      fallback: liveRecording.fullText)
+                                      fallback: liveRecording.fullText,
+                                      names: liveRecording.speakerNames)
     }
     private var transcriptReady: Bool {
         !transcript.isEmpty && liveRecording.status != .running && liveRecording.status != .pending

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -23,7 +23,8 @@ struct SendToLLMSheet: View {
 
     private var transcript: String {
         TranscriptFormatter.plainText(segments: liveRecording.segments,
-                                      fallback: liveRecording.fullText)
+                                      fallback: liveRecording.fullText,
+                                      names: liveRecording.speakerNames)
     }
 
     var body: some View {

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1157,6 +1157,10 @@ private struct DiarizationSettingsTabContent: View {
                 .accessibilityIdentifier("speakers.health.ok.probe")
                 .accessibilityLabel(diarization.healthCheckResult?.ok == true ? "ok" : "not_ok")
 
+            Divider()
+
+            KnownSpeakersSection()
+
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1279,6 +1283,65 @@ private struct DiarizationSettingsTabContent: View {
         if diarization.isHealthChecking { return "Checking…" }
         guard let result = diarization.healthCheckResult else { return "Not checked yet" }
         return result.ok ? "Speaker detection is working" : "Speaker detection unavailable"
+    }
+}
+
+/// "Known Speakers" — manage the persistent name list behind the
+/// transcript's speaker-rename popover. Names added here (or via the
+/// popover) are offered in every future recording's rename list.
+private struct KnownSpeakersSection: View {
+    @EnvironmentObject private var directory: SpeakerDirectory
+    @State private var newName = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Known speakers")
+                .font(.callout.weight(.semibold))
+            Text("Names you can assign to speakers by clicking their label in a transcript. Removing a name here doesn't change recordings it's already assigned to.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !directory.names.isEmpty {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(directory.names, id: \.self) { name in
+                            HStack {
+                                Text(name)
+                                Spacer()
+                                Button {
+                                    directory.remove(name)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Remove \"\(name)\" from the list")
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(maxHeight: 120)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            HStack(spacing: 8) {
+                TextField("Add a name…", text: $newName)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(addName)
+                Button("Add", action: addName)
+                    .disabled(newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private func addName() {
+        if directory.add(newName) != nil {
+            newName = ""
+        }
     }
 }
 

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1317,9 +1317,12 @@ private struct KnownSpeakersSection: View {
                                 }
                                 .buttonStyle(.borderless)
                                 .help("Remove \"\(name)\" from the list")
+                                .accessibilityIdentifier("speakers.known.remove.\(name)")
                             }
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
+                            .accessibilityElement(children: .contain)
+                            .accessibilityIdentifier("speakers.known.row.\(name)")
                         }
                     }
                     .padding(.vertical, 4)
@@ -1332,8 +1335,10 @@ private struct KnownSpeakersSection: View {
                 TextField("Add a name…", text: $newName)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(addName)
+                    .accessibilityIdentifier("speakers.known.addField")
                 Button("Add", action: addName)
                     .disabled(newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityIdentifier("speakers.known.addButton")
             }
         }
     }

--- a/Mila/Views/SpeakerNamePicker.swift
+++ b/Mila/Views/SpeakerNamePicker.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// Popover content for renaming a diarized speaker: type-to-filter over
+/// the persistent `SpeakerDirectory`, an "Add" row for new names, and a
+/// reset row back to the default "Speaker A" label. Shared by the
+/// completed-recording detail view and the live transcript pane — the
+/// caller decides where the assignment lands via `onAssign`.
+struct SpeakerNamePicker: View {
+    /// Resolved default label ("Speaker A" / "דובר א׳") shown in the
+    /// reset row when a custom name is currently assigned.
+    let defaultLabel: String
+    /// Name currently assigned to this speaker, nil when unnamed.
+    let currentName: String?
+    /// Called with the chosen name, or nil to reset to the default label.
+    let onAssign: (String?) -> Void
+
+    @EnvironmentObject private var directory: SpeakerDirectory
+    @Environment(\.dismiss) private var dismiss
+    @State private var query = ""
+    @FocusState private var searchFocused: Bool
+
+    private var filtered: [String] {
+        directory.matches(for: query)
+    }
+
+    /// The typed query has no exact (case-insensitive) match in the
+    /// directory yet — offer to add it as a brand-new name.
+    private var canAddQuery: Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return !directory.names.contains { $0.caseInsensitiveCompare(trimmed) == .orderedSame }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            TextField("Name this speaker…", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .focused($searchFocused)
+                .onSubmit(submitQuery)
+                .padding(10)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered, id: \.self) { name in
+                        row {
+                            assign(name)
+                        } label: {
+                            HStack {
+                                Text(name).lineLimit(1)
+                                Spacer()
+                                if name == currentName {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                        }
+                    }
+                    if canAddQuery {
+                        row {
+                            assign(query)
+                        } label: {
+                            Label("Add \"\(query.trimmingCharacters(in: .whitespacesAndNewlines))\"",
+                                  systemImage: "plus.circle.fill")
+                                .lineLimit(1)
+                        }
+                    }
+                    if filtered.isEmpty && !canAddQuery {
+                        Text("Type a name to add it")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 180)
+
+            if currentName != nil {
+                Divider()
+                row {
+                    onAssign(nil)
+                    dismiss()
+                } label: {
+                    Label("Use default (\(defaultLabel))", systemImage: "arrow.uturn.backward")
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .frame(width: 260)
+        .onAppear { searchFocused = true }
+    }
+
+    /// Enter in the search field: exact match wins, otherwise the top
+    /// filtered suggestion, otherwise add the typed name.
+    private func submitQuery() {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if let exact = directory.names.first(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            assign(exact)
+        } else if let top = filtered.first {
+            assign(top)
+        } else {
+            assign(trimmed)
+        }
+    }
+
+    /// Route every assignment through the directory so names typed here
+    /// (not just ones picked from the list) persist for future recordings.
+    private func assign(_ name: String) {
+        guard let canonical = directory.add(name) else { return }
+        onAssign(canonical)
+        dismiss()
+    }
+
+    private func row<L: View>(action: @escaping () -> Void,
+                              @ViewBuilder label: () -> L) -> some View {
+        Button(action: action) {
+            label()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Clickable speaker label used by both transcript panes (recording
+/// detail + live). Shows the resolved display name, underlines on hover,
+/// and opens `SpeakerNamePicker` in an anchored popover on click. Its
+/// own tap gesture takes precedence over any enclosing row gesture
+/// (e.g. the detail view's seek-on-tap), so clicking the label never
+/// scrubs playback.
+struct SpeakerLabelButton: View {
+    let rawID: String
+    let names: [String: String]
+    let language: String
+    let color: Color
+    /// Text appended after the name — the detail view's tight-prefix
+    /// layout uses ":", the live pane's fixed column uses nothing.
+    var suffix: String = ""
+    var font: Font = .body.weight(.semibold)
+    /// Receives the chosen name (nil = reset to the default label);
+    /// the caller persists it wherever this transcript's names live.
+    let onAssign: (String?) -> Void
+
+    @State private var showingPicker = false
+    @State private var hovering = false
+
+    var body: some View {
+        Text(rawID.displaySpeakerName(names: names, language: language) + suffix)
+            .font(font)
+            .foregroundStyle(color)
+            .underline(hovering)
+            .contentShape(Rectangle())
+            .onHover { hovering = $0 }
+            .onTapGesture { showingPicker = true }
+            .popover(isPresented: $showingPicker, arrowEdge: .bottom) {
+                SpeakerNamePicker(
+                    defaultLabel: rawID.friendlySpeakerLabel(language: language),
+                    currentName: names[rawID],
+                    onAssign: onAssign
+                )
+            }
+            .help("Rename speaker")
+    }
+}

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -64,6 +64,45 @@ final class RecordingStoreTests: XCTestCase {
                       "Tombstones must persist across store instances")
     }
 
+    func test_setSpeakerName_sets_clears_and_persists() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Meeting", source: .meeting,
+                            audioFileName: "meeting.wav",
+                            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")])
+        store.add(rec)
+
+        store.setSpeakerName("  Daniel ", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(store.recordings.first?.speakerNames, ["SPEAKER_00": "Daniel"],
+                       "Name must be trimmed and stored keyed by the raw ID")
+
+        // Survives a relaunch via recordings.json.
+        let reloaded = RecordingStore(rootDirectory: tempRoot)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, ["SPEAKER_00": "Daniel"])
+
+        // nil (and empty/whitespace) clears the assignment.
+        reloaded.setSpeakerName(nil, forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, [:])
+        reloaded.setSpeakerName("Noa", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        reloaded.setSpeakerName("   ", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, [:])
+    }
+
+    func test_setSpeakerName_regenerates_srt_sidecar_for_completed_recording() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Meeting", source: .meeting,
+                            audioFileName: "meeting.wav",
+                            status: .completed,
+                            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")])
+        store.add(rec)
+
+        store.setSpeakerName("Daniel", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+
+        let srtURL = store.recordingsDirectory.appendingPathComponent("meeting.srt")
+        let srt = try String(contentsOf: srtURL, encoding: .utf8)
+        XCTAssertTrue(srt.contains("Daniel: hi"),
+                      "The on-disk .srt sidecar must be rewritten with the assigned name")
+    }
+
     func test_permanently_deleting_non_import_leaves_no_tombstone() {
         let store = RecordingStore(rootDirectory: tempRoot)
         let rec = Recording(title: "Mic recording", source: .microphone,

--- a/MilaTests/RecordingTests.swift
+++ b/MilaTests/RecordingTests.swift
@@ -44,6 +44,48 @@ final class RecordingTests: XCTestCase {
                        "fullText key must not appear in the JSON-encoded blob")
     }
 
+    func test_speakerNames_round_trip_and_are_omitted_when_empty() throws {
+        let named = Recording(
+            title: "Named",
+            source: .meeting,
+            audioFileName: "named.wav",
+            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")],
+            speakerNames: ["SPEAKER_00": "Daniel"]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let decoded = try decoder.decode(Recording.self, from: encoder.encode(named))
+        XCTAssertEqual(decoded.speakerNames, ["SPEAKER_00": "Daniel"])
+
+        // Recordings with no renames must not grow a noise key in
+        // recordings.json.
+        let unnamed = Recording(title: "Plain", source: .microphone, audioFileName: "p.wav")
+        let json = String(data: try encoder.encode(unnamed), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"speakerNames\""))
+    }
+
+    func test_legacy_records_without_speakerNames_decode_to_empty_map() throws {
+        let legacy = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Legacy",
+          "createdAt": "2025-01-01T00:00:00Z",
+          "duration": 1.0,
+          "source": "microphone",
+          "audioFileName": "Legacy.wav",
+          "status": "completed",
+          "language": "en"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Recording.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded.speakerNames, [:])
+    }
+
     func test_legacy_records_with_inline_fullText_still_decode() throws {
         // Records persisted under the pre-sidecar schema had `fullText`
         // inside the JSON. We have to keep decoding them so the first

--- a/MilaTests/SpeakerDirectoryTests.swift
+++ b/MilaTests/SpeakerDirectoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class SpeakerDirectoryTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaTests-SpeakerDirectory-\(UUID())", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        super.tearDown()
+    }
+
+    func test_add_trims_and_rejects_empty_input() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(dir.add("  Daniel  "), "Daniel")
+        XCTAssertNil(dir.add("   "))
+        XCTAssertNil(dir.add(""))
+        XCTAssertEqual(dir.names, ["Daniel"])
+    }
+
+    func test_add_dedupes_case_insensitively_returning_canonical_spelling() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(dir.add("Daniel"), "Daniel")
+        // Re-adding with different casing must NOT create a duplicate and
+        // must hand back the existing spelling — the picker relies on this
+        // to land typed names on the canonical entry.
+        XCTAssertEqual(dir.add("daniel"), "Daniel")
+        XCTAssertEqual(dir.names, ["Daniel"])
+    }
+
+    func test_names_stay_sorted() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("noa")
+        dir.add("Avi")
+        dir.add("dana")
+        XCTAssertEqual(dir.names, ["Avi", "dana", "noa"])
+    }
+
+    func test_remove_deletes_case_insensitively() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("Daniel")
+        dir.remove("DANIEL")
+        XCTAssertTrue(dir.names.isEmpty)
+    }
+
+    func test_matches_filters_case_insensitively_and_empty_query_returns_all() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("Daniel")
+        dir.add("Dana")
+        dir.add("Noa")
+        XCTAssertEqual(dir.matches(for: "da"), ["Dana", "Daniel"])
+        XCTAssertEqual(dir.matches(for: "  "), ["Dana", "Daniel", "Noa"])
+        XCTAssertEqual(dir.matches(for: "zzz"), [])
+    }
+
+    func test_names_persist_across_instances() {
+        let first = SpeakerDirectory(directory: tempRoot)
+        first.add("Daniel")
+        first.add("Noa")
+
+        let second = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(second.names, ["Daniel", "Noa"])
+
+        second.remove("Daniel")
+        let third = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(third.names, ["Noa"])
+    }
+}

--- a/MilaTests/SpeakerNameRemapperTests.swift
+++ b/MilaTests/SpeakerNameRemapperTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+final class SpeakerNameRemapperTests: XCTestCase {
+
+    private func seg(_ start: Double, _ end: Double, _ speaker: String?) -> TranscriptSegment {
+        TranscriptSegment(start: start, end: end, text: "t", speaker: speaker)
+    }
+
+    /// Re-key a segment list's speakers the way `rediarizeSegments` does:
+    /// same array, only `.speaker` changes per index.
+    private func rekeyed(_ old: [TranscriptSegment], to newSpeakers: [String?]) -> [TranscriptSegment] {
+        var out = old
+        for i in out.indices { out[i].speaker = newSpeakers[i] }
+        return out
+    }
+
+    func test_identity_rekey_keeps_names() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_swapped_ids_follow_the_utterances() {
+        // The offline pass assigned the IDs in the opposite order — the
+        // name must follow the person (their utterances), not the ID.
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_01", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_01": "Daniel"])
+    }
+
+    func test_merge_dominant_name_wins_by_duration() {
+        // Live over-segmented one person into 00 (8s, named) and 01 (2s,
+        // named differently); offline merges them into a single SPEAKER_00.
+        let old = [seg(0, 8, "SPEAKER_00"), seg(8, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(
+            names: ["SPEAKER_00": "Daniel", "SPEAKER_01": "Noa"],
+            from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_split_propagates_name_to_both_halves() {
+        // Live lumped two utterances under one (named) speaker; offline
+        // splits them. Both halves keep the name — better than silently
+        // dropping it from one, and trivially correctable in the UI.
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_00")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel", "SPEAKER_01": "Daniel"])
+    }
+
+    func test_unnamed_speakers_produce_no_entries() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_01", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertNil(remapped["SPEAKER_00"],
+                     "The unnamed old SPEAKER_01 (now SPEAKER_00) must stay unnamed")
+    }
+
+    func test_nil_speaker_segments_are_ignored() {
+        let old = [seg(0, 5, nil), seg(5, 10, "SPEAKER_00")]
+        let new = rekeyed(old, to: [nil, "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_empty_inputs() {
+        XCTAssertTrue(SpeakerNameRemapper.remap(names: [:], from: [], to: []).isEmpty)
+        XCTAssertTrue(SpeakerNameRemapper.remap(names: ["SPEAKER_00": "D"], from: [], to: []).isEmpty)
+    }
+
+    func test_zero_duration_segments_still_vote() {
+        // Degenerate timestamps (start == end) must not drop the vote.
+        let old = [seg(3, 3, "SPEAKER_00")]
+        let new = rekeyed(old, to: ["SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_01": "Daniel"])
+    }
+}

--- a/MilaTests/TranscriptExporterTests.swift
+++ b/MilaTests/TranscriptExporterTests.swift
@@ -45,6 +45,20 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertFalse(body.contains("3\n"))
     }
 
+    func test_srt_body_uses_assigned_names_with_raw_id_fallback() {
+        var rec = makeRecording(segments: [
+            .init(start: 0.0, end: 1.0, text: "Hi", speaker: "SPEAKER_00"),
+            .init(start: 1.0, end: 2.0, text: "Hello", speaker: "SPEAKER_01")
+        ])
+        rec.speakerNames = ["SPEAKER_00": "Daniel"]
+
+        let body = TranscriptExporter.srtBody(for: rec)
+        XCTAssertTrue(body.contains("Daniel: Hi"),
+                      "Named speaker must export under the assigned name")
+        XCTAssertTrue(body.contains("SPEAKER_01: Hello"),
+                      "Unnamed speaker keeps the raw diarizer ID")
+    }
+
     func test_srt_body_uses_commas_for_decimal_separator() {
         let rec = makeRecording(segments: [
             .init(start: 1.5, end: 2.5, text: "Hi")

--- a/MilaTests/TranscriptFormatterTests.swift
+++ b/MilaTests/TranscriptFormatterTests.swift
@@ -77,4 +77,40 @@ final class TranscriptFormatterTests: XCTestCase {
         )
         XCTAssertEqual(formatted, "Untagged opener\nSPEAKER_00: Tagged line")
     }
+
+    func test_assigned_names_replace_raw_ids_and_unnamed_keep_raw() {
+        let segments = [
+            TranscriptSegment(start: 0, end: 1, text: "Hi", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 2, text: "Hello back", speaker: "SPEAKER_01"),
+        ]
+        let formatted = TranscriptFormatter.plainText(
+            segments: segments,
+            fallback: "ignored",
+            names: ["SPEAKER_00": "Daniel"]
+        )
+        XCTAssertEqual(formatted, "Daniel: Hi\nSPEAKER_01: Hello back")
+    }
+
+    func test_two_raw_ids_with_the_same_assigned_name_collapse_into_one_paragraph() {
+        // The user's fix for an over-split speaker: naming both raw IDs
+        // identically must merge their consecutive turns, same as if the
+        // diarizer had gotten it right.
+        let segments = [
+            TranscriptSegment(start: 0, end: 1, text: "First.", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 2, text: "Second.", speaker: "SPEAKER_01"),
+            TranscriptSegment(start: 2, end: 3, text: "Other person.", speaker: "SPEAKER_02"),
+        ]
+        let formatted = TranscriptFormatter.plainText(
+            segments: segments,
+            fallback: "ignored",
+            names: ["SPEAKER_00": "Daniel", "SPEAKER_01": "Daniel"]
+        )
+        XCTAssertEqual(
+            formatted,
+            """
+            Daniel: First. Second.
+            SPEAKER_02: Other person.
+            """
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Implements manual speaker relabeling (the alternative discussed in #24): click a speaker label in any transcript to assign a real name.

- **Rename anywhere** — clicking a "Speaker A" / "דובר א׳" label (hover underlines it) opens a popover in both the recording detail view and the live transcript mid-recording, sharing one `SpeakerNamePicker` component.
- **Persistent directory** — names live in a new `SpeakerDirectory` (`speaker-names.json` in Application Support, app-wide like the tombstones, not the relocatable recordings folder). The popover is type-to-filter with an `Add "…"` row and a reset-to-default row; a "Known speakers" section in Settings → Speakers manages the list.
- **Names flow everywhere** — per-recording overlay map `Recording.speakerNames` (segments keep raw `SPEAKER_NN` IDs) resolves in the UI, Copy Transcript, the `.srt` sidecar (regenerated on rename), live SRT export, and the LLM title feed. Unnamed speakers fall back to the friendly label / raw ID exactly as before.
- **Live renames survive re-diarization** — the post-stop offline pass re-keys all speaker IDs; `SpeakerNameRemapper` carries names onto the new IDs via a duration-weighted vote over the index-aligned segment arrays (handles merges and splits). Batch re-transcribes clear names instead, since fresh clustering has no alignment to the old IDs.
- **Merge by same name** — naming two over-split IDs identically gives them a shared color and collapses their consecutive turns in copied/exported text.

## Test plan

- [x] 21 new unit tests: `SpeakerDirectoryTests` (persistence, dedupe, filtering), `SpeakerNameRemapperTests` (identity/swap/merge/split/edge cases), Recording codable round-trip + legacy decode, formatter/exporter with names incl. same-name collapse, `RecordingStore.setSpeakerName` persistence + SRT regeneration
- [x] Full suite: 452 unit tests pass (the 9 MilaUITests failures are the known XCUITest-foregrounding environment issue — CI runs those non-fatally)
- [x] Manual: built a signed 1.9.0-beta.1 DMG with bundled PythonRuntime and installed locally for end-to-end testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign custom display names to diarized speakers in both live sessions and recordings.
  * Copy live transcripts with speaker names and export SRT subtitles using assigned names.
  * Manage a persistent “Known speakers” list in Settings.
* **Improvements**
  * Enhanced adaptive microphone gain with better handling of quiet speech and sustained background noise.
  * Speaker labels now stay consistent through re-diarization and offline post-processing.
* **Bug Fixes**
  * Transcript previews and send-to-LLM formatting now respect assigned speaker names.
* **Documentation**
  * Updated local DMG build/signing guidance for “Mila Local Dev” and signature verification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->