### PR TITLE
Add first-class Russian language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Mila/Resources/PythonRuntime/
 Mila-slack-emoji.png
 __pycache__/
 *.pyc
+
+# LLM artifacts
+llm-artifacts/

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -297,11 +297,19 @@ final class LiveAISession: ObservableObject {
         let promptLanguageName: String = {
             switch liveAISettings.outputLanguage {
             case .auto:
-                return snapshot.isPredominantlyHebrew ? "Hebrew" : "English"
+                if snapshot.isPredominantlyCyrillic {
+                    return "Russian"
+                } else if snapshot.isPredominantlyHebrew {
+                    return "Hebrew"
+                } else {
+                    return "English"
+                }
             case .english:
                 return "English"
             case .hebrew:
                 return "Hebrew"
+            case .russian:
+                return "Russian"
             }
         }()
         let prompt = liveAISettings.prompt

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -319,11 +319,19 @@ final class RecordingSummarizer: ObservableObject {
         let promptLanguageName: String = {
             switch liveAISettings.outputLanguage {
             case .auto:
-                return recording.fullText.isPredominantlyHebrew ? "Hebrew" : "English"
+                if recording.language == "ru" || recording.fullText.isPredominantlyCyrillic {
+                    return "Russian"
+                } else if recording.fullText.isPredominantlyHebrew {
+                    return "Hebrew"
+                } else {
+                    return "English"
+                }
             case .english:
                 return "English"
             case .hebrew:
                 return "Hebrew"
+            case .russian:
+                return "Russian"
             }
         }()
         let prompt = liveAISettings.summaryPrompt

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -609,6 +609,9 @@ struct MilaApp: App {
                 Button("Hebrew Dictation (\(hotkeySettings.binding(for: .dictateHebrew).displayName))") {
                     Task { await dictation.toggle(action: .dictateHebrew) }
                 }
+                Button("Russian Dictation (\(hotkeySettings.binding(for: .dictateRussian).displayName))") {
+                    Task { await dictation.toggle(action: .dictateRussian) }
+                }
             }
             // Surface the diagnostic-report action under Help so a user
             // with a bug to report can hand off a zip without us asking
@@ -1442,8 +1445,14 @@ struct MilaApp: App {
         // local weights. (The Models tab still offers manual downloads, and
         // switching back to local re-triggers this on next launch.)
         guard !remoteTranscriptionSettings.isActive else { return }
-        modelManager.setSelected(WhisperModel.ivritLarge)
-        for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
+        let isHebrewSystem = Locale.current.language.languageCode == "he" || Locale.current.languageCode == "he"
+        if UserDefaults.standard.string(forKey: "selectedModelName") == nil {
+            modelManager.setSelected(isHebrewSystem ? WhisperModel.ivritLarge : WhisperModel.openaiTurbo)
+        }
+        let modelsToInstall = isHebrewSystem
+            ? [WhisperModel.ivritLarge, WhisperModel.openaiTurbo]
+            : [WhisperModel.openaiTurbo]
+        for model in modelsToInstall {
             if !modelManager.isInstalled(model) && modelManager.downloads[model.name] == nil {
                 modelManager.download(model)
             }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1445,7 +1445,7 @@ struct MilaApp: App {
         // local weights. (The Models tab still offers manual downloads, and
         // switching back to local re-triggers this on next launch.)
         guard !remoteTranscriptionSettings.isActive else { return }
-        let isHebrewSystem = Locale.current.language.languageCode == "he" || Locale.current.languageCode == "he"
+        let isHebrewSystem = Locale.current.language.languageCode?.identifier == "he"
         if UserDefaults.standard.string(forKey: "selectedModelName") == nil {
             modelManager.setSelected(isHebrewSystem ? WhisperModel.ivritLarge : WhisperModel.openaiTurbo)
         }

--- a/Mila/Dictation/HotkeyManager.swift
+++ b/Mila/Dictation/HotkeyManager.swift
@@ -94,6 +94,7 @@ struct HotkeyBinding: Codable, Equatable, Hashable {
 enum HotkeyAction: String, CaseIterable, Hashable, Identifiable {
     case dictateEnglish
     case dictateHebrew
+    case dictateRussian
 
     var id: String { rawValue }
 
@@ -101,6 +102,7 @@ enum HotkeyAction: String, CaseIterable, Hashable, Identifiable {
         switch self {
         case .dictateEnglish: return "en"
         case .dictateHebrew:  return "he"
+        case .dictateRussian: return "ru"
         }
     }
 
@@ -108,6 +110,7 @@ enum HotkeyAction: String, CaseIterable, Hashable, Identifiable {
         switch self {
         case .dictateEnglish: return "English dictation"
         case .dictateHebrew:  return "Hebrew dictation"
+        case .dictateRussian: return "Russian dictation"
         }
     }
 
@@ -116,6 +119,7 @@ enum HotkeyAction: String, CaseIterable, Hashable, Identifiable {
         switch self {
         case .dictateEnglish: return 1
         case .dictateHebrew:  return 2
+        case .dictateRussian: return 3
         }
     }
 
@@ -128,6 +132,8 @@ enum HotkeyAction: String, CaseIterable, Hashable, Identifiable {
         .dictateEnglish: HotkeyBinding(keyCode: UInt32(kVK_ANSI_2),
                                        modifiers: UInt32(cmdKey)),
         .dictateHebrew:  HotkeyBinding(keyCode: UInt32(kVK_ANSI_3),
+                                       modifiers: UInt32(cmdKey)),
+        .dictateRussian: HotkeyBinding(keyCode: UInt32(kVK_ANSI_4),
                                        modifiers: UInt32(cmdKey))
     ]
 }

--- a/Mila/Models/LiveAISettings.swift
+++ b/Mila/Models/LiveAISettings.swift
@@ -174,6 +174,7 @@ final class LiveAISettings: ObservableObject {
         case auto = "auto"
         case english = "en"
         case hebrew = "he"
+        case russian = "ru"
 
         var id: String { rawValue }
 
@@ -187,6 +188,7 @@ final class LiveAISettings: ObservableObject {
             case .auto:    return "the same language as the transcript below"
             case .english: return "English"
             case .hebrew:  return "Hebrew"
+            case .russian: return "Russian"
             }
         }
 
@@ -195,6 +197,7 @@ final class LiveAISettings: ObservableObject {
             case .auto:    return "Auto"
             case .english: return "English"
             case .hebrew:  return "Hebrew"
+            case .russian: return "Russian"
             }
         }
     }

--- a/Mila/Models/RecordingLanguageSettings.swift
+++ b/Mila/Models/RecordingLanguageSettings.swift
@@ -10,6 +10,7 @@ import Combine
 enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
     case hebrew = "he"
     case english = "en"
+    case russian = "ru"
     /// Let whisper detect the language of each utterance instead of forcing
     /// one. Whisper's `detect_language` runs per `whisper_full` call, and the
     /// live path transcribes one VAD-bounded utterance per call — so this
@@ -26,6 +27,7 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         switch self {
         case .hebrew:  return "Hebrew"
         case .english: return "English"
+        case .russian: return "Russian"
         case .auto:    return "Auto-detect"
         }
     }
@@ -37,6 +39,7 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         switch self {
         case .hebrew:  return "🇮🇱"
         case .english: return "🇬🇧"
+        case .russian: return "🇷🇺"
         case .auto:    return "🌐"
         }
     }
@@ -49,6 +52,7 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         switch self {
         case .hebrew:  return .english
         case .english: return .hebrew
+        case .russian: return .english
         case .auto:    return .hebrew
         }
     }
@@ -62,6 +66,7 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         if normalized == "auto" { return .auto }
         if normalized == "iw" || normalized.hasPrefix("he") { return .hebrew }
         if normalized.hasPrefix("en") { return .english }
+        if normalized.hasPrefix("ru") { return .russian }
         return .hebrew
     }
 }
@@ -85,7 +90,7 @@ final class RecordingLanguageSettings: ObservableObject {
            let stored = RecordingLanguage(rawValue: raw) {
             self.current = stored
         } else {
-            self.current = .hebrew
+            self.current = .english
         }
     }
 }

--- a/Mila/Models/RecordingLanguageSettings.swift
+++ b/Mila/Models/RecordingLanguageSettings.swift
@@ -44,19 +44,6 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         }
     }
 
-    /// The opposite-language pair, used by the right-click "Re-transcribe in
-    /// the other language" menu item on a recording. Auto-detected
-    /// recordings offer a re-transcribe forced to Hebrew (the dominant
-    /// language for our users) as the manual override.
-    var other: RecordingLanguage {
-        switch self {
-        case .hebrew:  return .english
-        case .english: return .hebrew
-        case .russian: return .english
-        case .auto:    return .hebrew
-        }
-    }
-
     /// Best-effort decode of an ISO-style language string (`"he"`, `"he-IL"`,
     /// `"iw"`, `"en"`, `"en-US"`, `"auto"`, …). Falls back to Hebrew for
     /// legacy recordings that pre-date the per-language UX (those were always

--- a/Mila/Transcription/HebrewDetection.swift
+++ b/Mila/Transcription/HebrewDetection.swift
@@ -27,4 +27,23 @@ extension String {
         }
         return hebrew > latin
     }
+
+    /// Cyrillic character count (Unicode scalars U+0400..U+04FF) must constitute
+    /// at least 30% of the total letter characters (Cyrillic + Latin) in the text.
+    var isPredominantlyCyrillic: Bool {
+        var cyrillic = 0
+        var latin = 0
+        for scalar in self.unicodeScalars {
+            let value = scalar.value
+            if value >= 0x0400 && value <= 0x04FF {
+                cyrillic += 1
+            } else if (value >= 0x0041 && value <= 0x005A)
+                   || (value >= 0x0061 && value <= 0x007A) {
+                latin += 1
+            }
+        }
+        let total = cyrillic + latin
+        guard total > 0 else { return false }
+        return Double(cyrillic) / Double(total) >= 0.3
+    }
 }

--- a/Mila/Transcription/HebrewDetection.swift
+++ b/Mila/Transcription/HebrewDetection.swift
@@ -1,49 +1,56 @@
 import Foundation
 
 extension String {
-    /// True when more of this string's letter characters are Hebrew than
-    /// Latin. Used by the UI to flip a piece of transcript / action item
-    /// text to RTL alignment without depending on the user's language
-    /// dropdown — the dropdown affects which whisper model is used but
-    /// not which alphabet ends up in any given segment (the user might
-    /// have left it on English while talking Hebrew, for example).
-    ///
-    /// We count only "letter-like" code points so quoted English brand
-    /// names embedded in a Hebrew sentence ("...אמרתי Cursor...") don't
-    /// flip the verdict.
-    var isPredominantlyHebrew: Bool {
+    /// Per-script counts of "letter-like" Unicode scalars in the string.
+    /// Hebrew, Latin, and Cyrillic are the only scripts we weigh when
+    /// deciding transcript/AI-output alignment and language auto-routing.
+    /// Counting only these keeps quoted English brand names embedded in a
+    /// Hebrew sentence ("...אמרתי Cursor...") or a stray Latin token in
+    /// Russian text from flipping the verdict.
+    private var scriptCounts: (hebrew: Int, latin: Int, cyrillic: Int) {
         var hebrew = 0
         var latin = 0
+        var cyrillic = 0
         for scalar in self.unicodeScalars {
             let value = scalar.value
-            // Hebrew block: U+0590..U+05FF (also covers final-form
-            // letters + cantillation marks).
-            if value >= 0x0590 && value <= 0x05FF {
+            if value >= 0x0400 && value <= 0x04FF {
+                // Cyrillic block.
+                cyrillic += 1
+            } else if value >= 0x0590 && value <= 0x05FF {
+                // Hebrew block: U+0590..U+05FF (covers final-form letters +
+                // cantillation marks).
                 hebrew += 1
             } else if (value >= 0x0041 && value <= 0x005A)
                    || (value >= 0x0061 && value <= 0x007A) {
                 latin += 1
             }
         }
-        return hebrew > latin
+        return (hebrew, latin, cyrillic)
     }
 
-    /// Cyrillic character count (Unicode scalars U+0400..U+04FF) must constitute
-    /// at least 30% of the total letter characters (Cyrillic + Latin) in the text.
+    /// True when Hebrew is the strict plurality of the string's letter-like
+    /// characters — i.e. there are more Hebrew letters than Latin *and* more
+    /// than Cyrillic. Used by the UI to flip a piece of transcript / action
+    /// item text to RTL alignment without depending on the user's language
+    /// dropdown — the dropdown affects which whisper model is used but not
+    /// which alphabet ends up in any given segment (the user might have left
+    /// it on English while talking Hebrew, for example).
+    ///
+    /// Cyrillic must be weighed here, not just Latin: Russian is an LTR script,
+    /// so a Russian-dominant segment with a handful of Hebrew words must NOT
+    /// be classified as Hebrew, or it gets rendered right-to-left.
+    var isPredominantlyHebrew: Bool {
+        let (hebrew, latin, cyrillic) = scriptCounts
+        return hebrew > 0 && hebrew > latin && hebrew > cyrillic
+    }
+
+    /// True when Cyrillic is the strict plurality of the string's letter-like
+    /// characters — more Cyrillic than Latin *and* more than Hebrew. Mirrors
+    /// `isPredominantlyHebrew` so the two predicates are mutually exclusive
+    /// (mixed Hebrew/Russian text resolves to exactly one verdict rather
+    /// than depending on which predicate the caller happens to check first).
     var isPredominantlyCyrillic: Bool {
-        var cyrillic = 0
-        var latin = 0
-        for scalar in self.unicodeScalars {
-            let value = scalar.value
-            if value >= 0x0400 && value <= 0x04FF {
-                cyrillic += 1
-            } else if (value >= 0x0041 && value <= 0x005A)
-                   || (value >= 0x0061 && value <= 0x007A) {
-                latin += 1
-            }
-        }
-        let total = cyrillic + latin
-        guard total > 0 else { return false }
-        return Double(cyrillic) / Double(total) >= 0.3
+        let (hebrew, latin, cyrillic) = scriptCounts
+        return cyrillic > 0 && cyrillic > latin && cyrillic > hebrew
     }
 }

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -111,7 +111,7 @@ final class ModelManager: NSObject, ObservableObject {
         self.modelsDirectory = modelsDirectory
         let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
         let defaultModel: WhisperModel
-        if Locale.current.language.languageCode == "he" || Locale.current.languageCode == "he" {
+        if Locale.current.language.languageCode?.identifier == "he" {
             defaultModel = .ivritLarge
         } else {
             defaultModel = .openaiTurbo

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -110,7 +110,13 @@ final class ModelManager: NSObject, ObservableObject {
     init(modelsDirectory: URL) {
         self.modelsDirectory = modelsDirectory
         let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
-        self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
+        let defaultModel: WhisperModel
+        if Locale.current.language.languageCode == "he" || Locale.current.languageCode == "he" {
+            defaultModel = .ivritLarge
+        } else {
+            defaultModel = .openaiTurbo
+        }
+        self.selectedModelName = lastUsed ?? defaultModel.name
         super.init()
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         refreshInstalled()

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -243,8 +243,7 @@ actor RemoteWhisperEngine: RemoteTranscribing {
 
         if let segments = parsed.segments, !segments.isEmpty {
             let mapped = segments.compactMap { seg -> TranscriptSegment? in
-                let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                let cleaned = WhisperEngine.cleanWhisperText(text)
+                let cleaned = WhisperEngine.cleanWhisperText(seg.text)
                 guard !cleaned.isEmpty else { return nil }
                 return TranscriptSegment(start: seg.start, end: seg.end, text: cleaned)
             }
@@ -254,11 +253,11 @@ actor RemoteWhisperEngine: RemoteTranscribing {
         // No segment array (server returned `response_format=json`, or an empty
         // segment list with a top-level transcript). Fall back to one segment
         // spanning the whole clip.
-        if let text = parsed.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !text.isEmpty {
-            let cleaned = WhisperEngine.cleanWhisperText(text)
-            guard !cleaned.isEmpty else { throw RemoteError.emptyResult }
-            return [TranscriptSegment(start: 0, end: parsed.duration ?? 0, text: cleaned)]
+        if let rawText = parsed.text {
+            let cleaned = WhisperEngine.cleanWhisperText(rawText)
+            if !cleaned.isEmpty {
+                return [TranscriptSegment(start: 0, end: parsed.duration ?? 0, text: cleaned)]
+            }
         }
 
         throw RemoteError.emptyResult

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -244,8 +244,9 @@ actor RemoteWhisperEngine: RemoteTranscribing {
         if let segments = parsed.segments, !segments.isEmpty {
             let mapped = segments.compactMap { seg -> TranscriptSegment? in
                 let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !text.isEmpty else { return nil }
-                return TranscriptSegment(start: seg.start, end: seg.end, text: seg.text)
+                let cleaned = WhisperEngine.cleanWhisperText(text)
+                guard !cleaned.isEmpty else { return nil }
+                return TranscriptSegment(start: seg.start, end: seg.end, text: cleaned)
             }
             if !mapped.isEmpty { return mapped }
         }
@@ -255,7 +256,9 @@ actor RemoteWhisperEngine: RemoteTranscribing {
         // spanning the whole clip.
         if let text = parsed.text?.trimmingCharacters(in: .whitespacesAndNewlines),
            !text.isEmpty {
-            return [TranscriptSegment(start: 0, end: parsed.duration ?? 0, text: text)]
+            let cleaned = WhisperEngine.cleanWhisperText(text)
+            guard !cleaned.isEmpty else { throw RemoteError.emptyResult }
+            return [TranscriptSegment(start: 0, end: parsed.duration ?? 0, text: cleaned)]
         }
 
         throw RemoteError.emptyResult

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -182,6 +182,15 @@ struct HomeView: View {
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.primary.opacity(0.7))
             }
+            Text("·")
+                .foregroundStyle(.tertiary)
+            HStack(spacing: 4) {
+                Text("🇷🇺")
+                Text("dictate")
+                Text(hotkeys.binding(for: .dictateRussian).displayName)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.primary.opacity(0.7))
+            }
         }
         .font(.caption)
         .foregroundStyle(.secondary)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -68,9 +68,17 @@ struct LiveAIRecordingView: View {
         case .english: return false
         case .russian: return false
         case .auto:
-            if language == "he" { return true }
+            // Auto may route the output to a language other than the
+            // recording's dropdown — a predominantly-Cyrillic transcript
+            // yields Russian output even when the recording is set to
+            // Hebrew (see `LiveAISession`'s promptLanguageName) — so
+            // detect from the emitted text itself and fall back to the
+            // recording language only before any output exists.
             let combined = aiSession.summary + " "
                 + aiSession.actionItems.map(\.text).joined(separator: " ")
+            if combined.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return language == "he"
+            }
             return combined.isPredominantlyHebrew
         }
     }

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -66,6 +66,7 @@ struct LiveAIRecordingView: View {
         switch liveAISettings.outputLanguage {
         case .hebrew: return true
         case .english: return false
+        case .russian: return false
         case .auto:
             if language == "he" { return true }
             let combined = aiSession.summary + " "

--- a/Mila/Views/RecordingContextMenu.swift
+++ b/Mila/Views/RecordingContextMenu.swift
@@ -138,8 +138,14 @@ private struct RecordingContextMenu: ViewModifier {
                 transcription.enqueue(prepared, isRetranscription: true)
             }
             .disabled(isBusy)
-            Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
-                retranscribe(recording, in: currentLang.other)
+            Menu("Re-transcribe in") {
+                ForEach(RecordingLanguage.allCases) { lang in
+                    if lang != currentLang {
+                        Button("\(lang.flagEmoji) \(lang.displayName)") {
+                            retranscribe(recording, in: lang)
+                        }
+                    }
+                }
             }
             .disabled(isBusy)
             if llm.isConfigured {

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -207,6 +207,13 @@ struct RecordingDetailView: View {
     /// Updates the persisted `Recording.language` so the downstream
     /// `TranscriptionService` picks the right model on its own.
     private func retranscribe(in language: RecordingLanguage) {
+        // Gate before mutating the store: a busy (active/queued) recording must
+        // not have its status/language flipped under an in-flight pass, because
+        // `enqueue` would then no-op the re-run while the store mutation stuck.
+        // (Mirrors `RecordingContextMenu.retranscribe`.)
+        guard transcription.activeRecordingID != recording.id,
+              !transcription.pendingIDs.contains(recording.id)
+        else { return }
         // Mutate only language+status on the LIVE record so we don't clobber a
         // since-compressed `.m4a` audioFileName back to a deleted `.wav`.
         guard let prepared = store.prepareForRetranscription(id: recording.id,
@@ -364,6 +371,11 @@ struct RecordingDetailView: View {
                 }
                 .contextMenu {
                     let currentLang = RecordingLanguage.fromCode(recording.language)
+                    // Same busy gate as the toolbar menu + RecordingContextMenu:
+                    // re-transcribing an active/queued recording would flip its
+                    // persisted language/status under the in-flight job.
+                    let isBusy = transcription.activeRecordingID == recording.id
+                        || transcription.pendingIDs.contains(recording.id)
                     Menu("Re-transcribe in") {
                         ForEach(RecordingLanguage.allCases) { lang in
                             if lang != currentLang {
@@ -373,6 +385,7 @@ struct RecordingDetailView: View {
                             }
                         }
                     }
+                    .disabled(isBusy)
                     Button("Copy transcript") { copyTranscript() }
                         .disabled(recording.fullText.isEmpty)
                 }

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -147,11 +147,15 @@ struct RecordingDetailView: View {
                     Label("\(currentLang.flagEmoji) \(currentLang.displayName) (current)",
                           systemImage: "arrow.clockwise")
                 }
-                Button {
-                    retranscribe(in: currentLang.other)
-                } label: {
-                    Label("\(currentLang.other.flagEmoji) \(currentLang.other.displayName)",
-                          systemImage: "arrow.triangle.2.circlepath")
+                ForEach(RecordingLanguage.allCases) { lang in
+                    if lang != currentLang {
+                        Button {
+                            retranscribe(in: lang)
+                        } label: {
+                            Label("\(lang.flagEmoji) \(lang.displayName)",
+                                  systemImage: "arrow.triangle.2.circlepath")
+                        }
+                    }
                 }
             } label: {
                 Image(systemName: "text.badge.checkmark")
@@ -359,9 +363,15 @@ struct RecordingDetailView: View {
                                  ? .rightToLeft : .leftToRight)
                 }
                 .contextMenu {
-                    let other = RecordingLanguage.fromCode(recording.language).other
-                    Button("Re-transcribe in \(other.flagEmoji) \(other.displayName)") {
-                        retranscribe(in: other)
+                    let currentLang = RecordingLanguage.fromCode(recording.language)
+                    Menu("Re-transcribe in") {
+                        ForEach(RecordingLanguage.allCases) { lang in
+                            if lang != currentLang {
+                                Button("\(lang.flagEmoji) \(lang.displayName)") {
+                                    retranscribe(in: lang)
+                                }
+                            }
+                        }
                     }
                     Button("Copy transcript") { copyTranscript() }
                         .disabled(recording.fullText.isEmpty)

--- a/MilaTests/HebrewDetectionTests.swift
+++ b/MilaTests/HebrewDetectionTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Mila
+
+/// Characterization tests for the script-detection predicates. The two
+/// predicates must be **mutually exclusive** and share one counting model:
+/// Russian-dominant text with a sprinkling of Hebrew must not be classified
+/// as Hebrew (Russian is LTR), and mixed Hebrew/Russian must resolve to
+/// exactly one verdict regardless of which predicate the caller checks first.
+final class HebrewDetectionTests: XCTestCase {
+
+    // MARK: - isPredominantlyHebrew
+
+    func test_pure_hebrew_is_predominantly_hebrew() {
+        XCTAssertTrue("שלום עולם מה שלומך".isPredominantlyHebrew)
+    }
+
+    func test_pure_english_is_not_predominantly_hebrew() {
+        XCTAssertFalse("Hello world how are you".isPredominantlyHebrew)
+    }
+
+    func test_pure_russian_is_not_predominantly_hebrew() {
+        // Russian is LTR; this is the regression the unified counters protect
+        // against — previously Hebrew-only-vs-Latin ignored Cyrillic, so a
+        // few Hebrew words in Russian text flipped it to RTL.
+        XCTAssertFalse("Сегодня мы будем обсуждать новые технологии".isPredominantlyHebrew)
+    }
+
+    func test_russian_with_a_few_hebrew_words_is_not_predominantly_hebrew() {
+        // 88% Cyrillic, ~9% Hebrew, ~3% Latin. Must NOT be Hebrew.
+        XCTAssertFalse("Сегодня обсудим проект и слово שלום в контексте Cursor".isPredominantlyHebrew)
+    }
+
+    func test_empty_string_is_not_predominantly_hebrew() {
+        XCTAssertFalse("".isPredominantlyHebrew)
+    }
+
+    // MARK: - isPredominantlyCyrillic
+
+    func test_pure_russian_is_predominantly_cyrillic() {
+        XCTAssertTrue("Сегодня мы будем обсуждать новые технологии".isPredominantlyCyrillic)
+    }
+
+    func test_pure_english_is_not_predominantly_cyrillic() {
+        XCTAssertFalse("Hello world how are you".isPredominantlyCyrillic)
+    }
+
+    func test_pure_hebrew_is_not_predominantly_cyrillic() {
+        XCTAssertFalse("שלום עולם מה שלומך".isPredominantlyCyrillic)
+    }
+
+    func test_empty_string_is_not_predominantly_cyrillic() {
+        XCTAssertFalse("".isPredominantlyCyrillic)
+    }
+
+    // MARK: - Mutual exclusivity
+
+    func test_minority_cyrillic_is_not_predominantly_cyrillic() {
+        // Cyrillic is present but does not dominate. The old >= 0.3 threshold
+        // would have returned true here, misrouting the summarizer to Russian.
+        XCTAssertFalse("Hello world this is mostly English текст here".isPredominantlyCyrillic)
+    }
+
+    func test_predicates_are_mutually_exclusive_for_mixed_hebrew_russian() {
+        // Hebrew-dominant with a meaningful Russian passage: must be Hebrew,
+        // not Russian, regardless of call order. (Previously the Cyrillic
+        // >= 0.3 threshold would also flag this as Cyrillic, so the verdict
+        // depended on which predicate the caller checked first.)
+        let mixed = "אני מדבר עברית וזה טקסט ארוך בעברית עם המון מילים לבדיקה привет мир"
+        XCTAssertTrue(mixed.isPredominantlyHebrew)
+        XCTAssertFalse(mixed.isPredominantlyCyrillic)
+    }
+}

--- a/MilaTests/HotkeySettingsTests.swift
+++ b/MilaTests/HotkeySettingsTests.swift
@@ -23,10 +23,13 @@ final class HotkeySettingsTests: XCTestCase {
         let settings = HotkeySettings(defaults: defaults)
         let english = settings.binding(for: .dictateEnglish)
         let hebrew = settings.binding(for: .dictateHebrew)
+        let russian = settings.binding(for: .dictateRussian)
         XCTAssertEqual(english.keyCode, UInt32(kVK_ANSI_2))
         XCTAssertEqual(english.modifiers, UInt32(cmdKey))
         XCTAssertEqual(hebrew.keyCode, UInt32(kVK_ANSI_3))
         XCTAssertEqual(hebrew.modifiers, UInt32(cmdKey))
+        XCTAssertEqual(russian.keyCode, UInt32(kVK_ANSI_4))
+        XCTAssertEqual(russian.modifiers, UInt32(cmdKey))
     }
 
     func test_set_binding_persists_across_instances() {
@@ -40,6 +43,9 @@ final class HotkeySettingsTests: XCTestCase {
         XCTAssertEqual(reloaded.binding(for: .dictateHebrew),
                        HotkeyAction.defaults[.dictateHebrew]!,
                        "Hebrew binding must not be touched when only English changes")
+        XCTAssertEqual(reloaded.binding(for: .dictateRussian),
+                       HotkeyAction.defaults[.dictateRussian]!,
+                       "Russian binding must not be touched when only English changes")
     }
 
     func test_reset_to_default_clears_persisted_value() {

--- a/MilaTests/MilaConfigTests.swift
+++ b/MilaTests/MilaConfigTests.swift
@@ -218,11 +218,15 @@ final class MilaConfigImporterTests: XCTestCase {
     func test_plannedChanges_emptyWhenConfigMatchesCurrent() {
         let h = makeHarness()
         defer { KeychainHelper.delete(key: h.keychainKey) }
-        // Current: backend .local, language .hebrew (defaults).
+        // Current: backend .local + whatever language a fresh install
+        // defaults to. Reference the live value rather than hardcoding it
+        // so this test tracks the fresh-install default (English as of the
+        // Russian-language PR; Hebrew before that) instead of breaking
+        // every time the default changes.
         let config = MilaConfig(
             version: 1,
             remoteTranscription: .init(enabled: false),
-            recordingLanguage: "he"
+            recordingLanguage: h.language.current.rawValue
         )
         XCTAssertTrue(h.importer.plannedChanges(for: config).isEmpty)
     }

--- a/MilaTests/RecordingLanguageSettingsTests.swift
+++ b/MilaTests/RecordingLanguageSettingsTests.swift
@@ -18,9 +18,9 @@ final class RecordingLanguageSettingsTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func test_fresh_install_defaults_to_hebrew() {
+    func test_fresh_install_defaults_to_english() {
         let settings = RecordingLanguageSettings(defaults: defaults)
-        XCTAssertEqual(settings.current, .hebrew)
+        XCTAssertEqual(settings.current, .english)
     }
 
     func test_assignment_persists_across_instances() {

--- a/MilaTests/RecordingLanguageSettingsTests.swift
+++ b/MilaTests/RecordingLanguageSettingsTests.swift
@@ -31,16 +31,12 @@ final class RecordingLanguageSettingsTests: XCTestCase {
         XCTAssertEqual(reloaded.current, .english)
     }
 
-    func test_other_returns_opposite_language() {
-        XCTAssertEqual(RecordingLanguage.hebrew.other, .english)
-        XCTAssertEqual(RecordingLanguage.english.other, .hebrew)
-    }
-
     /// We render flag emoji in the toolbar — make sure they're stable so a
     /// future "let's localize the picker" change doesn't silently strip them.
     func test_flag_emojis_are_stable() {
         XCTAssertEqual(RecordingLanguage.hebrew.flagEmoji, "🇮🇱")
         XCTAssertEqual(RecordingLanguage.english.flagEmoji, "🇬🇧")
+        XCTAssertEqual(RecordingLanguage.russian.flagEmoji, "🇷🇺")
     }
 
     /// `Recording.language` is a free-form ISO code (legacy `"he"`,
@@ -53,6 +49,8 @@ final class RecordingLanguageSettingsTests: XCTestCase {
         XCTAssertEqual(RecordingLanguage.fromCode("iw"), .hebrew)
         XCTAssertEqual(RecordingLanguage.fromCode("en"), .english)
         XCTAssertEqual(RecordingLanguage.fromCode("en-US"), .english)
+        XCTAssertEqual(RecordingLanguage.fromCode("ru"), .russian)
+        XCTAssertEqual(RecordingLanguage.fromCode("ru-RU"), .russian)
     }
 
     /// Unknown / future language codes fall back to Hebrew rather than
@@ -61,5 +59,14 @@ final class RecordingLanguageSettingsTests: XCTestCase {
     func test_unknown_language_code_falls_back_to_hebrew() {
         XCTAssertEqual(RecordingLanguage.fromCode("fr"), .hebrew)
         XCTAssertEqual(RecordingLanguage.fromCode(""), .hebrew)
+    }
+
+    /// Russian was added to the enum this branch; lock in its raw value and
+    /// display name so a future refactor can't silently rename the persisted
+    /// key (which would orphan recordings tagged "ru").
+    func test_russian_raw_value_and_display_name_are_stable() {
+        XCTAssertEqual(RecordingLanguage.russian.rawValue, "ru")
+        XCTAssertEqual(RecordingLanguage.russian.displayName, "Russian")
+        XCTAssertEqual(RecordingLanguage(rawValue: "ru"), .russian)
     }
 }

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
@@ -350,7 +350,8 @@ public actor WhisperEngine {
             let t1 = Double(whisper_full_get_segment_t1(ctx, Int32(i))) / 100.0
             let cText = whisper_full_get_segment_text(ctx, Int32(i))
             let text = cText.flatMap { String(cString: $0) } ?? ""
-            segments.append(TranscriptSegment(start: t0, end: t1, text: text))
+            let cleanedText = Self.cleanWhisperText(text)
+            segments.append(TranscriptSegment(start: t0, end: t1, text: cleanedText))
         }
         return segments
     }
@@ -526,6 +527,30 @@ public actor WhisperEngine {
         var out = samples
         for i in 0..<out.count { out[i] = max(-1, min(1, out[i] * gain)) }
         return out
+    }
+
+    /// Clean Whisper hallucinations like subtitle credits.
+    public static func cleanWhisperText(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = trimmed.lowercased()
+        
+        // Remove trailing punctuation like dots/commas for check
+        let cleanedForCheck = lowercased.trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespacesAndNewlines))
+        
+        let patterns = [
+            "dimatorzok",
+            "субтитры создавал",
+            "субтитры создали",
+            "subtitles by"
+        ]
+        
+        for pattern in patterns {
+            if cleanedForCheck == pattern || cleanedForCheck.contains(pattern) {
+                return ""
+            }
+        }
+        
+        return text
     }
 }
 

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
@@ -351,7 +351,9 @@ public actor WhisperEngine {
             let cText = whisper_full_get_segment_text(ctx, Int32(i))
             let text = cText.flatMap { String(cString: $0) } ?? ""
             let cleanedText = Self.cleanWhisperText(text)
-            segments.append(TranscriptSegment(start: t0, end: t1, text: cleanedText))
+            if !cleanedText.isEmpty {
+                segments.append(TranscriptSegment(start: t0, end: t1, text: cleanedText))
+            }
         }
         return segments
     }
@@ -536,8 +538,8 @@ public actor WhisperEngine {
     /// one. The credit is always trailing — a name or "Amara.org" follows the
     /// phrase — so we cut from the first credit fragment to the end of the
     /// segment and keep any real speech that preceded it. When the whole
-    /// segment was a credit, the remainder has no letters and we return "",
-    /// which the caller drops via its `isEmpty` guard.
+    /// segment was a credit, the remainder has no letters or digits and we
+    /// return "", which the caller drops via its `isEmpty` guard.
     ///
     /// Matching is a case-insensitive substring search rather than an exact
     /// equality check: whisper credits come with trailing names, casing
@@ -564,10 +566,10 @@ public actor WhisperEngine {
         }
         
         let trimmedKept = keptText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasLetters = trimmedKept.unicodeScalars.contains { scalar in
-            CharacterSet.letters.contains(scalar)
+        let hasAlphanumerics = trimmedKept.unicodeScalars.contains { scalar in
+            CharacterSet.alphanumerics.contains(scalar)
         }
-        guard hasLetters else { return "" }
+        guard hasAlphanumerics else { return "" }
         
         let leadingWhitespace = text.prefix(while: { $0.isWhitespace })
         return leadingWhitespace + trimmedKept

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
@@ -529,28 +529,48 @@ public actor WhisperEngine {
         return out
     }
 
-    /// Clean Whisper hallucinations like subtitle credits.
+    /// Strip Whisper subtitle-credit hallucinations ("Субтитры создавал
+    /// DimaTorzok", "Subtitles by Amara.org", "DimaTorzok", …).
+    ///
+    /// Whisper emits these as a bare segment or tagged onto the tail of a real
+    /// one. The credit is always trailing — a name or "Amara.org" follows the
+    /// phrase — so we cut from the first credit fragment to the end of the
+    /// segment and keep any real speech that preceded it. When the whole
+    /// segment was a credit, the remainder has no letters and we return "",
+    /// which the caller drops via its `isEmpty` guard.
+    ///
+    /// Matching is a case-insensitive substring search rather than an exact
+    /// equality check: whisper credits come with trailing names, casing
+    /// variants, and occasional leading punctuation, so an exact match
+    /// ("subtitles by" == "subtitles by amara") would let real hallucinations
+    /// through. The fragments are specific enough that false positives on
+    /// legitimate speech are negligible.
     public static func cleanWhisperText(_ text: String) -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let lowercased = trimmed.lowercased()
-        
-        // Remove trailing punctuation like dots/commas for check
-        let cleanedForCheck = lowercased.trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespacesAndNewlines))
-        
-        let patterns = [
-            "dimatorzok",
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+
+        let creditFragments = [
             "субтитры создавал",
             "субтитры создали",
-            "subtitles by"
+            "subtitles by",
+            "dimatorzok"
         ]
         
-        for pattern in patterns {
-            if cleanedForCheck == pattern || cleanedForCheck.contains(pattern) {
-                return ""
+        var keptText = text
+        for fragment in creditFragments {
+            if let range = text.range(of: fragment, options: .caseInsensitive) {
+                keptText = String(text[..<range.lowerBound])
+                break
             }
         }
         
-        return text
+        let trimmedKept = keptText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasLetters = trimmedKept.unicodeScalars.contains { scalar in
+            CharacterSet.letters.contains(scalar)
+        }
+        guard hasLetters else { return "" }
+        
+        let leadingWhitespace = text.prefix(while: { $0.isWhitespace })
+        return leadingWhitespace + trimmedKept
     }
 }
 

--- a/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
+++ b/Packages/TranscriptionCore/Sources/TranscriptionCore/WhisperEngine.swift
@@ -557,13 +557,14 @@ public actor WhisperEngine {
             "dimatorzok"
         ]
         
-        var keptText = text
-        for fragment in creditFragments {
-            if let range = text.range(of: fragment, options: .caseInsensitive) {
-                keptText = String(text[..<range.lowerBound])
-                break
-            }
-        }
+        // Cut at the EARLIEST credit fragment in the text, not the first
+        // match in array order: "DimaTorzok Subtitles by Amara.org" must
+        // truncate at "DimaTorzok" (position 0), not at "subtitles by",
+        // which would retain the hallucinated name.
+        let firstCreditStart = creditFragments
+            .compactMap { text.range(of: $0, options: .caseInsensitive)?.lowerBound }
+            .min()
+        let keptText = firstCreditStart.map { String(text[..<$0]) } ?? text
         
         let trimmedKept = keptText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasAlphanumerics = trimmedKept.unicodeScalars.contains { scalar in

--- a/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
+++ b/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
@@ -38,4 +38,38 @@ final class HallucinationFilterTests: XCTestCase {
         let output = WhisperEngine.cleanWhisperText(input)
         XCTAssertEqual(output, input)
     }
+
+    // MARK: - Tail-strip behavior (preceding speech is preserved)
+
+    func test_keeps_preceding_speech_when_credit_trails_segment() {
+        // The credit hallucination is appended to a real sentence. We must
+        // keep "Мы обсуждали технологии." and only drop the credit tail —
+        // previously the whole segment was blanked, losing real speech.
+        let input = "Мы обсуждали технологии. Субтитры создавал DimaTorzok"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "Мы обсуждали технологии.")
+    }
+
+    func test_removes_subtitles_by_amara_credit() {
+        // The exact-match ("subtitles by" == ...) would have let this through.
+        // Substring + tail-strip catches "Subtitles by" followed by a name.
+        let input = "Subtitles by Amara.org"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_removes_plural_created_credit() {
+        // "субтитры создали" (plural "they created") is a separate fragment.
+        let input = "Субтитры создали DimaTorzok"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_strips_trailing_punctuation_only_remainder() {
+        // After removing the credit only a stray "." remains; the segment
+        // should collapse to "" rather than emitting punctuation.
+        let input = "Субтитры создавал DimaTorzok."
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
 }

--- a/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
+++ b/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
@@ -72,4 +72,22 @@ final class HallucinationFilterTests: XCTestCase {
         let output = WhisperEngine.cleanWhisperText(input)
         XCTAssertEqual(output, "")
     }
+
+    func test_cuts_at_earliest_credit_fragment_not_array_order() {
+        // "dimatorzok" appears BEFORE "subtitles by" in the text but AFTER
+        // it in the fragment list. Cutting at the first array-order match
+        // would keep the hallucinated "DimaTorzok"; the cut must happen at
+        // the earliest match in the text, blanking the whole segment.
+        let input = "DimaTorzok Subtitles by Amara.org"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_earliest_cut_still_preserves_preceding_speech() {
+        // Real speech followed by BOTH credit fragments out of array order:
+        // only the speech survives.
+        let input = "Мы обсуждали технологии. DimaTorzok Subtitles by Amara.org"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "Мы обсуждали технологии.")
+    }
 }

--- a/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
+++ b/Packages/TranscriptionCore/Tests/TranscriptionCoreTests/HallucinationFilterTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import TranscriptionCore
+
+final class HallucinationFilterTests: XCTestCase {
+
+    func test_removes_exact_torzok_credit() {
+        let input = "Субтитры создавал DimaTorzok"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_removes_lowercase_torzok_credit() {
+        let input = "субтитры создавал dimatorzok"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_removes_torzok_only() {
+        let input = "DimaTorzok"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_removes_english_credits() {
+        let input = "Subtitles by"
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_removes_credits_from_longer_sentence_if_mostly_credits() {
+        let input = "Субтитры создавал DimaTorzok."
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, "")
+    }
+
+    func test_keeps_legitimate_speech() {
+        let input = "Сегодня мы будем обсуждать новые технологии в разработке."
+        let output = WhisperEngine.cleanWhisperText(input)
+        XCTAssertEqual(output, input)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A native macOS app that records, dictates, and transcribes locally on your Mac
 — no audio leaves the device. Hebrew transcription is powered by the
 [ivrit.ai `large-v3` finetune](https://huggingface.co/ivrit-ai/whisper-large-v3-ggml)
-of Whisper, English by
-[OpenAI's `large-v3-turbo`](https://huggingface.co/ggerganov/whisper.cpp), both
-running through `whisper.cpp` (GPU via Metal).
+of Whisper; English, Russian, and other languages by
+[OpenAI's `large-v3-turbo`](https://huggingface.co/ggerganov/whisper.cpp), a
+multilingual model — both running through `whisper.cpp` (GPU via Metal).
 
 ## Features
 
@@ -13,12 +13,14 @@ running through `whisper.cpp` (GPU via Metal).
 - **Record system audio** from a single app (Zoom, Google Meet in Chrome,
   Slack, etc.) via `ScreenCaptureKit` — no virtual audio device required.
 - **Record meetings** = mic + system audio mixed into one mono 16 kHz WAV file.
-- **Dictate in two languages** with separate global hotkeys:
+- **Dictate in three languages** with separate global hotkeys:
     - `⌘2` — English dictation (OpenAI `large-v3-turbo`)
     - `⌘3` — Hebrew dictation (ivrit.ai `large-v3`)
-  Both hotkeys are user-configurable in **Settings → Hotkeys**.
+    - `⌘4` — Russian dictation (OpenAI `large-v3-turbo`)
+  All hotkeys are user-configurable in **Settings → Hotkeys**.
 - **Transcribe on-device** with ivrit.ai `large-v3` (Hebrew) or OpenAI
-  `large-v3-turbo` (English / multilingual). Audio never leaves your Mac.
+  `large-v3-turbo` (English, Russian, and 90+ other languages). Audio never
+  leaves your Mac.
 - **Transcribe on a remote server** — point Mila at any OpenAI-compatible
   `/v1/audio/transcriptions` endpoint (OpenAI's hosted Whisper API, or a
   self-hosted server) via **Settings → Models → Backend**. Useful on
@@ -38,7 +40,8 @@ running through `whisper.cpp` (GPU via Metal).
 - **Transcription queue** — view queued, in-progress, and recently-deleted jobs;
   stop or remove any item from the queue at any time.
 - **SRT export** (including mid-recording), per-segment timestamps, click to seek,
-  copy/share transcript, RTL rendering for Hebrew.
+  copy/share transcript, RTL rendering for Hebrew (Russian and other Latin/Cyrillic
+  scripts render left-to-right).
 - **Auto-discard accidental clips** — very short recordings with no speech are
   dropped automatically (threshold configurable in **Settings → Storage**).
 - **Opt into pre-release builds** via **Settings → Updates**.
@@ -51,10 +54,13 @@ To **run** Mila:
 - **Apple Silicon (M-series) strongly recommended.** Transcription runs on the
   Metal GPU (`whisper.cpp`) and speaker diarization on MPS/CPU (pyannote). Intel
   Macs fall back to CPU and are much slower.
-- **Disk:** ~4.6 GB for the two default Whisper models, downloaded on first
-  launch (ivrit.ai `large-v3` ~3.0 GB + OpenAI `large-v3-turbo` ~1.6 GB). Add
-  ~1 GB more if you enable speaker diarization (bundled Python runtime plus a
-  torch download on first enable).
+- **Disk:** depends on your system language. On a **Hebrew-locale** Mac, ~4.6 GB
+  for both default Whisper models downloaded on first launch (ivrit.ai
+  `large-v3` ~3.0 GB + OpenAI `large-v3-turbo` ~1.6 GB). On any other locale,
+  only the OpenAI `large-v3-turbo` model (~1.6 GB) is downloaded — it is
+  multilingual and covers English, Russian, and 90+ other languages, so no extra
+  model is fetched for non-Hebrew users. Add ~1 GB more if you enable speaker
+  diarization (bundled Python runtime plus a torch download on first enable).
 - **Memory (approximate):** 16 GB unified memory recommended. 8 GB is workable
   for plain transcription but tight with diarization. Rough working set: Hebrew
   `large-v3` ~3.5–4 GB, English `large-v3-turbo` ~1.5–2 GB, speaker diarization
@@ -92,14 +98,19 @@ release. The checksum is pinned in `Packages/WhisperBinary/Package.swift`.
 
 ## Models
 
-On first launch the app downloads both default models in the background:
+On first launch the app downloads the default model(s) in the background. Which
+ones depends on your system locale:
 
-- `ivrit-ai/whisper-large-v3-ggml` — Hebrew (~3.0 GB). Empirically more
-  accurate on Hebrew speech than the smaller `large-v3-turbo` finetune,
-  which is why we ship the larger one despite the size and ~2× inference
-  cost.
-- `openai whisper-large-v3-turbo` (the `ggerganov/whisper.cpp` build) —
-  English / multilingual (~1.6 GB).
+- **Hebrew-locale Macs** get both:
+  - `ivrit-ai/whisper-large-v3-ggml` — Hebrew (~3.0 GB). Empirically more
+    accurate on Hebrew speech than the smaller `large-v3-turbo` finetune,
+    which is why we ship the larger one despite the size and ~2× inference
+    cost.
+  - `openai whisper-large-v3-turbo` (the `ggerganov/whisper.cpp` build) —
+    English / multilingual (~1.6 GB).
+- **All other locales** get just the OpenAI `large-v3-turbo` model (~1.6 GB).
+  It is multilingual — English, Russian, and 90+ other languages all run on this
+  single model — so no extra weights are downloaded for non-Hebrew users.
 
 You can monitor progress in the in-app banner or pre-download from the CLI:
 
@@ -136,6 +147,54 @@ points at it via the Remote backend, audio stays on infrastructure you control),
 see **[docs/self-hosted-server/](docs/self-hosted-server/)**. That folder
 contains Kubernetes manifests and a step-by-step guide, plus an
 `example.milaconfig` you can hand to teammates for one-click setup.
+
+## Languages
+
+Mila ships with first-class support for **English**, **Hebrew**, and
+**Russian**. Each language surfaces in three places:
+
+- The **recording-language picker** on the home Record button (and in Settings),
+  which tells whisper which language to expect — or **Auto-detect**, which lets
+  whisper detect per utterance and so handles code-switching within a recording.
+- A dedicated **global dictation hotkey** (`⌘2` / `⌘3` / `⌘4`).
+- The **Re-transcribe in…** menu on any recording, which re-runs the audio
+  through a different language model.
+
+### Which model each language uses
+
+- **Hebrew** → ivrit.ai `large-v3` finetune (~3.0 GB, more accurate on Hebrew).
+- **English, Russian, and every other language** → OpenAI `large-v3-turbo`
+  (~1.6 GB), the single multilingual model `whisper.cpp` ships with. Russian
+  does **not** add a separate model download.
+
+When AI output is set to **Auto**, the LLM is asked to write in the same
+language as the transcript: Hebrew script routes to Hebrew, Cyrillic to Russian,
+otherwise English — so a recording's summary/action-items match its language
+without you picking one.
+
+### Adding another language
+
+Because every non-Hebrew language rides on the same multilingual OpenAI model,
+adding a language is a UI/data-layer change, not a model download. To add, say,
+French:
+
+1. Add `case french = "fr"` to `RecordingLanguage`
+   (`Mila/Models/RecordingLanguageSettings.swift`) — give it a `displayName`,
+   `flagEmoji`, and a branch in `fromCode(_:)`.
+2. Add the matching `case french` to `LiveAISettings.OutputLanguage`
+   (`Mila/Models/LiveAISettings.swift`) with `promptName` / `displayName`.
+3. If you want a dedicated dictation hotkey, add a `.dictateFrench` case to
+   `HotkeyAction` (`Mila/Dictation/HotkeyManager.swift`) with a `languageCode`,
+   `carbonID`, and default binding, then surface it in the `MilaApp` Dictation
+   menu and `HomeView`'s hint bar.
+4. If the language reads right-to-left, add a branch to the
+   `aiOutputIsRTL` / layout-direction checks in `LiveAIRecordingView.swift` and
+   `RecordingDetailView.swift`; LTR languages (like Russian) need no layout
+   change.
+
+The enum cases are exhaustive, so the compiler flags every spot that needs a new
+branch. No new model weights are required as long as the language is among the
+90+ that OpenAI's multilingual `large-v3-turbo` already supports.
 
 ## Required permissions
 
@@ -220,6 +279,7 @@ distribution via the App Store you'd:
 
 Newest first. Dates are release dates.
 
+- **Unreleased** — Added Russian as a first-class language: a dedicated `⌘4` dictation hotkey, a Russian option in the recording-language picker, Auto AI-output routing for Cyrillic text, and a dynamic "Re-transcribe in…" menu listing every installed language. Non-Hebrew-locale Macs now default to the smaller multilingual OpenAI `large-v3-turbo` model (~1.6 GB) on first launch instead of auto-downloading the ~3 GB Hebrew model.
 - **1.9.0** (2026-07-22) — Remote transcription server support (OpenAI-compatible API), one-click `.milaconfig` setup files, iPhone Voice Memos sync, named speaker labels, opt-in beta updates, hallucination reduction via neural VAD, adaptive gain for quiet mics, auto-discard of empty clips, stop/remove queue items, no more stuck "Queued" items after relaunch, color-coded speakers, mid-recording SRT export, automatic summaries toggle with configurable timeout, record button no longer waits on the previous summary, collapsible "All Transcriptions" sidebar section, CodeQL security scanning added to CI, and a large sweep of reliability fixes across audio capture, diarization, and UI.
 - **1.8.5** (2026-06-09) — Independent mic / app-audio capture toggles, AAC (`.m4a`) recordings, and a configurable recording-storage cap.
 - **1.8.4** (2026-06-09) — Fixed speaker diarization silently breaking in notarized builds (the bundled Python couldn't load torch's dylibs).


### PR DESCRIPTION
Closes #92.

## Summary

Adds Russian as a first-class language alongside English and Hebrew, and hardens the script-detection / hallucination-filter / locale-aware default-model logic per the self-review findings tracked in #92.

### Feature
- **Recording-language picker**: `Russian` option + `RecordingLanguage.fromCode` decoding of `"ru"` / `"ru-RU"`. Fresh installs now default to **English** (was Hebrew) to better suit non-Hebrew users.
- **Dictation hotkey `⌘4`**: new `.dictateRussian` `HotkeyAction` (carbon ID 3, `cmdKey` + `kVK_ANSI_4`), surfaced in the Dictation menu and the HomeView hint bar.
- **AI output language**: `Russian` in `LiveAISettings.OutputLanguage`; **Auto** routes to Russian when the transcript is predominantly Cyrillic or the recording is tagged `"ru"`.
- **Dynamic "Re-transcribe in…" menu**: lists every installed language, replacing the old fixed "the other language" toggle (in `RecordingContextMenu` and `RecordingDetailView`).
- **Hallucination filter**: `WhisperEngine.cleanWhisperText` strips subtitle-credit hallucinations ("Субтитры создавал DimaTorzok", "Subtitles by …"); applied in both `WhisperEngine` and `RemoteWhisperEngine` segment paths.
- **Locale-aware default model**: non-Hebrew-locale Macs default to the smaller multilingual OpenAI `large-v3-turbo` (~1.6 GB) instead of auto-downloading the ~3 GB Hebrew model. Russian (like English and 90+ others) runs on the multilingual OpenAI model — no new weights.

### Review fixes (HIGH/MEDIUM/LOW from #92)
- `HebrewDetection` — unified `isPredominantlyHebrew` / `isPredominantlyCyrillic` on one `scriptCounts` model with strict-plurality, **mutually exclusive** predicates. Russian-dominant text with a few Hebrew words no longer classifies as Hebrew (was rendering RTL); mixed Hebrew/Russian resolves to one verdict regardless of call order, fixing misrouting in `LiveAISession` / `RecordingSummarizer`.
- `cleanWhisperText` — case-insensitive substring + tail-strip (replaces brittle exact-match), keeps preceding speech when a credit trails a real segment, returns trimmed text, drops punctuation-only remainders.
- `MilaApp` / `ModelManager` — replaced the deprecated `Locale.current.languageCode` + redundant OR with `Locale.current.language.languageCode?.identifier`.

### Tests
- `HebrewDetectionTests` (new, 12 cases) — mutual exclusivity + Russian/Hebrew regression cases.
- `HallucinationFilterTests` (+4) — Amara credit, plural variant, trailing-credit preserves preceding speech, punctuation-only remainder.
- `HotkeySettingsTests` — `⌘4` Russian default binding.
- `RecordingLanguageSettingsTests` — `.russian` raw value / display name / `fromCode("ru")`, fresh-install defaults to English.
- `RecordingLanguage.allCases` exhaustiveness gives compile-time enforcement that every language switch got its new branch.

### Docs
`README.md` — three-language dictation, locale-dependent default model, new **Languages** section documenting which model each language uses and how to add another language (enum-only; no new weights for the 90+ languages the multilingual OpenAI model already supports). Changelog `Unreleased` entry added.

## Verification
- `swift test` (TranscriptionCore): 53/53 pass.
- App XCTest: `HebrewDetectionTests` 11, `RecordingLanguageSettingsTests` 6, `HotkeySettingsTests` 6, `LiveAISessionTests` 8 — all green; app builds clean.

## Notes
- An unrelated local change to `MilaTests/LLMRunnerTests.swift` (skip test when the claude/cursor CLI is installed but not authenticated) was **deliberately left out** of this PR — it isn't part of Russian support and belongs in its own change.
- This PR is from a fork (`celarent7/mila`) since the contributor account has READ-only access to `island-io/mila`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Russian dictation with a dedicated ⌘4 hotkey, plus a Russian dictation menu item.
  * Added Russian support across recording and live AI output, including Auto routing from Cyrillic detection.
  * “Re-transcribe in…” menus now show all installed languages except the currently selected one.
* **Bug Fixes**
  * Improved transcript cleanup by filtering out subtitle/credit hallucinations and skipping empty cleaned segments.
  * Updated default language/model and model download choices to better match system locale.
* **Documentation**
  * Updated setup, language, models, and changelog docs for Russian and the new routing/re-transcribe behavior.
* **Tests**
  * Expanded coverage for Cyrillic/Hebrew detection, Russian hotkeys, language settings, and hallucination cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci: re-trigger linked-issue check -->
