### PR TITLE
feat(llm): add OpenAI-compatible endpoint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Mila/Resources/PythonRuntime/
 Mila-slack-emoji.png
 __pycache__/
 *.pyc
+
+# Local-only LLM implementation plans / scratch artifacts
+llm-artifacts/

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -295,6 +295,10 @@ enum LLMRunner {
         if timeout > 0 { request.timeoutInterval = timeout }
 
         do {
+            // Already cancelled before we even dispatch (e.g. the rename sheet
+            // closed while the transcript was still being assembled)? Don't
+            // spend the round trip — or the tokens. (CodeRabbit #2.)
+            try Task.checkCancellation()
             let (http, data) = try await transport.send(request)
             // A cooperative cancellation (Task.cancel, or a custom/test
             // transport that throws CancellationError) would otherwise fall

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -296,14 +296,24 @@ enum LLMRunner {
 
         do {
             let (http, data) = try await transport.send(request)
+            // A cooperative cancellation (Task.cancel, or a custom/test
+            // transport that throws CancellationError) would otherwise fall
+            // through to `.launchFailed`; surface it as a cancellation so the
+            // banner/auto-suggest callers drop it quietly. (CodeRabbit #2.)
+            try Task.checkCancellation()
             switch OpenAIClient.parse(data: data, response: http) {
             case .success(let content):
+                // Re-check after the (possibly slow) transport returned: a
+                // late response to a cancelled task shouldn't be delivered.
+                try Task.checkCancellation()
                 return content
             case .failure(let error):
                 throw error
             }
         } catch let error as OpenAIRequestError {
             throw error
+        } catch is CancellationError {
+            throw LLMRunnerError.cancelled
         } catch let urlError as URLError {
             switch urlError.code {
             case .cancelled:

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -280,7 +280,11 @@ enum LLMRunner {
                                     jsonMode: Bool,
                                     temperature: Double?,
                                     transport: OpenAITransport) async throws -> String {
-        var request = OpenAIClient.makeRequest(baseURL: baseURL,
+        // `makeRequest` throws `OpenAIRequestError.invalidEndpoint` for a
+        // malformed base URL (issue celarent7/mila#1). It's an
+        // `OpenAIRequestError`, so the typed-rethrow catch below surfaces it
+        // to the caller as a readable LocalizedError — not a crash.
+        var request = try OpenAIClient.makeRequest(baseURL: baseURL,
                                                model: model ?? "",
                                                prompt: prompt,
                                                transcript: transcript,
@@ -431,14 +435,26 @@ enum LLMRunner {
                 setupError: LLMRunnerError.toolDisabled.errorDescription
                     ?? "No OpenAI endpoint is configured in Settings → LLM.")
         }
-        var request = OpenAIClient.makeRequest(baseURL: trimmedBase,
-                                               model: model ?? "",
-                                               prompt: prompt,
-                                               transcript: transcript,
-                                               summary: summary,
-                                               apiKey: apiKey,
-                                               jsonMode: jsonMode,
-                                               temperature: nil)
+        // `makeRequest` throws `invalidEndpoint` for a malformed base URL
+        // (issue celarent7/mila#1). `diagnose` never throws, so surface it as
+        // a setup problem the test panel can render — not a crash.
+        var request: URLRequest
+        do {
+            request = try OpenAIClient.makeRequest(baseURL: trimmedBase,
+                                                   model: model ?? "",
+                                                   prompt: prompt,
+                                                   transcript: transcript,
+                                                   summary: summary,
+                                                   apiKey: apiKey,
+                                                   jsonMode: jsonMode,
+                                                   temperature: nil)
+        } catch let error as OpenAIRequestError {
+            return LLMTestResult(
+                setupError: error.errorDescription ?? "\(error)",
+                url: "\(trimmedBase)/chat/completions")
+        } catch {
+            return LLMTestResult(setupError: error.localizedDescription)
+        }
         if timeout > 0 { request.timeoutInterval = timeout }
         let url = request.url?.absoluteString ?? ""
         let requestBody = String(data: request.httpBody ?? Data(), encoding: .utf8) ?? ""

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -41,22 +41,38 @@ enum LLMRunnerError: LocalizedError {
 struct LLMTestResult: Equatable {
     /// The exact, shell-quoted command line that was launched (or would have
     /// been, if we got far enough to build it). Empty when no tool/executable
-    /// was resolved.
+    /// was resolved. For the OpenAI HTTP path this is `POST <url>`.
     var command: String = ""
-    /// True only when the CLI launched and exited 0.
+    /// True only when the CLI launched and exited 0, OR the HTTP endpoint
+    /// returned 2xx with parseable content.
     var succeeded: Bool = false
     /// Process exit code, or nil when the CLI never launched (setup error).
+    /// Always nil for the OpenAI HTTP path (there is no process).
     var exitCode: Int32? = nil
     var stdout: String = ""
     var stderr: String = ""
     var durationSeconds: TimeInterval = 0
     /// Set when something prevented the CLI from even running — no tool
-    /// selected, executable not on PATH, launch failure.
+    /// selected, executable not on PATH, launch failure — or when the OpenAI
+    /// transport couldn't reach the endpoint (network/timeout failure).
     var setupError: String? = nil
     var timedOut: Bool = false
+    // OpenAI HTTP diagnostics (Phase 7). Populated only by the
+    // `.openaiCompatible` diagnose branch; empty/nil for the CLI path.
+    /// The full request URL the POST was sent to.
+    var url: String = ""
+    /// HTTP status code of the response, or nil when the request never got a
+    /// response (transport failure). This — not `exitCode` — is the "did the
+    /// HTTP call actually run?" signal for the OpenAI path (AC-DIAG-04).
+    var httpStatus: Int? = nil
+    /// The JSON request body that was sent, for copy-paste / debugging.
+    var requestBody: String = ""
 
-    /// Whether anything actually ran. False for pure setup failures.
-    var didLaunch: Bool { exitCode != nil }
+    /// Whether anything actually ran. For the CLI path, "launched a process"
+    /// (`exitCode != nil`); for the OpenAI path, "got an HTTP response"
+    /// (`httpStatus != nil`). False for pure setup failures (no tool selected,
+    /// executable not found, transport couldn't connect).
+    var didLaunch: Bool { exitCode != nil || httpStatus != nil }
 }
 
 /// Spawns the configured `claude` or `cursor-agent` binary with the user's
@@ -134,8 +150,43 @@ enum LLMRunner {
                     model: String? = nil,
                     session: LLMSession = .none,
                     extraArgs: [String] = [],
-                    timeout: TimeInterval = LLMRunner.defaultTimeout) async throws -> String {
+                    timeout: TimeInterval = LLMRunner.defaultTimeout,
+                    // OpenAI-compatible endpoint config (Phase 6.0). Only
+                    // `transport` is caller-transparent — it defaults to a real
+                    // `URLSession` so CLI-only callers pass nothing and are
+                    // unchanged. `baseURL`/`apiKey`/`jsonMode` default to
+                    // nil/nil/false; callers that can land on
+                    // `.openaiCompatible` MUST thread them (see the plan's
+                    // 6.0.3 call-site audit). `model:` is reused for the
+                    // OpenAI model name (`LLMSettings.openAIModelName`).
+                    openAIBaseURL: String? = nil,
+                    openAIAPIKey: String? = nil,
+                    jsonMode: Bool = false,
+                    temperature: Double? = nil,
+                    transport: OpenAITransport? = nil) async throws -> String {
         guard tool != .none else { throw LLMRunnerError.toolDisabled }
+
+        // OpenAI-compatible HTTP path — handled before any CLI resolution, so
+        // `executablePathOverride` / `session` / `extraArgs` (CLI-only) are
+        // irrelevant here. Defense in depth: `run` has no `LLMSettings`, so it
+        // re-checks the base-URL readiness gate the Settings UI also enforces
+        // via `isConfigured` — a nil/empty base URL can't send anything.
+        if tool == .openaiCompatible {
+            guard let baseURL = openAIBaseURL,
+                  !baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { throw LLMRunnerError.toolDisabled }
+            let t = transport ?? URLSessionTransport(URLSession.shared)
+            return try await runOpenAICompatible(prompt: prompt,
+                                                 transcript: transcript,
+                                                 summary: summary,
+                                                 model: model,
+                                                 timeout: timeout,
+                                                 baseURL: baseURL,
+                                                 apiKey: openAIAPIKey ?? "",
+                                                 jsonMode: jsonMode,
+                                                 temperature: temperature,
+                                                 transport: t)
+        }
 
         let executable = try resolveExecutable(tool: tool,
                                                override: executablePathOverride)
@@ -200,6 +251,69 @@ enum LLMRunner {
         }
     }
 
+    /// HTTP path for `tool == .openaiCompatible`: build the
+    /// `/chat/completions` request via the pure `OpenAIClient.makeRequest`,
+    /// send it through the injectable transport, then decode via the pure
+    /// `OpenAIClient.parse`. `timeout` is applied as the request's
+    /// `timeoutInterval` (and `URLSession.data` surfaces the expiry as
+    /// `URLError.timedOut`); Task cancellation surfaces as
+    /// `URLError.cancelled`. Both are mapped back onto `LLMRunnerError` so
+    /// callers see the same error vocabulary the CLI path produces.
+    ///
+    /// Error mapping:
+    ///  - `OpenAIRequestError` (from `parse`) → rethrown as-is (typed,
+    ///    `LocalizedError`, rendered by the Settings sheet / rename sheet).
+    ///  - `URLError.cancelled` → `.cancelled` (mirrors the CLI's
+    ///    `ProcessHandle`-driven cancellation).
+    ///  - `URLError.timedOut` → `.timedOut(seconds:)`, rounded *up* to match
+    ///    the CLI path's `Int(timeout.rounded(.up))` so AC-TIMEOUT-02's
+    ///    "matches the CLI format" holds.
+    ///  - any other transport failure → `.launchFailed` (the closest existing
+    ///    bucket for "couldn't reach the endpoint").
+    static func runOpenAICompatible(prompt: String,
+                                    transcript: String,
+                                    summary: String,
+                                    model: String?,
+                                    timeout: TimeInterval,
+                                    baseURL: String,
+                                    apiKey: String,
+                                    jsonMode: Bool,
+                                    temperature: Double?,
+                                    transport: OpenAITransport) async throws -> String {
+        var request = OpenAIClient.makeRequest(baseURL: baseURL,
+                                               model: model ?? "",
+                                               prompt: prompt,
+                                               transcript: transcript,
+                                               summary: summary,
+                                               apiKey: apiKey,
+                                               jsonMode: jsonMode,
+                                               temperature: temperature)
+        if timeout > 0 { request.timeoutInterval = timeout }
+
+        do {
+            let (http, data) = try await transport.send(request)
+            switch OpenAIClient.parse(data: data, response: http) {
+            case .success(let content):
+                return content
+            case .failure(let error):
+                throw error
+            }
+        } catch let error as OpenAIRequestError {
+            throw error
+        } catch let urlError as URLError {
+            switch urlError.code {
+            case .cancelled:
+                throw LLMRunnerError.cancelled
+            case .timedOut:
+                throw LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up)))
+            default:
+                throw LLMRunnerError.launchFailed(urlError)
+            }
+        } catch {
+            throw LLMRunnerError.launchFailed(error)
+        }
+    }
+
     /// Run the configured CLI like `run` does, but never throw — capture the
     /// exact command line, exit code, stdout, and stderr and hand them all
     /// back so the Settings → LLM test panel can show the user precisely what
@@ -219,9 +333,31 @@ enum LLMRunner {
                          extraArgs: [String] = [],
                          executablePathOverride: String?,
                          model: String? = nil,
-                         timeout: TimeInterval = 120) async -> LLMTestResult {
+                         timeout: TimeInterval = 120,
+                         // OpenAI-compatible config (Phase 6.0/7). Same four
+                         // defaulted params as `run`; only `transport` is
+                         // caller-transparent. `diagnose` is non-throwing, so
+                         // the base-URL guard and transport failures come back
+                         // as `setupError` rather than exceptions.
+                         openAIBaseURL: String? = nil,
+                         openAIAPIKey: String? = nil,
+                         jsonMode: Bool = false,
+                         transport: OpenAITransport? = nil) async -> LLMTestResult {
         guard tool != .none else {
             return LLMTestResult(setupError: LLMRunnerError.toolDisabled.errorDescription ?? "No LLM configured.")
+        }
+        // OpenAI HTTP path — handled before CLI resolution, so no
+        // `executablePath` is required (AC-DIAG-05).
+        if tool == .openaiCompatible {
+            return await diagnoseOpenAICompatible(prompt: prompt,
+                                                  transcript: transcript,
+                                                  summary: summary,
+                                                  model: model,
+                                                  timeout: timeout,
+                                                  baseURL: openAIBaseURL ?? "",
+                                                  apiKey: openAIAPIKey ?? "",
+                                                  jsonMode: jsonMode,
+                                                  transport: transport)
         }
         let executable: URL
         do {
@@ -268,6 +404,100 @@ enum LLMRunner {
             }
         } onCancel: {
             handle.terminate()
+        }
+    }
+
+    /// Non-throwing HTTP diagnostic for `tool == .openaiCompatible` — the
+    /// "test" path the Settings → LLM panel uses to explain an OpenAI endpoint
+    /// to the user. Mirrors `runOpenAICompatible`'s request building but,
+    /// because `diagnose` never throws, captures every outcome into the
+    /// `LLMTestResult` fields: `url`/`requestBody`/`httpStatus` for the request
+    /// + response, `succeeded` iff 2xx with parseable content, the response
+    /// body in `stdout`, a typed error message in `stderr` for 4xx/5xx, and
+    /// `setupError`/`timedOut` for transport failures (so the panel can tell
+    /// "couldn't reach the endpoint" from "endpoint returned an error").
+    static func diagnoseOpenAICompatible(prompt: String,
+                                         transcript: String,
+                                         summary: String,
+                                         model: String?,
+                                         timeout: TimeInterval,
+                                         baseURL: String,
+                                         apiKey: String,
+                                         jsonMode: Bool,
+                                         transport: OpenAITransport?) async -> LLMTestResult {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBase.isEmpty else {
+            return LLMTestResult(
+                setupError: LLMRunnerError.toolDisabled.errorDescription
+                    ?? "No OpenAI endpoint is configured in Settings → LLM.")
+        }
+        var request = OpenAIClient.makeRequest(baseURL: trimmedBase,
+                                               model: model ?? "",
+                                               prompt: prompt,
+                                               transcript: transcript,
+                                               summary: summary,
+                                               apiKey: apiKey,
+                                               jsonMode: jsonMode,
+                                               temperature: nil)
+        if timeout > 0 { request.timeoutInterval = timeout }
+        let url = request.url?.absoluteString ?? ""
+        let requestBody = String(data: request.httpBody ?? Data(), encoding: .utf8) ?? ""
+        let command = "POST \(url)"
+        let start = Date()
+        let t = transport ?? URLSessionTransport(URLSession.shared)
+
+        do {
+            let (http, data) = try await t.send(request)
+            let status = http.statusCode
+            let bodyString = String(data: data, encoding: .utf8) ?? ""
+            switch OpenAIClient.parse(data: data, response: http) {
+            case .success(let content):
+                return LLMTestResult(
+                    command: command,
+                    succeeded: true,
+                    stdout: content,
+                    durationSeconds: Date().timeIntervalSince(start),
+                    url: url,
+                    httpStatus: status,
+                    requestBody: requestBody)
+            case .failure(let error):
+                // 4xx/5xx: the endpoint ran (httpStatus set) but didn't
+                // succeed. Surface the readable typed message in stderr and
+                // the raw body in stdout so the user can self-diagnose.
+                return LLMTestResult(
+                    command: command,
+                    succeeded: false,
+                    stdout: bodyString,
+                    stderr: (error as? LocalizedError)?.errorDescription ?? "\(error)",
+                    durationSeconds: Date().timeIntervalSince(start),
+                    url: url,
+                    httpStatus: status,
+                    requestBody: requestBody)
+            }
+        } catch let urlError as URLError {
+            if urlError.code == .timedOut {
+                return LLMTestResult(
+                    command: command,
+                    durationSeconds: Date().timeIntervalSince(start),
+                    setupError: LLMRunnerError.timedOut(
+                        seconds: Int(timeout.rounded(.up))).errorDescription,
+                    timedOut: true,
+                    url: url,
+                    requestBody: requestBody)
+            }
+            return LLMTestResult(
+                command: command,
+                durationSeconds: Date().timeIntervalSince(start),
+                setupError: urlError.localizedDescription,
+                url: url,
+                requestBody: requestBody)
+        } catch {
+            return LLMTestResult(
+                command: command,
+                durationSeconds: Date().timeIntervalSince(start),
+                setupError: error.localizedDescription,
+                url: url,
+                requestBody: requestBody)
         }
     }
 

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -316,14 +316,20 @@ final class LLMSettings: ObservableObject {
     }
 
     /// Convenience the UI uses to decide whether to surface the rename /
-    /// run-action buttons at all. "Enabled AND ready": the OpenAI tool needs a
-    /// non-blank base URL; the CLI tools are ready as soon as they're selected
-    /// (per `.claude/rules/feature-gates.md`).
+    /// run-action buttons at all. "Enabled AND ready" (per
+    /// `.claude/rules/feature-gates.md`): the OpenAI tool needs a non-blank
+    /// base URL AND a non-blank model name — without a model, auto-title/summary
+    /// would launch HTTP requests guaranteed to fail (issue celarent7/mila#3/#4,
+    /// CodeRabbit #3). The API key stays optional so local/anonymous endpoints
+    /// (e.g. Ollama at localhost) count as configured without one. The CLI tools
+    /// are ready as soon as they're selected.
     var isConfigured: Bool {
         switch tool {
         case .none:             return false
         case .openaiCompatible:
-            return !openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            let url = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            let model = openAIModelName.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !url.isEmpty && !model.isEmpty
         default:                return true
         }
     }

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -315,21 +315,46 @@ final class LLMSettings: ObservableObject {
         }
     }
 
+    /// Whether a blank API key makes the configured endpoint unusable, so
+    /// `isConfigured` must report "not ready" rather than let auto-title /
+    /// auto-summary fire requests that are guaranteed to come back 401.
+    ///
+    /// Mirrors `RemoteTranscriptionSettings.requiresAPIKey`: a *named hosted*
+    /// preset (OpenAI, Groq, OpenRouter, DeepSeek, Ollama Cloud) always needs a
+    /// token; a local server and a `.custom` endpoint do not — a self-hosted or
+    /// LAN box is assumed open unless the user supplies one, and guessing
+    /// otherwise would lock those users out of the feature entirely.
+    static func requiresAPIKeyForReadiness(provider: OpenAIProvider,
+                                           baseURL: String) -> Bool {
+        switch provider {
+        case .ollamaLocal, .custom:
+            return false
+        default:
+            // A named preset repointed at localhost (e.g. a local proxy) is
+            // local-server territory too — don't demand a key there either.
+            return !OpenAILocality.isLocal(baseURL: baseURL)
+        }
+    }
+
     /// Convenience the UI uses to decide whether to surface the rename /
     /// run-action buttons at all. "Enabled AND ready" (per
     /// `.claude/rules/feature-gates.md`): the OpenAI tool needs a non-blank
     /// base URL AND a non-blank model name — without a model, auto-title/summary
     /// would launch HTTP requests guaranteed to fail (issue celarent7/mila#3/#4,
-    /// CodeRabbit #3). The API key stays optional so local/anonymous endpoints
-    /// (e.g. Ollama at localhost) count as configured without one. The CLI tools
-    /// are ready as soon as they're selected.
+    /// CodeRabbit #3) — plus an API key whenever the selected provider is a
+    /// named hosted one (see `requiresAPIKeyForReadiness`). Local/anonymous and
+    /// `.custom` endpoints stay configured without a key. The CLI tools are
+    /// ready as soon as they're selected.
     var isConfigured: Bool {
         switch tool {
         case .none:             return false
         case .openaiCompatible:
             let url = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
             let model = openAIModelName.trimmingCharacters(in: .whitespacesAndNewlines)
-            return !url.isEmpty && !model.isEmpty
+            guard !url.isEmpty, !model.isEmpty else { return false }
+            guard Self.requiresAPIKeyForReadiness(provider: openAIProvider,
+                                                  baseURL: url) else { return true }
+            return !openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         default:                return true
         }
     }

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -1,6 +1,70 @@
 import Foundation
 import Combine
 
+/// A closed set of OpenAI-compatible `/v1/chat/completions` providers. Each
+/// ships a base URL and a default model name so the Settings UI can offer
+/// working one-click presets, with `.custom` for anything else that speaks
+/// the same protocol.
+///
+/// There is deliberately **no** single hardcoded model fallback: every
+/// non-custom preset carries its own `defaultModelName` (see AC-PRESET-06).
+/// The locale-aware default-model mechanism in `ModelManager` applies to
+/// Whisper *transcription* models only and is not reused here.
+enum OpenAIProvider: String, CaseIterable, Identifiable, Codable {
+    case ollamaLocal
+    case ollamaCloud
+    case openai
+    case openrouter
+    case groq
+    case deepseek
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .ollamaLocal:  return "Ollama (local)"
+        case .ollamaCloud:  return "Ollama Cloud"
+        case .openai:       return "OpenAI"
+        case .openrouter:   return "OpenRouter"
+        case .groq:         return "Groq"
+        case .deepseek:     return "DeepSeek"
+        case .custom:       return "Custom"
+        }
+    }
+
+    /// Base URL the client appends `chat/completions` to. Empty for `.custom`
+    /// (the user supplies it).
+    var baseURL: String {
+        switch self {
+        case .ollamaLocal:  return "http://localhost:11434/v1"
+        case .ollamaCloud:  return "https://ollama.com/v1"
+        case .openai:       return "https://api.openai.com/v1"
+        case .openrouter:   return "https://openrouter.ai/api/v1"
+        case .groq:         return "https://api.groq.com/openai/v1"
+        case .deepseek:     return "https://api.deepseek.com/v1"
+        case .custom:       return ""
+        }
+    }
+
+    /// Whether the endpoint expects a Bearer token. A local Ollama server has
+    /// no auth by default; every hosted provider does.
+    var requiresAPIKey: Bool { self != .ollamaLocal }
+
+    /// Per-preset default model name. Empty for `.custom` (user-supplied).
+    var defaultModelName: String {
+        switch self {
+        case .ollamaLocal:  return "llama3.1"
+        case .ollamaCloud:  return "llama3.1"
+        case .openai:       return "gpt-4o-mini"
+        case .openrouter:   return "openai/gpt-4o-mini"
+        case .groq:         return "llama-3.3-70b-versatile"
+        case .deepseek:     return "deepseek-chat"
+        case .custom:       return ""
+        }
+    }
+}
+
 /// Which local LLM CLI Mila will shell out to for naming
 /// recordings and running post-recording actions. We deliberately keep this
 /// to a closed set of two so the Settings UI can show working defaults +
@@ -10,23 +74,28 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
     case none
     case claude
     case cursor
+    case openaiCompatible = "openai_compatible"
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .none:   return "Off"
-        case .claude: return "Claude (claude CLI)"
-        case .cursor: return "Cursor (cursor-agent CLI)"
+        case .none:            return "Off"
+        case .claude:          return "Claude (claude CLI)"
+        case .cursor:          return "Cursor (cursor-agent CLI)"
+        case .openaiCompatible: return "OpenAI Compatible"
         }
     }
 
-    /// Default executable name (looked up via the user's `$PATH`).
+    /// Default executable name (looked up via the user's `$PATH`). Empty for
+    /// `.openaiCompatible` — the HTTP branch in `LLMRunner.run` returns before
+    /// `resolveExecutable` is ever reached for this case.
     var executableName: String {
         switch self {
-        case .none:   return ""
-        case .claude: return "claude"
-        case .cursor: return "cursor-agent"
+        case .none:            return ""
+        case .claude:          return "claude"
+        case .cursor:          return "cursor-agent"
+        case .openaiCompatible: return ""
         }
     }
 
@@ -62,7 +131,8 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         let trimmedModel = model?.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasModel = !(trimmedModel?.isEmpty ?? true)
         switch self {
-        case .none:   return []
+        case .none:            return []
+        case .openaiCompatible: return []   // HTTP path never spawns a process
         case .claude:
             var args: [String] = ["-p", prompt]
             if hasModel, let m = trimmedModel {
@@ -106,6 +176,10 @@ final class LLMSettings: ObservableObject {
         didSet {
             guard tool != oldValue else { return }
             defaults.set(tool.rawValue, forKey: Keys.tool)
+            // Defer the Keychain read until the user actually selects the
+            // OpenAI tool — local/CLI-only users never trigger the macOS
+            // Keychain prompt. Mirrors `RemoteTranscriptionSettings.backend`.
+            if tool == .openaiCompatible { loadOpenAIAPIKeyIfNeeded() }
         }
     }
 
@@ -177,9 +251,96 @@ final class LLMSettings: ObservableObject {
     /// `extraArgs` parsed into an argv array, ready to hand to `LLMRunner`.
     var extraArgsTokens: [String] { LLMRunner.tokenizeArguments(extraArgs) }
 
+    // MARK: - OpenAI-compatible endpoint
+
+    /// Which OpenAI-compatible provider the user picked (drives the preset
+    /// picker). Defaults to `.custom` so the base URL / model fields start
+    /// empty and the user chooses a provider to fill them.
+    @Published var openAIProvider: OpenAIProvider {
+        didSet {
+            guard openAIProvider != oldValue else { return }
+            defaults.set(openAIProvider.rawValue, forKey: Keys.openAIProvider)
+        }
+    }
+
+    @Published var openAIBaseURL: String {
+        didSet {
+            guard openAIBaseURL != oldValue else { return }
+            defaults.set(openAIBaseURL, forKey: Keys.openAIBaseURL)
+        }
+    }
+
+    @Published var openAIModelName: String {
+        didSet {
+            guard openAIModelName != oldValue else { return }
+            defaults.set(openAIModelName, forKey: Keys.openAIModelName)
+        }
+    }
+
+    /// Bearer token for the OpenAI-compatible endpoint. Stored in the
+    /// **Keychain**, never `UserDefaults` — mirrors `RemoteTranscriptionSettings`
+    /// verbatim: write-through on `didSet`, lazy restore via
+    /// `loadOpenAIAPIKeyIfNeeded`, and an `isAdoptingStoredAPIKey` guard so
+    /// adopting the stored value doesn't trigger a redundant Keychain write.
+    @Published var openAIAPIKey: String {
+        didSet {
+            guard openAIAPIKey != oldValue else { return }
+            guard !isAdoptingStoredAPIKey else { return }
+            KeychainHelper.save(key: apiKeyKeychainKey, value: openAIAPIKey)
+        }
+    }
+
+    /// Apply a provider preset: fills the base URL + model fields only when
+    /// they are empty or still carry the *previous* preset's default, so a
+    /// user's custom value survives a preset change. The provider itself is
+    /// always updated (and persisted via `openAIProvider.didSet`).
+    func applyPreset(_ newPreset: OpenAIProvider) {
+        let previous = openAIProvider
+        openAIProvider = newPreset
+        if openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || openAIBaseURL == previous.baseURL {
+            openAIBaseURL = newPreset.baseURL
+        }
+        if openAIModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || openAIModelName == previous.defaultModelName {
+            openAIModelName = newPreset.defaultModelName
+        }
+    }
+
     /// Convenience the UI uses to decide whether to surface the rename /
-    /// run-action buttons at all.
-    var isConfigured: Bool { tool != .none }
+    /// run-action buttons at all. "Enabled AND ready": the OpenAI tool needs a
+    /// non-blank base URL; the CLI tools are ready as soon as they're selected
+    /// (per `.claude/rules/feature-gates.md`).
+    var isConfigured: Bool {
+        switch tool {
+        case .none:             return false
+        case .openaiCompatible:
+            return !openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        default:                return true
+        }
+    }
+
+    /// True iff the OpenAI-compatible endpoint is the active tool. Drives the
+    /// Settings UI's CLI-vs-HTTP field swap (AC-UI-01/02): CLI-only fields
+    /// (executable path, extra args) render only when this is false.
+    var isOpenAICompatible: Bool { tool == .openaiCompatible }
+
+    /// Label for the timeout row. Drops the "CLI" qualifier for the OpenAI
+    /// path, where the timeout bounds an HTTP request, not a process
+    /// (AC-UI-04).
+    var timeoutLabel: String { isOpenAICompatible ? "Timeout" : "CLI timeout" }
+
+    /// True when Live AI must NOT run for this tool (Phase 9, Option C).
+    /// Remote OpenAI-compatible endpoints re-bill the full transcript every
+    /// stateless tick with no prompt-cache discount, so Live AI is gated to
+    /// *local* endpoints only (localhost / loopback / `.local`). Local ones
+    /// are free and run the existing stateless `kick()` branch. Reuses the
+    /// Phase 8 `OpenAILocality.isLocal` host helper (same one the privacy
+    /// disclaimer uses) rather than duplicating the classification.
+    var liveAIDisabledByRemoteOpenAI: Bool {
+        guard tool == .openaiCompatible else { return false }
+        return !OpenAILocality.isLocal(baseURL: openAIBaseURL)
+    }
 
     // MARK: - Test / diagnostics
     //
@@ -226,16 +387,26 @@ final class LLMSettings: ObservableObject {
         isTesting = true
         lastTestResult = nil
         defer { isTesting = false }
+        // Only the OpenAI path needs a model from settings (the CLIs pick their
+        // own); passing `openAIModelName` here lets the test panel exercise the
+        // exact endpoint+model the user configured without an executable path.
+        let model: String? = (tool == .openaiCompatible)
+            ? (openAIModelName.isEmpty ? nil : openAIModelName)
+            : nil
         let result = await LLMRunner.diagnose(
             tool: tool,
             prompt: testPrompt,
             transcript: testTranscript,
             extraArgs: extraArgsTokens,
             executablePathOverride: executablePath.isEmpty ? nil : executablePath,
+            model: model,
             // Use the same timeout real runs use so the test faithfully
             // reproduces production behaviour — including letting the user
             // confirm that raising the timeout fixes a slow agentic run.
-            timeout: cliTimeout)
+            timeout: cliTimeout,
+            openAIBaseURL: openAIBaseURL,
+            openAIAPIKey: openAIAPIKey,
+            jsonMode: false)
         lastTestResult = result
     }
 
@@ -253,9 +424,19 @@ final class LLMSettings: ObservableObject {
         """
 
     private let defaults: UserDefaults
+    /// Keychain item the OpenAI API key is stored under. Injectable so tests
+    /// never read/clobber the real app's item — mirrors
+    /// `RemoteTranscriptionSettings.apiKeyKeychainKey`. Net-new param with a
+    /// production-safe default (existing `MilaApp.init()` call site is
+    /// unchanged).
+    private let apiKeyKeychainKey: String
+    private var hasLoadedOpenAIAPIKey = false
+    private var isAdoptingStoredAPIKey = false
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = .standard,
+         apiKeyKeychainKey: String = Keys.openAIAPIKey) {
         self.defaults = defaults
+        self.apiKeyKeychainKey = apiKeyKeychainKey
         let rawTool = defaults.string(forKey: Keys.tool) ?? LLMTool.none.rawValue
         self.tool = LLMTool(rawValue: rawTool) ?? .none
         self.executablePath = defaults.string(forKey: Keys.executablePath) ?? ""
@@ -269,6 +450,33 @@ final class LLMSettings: ObservableObject {
         self.summaryEnabled = (defaults.object(forKey: Keys.summaryEnabled) as? Bool) ?? true
         self.cliTimeout = (defaults.object(forKey: Keys.cliTimeout) as? Double) ?? 300
         self.extraArgs = defaults.string(forKey: Keys.extraArgs) ?? ""
+
+        self.openAIProvider = OpenAIProvider(rawValue:
+            defaults.string(forKey: Keys.openAIProvider) ?? "") ?? .custom
+        self.openAIBaseURL = defaults.string(forKey: Keys.openAIBaseURL) ?? ""
+        self.openAIModelName = defaults.string(forKey: Keys.openAIModelName) ?? ""
+        // Start empty; defer the Keychain read until OpenAI is the active tool
+        // (here if it's the restored choice, otherwise lazily in `tool.didSet`).
+        self.openAIAPIKey = ""
+        if tool == .openaiCompatible { loadOpenAIAPIKeyIfNeeded() }
+    }
+
+    /// Lazily read the OpenAI API key from the Keychain the first time the
+    /// OpenAI tool becomes active. Idempotent (guarded by
+    /// `hasLoadedOpenAIAPIKey`) and non-destructive: an in-progress user edit
+    /// is kept rather than overwritten by the stored value.
+    private func loadOpenAIAPIKeyIfNeeded() {
+        guard !hasLoadedOpenAIAPIKey else { return }
+        hasLoadedOpenAIAPIKey = true
+        guard openAIAPIKey.isEmpty else { return }
+        guard let stored = KeychainHelper.load(key: apiKeyKeychainKey),
+              !stored.isEmpty else { return }
+        // Suppress the `apiKey.didSet` write-through for this one assignment
+        // so adopting the stored value doesn't re-save it (a redundant Keychain
+        // write that could itself prompt).
+        isAdoptingStoredAPIKey = true
+        openAIAPIKey = stored
+        isAdoptingStoredAPIKey = false
     }
 
     /// Default name prompt is deliberately *tool-free*. The previous default
@@ -304,5 +512,9 @@ final class LLMSettings: ObservableObject {
         static let summaryEnabled = "llm.summary.enabled"
         static let cliTimeout = "llm.cli.timeout"
         static let extraArgs = "llm.extraArgs"
+        static let openAIProvider = "llm.openai.provider"
+        static let openAIBaseURL = "llm.openai.baseURL"
+        static let openAIModelName = "llm.openai.modelName"
+        static let openAIAPIKey = "llm.openai.apiKey"   // Keychain item, not UserDefaults
     }
 }

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -294,8 +294,16 @@ final class LLMSettings: ObservableObject {
     /// they are empty or still carry the *previous* preset's default, so a
     /// user's custom value survives a preset change. The provider itself is
     /// always updated (and persisted via `openAIProvider.didSet`).
-    func applyPreset(_ newPreset: OpenAIProvider) {
-        let previous = openAIProvider
+    ///
+    /// `previous` MUST be the provider value *before* this change. In the
+    /// Settings UI the `Picker` binding updates `openAIProvider` to the new
+    /// preset **before** `.onChange` fires, so `openAIProvider` is already
+    /// the new value by the time this runs — re-reading it here would
+    /// compare against the *new* preset and never overwrite the field, so
+    /// switching OpenAI→Groq would leave the endpoint pointed at OpenAI.
+    /// The Picker's `.onChange(old, new)` passes the real previous value
+    /// explicitly (issue celarent7/mila#2).
+    func applyPreset(_ newPreset: OpenAIProvider, previous: OpenAIProvider) {
         openAIProvider = newPreset
         if openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || openAIBaseURL == previous.baseURL {

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -499,6 +499,14 @@ TRANSCRIPT SO FAR:
         // cross-recording bleed bug (the session wasn't freshly started); a
         // healthy recording always opens with `.new`.
         liveAILog.log("tick \(kickTag, privacy: .public): session=\(String(describing: llmSession), privacy: .public) established=\(self.sessionEstablished, privacy: .public)")
+        // Capture the OpenAI endpoint config up front (kick-time snapshot).
+        // The Task below captures `[weak self]`, so touching `self.llmSettings`
+        // inside it would either require `self?.` (and read mid-flight state) or
+        // — as the bare access did — implicitly strong-capture self, defeating
+        // the weak capture (a Swift 6 error). Snapshotting here mirrors the
+        // `perform`/`kickSessionID` captures above. (CodeRabbit #1.)
+        let openAIBaseURL = llmSettings.openAIBaseURL
+        let openAIAPIKey = llmSettings.openAIAPIKey
         inFlight = Task { @MainActor [weak self] in
             let llmStart = Date()
             do {
@@ -514,8 +522,8 @@ TRANSCRIPT SO FAR:
                     // local OpenAI Live AI ticks hit `/chat/completions` with
                     // JSON mode + a low temperature for envelope reliability.
                     // Remote endpoints never reach here (gated above).
-                    openAIBaseURL: (tool == .openaiCompatible) ? llmSettings.openAIBaseURL : nil,
-                    openAIAPIKey: (tool == .openaiCompatible) ? llmSettings.openAIAPIKey : nil,
+                    openAIBaseURL: (tool == .openaiCompatible) ? openAIBaseURL : nil,
+                    openAIAPIKey: (tool == .openaiCompatible) ? openAIAPIKey : nil,
                     jsonMode: tool == .openaiCompatible,
                     temperature: tool == .openaiCompatible ? 0.2 : nil
                 ))

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -68,6 +68,14 @@ final class LiveAISession: ObservableObject {
         let model: String
         let session: LLMSession
         let timeout: TimeInterval
+        // OpenAI-compatible endpoint config (Phase 6.0.2). Populated from
+        // `llmSettings` by `kick()` (Phase 9 wires Live AI's local/remote
+        // split); defaulted so existing call sites compile unchanged.
+        var openAIBaseURL: String? = nil
+        var openAIAPIKey: String? = nil
+        var jsonMode: Bool = false
+        var temperature: Double? = nil
+        var transport: OpenAITransport? = nil
     }
     var performCall: (LLMCall) async throws -> String = { call in
         try await LLMRunner.run(
@@ -77,7 +85,12 @@ final class LiveAISession: ObservableObject {
             executablePathOverride: call.executablePathOverride,
             model: call.model,
             session: call.session,
-            timeout: call.timeout
+            timeout: call.timeout,
+            openAIBaseURL: call.openAIBaseURL,
+            openAIAPIKey: call.openAIAPIKey,
+            jsonMode: call.jsonMode,
+            temperature: call.temperature,
+            transport: call.transport
         )
     }
 
@@ -282,6 +295,18 @@ final class LiveAISession: ObservableObject {
     /// elapses, or fold into the running call.
     private func scheduleKick(immediate: Bool = false) {
         guard llmSettings.isConfigured, !latestTranscript.isEmpty else { return }
+        // Phase 9 (Option C): a remote OpenAI-compatible endpoint must never
+        // run the Live AI loop (full-transcript re-bill each tick, no
+        // prompt-cache discount). Defense in depth alongside the `aiActive`
+        // gates in `LiveAIRecordingView` / `MilaApp` — drop any deferred tick
+        // too, so a pendingKickTask sleeping out the min-interval floor can't
+        // wake into a stray remote call.
+        guard !llmSettings.liveAIDisabledByRemoteOpenAI else {
+            pendingKickTask?.cancel()
+            pendingKickTask = nil
+            coalesced = false
+            return
+        }
         // Live AI toggled off mid-recording: don't fire, and drop any
         // deferred tick. The feed loop stops calling feed() on toggle-off,
         // but a pendingKickTask already sleeping out the min-interval floor
@@ -324,6 +349,7 @@ final class LiveAISession: ObservableObject {
 
     private func kick() {
         guard llmSettings.isConfigured else { return }
+        guard !llmSettings.liveAIDisabledByRemoteOpenAI else { return }
         guard !latestTranscript.isEmpty else { return }
         let snapshot = latestTranscript
         let tool = llmSettings.tool
@@ -380,7 +406,11 @@ final class LiveAISession: ObservableObject {
             liveAISettings.prompt
                 .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName),
             context: context)
-        let model = liveAISettings.model
+        // OpenAI-compatible ticks use the endpoint's model name from
+        // `LLMSettings.openAIModelName`; CLI ticks use Live AI's model override.
+        let model = (tool == .openaiCompatible)
+            ? llmSettings.openAIModelName
+            : liveAISettings.model
         let useSession = (sessionID != nil)
         // Cold-start the first tick gets a longer timeout (see
         // `firstCallTimeoutSeconds`). All subsequent ticks use the
@@ -479,7 +509,15 @@ TRANSCRIPT SO FAR:
                     executablePathOverride: exe,
                     model: model,
                     session: llmSession,
-                    timeout: timeout
+                    timeout: timeout,
+                    // Phase 9: thread the OpenAI-compatible endpoint config so
+                    // local OpenAI Live AI ticks hit `/chat/completions` with
+                    // JSON mode + a low temperature for envelope reliability.
+                    // Remote endpoints never reach here (gated above).
+                    openAIBaseURL: (tool == .openaiCompatible) ? llmSettings.openAIBaseURL : nil,
+                    openAIAPIKey: (tool == .openaiCompatible) ? llmSettings.openAIAPIKey : nil,
+                    jsonMode: tool == .openaiCompatible,
+                    temperature: tool == .openaiCompatible ? 0.2 : nil
                 ))
                 let elapsed = Date().timeIntervalSince(llmStart)
                 let parsed = Self.parseEnvelope(from: raw)

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// Typed errors surfaced by `OpenAIClient.parse` (HTTP-status-driven) and
+/// mapped from transport failures by `runOpenAICompatible`. Conforms to
+/// `LocalizedError` so the Settings sheet can render `errorDescription`
+/// directly. (Top-level so callers — including tests — reference it
+/// unqualified, matching the plan's flat layout.)
+enum OpenAIRequestError: LocalizedError, Equatable {
+    case auth(String)
+    case notFound(String)
+    case server(status: Int, message: String)
+    case emptyOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .auth(let m):
+            return "Authentication failed (401). \(m)"
+        case .notFound(let m):
+            return "Model or endpoint not found (404). \(m)"
+        case .server(let status, let m):
+            return "Server returned HTTP \(status). \(m)"
+        case .emptyOutput:
+            return "The model returned no content."
+        }
+    }
+}
+
+/// Host-locality classification for an OpenAI-compatible base URL, used by
+/// the Settings UI to decide whether to show the "your transcript is sent to
+/// a remote server" privacy disclaimer (AC-UI-03). `localhost`, the loopback
+/// addresses, and Bonjour `.local` hosts count as local — everything else is
+/// remote. Unparseable input is treated as remote (non-local) so the disclaimer
+/// errs toward showing.
+enum OpenAILocality {
+    static func isLocal(baseURL: String) -> Bool {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let comps = URLComponents(string: trimmed),
+              let rawHost = comps.host?.lowercased(),
+              !rawHost.isEmpty
+        else { return false }
+        // URLComponents may return an IPv6 host bracketed ("[::1]"); strip them
+        // so the loopback comparison matches.
+        let host = rawHost
+            .replacingOccurrences(of: "[", with: "")
+            .replacingOccurrences(of: "]", with: "")
+        if host == "localhost" || host == "127.0.0.1"
+            || host == "0.0.0.0" || host == "::1" {
+            return true
+        }
+        // Bonjour / mDNS local hosts, e.g. "myllama.local".
+        if host.hasSuffix(".local") { return true }
+        return false
+    }
+}
+
+/// Performs the actual HTTP send for an OpenAI-compatible request.
+///
+/// Injected (rather than `URLSession`-inlined) so `LLMRunner.run`'s
+/// `.openaiCompatible` branch is unit-testable without a network: production
+/// wires `URLSessionTransport(URLSession.shared)`, tests wire a stub that
+/// records the `URLRequest` and returns a canned response. `Sendable` so the
+/// transport can cross the async boundary from the static, non-isolated
+/// `LLMRunner`. Only `transport` is caller-transparent — `baseURL`/`apiKey`/
+/// `jsonMode` are threaded explicitly at every call site (see the plan's
+/// Phase 6.0).
+protocol OpenAITransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data)
+}
+
+/// Production `OpenAITransport`: a thin `URLSession` wrapper. `URLSession.data`
+/// throws `URLError.cancelled` when the driving Task is cancelled and
+/// `URLError.timedOut` when the request exceeds its timeout — both mapped by
+/// `LLMRunner.runOpenAICompatible`.
+struct URLSessionTransport: OpenAITransport {
+    let session: URLSession
+    init(_ session: URLSession) { self.session = session }
+
+    func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        return (http, data)
+    }
+}
+
+/// Pure, testable OpenAI-compatible `/v1/chat/completions` client.
+///
+/// Split into three layers so the bulk of behaviour is covered without a
+/// network: `makeRequest` builds a `URLRequest` (pure), `parse` decodes a
+/// `(Data, HTTPURLResponse)` into content or a typed error (pure), and an
+/// injectable `OpenAITransport` performs the actual send. `LLMRunner.run` /
+/// `diagnose` compose the three layers; the transport defaults to a real
+/// `URLSession` in production and to a test stub in tests.
+///
+/// Only `transport` is caller-transparent — `baseURL`/`apiKey`/`jsonMode` are
+/// threaded explicitly at every `LLMRunner.run`/`diagnose` call site (see the
+/// implementation plan's Phase 6.0).
+enum OpenAIClient {
+
+    // MARK: - Wire types
+
+    struct OpenAIChatMessage: Codable {
+        let role: String
+        let content: String
+    }
+
+    struct OpenAIResponseFormat: Codable {
+        let type: String
+    }
+
+    struct OpenAIChatRequest: Codable {
+        let model: String
+        let messages: [OpenAIChatMessage]
+        let temperature: Double?
+        let response_format: OpenAIResponseFormat?
+        let max_tokens: Int?
+        let stream: Bool
+    }
+
+    struct OpenAIChatResponse: Codable {
+        struct Choice: Codable { let message: OpenAIChatMessage }
+        let choices: [Choice]
+    }
+
+    struct OpenAIErrorResponse: Codable {
+        struct ErrorBody: Codable {
+            let message: String
+            let type: String?
+            let code: String?
+        }
+        let error: ErrorBody?
+    }
+
+    // MARK: - Request builder (pure)
+
+    /// Build the `/chat/completions` `URLRequest` for a single composed
+    /// `user` message. `baseURL` is trimmed of trailing slashes and joined
+    /// with `chat/completions`; `Authorization` is set iff `apiKey` is
+    /// non-empty; `response_format` is included iff `jsonMode`; `stream` is
+    /// always `false`. `temperature` is included iff non-nil.
+    static func makeRequest(baseURL: String,
+                            model: String,
+                            prompt: String,
+                            transcript: String,
+                            summary: String,
+                            apiKey: String,
+                            jsonMode: Bool,
+                            temperature: Double?) -> URLRequest {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let url = URL(string: "\(trimmedBase)/chat/completions")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body = OpenAIChatRequest(
+            model: model.trimmingCharacters(in: .whitespacesAndNewlines),
+            messages: [OpenAIChatMessage(
+                role: "user",
+                content: LLMRunner.composedPrompt(prompt, transcript: transcript, summary: summary)
+            )],
+            temperature: temperature,
+            response_format: jsonMode ? OpenAIResponseFormat(type: "json_object") : nil,
+            max_tokens: nil,
+            stream: false
+        )
+        request.httpBody = try? JSONEncoder().encode(body)
+        return request
+    }
+
+    // MARK: - Response / error parser (pure)
+
+    /// Decode an OpenAI-compatible response body into the trimmed first-choice
+    /// content, or a typed `OpenAIRequestError`. Pure: takes the data + HTTP
+    /// status, performs no network. Transport-level failures (`URLError`) are
+    /// not seen here — they are mapped in `runOpenAICompatible`.
+    static func parse(data: Data, response: HTTPURLResponse) -> Result<String, Error> {
+        let status = response.statusCode
+        if (200..<300).contains(status) {
+            if let parsed = try? JSONDecoder().decode(OpenAIChatResponse.self, from: data) {
+                if let content = parsed.choices.first?.message.content
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !content.isEmpty {
+                    return .success(content)
+                }
+                return .failure(OpenAIRequestError.emptyOutput)
+            }
+            // 2xx but unparseable body — treat as no usable content.
+            return .failure(OpenAIRequestError.emptyOutput)
+        }
+
+        // 4xx / 5xx: pull a message out of an OpenAI-style error body, with a
+        // status-only fallback when the body is missing or undecodable.
+        var serverMessage = "HTTP \(status)"
+        if let body = try? JSONDecoder().decode(OpenAIErrorResponse.self, from: data),
+           let msg = body.error?.message, !msg.isEmpty {
+            serverMessage = msg
+        }
+
+        switch status {
+        case 401, 403:
+            return .failure(OpenAIRequestError.auth(serverMessage))
+        case 404:
+            // A 404 with model-not-found wording is a distinct, common case.
+            if serverMessage.lowercased().contains("model") {
+                return .failure(OpenAIRequestError.notFound(serverMessage))
+            }
+            return .failure(OpenAIRequestError.server(status: status, message: serverMessage))
+        default:
+            return .failure(OpenAIRequestError.server(status: status, message: serverMessage))
+        }
+    }
+}

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -150,9 +150,12 @@ enum OpenAIClient {
     /// always `false`. `temperature` is included iff non-nil.
     ///
     /// Throws `OpenAIRequestError.invalidEndpoint` if the trimmed base URL
-    /// can't be parsed into a URL (e.g. it contains a space). `baseURL` is
-    /// free-text user input — the builder must not assume it's well-formed
-    /// (issue celarent7/mila#1).
+    /// can't be parsed into an *absolute* `http`/`https` URL with a host —
+    /// e.g. it contains a space (`URL(string:)` returns nil), omits the scheme
+    /// (`api.openai.com/v1` parses as a relative path with no host and would
+    /// fail deep inside `URLSession` with an opaque "unsupported URL"), or uses
+    /// a scheme `URLSession` can't POST to. `baseURL` is free-text user input —
+    /// the builder must not assume it's well-formed (issue celarent7/mila#1).
     static func makeRequest(baseURL: String,
                             model: String,
                             prompt: String,
@@ -163,7 +166,11 @@ enum OpenAIClient {
                             temperature: Double?) throws -> URLRequest {
         let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard let url = URL(string: "\(trimmedBase)/chat/completions") else {
+        guard let url = URL(string: "\(trimmedBase)/chat/completions"),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host, !host.isEmpty
+        else {
             throw OpenAIRequestError.invalidEndpoint(trimmedBase)
         }
         var request = URLRequest(url: url)
@@ -185,7 +192,10 @@ enum OpenAIClient {
             max_tokens: nil,
             stream: false
         )
-        request.httpBody = try? JSONEncoder().encode(body)
+        // `try`, not `try?`: silently dropping the body would POST an empty
+        // request that the endpoint rejects with an unhelpful 400. The function
+        // already throws, so let the encoding error surface.
+        request.httpBody = try JSONEncoder().encode(body)
         return request
     }
 

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -10,6 +10,12 @@ enum OpenAIRequestError: LocalizedError, Equatable {
     case notFound(String)
     case server(status: Int, message: String)
     case emptyOutput
+    /// The configured base URL couldn't be turned into a valid request URL
+    /// (e.g. it contains a space or other character `URL(string:)` rejects).
+    /// Raised by `OpenAIClient.makeRequest` instead of force-unwrapping — a
+    /// malformed base URL is user input and must surface as a readable error,
+    /// not crash the app (issue celarent7/mila#1).
+    case invalidEndpoint(String)
 
     var errorDescription: String? {
         switch self {
@@ -21,6 +27,8 @@ enum OpenAIRequestError: LocalizedError, Equatable {
             return "Server returned HTTP \(status). \(m)"
         case .emptyOutput:
             return "The model returned no content."
+        case .invalidEndpoint(let baseURL):
+            return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → LLM (it must look like https://api.openai.com/v1)."
         }
     }
 }
@@ -140,6 +148,11 @@ enum OpenAIClient {
     /// with `chat/completions`; `Authorization` is set iff `apiKey` is
     /// non-empty; `response_format` is included iff `jsonMode`; `stream` is
     /// always `false`. `temperature` is included iff non-nil.
+    ///
+    /// Throws `OpenAIRequestError.invalidEndpoint` if the trimmed base URL
+    /// can't be parsed into a URL (e.g. it contains a space). `baseURL` is
+    /// free-text user input — the builder must not assume it's well-formed
+    /// (issue celarent7/mila#1).
     static func makeRequest(baseURL: String,
                             model: String,
                             prompt: String,
@@ -147,10 +160,12 @@ enum OpenAIClient {
                             summary: String,
                             apiKey: String,
                             jsonMode: Bool,
-                            temperature: Double?) -> URLRequest {
+                            temperature: Double?) throws -> URLRequest {
         let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let url = URL(string: "\(trimmedBase)/chat/completions")!
+        guard let url = URL(string: "\(trimmedBase)/chat/completions") else {
+            throw OpenAIRequestError.invalidEndpoint(trimmedBase)
+        }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -33,8 +33,10 @@ final class PostRecordingCoordinator: ObservableObject {
     /// Injectable LLM-run seam so tests can assert what `PostRecordingCoordinator`
     /// sends to `LLMRunner` (e.g. that the OpenAI path threads `openAIModelName`
     /// — issue celarent7/mila#3) without spawning a CLI or hitting the network.
-    /// Mirrors `RecordingSummarizer.RunLLM`. Defaults to `LLMRunner.run`.
-    typealias RunLLM = (
+    /// Mirrors `RecordingSummarizer.RunLLM`, including its `@MainActor` isolation,
+    /// so test stubs that capture/mutate main-actor variables stay data-race-clean
+    /// under Swift 6 strict concurrency (CodeRabbit #7). Defaults to `LLMRunner.run`.
+    typealias RunLLM = @MainActor (
         _ tool: LLMTool,
         _ prompt: String,
         _ transcript: String,
@@ -298,6 +300,14 @@ final class PostRecordingCoordinator: ObservableObject {
         postStatus("Sending to \(toolName)…")
 
         let timeout = transcriptWaitTimeout
+        // Capture the OpenAI endpoint config at click time. The Task below may
+        // wait on `awaitTranscript` (potentially long) before reading endpoint
+        // values; reading `self.llm` inside it would pair a mid-flight Settings
+        // edit with the click-time `tool`/`prompt`. Snapshot up front instead —
+        // mirrors `armAutoSuggestTitle` (CodeRabbit #8, issue celarent7/mila#8).
+        let openAIBaseURL = llm.openAIBaseURL
+        let openAIAPIKey = llm.openAIAPIKey
+        let openAIModelName = llm.openAIModelName
         let task = Task { @MainActor [weak self] in
             defer {
                 // Only relinquish the slot if we finished on our own. If we
@@ -326,7 +336,8 @@ final class PostRecordingCoordinator: ObservableObject {
             do {
                 // OpenAI-compatible runs need the model name threaded (the
                 // HTTP path can't pick its own). Issue celarent7/mila#3.
-                let openAIModelName = self.llm.openAIModelName
+                // `openAIModelName`/`openAIBaseURL`/`openAIAPIKey` are the
+                // click-time captures from above (#8).
                 let openAIModel: String? = (tool == .openaiCompatible && !openAIModelName.isEmpty)
                     ? openAIModelName : nil
                 let output = try await runLLM(
@@ -338,8 +349,8 @@ final class PostRecordingCoordinator: ObservableObject {
                     openAIModel,
                     extraArgs,
                     cliTimeout,
-                    self.llm.openAIBaseURL,
-                    self.llm.openAIAPIKey,
+                    openAIBaseURL,
+                    openAIAPIKey,
                     false,
                     nil)
                 let preview = output

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -110,6 +110,8 @@ final class PostRecordingCoordinator: ObservableObject {
         let prompt = llm.namePrompt
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let cliTimeout = llm.cliTimeout
+        let openAIBaseURL = llm.openAIBaseURL
+        let openAIAPIKey = llm.openAIAPIKey
         let waitTimeout = transcriptWaitTimeout
         autoSuggestingIDs.insert(id)
         let task = Task { @MainActor [weak self] in
@@ -133,7 +135,10 @@ final class PostRecordingCoordinator: ObservableObject {
                     prompt: prompt,
                     transcript: transcript,
                     executablePathOverride: executableOverride,
-                    timeout: cliTimeout
+                    timeout: cliTimeout,
+                    openAIBaseURL: openAIBaseURL,
+                    openAIAPIKey: openAIAPIKey,
+                    jsonMode: false
                 )
                 if Task.isCancelled { return }
                 let title = Self.cleanedTitle(from: suggestion)
@@ -279,7 +284,10 @@ final class PostRecordingCoordinator: ObservableObject {
                     summary: summary,
                     executablePathOverride: executableOverride,
                     extraArgs: extraArgs,
-                    timeout: cliTimeout
+                    timeout: cliTimeout,
+                    openAIBaseURL: self.llm.openAIBaseURL,
+                    openAIAPIKey: self.llm.openAIAPIKey,
+                    jsonMode: false
                 )
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -30,6 +30,26 @@ final class PostRecordingCoordinator: ObservableObject {
     private let transcription: TranscriptionService
     private let llm: LLMSettings
 
+    /// Injectable LLM-run seam so tests can assert what `PostRecordingCoordinator`
+    /// sends to `LLMRunner` (e.g. that the OpenAI path threads `openAIModelName`
+    /// — issue celarent7/mila#3) without spawning a CLI or hitting the network.
+    /// Mirrors `RecordingSummarizer.RunLLM`. Defaults to `LLMRunner.run`.
+    typealias RunLLM = (
+        _ tool: LLMTool,
+        _ prompt: String,
+        _ transcript: String,
+        _ summary: String,
+        _ executablePathOverride: String?,
+        _ model: String?,
+        _ extraArgs: [String],
+        _ timeout: TimeInterval,
+        _ openAIBaseURL: String?,
+        _ openAIAPIKey: String?,
+        _ jsonMode: Bool,
+        _ transport: OpenAITransport?
+    ) async throws -> String
+    private let runLLM: RunLLM
+
     /// LLM work spawned from inside the rename sheet (manual Suggest) plus
     /// the background auto-suggest job. Tracked here — not in the sheet's view
     /// state — so the Cancel button can kill it even after the sheet is
@@ -60,10 +80,26 @@ final class PostRecordingCoordinator: ObservableObject {
 
     init(store: RecordingStore,
          transcription: TranscriptionService,
-         llm: LLMSettings) {
+         llm: LLMSettings,
+         runLLM: @escaping RunLLM = { tool, prompt, transcript, summary, executablePathOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport in
+        try await LLMRunner.run(
+            tool: tool,
+            prompt: prompt,
+            transcript: transcript,
+            summary: summary,
+            executablePathOverride: executablePathOverride,
+            model: model,
+            extraArgs: extraArgs,
+            timeout: timeout,
+            openAIBaseURL: openAIBaseURL,
+            openAIAPIKey: openAIAPIKey,
+            jsonMode: jsonMode,
+            transport: transport)
+    }) {
         self.store = store
         self.transcription = transcription
         self.llm = llm
+        self.runLLM = runLLM
     }
 
     /// Open the rename sheet for a freshly-added recording. Called by
@@ -112,6 +148,14 @@ final class PostRecordingCoordinator: ObservableObject {
         let cliTimeout = llm.cliTimeout
         let openAIBaseURL = llm.openAIBaseURL
         let openAIAPIKey = llm.openAIAPIKey
+        // OpenAI-compatible runs need the model name threaded explicitly
+        // (the CLIs pick their own; the HTTP path can't). Captured up front
+        // like the other OpenAI fields so the detached call doesn't touch
+        // `self.llm` (issue celarent7/mila#3 — otherwise the request POSTs
+        // an empty model name and the suggestion fails silently).
+        let openAIModelName = llm.openAIModelName
+        let openAIModel: String? = (tool == .openaiCompatible && !openAIModelName.isEmpty)
+            ? openAIModelName : nil
         let waitTimeout = transcriptWaitTimeout
         autoSuggestingIDs.insert(id)
         let task = Task { @MainActor [weak self] in
@@ -130,16 +174,19 @@ final class PostRecordingCoordinator: ObservableObject {
             }
             if Task.isCancelled { return }
             do {
-                let suggestion = try await LLMRunner.run(
-                    tool: tool,
-                    prompt: prompt,
-                    transcript: transcript,
-                    executablePathOverride: executableOverride,
-                    timeout: cliTimeout,
-                    openAIBaseURL: openAIBaseURL,
-                    openAIAPIKey: openAIAPIKey,
-                    jsonMode: false
-                )
+                let suggestion = try await runLLM(
+                    tool,
+                    prompt,
+                    transcript,
+                    "",                       // summary — title path has none
+                    executableOverride,
+                    openAIModel,
+                    [],                       // extraArgs — title path has none
+                    cliTimeout,
+                    openAIBaseURL,
+                    openAIAPIKey,
+                    false,
+                    nil)
                 if Task.isCancelled { return }
                 let title = Self.cleanedTitle(from: suggestion)
                 guard !title.isEmpty else { return }
@@ -277,18 +324,24 @@ final class PostRecordingCoordinator: ObservableObject {
             }
             if Task.isCancelled { return }
             do {
-                let output = try await LLMRunner.run(
-                    tool: tool,
-                    prompt: prompt,
-                    transcript: resolved,
-                    summary: summary,
-                    executablePathOverride: executableOverride,
-                    extraArgs: extraArgs,
-                    timeout: cliTimeout,
-                    openAIBaseURL: self.llm.openAIBaseURL,
-                    openAIAPIKey: self.llm.openAIAPIKey,
-                    jsonMode: false
-                )
+                // OpenAI-compatible runs need the model name threaded (the
+                // HTTP path can't pick its own). Issue celarent7/mila#3.
+                let openAIModelName = self.llm.openAIModelName
+                let openAIModel: String? = (tool == .openaiCompatible && !openAIModelName.isEmpty)
+                    ? openAIModelName : nil
+                let output = try await runLLM(
+                    tool,
+                    prompt,
+                    resolved,
+                    summary,
+                    executableOverride,
+                    openAIModel,
+                    extraArgs,
+                    cliTimeout,
+                    self.llm.openAIBaseURL,
+                    self.llm.openAIAPIKey,
+                    false,
+                    nil)
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")
                     .prefix(80)

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -52,7 +52,11 @@ final class RecordingSummarizer: ObservableObject {
         _ executablePathOverride: String?,
         _ model: String?,
         _ extraArgs: [String],
-        _ timeout: TimeInterval
+        _ timeout: TimeInterval,
+        _ openAIBaseURL: String?,
+        _ openAIAPIKey: String?,
+        _ jsonMode: Bool,
+        _ transport: OpenAITransport?
     ) async throws -> String
 
     private let runLLM: RunLLM
@@ -96,7 +100,7 @@ final class RecordingSummarizer: ObservableObject {
     init(store: RecordingStore,
          llmSettings: LLMSettings,
          liveAISettings: LiveAISettings,
-         runLLM: @escaping RunLLM = { tool, prompt, transcript, executableOverride, model, extraArgs, timeout in
+         runLLM: @escaping RunLLM = { tool, prompt, transcript, executableOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport in
              try await LLMRunner.run(
                  tool: tool,
                  prompt: prompt,
@@ -104,7 +108,11 @@ final class RecordingSummarizer: ObservableObject {
                  executablePathOverride: executableOverride,
                  model: model,
                  extraArgs: extraArgs,
-                 timeout: timeout
+                 timeout: timeout,
+                 openAIBaseURL: openAIBaseURL,
+                 openAIAPIKey: openAIAPIKey,
+                 jsonMode: jsonMode,
+                 transport: transport
              )
          }) {
         self.store = store
@@ -330,6 +338,12 @@ final class RecordingSummarizer: ObservableObject {
             .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName)
         let transcript = recording.fullText
         let timeout = timeoutSeconds
+        // OpenAI-compatible config captured up front so the detached call
+        // doesn't depend on `self` (mirrors tool/prompt/etc. above). Summary
+        // is free-text, so `jsonMode` is false; `transport` stays nil so the
+        // production `URLSession` default applies.
+        let openAIBaseURL = llmSettings.openAIBaseURL
+        let openAIAPIKey = llmSettings.openAIAPIKey
         let startedAt = Date()
         // Captured strongly: the runner closure holds no reference to
         // `self`, so this can't create a retain cycle, and capturing it
@@ -366,7 +380,11 @@ final class RecordingSummarizer: ObservableObject {
                     executableOverride,
                     model.isEmpty ? nil : model,
                     extraArgs,
-                    timeout
+                    timeout,
+                    openAIBaseURL,
+                    openAIAPIKey,
+                    false,
+                    nil
                 )
                 let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !cleaned.isEmpty else {

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -322,7 +322,15 @@ final class RecordingSummarizer: ObservableObject {
         let executableOverride = llmSettings.executablePath.isEmpty
             ? nil
             : llmSettings.executablePath
-        let model = liveAISettings.model
+        // OpenAI-compatible runs use the endpoint's model name from
+        // `llmSettings.openAIModelName`; CLI runs use Live AI's model
+        // override. Mirrors `LiveAISession.kick`'s tool-conditional selection
+        // (issue celarent7/mila#4 — previously this always sent
+        // `liveAISettings.model`, e.g. "claude-sonnet-4-6", to the OpenAI
+        // endpoint, which 404'd on model-not-found).
+        let model = (tool == .openaiCompatible)
+            ? llmSettings.openAIModelName
+            : liveAISettings.model
         let extraArgs = llmSettings.extraArgsTokens
         let promptLanguageName: String = {
             switch liveAISettings.outputLanguage {

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1227,6 +1227,7 @@ struct MilaApp: App {
                         // flipped off → ticks stop; the LLM session
                         // preserves whatever it has produced so far.
                         let aiActive = aiSettings.enabled && llmSettingsRef.isConfigured
+                            && !llmSettingsRef.liveAIDisabledByRemoteOpenAI
                         // Speaker labels are a transcription feature,
                         // not an LLM feature — apply them whenever the
                         // diarizer has produced intervals, regardless

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -57,7 +57,10 @@ struct LiveAIRecordingView: View {
     /// transcript pane + friendly speaker labels.
     private var language: String { languageSettings.current.rawValue }
     private var isRTL: Bool { language == "he" }
-    private var aiActive: Bool { liveAISettings.enabled && llmSettings.isConfigured }
+    private var aiActive: Bool {
+        liveAISettings.enabled && llmSettings.isConfigured
+            && !llmSettings.liveAIDisabledByRemoteOpenAI
+    }
 
     /// RTL for the AI pane (summary + action items). The AI output is its
     /// own language setting; for `.auto` we detect from the actual emitted

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -489,7 +489,13 @@ struct RenameRecordingSheet: View {
                 prompt: llm.namePrompt,
                 transcript: transcript,
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
-                model: llm.openAIModelName,
+                // Only the HTTP path needs a model from settings — the CLIs pick
+                // their own. Passing `openAIModelName` unconditionally would append
+                // `--model <openai-model>` to every `claude` / `cursor-agent`
+                // invocation for anyone who has ever configured an endpoint,
+                // breaking the CLI path (AC-REGRESS-01).
+                model: llm.tool == .openaiCompatible && !llm.openAIModelName.isEmpty
+                    ? llm.openAIModelName : nil,
                 extraArgs: llm.extraArgsTokens,
                 timeout: llm.cliTimeout,
                 openAIBaseURL: llm.openAIBaseURL,

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -489,6 +489,7 @@ struct RenameRecordingSheet: View {
                 prompt: llm.namePrompt,
                 transcript: transcript,
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
+                model: llm.openAIModelName,
                 extraArgs: llm.extraArgsTokens,
                 timeout: llm.cliTimeout,
                 openAIBaseURL: llm.openAIBaseURL,

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -490,7 +490,10 @@ struct RenameRecordingSheet: View {
                 transcript: transcript,
                 executablePathOverride: llm.executablePath.isEmpty ? nil : llm.executablePath,
                 extraArgs: llm.extraArgsTokens,
-                timeout: llm.cliTimeout
+                timeout: llm.cliTimeout,
+                openAIBaseURL: llm.openAIBaseURL,
+                openAIAPIKey: llm.openAIAPIKey,
+                jsonMode: false
             )
             let cleaned = PostRecordingCoordinator.cleanedTitle(from: suggestion)
             if cleaned.isEmpty {

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -848,8 +848,13 @@ private struct LLMSettingsTab: View {
                     }
                 }
                 .pickerStyle(.menu)
-                .onChange(of: settings.openAIProvider) { _, newPreset in
-                    settings.applyPreset(newPreset)
+                .onChange(of: settings.openAIProvider) { oldPreset, newPreset in
+                    // Pass the PREVIOUS provider explicitly: the Picker
+                    // binding has already set `openAIProvider` to
+                    // `newPreset` by the time `.onChange` fires, so
+                    // `applyPreset` cannot derive the old value itself
+                    // (issue celarent7/mila#2).
+                    settings.applyPreset(newPreset, previous: oldPreset)
                 }
             }
             .font(.callout)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -805,28 +805,94 @@ private struct LLMSettingsTab: View {
             }
             .pickerStyle(.segmented)
 
+            if settings.isOpenAICompatible {
+                openAISection
+            } else {
+                HStack {
+                    Text("Executable path").frame(width: 130, alignment: .leading)
+                    TextField("(use $PATH)", text: $settings.executablePath)
+                        .textFieldStyle(.roundedBorder)
+                }
+                .font(.callout)
+                Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack {
+                    Text("Extra CLI args").frame(width: 130, alignment: .leading)
+                    TextField("(none) e.g. --model claude-sonnet-4-6", text: $settings.extraArgs)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.callout, design: .monospaced))
+                }
+                .font(.callout)
+                Text("Appended to every run (name suggestion, auto-summary, Send action, and the test below). Shell-style quoting is supported; for most CLIs a flag here overrides an earlier one. Live AI manages its own model and is unaffected.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// OpenAI-compatible endpoint configuration, shown only when the tool
+    /// picker is on "OpenAI Compatible": a provider preset (which fills the
+    /// base URL + default model), editable base URL / model name, a
+    /// Keychain-backed API key, and a remote-host privacy disclaimer.
+    private var openAISection: some View {
+        VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Text("Executable path").frame(width: 130, alignment: .leading)
-                TextField("(use $PATH)", text: $settings.executablePath)
+                Text("Provider").frame(width: 130, alignment: .leading)
+                Picker("Provider", selection: $settings.openAIProvider) {
+                    ForEach(OpenAIProvider.allCases) { preset in
+                        Text(preset.displayName).tag(preset)
+                    }
+                }
+                .pickerStyle(.menu)
+                .onChange(of: settings.openAIProvider) { _, newPreset in
+                    settings.applyPreset(newPreset)
+                }
+            }
+            .font(.callout)
+
+            HStack {
+                Text("Base URL").frame(width: 130, alignment: .leading)
+                TextField("https://api.openai.com/v1", text: $settings.openAIBaseURL)
                     .textFieldStyle(.roundedBorder)
             }
             .font(.callout)
-            Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
+            Text("The OpenAI-compatible /chat/completions endpoint. A trailing slash is ignored.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             HStack {
-                Text("Extra CLI args").frame(width: 130, alignment: .leading)
-                TextField("(none) e.g. --model claude-sonnet-4-6", text: $settings.extraArgs)
+                Text("Model name").frame(width: 130, alignment: .leading)
+                TextField("gpt-4o-mini", text: $settings.openAIModelName)
                     .textFieldStyle(.roundedBorder)
-                    .font(.system(.callout, design: .monospaced))
             }
             .font(.callout)
-            Text("Appended to every run (name suggestion, auto-summary, Send action, and the test below). Shell-style quoting is supported; for most CLIs a flag here overrides an earlier one. Live AI manages its own model and is unaffected.")
+
+            HStack {
+                Text("API key").frame(width: 130, alignment: .leading)
+                SecureField("Required for most providers", text: $settings.openAIAPIKey)
+                    .textFieldStyle(.roundedBorder)
+            }
+            .font(.callout)
+            Text("Stored in your Keychain. Leave blank only for a local server without auth (e.g. Ollama Local).")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            if !OpenAILocality.isLocal(baseURL: settings.openAIBaseURL) {
+                Label {
+                    Text("This endpoint is on a remote server, so your transcript text is sent off your machine for processing. Choose a provider you trust.")
+                        .font(.caption)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
@@ -842,10 +908,19 @@ private struct LLMSettingsTab: View {
         }
     }
 
+    /// Help text under the timeout stepper. Worded for an HTTP request when
+    /// the OpenAI endpoint is active, for a CLI process otherwise.
+    private var timeoutHelp: String {
+        if settings.isOpenAICompatible {
+            return "Maximum time Mila waits for the endpoint to respond before giving up. Applies to title generation, auto-summary, and the Send-action button."
+        }
+        return "Maximum time Mila waits for a CLI response before giving up. Applies to title generation, auto-summary, and the Send-action button. Raise this if your prompt uses agentic tools (e.g. calendar lookup) that need extra time to complete."
+    }
+
     private var timeoutSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text("CLI timeout").frame(width: 100, alignment: .leading)
+                Text(settings.timeoutLabel).frame(width: 100, alignment: .leading)
                 Stepper(value: $settings.cliTimeout, in: 30...900, step: 30) {
                     EmptyView()
                 }
@@ -858,7 +933,7 @@ private struct LLMSettingsTab: View {
                     .font(.callout)
             }
             .font(.callout)
-            Text("Maximum time Mila waits for a CLI response before giving up. Applies to title generation, auto-summary, and the Send-action button. Raise this if your prompt uses agentic tools (e.g. calendar lookup) that need extra time to complete.")
+            Text(timeoutHelp)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -907,7 +982,7 @@ private struct LLMSettingsTab: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Test")
                 .font(.title3.weight(.semibold))
-            Text("Run the configured prompt against a sample transcript to see exactly what Mila sends and what your CLI returns. Use this to debug a tool that isn't working — the command shown below is the literal one Mila runs, so you can copy it into a terminal yourself.")
+            Text("Run the configured prompt against a sample transcript to see exactly what Mila sends and what your \(settings.isOpenAICompatible ? "endpoint" : "CLI") returns. Use this to debug a tool that isn't working — the \(settings.isOpenAICompatible ? "request shown below is the literal one Mila sends" : "command shown below is the literal one Mila runs"), so you can copy it into a terminal yourself.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -927,9 +1002,15 @@ private struct LLMSettingsTab: View {
                 .overlay(RoundedRectangle(cornerRadius: 6)
                     .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
 
-            Text("The test uses your configured Extra CLI args (above), so it reproduces exactly what a real run does.")
-                .font(.caption).foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            if !settings.isOpenAICompatible {
+                Text("The test uses your configured Extra CLI args (above), so it reproduces exactly what a real run does.")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("The test uses your configured Base URL, Model name, and API key (above), so it reproduces exactly what a real run does.")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             HStack(spacing: 10) {
                 Button {
@@ -973,18 +1054,26 @@ private struct LLMTestResultView: View {
             if !result.command.isEmpty {
                 labeledBlock("Command", text: result.command, copyable: true)
             }
+            // OpenAI HTTP path: show the JSON body that was POSTed, for
+            // copy-paste debugging. Empty for the CLI path.
+            if !result.requestBody.isEmpty {
+                labeledBlock("Request body", text: result.requestBody, copyable: true)
+            }
             if let error = result.setupError {
                 labeledBlock("Problem", text: error, copyable: false)
             }
             if result.didLaunch {
+                let outputLabel = isHTTP ? "Response" : "Output (stdout)"
+                let diagLabel = isHTTP ? "Error" : "Diagnostics (stderr)"
                 if !result.stdout.isEmpty {
-                    labeledBlock("Output (stdout)", text: result.stdout, copyable: true)
+                    labeledBlock(outputLabel, text: result.stdout, copyable: true)
                 }
                 if !trimmed(result.stderr).isEmpty {
-                    labeledBlock("Diagnostics (stderr)", text: result.stderr, copyable: true)
+                    labeledBlock(diagLabel, text: result.stderr, copyable: true)
                 }
                 if result.stdout.isEmpty && trimmed(result.stderr).isEmpty {
-                    Text("The CLI produced no output.")
+                    Text(isHTTP ? "The endpoint returned no content."
+                                : "The CLI produced no output.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
             }
@@ -992,6 +1081,10 @@ private struct LLMTestResultView: View {
         .padding(12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
     }
+
+    /// True for the OpenAI HTTP diagnostic path (which populates `url`),
+    /// false for the CLI path. Picks Response/Error vs stdout/stderr labels.
+    private var isHTTP: Bool { !result.url.isEmpty }
 
     private var statusLine: some View {
         HStack(spacing: 8) {
@@ -1018,9 +1111,13 @@ private struct LLMTestResultView: View {
 
     private var statusText: String {
         if result.succeeded { return "Success" }
-        if result.timedOut { return "Timed out — the CLI didn't respond in time" }
+        if result.timedOut {
+            return isHTTP ? "Timed out — the endpoint didn't respond in time"
+                          : "Timed out — the CLI didn't respond in time"
+        }
         if let error = result.setupError, !result.didLaunch { return error }
         if let code = result.exitCode { return "CLI exited with status \(code)" }
+        if let status = result.httpStatus { return "HTTP \(status)" }
         return "Failed"
     }
 

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -473,4 +473,80 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertFalse(result.lowercased().contains("could you paste"),
                        "cursor-agent never saw the transcript — runner regressed: \(result)")
     }
+
+    // MARK: - Phase 10 — CLI regression guard (OpenAI branch must not leak)
+
+    /// AC-REGRESS-01 — the early `.openaiCompatible` branch added in Phase 6
+    /// must NOT divert `.claude` (or any CLI tool) into the HTTP path, even
+    /// when the new OpenAI params are explicitly passed. We prove it by
+    /// handing `.claude` a non-nil `openAIBaseURL` + `jsonMode` + `temperature`
+    /// AND a `makeScript` stand-in: if the branch were mis-scoped (e.g.
+    /// `tool != .none`), the runner would hit the HTTP transport instead of
+    /// spawning the script, and the marker would never come back. Uses the
+    /// shell-script stand-in (m1) — not `/bin/cat`.
+    func test_run_claude_unchanged_resolvesExecutableAndSpawns() async throws {
+        let script = makeScript("""
+            #!/bin/sh
+            printf 'CLI-PATH-MARKER:%s' "${@: -1}"
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let out = try await LLMRunner.run(
+            tool: .claude,
+            prompt: "hello",
+            transcript: "world",
+            executablePathOverride: script.path,
+            timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1",
+            openAIAPIKey: "ignored-by-cli-path",
+            jsonMode: true,
+            temperature: 0.5
+        )
+        XCTAssertTrue(out.contains("CLI-PATH-MARKER:"),
+                      "claude was diverted away from the CLI spawn path: \(out)")
+        XCTAssertTrue(out.contains("hello"),
+                      "composed prompt didn't reach the CLI: \(out)")
+    }
+
+    /// AC-REGRESS-02 — the OpenAI branch must not leak into `.none` or
+    /// `.cursor`. `.none` still throws `toolDisabled` (not an OpenAI/HTTP
+    /// error) even with OpenAI params present; `.cursor` still spawns the CLI
+    /// stand-in and ignores the OpenAI params. The existing suite is the
+    /// guard; this test pins the "no leak" invariant explicitly.
+    func test_existingLLMRunnerTestsStillPass() async throws {
+        // .none: OpenAI params present, but tool-disabled wins — no HTTP
+        // attempt, no OpenAIRequestError, just .toolDisabled.
+        do {
+            _ = try await LLMRunner.run(tool: .none,
+                                        prompt: "x", transcript: "y",
+                                        executablePathOverride: nil,
+                                        openAIBaseURL: "http://localhost:11434/v1",
+                                        openAIAPIKey: "k",
+                                        jsonMode: true,
+                                        temperature: 0.5)
+            XCTFail("Expected toolDisabled for .none")
+        } catch let error as LLMRunnerError {
+            guard case .toolDisabled = error else {
+                XCTFail(".none leaked into a non-toolDisabled path: \(error)"); return
+            }
+        } catch {
+            XCTFail("Wrong error type for .none: \(error)")
+        }
+
+        // .cursor: still spawns the CLI stand-in, ignoring the OpenAI params.
+        let script = makeScript("""
+            #!/bin/sh
+            printf 'cursor-ran'
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let out = try await LLMRunner.run(tool: .cursor,
+                                          prompt: "x", transcript: "y",
+                                          executablePathOverride: script.path,
+                                          timeout: 30,
+                                          openAIBaseURL: "http://localhost:11434/v1",
+                                          openAIAPIKey: "k",
+                                          jsonMode: true,
+                                          temperature: 0.5)
+        XCTAssertEqual(out, "cursor-ran",
+                       "cursor was diverted away from the CLI spawn path: \(out)")
+    }
 }

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -1,0 +1,1066 @@
+import XCTest
+@testable import Mila
+
+// Test home for OpenAI-compatible endpoint support (see
+// llm-artifacts/openai_compatible_endpoint_*). Grown incrementally per the
+// implementation plan's phases; each phase adds the test class for the unit it
+// proves. HTTP is stubbed via a transport-injection seam (RecordingTransport),
+// not the per-session URLProtocol convention used by the transcription tests —
+// see the plan's TDD-discipline note.
+
+// MARK: - Phase 4: LLMSettings OpenAI readiness + keychain
+
+@MainActor
+final class LLMSettingsOpenAIReadinessTests: XCTestCase {
+
+    private func makeSettings(_ label: String = #function) -> LLMSettings {
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAI.\(label)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAI.\(label)")
+        return LLMSettings(defaults: suite,
+                           apiKeyKeychainKey: "LLMSettingsOpenAI.\(label).apiKey")
+    }
+
+    /// AC-READY-01
+    func test_isConfigured_falseForNone() {
+        let s = makeSettings()
+        XCTAssertEqual(s.tool, .none)
+        XCTAssertFalse(s.isConfigured)
+    }
+
+    /// AC-READY-02 / AC-READY-03 — the OpenAI tool requires a non-blank base URL.
+    func test_isConfigured_falseForOpenAI_whenBaseURLEmpty() {
+        let s = makeSettings()
+        s.tool = .openaiCompatible
+        s.openAIBaseURL = ""
+        XCTAssertFalse(s.isConfigured)
+    }
+
+    func test_isConfigured_falseForOpenAI_whenBaseURLWhitespace() {
+        let s = makeSettings()
+        s.tool = .openaiCompatible
+        s.openAIBaseURL = "   \n  "
+        XCTAssertFalse(s.isConfigured)
+    }
+
+    /// AC-READY-04
+    func test_isConfigured_trueForOpenAI_whenBaseURLPresent() {
+        let s = makeSettings()
+        s.tool = .openaiCompatible
+        s.openAIBaseURL = "https://api.openai.com/v1"
+        XCTAssertTrue(s.isConfigured)
+    }
+
+    /// AC-READY — a local/anonymous endpoint is configured without a key.
+    func test_isConfigured_trueForOpenAI_evenWhenAPIKeyEmpty() {
+        let s = makeSettings()
+        s.tool = .openaiCompatible
+        s.openAIBaseURL = "http://localhost:11434/v1"
+        s.openAIAPIKey = ""
+        XCTAssertTrue(s.isConfigured)
+    }
+
+    /// AC-READY — the existing CLI tools stay configured regardless of OpenAI state.
+    func test_isConfigured_trueForClaude_regardlessOfOpenAIFields() {
+        let s = makeSettings()
+        s.tool = .claude
+        s.openAIBaseURL = ""
+        XCTAssertTrue(s.isConfigured)
+    }
+}
+
+@MainActor
+final class OpenAIAPIKeyKeychainTests: XCTestCase {
+
+    private func makeSettings(_ label: String = #function) -> LLMSettings {
+        let key = "LLMSettingsOpenAIKeychain.\(label).apiKey"
+        KeychainHelper.delete(key: key)
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(label)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(label)")
+        return LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+    }
+
+    /// AC-KEY-01 — the key is persisted to the Keychain, never UserDefaults.
+    func test_settingAPIKey_writesToKeychain_notUserDefaults() {
+        let key = "LLMSettingsOpenAIKeychain.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        s.openAIAPIKey = "sk-secret"
+        XCTAssertEqual(KeychainHelper.load(key: key), "sk-secret")
+        XCTAssertNil(suite.string(forKey: "llm.openai.apiKey"),
+                     "The API key must never land in UserDefaults")
+    }
+
+    /// AC-KEY-02 — restoring at launch when OpenAI was the persisted tool.
+    func test_restoredFromKeychain_onInit_whenToolIsOpenAI() {
+        let key = "LLMSettingsOpenAIKeychain.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(#function)")
+        suite.set(LLMTool.openaiCompatible.rawValue, forKey: "llm.tool")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        XCTAssertEqual(s.tool, .openaiCompatible)
+        XCTAssertEqual(s.openAIAPIKey, "sk-stored",
+                       "Stored key must load at init when OpenAI is the persisted tool")
+    }
+
+    /// AC-KEY-03 — an in-progress edit must survive the lazy load on tool switch.
+    func test_notOverwrittenByStoredValue_whenUserTypedOne() {
+        let key = "LLMSettingsOpenAIKeychain.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        XCTAssertEqual(s.tool, .none)
+
+        s.openAIAPIKey = "sk-user-typed"
+        s.tool = .openaiCompatible
+        XCTAssertEqual(s.openAIAPIKey, "sk-user-typed",
+                       "An in-progress edit must not be clobbered by the lazy load")
+    }
+
+    /// AC-KEY-04 (idempotency) — once loaded, toggling the tool must not re-read
+    /// or clobber the key. Mirrors `RemoteTranscriptionSettingsTests`.
+    func test_lazyLoad_isIdempotentAcrossToolToggles() {
+        let key = "LLMSettingsOpenAIKeychain.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        KeychainHelper.save(key: key, value: "sk-stored")
+        defer { KeychainHelper.delete(key: key) }
+
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        s.tool = .openaiCompatible
+        XCTAssertEqual(s.openAIAPIKey, "sk-stored")
+        s.openAIAPIKey = ""
+        s.tool = .claude
+        s.tool = .openaiCompatible
+        XCTAssertEqual(s.openAIAPIKey, "",
+                       "An already-cleared key must not be re-read on a later switch")
+    }
+
+    /// AC-KEY-05 — clearing the field removes the Keychain item.
+    func test_emptyAPIKey_deletesKeychainItem() {
+        let key = "LLMSettingsOpenAIKeychain.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAIKeychain.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAIKeychain.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        s.openAIAPIKey = "sk-then-cleared"
+        XCTAssertEqual(KeychainHelper.load(key: key), "sk-then-cleared")
+        s.openAIAPIKey = ""
+        XCTAssertNil(KeychainHelper.load(key: key),
+                     "An empty key must delete the Keychain item, not store an empty string")
+    }
+}
+
+// MARK: - Phase 3: OpenAIClient.parse (pure response/error parser)
+
+@MainActor
+final class OpenAIResponseParserTests: XCTestCase {
+
+    private func http(_ status: Int, _ body: String) -> (Data, HTTPURLResponse) {
+        let data = Data(body.utf8)
+        let resp = HTTPURLResponse(url: URL(string: "https://x/v1/chat/completions")!,
+                                   statusCode: status, httpVersion: nil,
+                                   headerFields: ["Content-Type": "application/json"])!
+        return (data, resp)
+    }
+
+    private func expectFailure(_ result: Result<String, Error>) -> Error {
+        switch result {
+        case .success: return XCTFail("expected failure, got success") as! Error
+        case .failure(let e): return e
+        }
+    }
+
+    /// AC-RESP-01
+    func test_parse_2xx_returnsFirstChoiceContentTrimmed() {
+        let (data, resp) = http(200, #"{"choices":[{"message":{"role":"assistant","content":"  hello  "}}]}"#)
+        let result = OpenAIClient.parse(data: data, response: resp)
+        XCTAssertEqual(try? result.get(), "hello")
+    }
+
+    /// AC-RESP-02
+    func test_parse_2xx_multiChoice_usesFirstChoice() {
+        let body = #"{"choices":[{"message":{"role":"assistant","content":"first"}},{"message":{"role":"assistant","content":"second"}}]}"#
+        let (data, resp) = http(200, body)
+        XCTAssertEqual(try? OpenAIClient.parse(data: data, response: resp).get(), "first")
+    }
+
+    /// AC-RESP-03
+    func test_parse_2xx_emptyChoices_throwsEmptyOutput() {
+        let (data, resp) = http(200, #"{"choices":[]}"#)
+        let err = expectFailure(OpenAIClient.parse(data: data, response: resp))
+        XCTAssertTrue(err is OpenAIRequestError, "got \(type(of: err))")
+        XCTAssertEqual(err as? OpenAIRequestError, .emptyOutput)
+    }
+
+    /// AC-ERR-01
+    func test_parse_401_decodesErrorMessage_readableAuthError() {
+        let (data, resp) = http(401, #"{"error":{"message":"Incorrect API key provided: sk-xx"}}"#)
+        let err = expectFailure(OpenAIClient.parse(data: data, response: resp))
+        guard case .auth(let msg)? = err as? OpenAIRequestError else {
+            return XCTFail("expected .auth, got \(err)")
+        }
+        XCTAssertTrue(msg.contains("API key"), "auth message should surface the server text: \(msg)")
+        XCTAssertNotNil((err as? LocalizedError)?.errorDescription)
+    }
+
+    /// AC-ERR-02
+    func test_parse_404_modelNotFound_readableMessage() {
+        let (data, resp) = http(404, #"{"error":{"message":"The model 'gpt-5' does not exist"}}"#)
+        let err = expectFailure(OpenAIClient.parse(data: data, response: resp))
+        guard case .notFound(let msg)? = err as? OpenAIRequestError else {
+            return XCTFail("expected .notFound, got \(err)")
+        }
+        XCTAssertTrue(msg.lowercased().contains("model"), "notFound message should mention the model: \(msg)")
+    }
+
+    /// AC-ERR-03
+    func test_parse_500_includesStatusAndMessage() {
+        let (data, resp) = http(500, #"{"error":{"message":"internal boom"}}"#)
+        let err = expectFailure(OpenAIClient.parse(data: data, response: resp))
+        guard case .server(let status, let msg)? = err as? OpenAIRequestError else {
+            return XCTFail("expected .server, got \(err)")
+        }
+        XCTAssertEqual(status, 500)
+        XCTAssertTrue(msg.contains("internal boom"), "server message should include server text: \(msg)")
+    }
+
+    /// AC-ERR-04 — undecodable error body falls back to a status-only message.
+    func test_parse_undecodableErrorBody_fallsBackToHTTPStatus() {
+        let (data, resp) = http(502, "not-json-at-all")
+        let err = expectFailure(OpenAIClient.parse(data: data, response: resp))
+        guard case .server(let status, let msg)? = err as? OpenAIRequestError else {
+            return XCTFail("expected .server fallback, got \(err)")
+        }
+        XCTAssertEqual(status, 502)
+        XCTAssertTrue(msg.contains("502"), "fallback should name the status: \(msg)")
+    }
+
+    /// AC-ERR-06 — every HTTP error case is a readable LocalizedError.
+    func test_allHTTPErrors_conformToLocalizedError() {
+        let cases: [OpenAIRequestError] = [
+            .auth("bad key"),
+            .notFound("no model"),
+            .server(status: 500, message: "boom"),
+            .emptyOutput
+        ]
+        for e in cases {
+            XCTAssertNotNil((e as LocalizedError).errorDescription,
+                            "\(e) must provide an errorDescription")
+        }
+    }
+}
+
+// MARK: - Phase 2: OpenAIClient.makeRequest (pure request builder)
+
+@MainActor
+final class OpenAIRequestBuilderTests: XCTestCase {
+
+    private func bodyJSON(_ request: URLRequest) -> [String: Any] {
+        let data = request.httpBody ?? Data()
+        return (try! JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    /// AC-REQ-01 — `<trimmed baseURL>/chat/completions`, trailing-slash tolerant.
+    func test_makeRequest_postURL_joinsBaseURLWithChatCompletions() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1",
+                                         model: "gpt-4o-mini", prompt: "p",
+                                         transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertEqual(r.url?.absoluteString,
+                       "https://api.openai.com/v1/chat/completions")
+        XCTAssertEqual(r.httpMethod, "POST")
+    }
+
+    func test_makeRequest_stripsTrailingSlashFromBaseURL() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1/",
+                                         model: "m", prompt: "p", transcript: "t",
+                                         summary: "", apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertEqual(r.url?.absoluteString,
+                       "https://api.openai.com/v1/chat/completions")
+    }
+
+    /// AC-REQ-02
+    func test_makeRequest_setsContentTypeJSON() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertEqual(r.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    /// AC-REQ-03
+    func test_makeRequest_setsBearerAuthorization_whenKeyPresent() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "sk-abc", jsonMode: false, temperature: nil)
+        XCTAssertEqual(r.value(forHTTPHeaderField: "Authorization"), "Bearer sk-abc")
+    }
+
+    func test_makeRequest_omitsAuthorizationHeader_whenKeyEmpty() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "", jsonMode: false, temperature: nil)
+        XCTAssertNil(r.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    /// AC-REQ-04 — a single `user` message holding the composed prompt.
+    func test_makeRequest_bodyMessages_singleUserMessageWithComposedPrompt() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "Summarize.", transcript: "hello world",
+                                         summary: "gist", apiKey: "k", jsonMode: false, temperature: nil)
+        let body = bodyJSON(r)
+        let messages = body["messages"] as? [[String: String]]
+        XCTAssertEqual(messages?.count, 1)
+        XCTAssertEqual(messages?.first?["role"], "user")
+        let expected = LLMRunner.composedPrompt("Summarize.", transcript: "hello world", summary: "gist")
+        XCTAssertEqual(messages?.first?["content"], expected)
+    }
+
+    /// AC-REQ-05 — model name is trimmed.
+    func test_makeRequest_bodyModel_equalsTrimmedModelName() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "  gpt-4o-mini  ",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertEqual(bodyJSON(r)["model"] as? String, "gpt-4o-mini")
+    }
+
+    /// AC-REQ-06 — response_format present iff jsonMode.
+    func test_makeRequest_includesResponseFormat_whenJSONModeRequested() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: true, temperature: nil)
+        let rf = bodyJSON(r)["response_format"] as? [String: String]
+        XCTAssertEqual(rf?["type"], "json_object")
+    }
+
+    func test_makeRequest_omitsResponseFormat_whenJSONModeNotRequested() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertNil(bodyJSON(r)["response_format"])
+    }
+
+    /// AC-REQ-07 — non-streaming only.
+    func test_makeRequest_streamAlwaysFalse() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: true, temperature: nil)
+        XCTAssertEqual(bodyJSON(r)["stream"] as? Bool, false)
+    }
+
+    /// AC-REQ-09 — temperature included iff non-nil.
+    func test_makeRequest_includesTemperature_whenSet() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: 0.2)
+        XCTAssertEqual(bodyJSON(r)["temperature"] as? Double, 0.2)
+    }
+
+    func test_makeRequest_omitsTemperature_whenNil() {
+        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+                                         prompt: "p", transcript: "t", summary: "",
+                                         apiKey: "k", jsonMode: false, temperature: nil)
+        XCTAssertNil(bodyJSON(r)["temperature"])
+    }
+
+    /// AC-REQ-10 — the HTTP tool contributes no argv; the runner's HTTP branch
+    /// never reaches `arguments`.
+    func test_llmTool_arguments_returnsEmptyForOpenAICompatible() {
+        XCTAssertTrue(LLMTool.openaiCompatible.arguments(prompt: "p").isEmpty)
+        XCTAssertEqual(LLMTool.openaiCompatible.executableName, "")
+        XCTAssertEqual(LLMTool.openaiCompatible.displayName, "OpenAI Compatible")
+    }
+}
+
+// MARK: - Phase 1: OpenAIProvider preset enum (pure)
+
+@MainActor
+final class OpenAIProviderTests: XCTestCase {
+
+    /// AC-PRESET-01 — the closed set of presets the UI picker offers.
+    func test_provider_allCases_containsExpectedPresets() {
+        let names = OpenAIProvider.allCases.map(\.rawValue)
+        XCTAssertEqual(names, [
+            "ollamaLocal", "ollamaCloud", "openai",
+            "openrouter", "groq", "deepseek", "custom"
+        ])
+    }
+
+    /// AC-PRESET-02 — each preset ships a base URL (empty for `.custom`).
+    func test_provider_baseURL_matchesExpectedForEachPreset() {
+        XCTAssertEqual(OpenAIProvider.ollamaLocal.baseURL, "http://localhost:11434/v1")
+        XCTAssertEqual(OpenAIProvider.ollamaCloud.baseURL, "https://ollama.com/v1")
+        XCTAssertEqual(OpenAIProvider.openai.baseURL, "https://api.openai.com/v1")
+        XCTAssertEqual(OpenAIProvider.openrouter.baseURL, "https://openrouter.ai/api/v1")
+        XCTAssertEqual(OpenAIProvider.groq.baseURL, "https://api.groq.com/openai/v1")
+        XCTAssertEqual(OpenAIProvider.deepseek.baseURL, "https://api.deepseek.com/v1")
+        XCTAssertEqual(OpenAIProvider.custom.baseURL, "")
+    }
+
+    /// AC-PRESET-03 — only a local server may run without an API key.
+    func test_provider_requiresAPIKey_trueExceptOllamaLocal() {
+        XCTAssertFalse(OpenAIProvider.ollamaLocal.requiresAPIKey,
+                       "A local Ollama server has no auth by default")
+        for p in OpenAIProvider.allCases where p != .ollamaLocal {
+            XCTAssertTrue(p.requiresAPIKey, "\(p.rawValue) must require an API key")
+        }
+    }
+
+    /// AC-PRESET-06 — every preset carries its OWN default model name; there is
+    /// no single hardcoded `llama3` fallback. (The locale-aware default-model
+    /// mechanism in `ModelManager` is Whisper-transcription-only and does not
+    /// apply here — see C2.)
+    func test_provider_defaultModelName_isPerPreset_notHardcodedLlama3() {
+        for p in OpenAIProvider.allCases {
+            XCTAssertFalse(p.defaultModelName == "llama3",
+                           "\(p.rawValue) must not fall back to the bare 'llama3' default")
+        }
+        // Non-custom presets ship a concrete default; custom is user-supplied.
+        for p in OpenAIProvider.allCases where p != .custom {
+            XCTAssertFalse(p.defaultModelName.isEmpty,
+                           "\(p.rawValue) must ship a default model name")
+        }
+        XCTAssertEqual(OpenAIProvider.custom.defaultModelName, "")
+    }
+
+    // MARK: Preset fill / persistence (lives here because it exercises the
+    // OpenAIProvider preset values through LLMSettings.applyPreset).
+
+    private func makeSettings(_ label: String = #function) -> LLMSettings {
+        let suite = UserDefaults(suiteName: "OpenAIProviderTests.\(label)")!
+        suite.removePersistentDomain(forName: "OpenAIProviderTests.\(label)")
+        let key = "OpenAIProviderTests.\(label).apiKey"
+        KeychainHelper.delete(key: key)
+        return LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+    }
+
+    /// AC-PRESET-04 — picking a preset fills empty base URL + model fields.
+    func test_selectingPreset_fillsBaseURLAndModel_whenFieldsEmpty() {
+        let s = makeSettings()
+        s.applyPreset(.openai)
+        XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.openai.baseURL)
+        XCTAssertEqual(s.openAIModelName, OpenAIProvider.openai.defaultModelName)
+        XCTAssertEqual(s.openAIProvider, .openai)
+    }
+
+    /// AC-PRESET-04 — a user-customized base URL survives a preset change.
+    func test_selectingPreset_doesNotOverwriteCustomBaseURL() {
+        let s = makeSettings()
+        s.openAIBaseURL = "https://my-hosted.example/v1"
+        s.openAIModelName = "my-model"
+        s.applyPreset(.groq)
+        XCTAssertEqual(s.openAIBaseURL, "https://my-hosted.example/v1",
+                       "A custom base URL must not be overwritten by a preset")
+        XCTAssertEqual(s.openAIModelName, "my-model",
+                       "A custom model must not be overwritten by a preset")
+        XCTAssertEqual(s.openAIProvider, .groq)
+    }
+
+    /// AC-PRESET-04 — switching presets replaces the *previous* preset's
+    /// default values but not a user edit.
+    func test_selectingPreset_overwritesPreviousPresetDefault() {
+        let s = makeSettings()
+        s.applyPreset(.openai)            // fills openai defaults
+        XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.openai.baseURL)
+        s.applyPreset(.groq)              // openai defaults → groq defaults
+        XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.groq.baseURL)
+        XCTAssertEqual(s.openAIModelName, OpenAIProvider.groq.defaultModelName)
+    }
+
+    /// AC-PRESET-05 — OpenAI fields survive a settings re-creation (same defaults).
+    func test_openAIFields_persistAcrossInstances() {
+        let suite = UserDefaults(suiteName: "OpenAIProviderTests.\(#function)")!
+        suite.removePersistentDomain(forName: "OpenAIProviderTests.\(#function)")
+        let key = "OpenAIProviderTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+
+        let first = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        first.tool = .openaiCompatible
+        first.openAIProvider = .deepseek
+        first.openAIBaseURL = "https://api.deepseek.com/v1"
+        first.openAIModelName = "deepseek-chat"
+        first.openAIAPIKey = "sk-persist"
+
+        let second = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        XCTAssertEqual(second.tool, .openaiCompatible)
+        XCTAssertEqual(second.openAIProvider, .deepseek)
+        XCTAssertEqual(second.openAIBaseURL, "https://api.deepseek.com/v1")
+        XCTAssertEqual(second.openAIModelName, "deepseek-chat")
+        XCTAssertEqual(second.openAIAPIKey, "sk-persist",
+                       "API key must round-trip through the Keychain")
+    }
+}
+
+// MARK: - Phase 6: transport protocol + LLMRunner.run HTTP branch
+
+/// Test-only `OpenAITransport` stub. Records every `URLRequest` it was handed
+/// and returns a canned `(HTTPURLResponse, Data)` or throws a canned error —
+/// so `LLMRunner.run`'s `.openaiCompatible` branch can be driven end-to-end
+/// without a network. `hangUntilCancelled` models `URLSession`'s cancel
+/// behaviour: `send` suspends until the owning Task is cancelled, then throws
+/// `URLError(.cancelled)` (and yields the canned response on a manual
+/// `release()` if one was staged — so the "cancel wins over a late response"
+/// assertion is expressible).
+final class RecordingTransport: OpenAITransport, @unchecked Sendable {
+    private(set) var requests: [URLRequest] = []
+    var cannedResponse: (HTTPURLResponse, Data)?
+    var cannedError: Error?
+    var hangUntilCancelled = false
+    private var hang: CheckedContinuation<Void, Never>?
+
+    func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
+        requests.append(request)
+        if let cannedError { throw cannedError }
+        if hangUntilCancelled {
+            let cancelled: Bool = await withTaskCancellationHandler {
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    if Task.isCancelled { cont.resume(); return }
+                    self.hang = cont
+                }
+                return Task.isCancelled
+            } onCancel: {
+                self.hang?.resume()
+                self.hang = nil
+            }
+            if cancelled || Task.isCancelled { throw URLError(.cancelled) }
+            // Resumed by `release()` with a staged response.
+            if let cannedResponse { return cannedResponse }
+            throw URLError(.resourceUnavailable)
+        }
+        guard let cannedResponse else { throw URLError(.resourceUnavailable) }
+        return cannedResponse
+    }
+
+    /// Release a hanging `send` (for the "late response" assertion).
+    func release() {
+        hang?.resume()
+        hang = nil
+    }
+}
+
+final class OpenAITransportTests: XCTestCase {
+
+    private func response(status: Int, body: String) -> (HTTPURLResponse, Data) {
+        let url = URL(string: "http://localhost:11434/v1/chat/completions")!
+        let http = HTTPURLResponse(url: url, statusCode: status,
+                                   httpVersion: nil, headerFields: nil)!
+        return (http, Data(body.utf8))
+    }
+
+    // Phase 6.0.5 — pins the new `run` signature + the defense-in-depth guard.
+    func test_run_openAICompatible_withoutBaseURL_throwsToolDisabled() async throws {
+        let transport = RecordingTransport()
+        do {
+            _ = try await LLMRunner.run(tool: .openaiCompatible,
+                                        prompt: "Summarize", transcript: "hello",
+                                        executablePathOverride: nil, model: "m",
+                                        timeout: 10,
+                                        openAIBaseURL: nil, openAIAPIKey: "k",
+                                        jsonMode: false, transport: transport)
+            XCTFail("expected LLMRunnerError.toolDisabled")
+        } catch LLMRunnerError.toolDisabled {
+            // pass
+        } catch {
+            XCTFail("expected .toolDisabled, got \(error)")
+        }
+        XCTAssertEqual(transport.requests.count, 0,
+                       "no base URL ⇒ transport must never be invoked")
+    }
+
+    // AC-RESP-01 end-to-end.
+    func test_run_success_endToEnd_returnsContent() async throws {
+        let transport = RecordingTransport()
+        transport.cannedResponse = response(
+            status: 200,
+            body: #"{"choices":[{"message":{"role":"assistant","content":"Hello there"}}]}"#)
+        let out = try await LLMRunner.run(tool: .openaiCompatible,
+                                          prompt: "Greet", transcript: "hi",
+                                          executablePathOverride: nil, model: "gpt-4o-mini",
+                                          timeout: 30,
+                                          openAIBaseURL: "http://localhost:11434/v1",
+                                          openAIAPIKey: "k", jsonMode: false,
+                                          transport: transport)
+        XCTAssertEqual(out, "Hello there")
+        XCTAssertEqual(transport.requests.count, 1)
+    }
+
+    // AC-ERR-01 end-to-end (401 → readable auth error surfaces from `run`).
+    func test_run_propagates401_asReadableError() async throws {
+        let transport = RecordingTransport()
+        transport.cannedResponse = response(
+            status: 401,
+            body: #"{"error":{"message":"Invalid API key","type":"invalid_request_error"}}"#)
+        do {
+            _ = try await LLMRunner.run(tool: .openaiCompatible,
+                                        prompt: "x", transcript: "t",
+                                        executablePathOverride: nil, model: "m",
+                                        timeout: 30,
+                                        openAIBaseURL: "http://localhost:11434/v1",
+                                        openAIAPIKey: "bad", jsonMode: false,
+                                        transport: transport)
+            XCTFail("expected auth error")
+        } catch let e as OpenAIRequestError {
+            XCTAssertEqual(e, .auth("Invalid API key"))
+            XCTAssertTrue((e.errorDescription ?? "").contains("401"))
+        } catch {
+            XCTFail("expected OpenAIRequestError.auth, got \(error)")
+        }
+    }
+
+    // AC-REQ-08 — CLI-only params are absent from the HTTP request.
+    func test_makeRequest_ignoresExecutablePathOverrideAndExtraArgs() async throws {
+        let transport = RecordingTransport()
+        transport.cannedResponse = response(
+            status: 200,
+            body: #"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#)
+        _ = try await LLMRunner.run(tool: .openaiCompatible,
+                                    prompt: "p", transcript: "t",
+                                    executablePathOverride: "/usr/local/bin/claude",
+                                    model: "m", extraArgs: ["--model", "bogus"],
+                                    timeout: 30,
+                                    openAIBaseURL: "http://localhost:11434/v1",
+                                    openAIAPIKey: "k", jsonMode: false,
+                                    transport: transport)
+        let req = try XCTUnwrap(transport.requests.first)
+        let url = req.url?.absoluteString ?? ""
+        XCTAssertFalse(url.contains("claude"))
+        XCTAssertFalse(url.contains("bogus"))
+        // Body must not mention the extra arg either.
+        let bodyStr = String(data: req.httpBody ?? Data(), encoding: .utf8) ?? ""
+        XCTAssertFalse(bodyStr.contains("bogus"))
+    }
+
+    // AC-CANCEL-01.
+    func test_cancel_abortsRequestAndThrowsCancelled() async throws {
+        let transport = RecordingTransport()
+        transport.hangUntilCancelled = true
+        let task = Task<String, Error> {
+            try await LLMRunner.run(tool: .openaiCompatible,
+                                    prompt: "p", transcript: "t",
+                                    executablePathOverride: nil, model: "m",
+                                    timeout: 30,
+                                    openAIBaseURL: "http://localhost:11434/v1",
+                                    openAIAPIKey: "k", jsonMode: false,
+                                    transport: transport)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected LLMRunnerError.cancelled")
+        } catch LLMRunnerError.cancelled {
+            // pass
+        } catch {
+            XCTFail("expected .cancelled, got \(error)")
+        }
+        XCTAssertEqual(transport.requests.count, 1,
+                       "the request was dispatched before cancellation aborted it")
+    }
+
+    // AC-CANCEL-02 — cancel wins over a response that arrives just after.
+    func test_cancel_winsOverLateResponse() async throws {
+        let transport = RecordingTransport()
+        transport.hangUntilCancelled = true
+        transport.cannedResponse = response(
+            status: 200,
+            body: #"{"choices":[{"message":{"role":"assistant","content":"late"}}]}"#)
+        let task = Task<String, Error> {
+            try await LLMRunner.run(tool: .openaiCompatible,
+                                    prompt: "p", transcript: "t",
+                                    executablePathOverride: nil, model: "m",
+                                    timeout: 30,
+                                    openAIBaseURL: "http://localhost:11434/v1",
+                                    openAIAPIKey: "k", jsonMode: false,
+                                    transport: transport)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation to win")
+        } catch LLMRunnerError.cancelled {
+            // pass
+        } catch {
+            XCTFail("expected .cancelled, got \(error)")
+        }
+    }
+
+    // AC-TIMEOUT-01/02 — transport-level timeout maps to the CLI error format.
+    func test_timeout_throwsTimedOutWithSeconds() async throws {
+        let transport = RecordingTransport()
+        transport.cannedError = URLError(.timedOut)
+        do {
+            _ = try await LLMRunner.run(tool: .openaiCompatible,
+                                        prompt: "p", transcript: "t",
+                                        executablePathOverride: nil, model: "m",
+                                        timeout: 45,
+                                        openAIBaseURL: "http://localhost:11434/v1",
+                                        openAIAPIKey: "k", jsonMode: false,
+                                        transport: transport)
+            XCTFail("expected timedOut")
+        } catch LLMRunnerError.timedOut(let seconds) {
+            // CLI path rounds up; the HTTP branch must match.
+            XCTAssertEqual(seconds, 45)
+        } catch {
+            XCTFail("expected .timedOut(45), got \(error)")
+        }
+    }
+}
+
+// MARK: - Phase 7: diagnose HTTP branch + LLMTestResult extension
+
+@MainActor
+final class OpenAIDiagnoseTests: XCTestCase {
+
+    private func http(_ status: Int, _ body: String) -> (HTTPURLResponse, Data) {
+        let url = URL(string: "http://localhost:11434/v1/chat/completions")!
+        return (HTTPURLResponse(url: url, statusCode: status,
+                                httpVersion: nil, headerFields: nil)!,
+                Data(body.utf8))
+    }
+
+    // AC-DIAG-01 — the new diagnostic fields exist and round-trip.
+    func test_LLMTestResult_hasURLHTTPStatusRequestBodyFields() {
+        var result = LLMTestResult()
+        result.url = "http://localhost:11434/v1/chat/completions"
+        result.httpStatus = 200
+        result.requestBody = #"{"model":"m"}"#
+        XCTAssertEqual(result.url, "http://localhost:11434/v1/chat/completions")
+        XCTAssertEqual(result.httpStatus, 200)
+        XCTAssertEqual(result.requestBody, #"{"model":"m"}"#)
+        XCTAssertNil(result.exitCode, "HTTP results never carry an exit code")
+    }
+
+    // AC-DIAG-02.
+    func test_diagnose_populatesURLAndRequestBody_forOpenAI() async {
+        let transport = RecordingTransport()
+        transport.cannedResponse = http(
+            200, #"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#)
+        let result = await LLMRunner.diagnose(
+            tool: .openaiCompatible, prompt: "p", transcript: "t",
+            executablePathOverride: nil, model: "gpt-4o-mini", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: transport)
+        XCTAssertTrue(result.url.contains("chat/completions"))
+        XCTAssertTrue(result.requestBody.contains("gpt-4o-mini"))
+        XCTAssertEqual(result.httpStatus, 200)
+    }
+
+    // AC-DIAG-03.
+    func test_diagnose_succeeded_trueOnlyFor2xxWithContent() async {
+        let good = RecordingTransport()
+        good.cannedResponse = http(
+            200, #"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#)
+        let r1 = await LLMRunner.diagnose(tool: .openaiCompatible, prompt: "p",
+            transcript: "t", executablePathOverride: nil, model: "m", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: good)
+        XCTAssertTrue(r1.succeeded, "2xx with content ⇒ succeeded")
+
+        let empty = RecordingTransport()
+        empty.cannedResponse = http(200, #"{"choices":[]}"#)
+        let r2 = await LLMRunner.diagnose(tool: .openaiCompatible, prompt: "p",
+            transcript: "t", executablePathOverride: nil, model: "m", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: empty)
+        XCTAssertFalse(r2.succeeded, "2xx with no content ⇒ not succeeded")
+
+        let serverErr = RecordingTransport()
+        serverErr.cannedResponse = http(500, #"{"error":{"message":"boom"}}"#)
+        let r3 = await LLMRunner.diagnose(tool: .openaiCompatible, prompt: "p",
+            transcript: "t", executablePathOverride: nil, model: "m", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: serverErr)
+        XCTAssertFalse(r3.succeeded, "5xx ⇒ not succeeded")
+    }
+
+    // AC-DIAG-04 — httpStatus is the "did it run?" signal, not exitCode.
+    func test_diagnose_httpStatusNotNil_isTheDidRunSignal_notExitCode() async {
+        let transport = RecordingTransport()
+        transport.cannedResponse = http(
+            200, #"{"choices":[{"message":{"role":"assistant","content":"x"}}]}"#)
+        let result = await LLMRunner.diagnose(
+            tool: .openaiCompatible, prompt: "p", transcript: "t",
+            executablePathOverride: nil, model: "m", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: transport)
+        XCTAssertEqual(result.httpStatus, 200)
+        XCTAssertNil(result.exitCode)
+        XCTAssertTrue(result.didLaunch,
+                      "didLaunch must be true when httpStatus is set")
+    }
+
+    // AC-DIAG-05 — runTest routes .openaiCompatible through the HTTP branch
+    // (no executable path needed). Hits a refused localhost port so it fails
+    // fast at the transport layer — the assertion is that it did NOT fail at
+    // CLI resolution (no "find on PATH" / executableNotFound wording) and that
+    // the request URL was populated.
+    func test_runTest_routesOpenAIWithoutExecutablePath() async throws {
+        let suite = UserDefaults(
+            suiteName: "OpenAIDiagnoseTests.\(#function)")!
+        suite.removePersistentDomain(
+            forName: "OpenAIDiagnoseTests.\(#function)")
+        let key = "OpenAIDiagnoseTests.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+
+        let llm = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        llm.tool = .openaiCompatible
+        llm.openAIBaseURL = "http://127.0.0.1:1/v1"   // nothing listening → refused
+        llm.openAIModelName = "m"
+        llm.openAIAPIKey = "k"
+        llm.cliTimeout = 2                              // bound the failure
+
+        await llm.runTest()
+        let result = try XCTUnwrap(llm.lastTestResult)
+        XCTAssertTrue(result.url.contains("chat/completions"),
+                      "runTest must build an HTTP request for .openaiCompatible")
+        let setup = result.setupError ?? ""
+        XCTAssertFalse(setup.contains("find"),
+                       "must not route through CLI executable resolution: \(setup)")
+        XCTAssertFalse(setup.contains("PATH"),
+                       "must not route through CLI executable resolution: \(setup)")
+    }
+
+    // AC-DIAG-02 — transport failure surfaces as setupError, no httpStatus.
+    func test_diagnose_setupError_onTransportFailure() async {
+        let transport = RecordingTransport()
+        transport.cannedError = URLError(.cannotConnectToHost)
+        let result = await LLMRunner.diagnose(
+            tool: .openaiCompatible, prompt: "p", transcript: "t",
+            executablePathOverride: nil, model: "m", timeout: 30,
+            openAIBaseURL: "http://localhost:11434/v1", openAIAPIKey: "k",
+            jsonMode: false, transport: transport)
+        XCTAssertNotNil(result.setupError)
+        XCTAssertNil(result.httpStatus)
+        XCTAssertFalse(result.didLaunch)
+    }
+}
+
+// MARK: - Phase 8: UI predicates + host-locality helper
+
+@MainActor
+final class OpenAIUIPredicateTests: XCTestCase {
+
+    private func makeSettings() -> LLMSettings {
+        let suite = UserDefaults(suiteName: "OpenAIUIPredicateTests.\(UUID().uuidString)")!
+        return LLMSettings(defaults: suite,
+                           apiKeyKeychainKey: "OpenAIUIPredicateTests.dummy.key")
+    }
+
+    // AC-UI-01/02 — the predicate that gates the CLI-only fields.
+    func test_openAIFieldsHidden_forClaudeCursorNone() {
+        let llm = makeSettings()
+        llm.tool = .claude
+        XCTAssertFalse(llm.isOpenAICompatible, "CLI fields shown for .claude")
+        llm.tool = .cursor
+        XCTAssertFalse(llm.isOpenAICompatible, "CLI fields shown for .cursor")
+        llm.tool = .none
+        XCTAssertFalse(llm.isOpenAICompatible, "CLI fields shown for .none")
+    }
+
+    func test_openAIFieldsVisible_forOpenAICompatible() {
+        let llm = makeSettings()
+        llm.tool = .openaiCompatible
+        XCTAssertTrue(llm.isOpenAICompatible,
+                      "CLI fields hidden + OpenAI fields shown for .openaiCompatible")
+    }
+
+    // AC-UI-04 — the timeout section label drops "CLI" for OpenAI.
+    func test_timeoutLabel_isTimeoutNotCLI_forOpenAI() {
+        let llm = makeSettings()
+        llm.tool = .claude
+        XCTAssertEqual(llm.timeoutLabel, "CLI timeout")
+        llm.tool = .openaiCompatible
+        XCTAssertEqual(llm.timeoutLabel, "Timeout")
+    }
+}
+
+final class OpenAILocalityTests: XCTestCase {
+
+    // AC-UI-03 — privacy disclaimer shows iff the base URL host is non-local.
+    func test_isLocal_trueForLocalhostVariants() {
+        XCTAssertTrue(OpenAILocality.isLocal(baseURL: "http://localhost:11434/v1"))
+        XCTAssertTrue(OpenAILocality.isLocal(baseURL: "http://127.0.0.1:11434/v1"))
+        XCTAssertTrue(OpenAILocality.isLocal(baseURL: "http://0.0.0.0:11434/v1"))
+        XCTAssertTrue(OpenAILocality.isLocal(baseURL: "http://[::1]:11434/v1"))
+        XCTAssertTrue(OpenAILocality.isLocal(baseURL: "http://myllama.local/v1"))
+    }
+
+    func test_isLocal_falseForRemoteHosts() {
+        XCTAssertFalse(OpenAILocality.isLocal(baseURL: "https://api.openai.com/v1"))
+        XCTAssertFalse(OpenAILocality.isLocal(baseURL: "https://api.groq.com/openai/v1"))
+        XCTAssertFalse(OpenAILocality.isLocal(baseURL: "https://openrouter.ai/api/v1"))
+    }
+
+    func test_isLocal_falseForGarbageURL() {
+        // Unparseable base URL must NOT be treated as local (safer to warn).
+        XCTAssertFalse(OpenAILocality.isLocal(baseURL: ""))
+        XCTAssertFalse(OpenAILocality.isLocal(baseURL: "not a url"))
+    }
+}
+
+// MARK: - Phase 9 — Live AI local/remote split (Option C)
+
+/// Validates the Live AI local/remote gate for `.openaiCompatible`
+/// (Phase 9, Option C). Local OpenAI endpoints run the existing stateless
+/// `kick()` branch — full transcript + current state each tick, JSON mode,
+/// low temperature. Remote OpenAI endpoints disable Live AI entirely at the
+/// `scheduleKick`/`kick` defense guards (and at the `aiActive` sites in
+/// production, covered by `OpenAIUIPredicateTests`-style wiring).
+///
+/// Behavioural tests drive the REAL `feed → scheduleKick → kick` path with a
+/// stubbed `performCall` that records the `LLMCall`, an injected `nowProvider`,
+/// and `llmMinIntervalSeconds = 0` so kicks fire immediately.
+@MainActor
+final class OpenAILiveAISplitTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private final class TestClock {
+        var now: Date
+        init(_ start: Date) { now = start }
+    }
+
+    /// Records each stubbed LLM call so tests can inspect the `LLMCall` the
+    /// session built (session mode, jsonMode, temperature, transcript, model,
+    /// base URL) without spawning a subprocess or hitting the network.
+    private final class CallLog {
+        var calls: [LiveAISession.LLMCall] = []
+    }
+
+    /// Build a Live AI session backed by an `.openaiCompatible` LLMSettings
+    /// with the given base URL. `apiKeyKeychainKey` is isolated per test so
+    /// setting `openAIAPIKey` never clobbers the real app's Keychain item.
+    private func makeSession(baseURL: String,
+                             clock: TestClock,
+                             log: CallLog,
+                             suite: String) -> LiveAISession {
+        UserDefaults().removePersistentDomain(forName: "\(suite).llm")
+        UserDefaults().removePersistentDomain(forName: "\(suite).live")
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!,
+                              apiKeyKeychainKey: "\(suite).apiKey")
+        llm.tool = .openaiCompatible
+        llm.openAIBaseURL = baseURL
+        llm.openAIModelName = "test-model"
+        llm.openAIAPIKey = ""   // local endpoints don't require a key
+        let live = LiveAISettings(defaults: UserDefaults(suiteName: "\(suite).live")!)
+        live.enabled = true
+        live.llmMinIntervalSeconds = 0   // fire immediately
+
+        let session = LiveAISession(llmSettings: llm, liveAISettings: live)
+        session.nowProvider = { clock.now }
+        session.performCall = { call in
+            log.calls.append(call)
+            // Minimal valid envelope so the success path runs.
+            return #"{"summary":"ok","items":[]}"#
+        }
+        session.start()   // .openaiCompatible → sessionID nil → stateless
+        return session
+    }
+
+    private func waitUntilIdle(_ session: LiveAISession,
+                               timeout: TimeInterval = 2) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while session.isThinking && Date() < deadline {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000) // 1 ms
+        }
+    }
+
+    // MARK: - AC-LIVEAI-01 / AC-LIVEAI-03 — local ⇒ stateless, full transcript
+
+    func test_liveAI_localBaseURL_runsStateless_fullTranscriptEachTick() async {
+        let clock = TestClock(Date())
+        let log = CallLog()
+        let session = makeSession(baseURL: "http://localhost:11434/v1",
+                                  clock: clock, log: log,
+                                  suite: "OpenAILiveAISplit.local")
+
+        session.feed(transcript: "segment one", immediate: true)
+        await waitUntilIdle(session)
+        session.feed(transcript: "segment one segment two", immediate: true)
+        await waitUntilIdle(session)
+
+        // Two ticks fired (one per feed).
+        XCTAssertGreaterThanOrEqual(log.calls.count, 2)
+        // Stateless: the second tick ships the FULL latest transcript, not a
+        // delta — so it must contain both segments.
+        let second = log.calls.last!
+        XCTAssertTrue(second.transcript.contains("segment one"))
+        XCTAssertTrue(second.transcript.contains("segment two"))
+        // LLMSession is always `.none` on the OpenAI HTTP path.
+        XCTAssertEqual(second.session, .none)
+    }
+
+    // MARK: - AC-LIVEAI-02 — remote ⇒ disabled, no run called
+
+    func test_liveAI_remoteBaseURL_isDisabled_noRunCalled() async {
+        let clock = TestClock(Date())
+        let log = CallLog()
+        let session = makeSession(baseURL: "https://api.openai.com/v1",
+                                  clock: clock, log: log,
+                                  suite: "OpenAILiveAISplit.remote")
+
+        session.feed(transcript: "hello world", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(log.calls.count, 0,
+                       "Remote OpenAI base URL must disable Live AI — no tick fired.")
+    }
+
+    // MARK: - AC-LIVEAI-04 — JSON mode + low temperature for envelope reliability
+
+    func test_liveAI_openAICompatible_requestsJSONModeAndLowTemp() async {
+        let clock = TestClock(Date())
+        let log = CallLog()
+        let session = makeSession(baseURL: "http://localhost:11434/v1",
+                                  clock: clock, log: log,
+                                  suite: "OpenAILiveAISplit.jsonmode")
+
+        session.feed(transcript: "hello world", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(log.calls.count, 1)
+        XCTAssertTrue(log.calls[0].jsonMode,
+                      "Live AI OpenAI ticks must request JSON mode for reliable envelopes.")
+        XCTAssertEqual(log.calls[0].temperature, 0.2,
+                       "Live AI OpenAI ticks must use a low temperature (0.2) for stable output.")
+        // The OpenAI config is threaded from llmSettings into the LLMCall.
+        XCTAssertEqual(log.calls[0].openAIBaseURL, "http://localhost:11434/v1")
+        XCTAssertEqual(log.calls[0].model, "test-model")
+    }
+
+    // MARK: - AC-LIVEAI-05 — parser tolerates ```json fences from local models
+
+    func test_parseEnvelope_handlesFencedJSONFromLocalModel() {
+        // Local models often wrap JSON in ```json fences. parseEnvelope
+        // extracts the first balanced JSON object regardless of fences.
+        let fenced = """
+        Here is the result:
+        ```json
+        {"summary":"team sync","items":[]}
+        ```
+        """
+        let parsed = LiveAISession.parseEnvelope(from: fenced)
+        XCTAssertEqual(parsed.summary, "team sync")
+        XCTAssertEqual(parsed.items.count, 0)
+    }
+}

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -645,14 +645,6 @@ final class RecordingTransport: OpenAITransport, @unchecked Sendable {
     var hangUntilCancelled = false
     private var hang: CheckedContinuation<Void, Never>?
 
-    // Explicit deinit to satisfy the `required_deinit` lint (CodeRabbit #6).
-    // Intentionally a no-op: `hang` is a `CheckedContinuation`, and resuming it
-    // here would crash if `release()`/cancellation already resumed it (a
-    // `CheckedContinuation` resumed twice is a fatal error). The suspended
-    // continuation is owned by the test Task that's cancelled during teardown,
-    // so it resolves with the test's lifetime — we don't resume from deinit.
-    deinit {}
-
     func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
         lock.lock()
         _requests.append(request)

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -42,19 +42,34 @@ final class LLMSettingsOpenAIReadinessTests: XCTestCase {
         XCTAssertFalse(s.isConfigured)
     }
 
-    /// AC-READY-04
-    func test_isConfigured_trueForOpenAI_whenBaseURLPresent() {
+    /// AC-READY-04 — a base URL alone is NOT enough; the OpenAI HTTP path
+    /// can't pick its own model, so a blank model name means any auto-title /
+    /// summary request is doomed. `isConfigured` must require both (CodeRabbit
+    /// #3 / `.claude/rules/feature-gates.md` — "enabled AND ready").
+    func test_isConfigured_falseForOpenAI_whenModelNameEmpty() {
         let s = makeSettings()
         s.tool = .openaiCompatible
         s.openAIBaseURL = "https://api.openai.com/v1"
+        s.openAIModelName = ""
+        XCTAssertFalse(s.isConfigured)
+    }
+
+    /// AC-READY-04 — base URL + model name together mark the tool ready.
+    func test_isConfigured_trueForOpenAI_whenBaseURLAndModelPresent() {
+        let s = makeSettings()
+        s.tool = .openaiCompatible
+        s.openAIBaseURL = "https://api.openai.com/v1"
+        s.openAIModelName = "gpt-4o-mini"
         XCTAssertTrue(s.isConfigured)
     }
 
-    /// AC-READY — a local/anonymous endpoint is configured without a key.
+    /// AC-READY — a local/anonymous endpoint is configured without a key, but
+    /// still needs a model name (the API key is the only optional field).
     func test_isConfigured_trueForOpenAI_evenWhenAPIKeyEmpty() {
         let s = makeSettings()
         s.tool = .openaiCompatible
         s.openAIBaseURL = "http://localhost:11434/v1"
+        s.openAIModelName = "llama3.2"
         s.openAIAPIKey = ""
         XCTAssertTrue(s.isConfigured)
     }
@@ -182,7 +197,13 @@ final class OpenAIResponseParserTests: XCTestCase {
 
     private func expectFailure(_ result: Result<String, Error>) -> Error {
         switch result {
-        case .success: return XCTFail("expected failure, got success") as! Error
+        case .success:
+            // `XCTFail` returns Void and doesn't halt execution; force-casting it
+            // to `Error` (the old `as! Error`) traps on regression. Record the
+            // failure, then hand back a sentinel so the caller's assertion can
+            // run instead of crashing the test host. (CodeRabbit #5.)
+            XCTFail("expected failure, got success")
+            return NSError(domain: "OpenAIResponseParserTests", code: 1, userInfo: nil)
         case .failure(let e): return e
         }
     }
@@ -274,7 +295,15 @@ final class OpenAIRequestBuilderTests: XCTestCase {
 
     private func bodyJSON(_ request: URLRequest) -> [String: Any] {
         let data = request.httpBody ?? Data()
-        return (try! JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        // `try!` would trap on a malformed body (and `XCTFail` doesn't halt
+        // execution, so a later `as!`/subscript could still crash). Decode
+        // softly and record the failure. (CodeRabbit #5.)
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any] else {
+            XCTFail("request body is not a JSON object: \(String(data: data, encoding: .utf8) ?? "<binary>")")
+            return [:]
+        }
+        return dict
     }
 
     /// AC-REQ-01 — `<trimmed baseURL>/chat/completions`, trailing-slash tolerant.
@@ -603,6 +632,14 @@ final class RecordingTransport: OpenAITransport, @unchecked Sendable {
     var hangUntilCancelled = false
     private var hang: CheckedContinuation<Void, Never>?
 
+    // Explicit deinit to satisfy the `required_deinit` lint (CodeRabbit #6).
+    // Intentionally a no-op: `hang` is a `CheckedContinuation`, and resuming it
+    // here would crash if `release()`/cancellation already resumed it (a
+    // `CheckedContinuation` resumed twice is a fatal error). The suspended
+    // continuation is owned by the test Task that's cancelled during teardown,
+    // so it resolves with the test's lifetime — we don't resume from deinit.
+    deinit {}
+
     func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
         requests.append(request)
         if let cannedError { throw cannedError }
@@ -750,6 +787,31 @@ final class OpenAITransportTests: XCTestCase {
         }
         XCTAssertEqual(transport.requests.count, 1,
                        "the request was dispatched before cancellation aborted it")
+    }
+
+    /// AC-CANCEL — a cooperative `CancellationError` (e.g. a custom/test
+    /// transport that throws it, rather than `URLSession`'s `URLError(.cancelled)`)
+    /// must map to `LLMRunnerError.cancelled`, not `.launchFailed` (CodeRabbit #2).
+    func test_runOpenAICompatible_mapsCancellationError_toCancelled() async throws {
+        struct CancelTransport: OpenAITransport {
+            func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
+                throw CancellationError()
+            }
+        }
+        do {
+            _ = try await LLMRunner.run(tool: .openaiCompatible,
+                                        prompt: "p", transcript: "t",
+                                        executablePathOverride: nil, model: "m",
+                                        timeout: 30,
+                                        openAIBaseURL: "http://localhost:11434/v1",
+                                        openAIAPIKey: "k", jsonMode: false,
+                                        transport: CancelTransport())
+            XCTFail("expected LLMRunnerError.cancelled")
+        } catch LLMRunnerError.cancelled {
+            // pass
+        } catch {
+            XCTFail("expected .cancelled, got \(error)")
+        }
     }
 
     // AC-CANCEL-02 — cancel wins over a response that arrives just after.
@@ -1080,8 +1142,13 @@ final class OpenAILiveAISplitTests: XCTestCase {
         // Two ticks fired (one per feed).
         XCTAssertGreaterThanOrEqual(log.calls.count, 2)
         // Stateless: the second tick ships the FULL latest transcript, not a
-        // delta — so it must contain both segments.
-        let second = log.calls.last!
+        // delta — so it must contain both segments. Guard rather than `last!`
+        // — `XCTAssertGreaterThanOrEqual` doesn't halt execution, so a failed
+        // count assertion would otherwise trap on the force-unwrap. (CodeRabbit #5.)
+        guard let second = log.calls.last else {
+            XCTFail("expected at least one tick call, got \(log.calls.count)")
+            return
+        }
         XCTAssertTrue(second.transcript.contains("segment one"))
         XCTAssertTrue(second.transcript.contains("segment two"))
         // LLMSession is always `.none` on the OpenAI HTTP path.

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -278,8 +278,8 @@ final class OpenAIRequestBuilderTests: XCTestCase {
     }
 
     /// AC-REQ-01 — `<trimmed baseURL>/chat/completions`, trailing-slash tolerant.
-    func test_makeRequest_postURL_joinsBaseURLWithChatCompletions() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1",
+    func test_makeRequest_postURL_joinsBaseURLWithChatCompletions() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1",
                                          model: "gpt-4o-mini", prompt: "p",
                                          transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: nil)
@@ -288,8 +288,8 @@ final class OpenAIRequestBuilderTests: XCTestCase {
         XCTAssertEqual(r.httpMethod, "POST")
     }
 
-    func test_makeRequest_stripsTrailingSlashFromBaseURL() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1/",
+    func test_makeRequest_stripsTrailingSlashFromBaseURL() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://api.openai.com/v1/",
                                          model: "m", prompt: "p", transcript: "t",
                                          summary: "", apiKey: "k", jsonMode: false, temperature: nil)
         XCTAssertEqual(r.url?.absoluteString,
@@ -297,31 +297,31 @@ final class OpenAIRequestBuilderTests: XCTestCase {
     }
 
     /// AC-REQ-02
-    func test_makeRequest_setsContentTypeJSON() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_setsContentTypeJSON() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: nil)
         XCTAssertEqual(r.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
     /// AC-REQ-03
-    func test_makeRequest_setsBearerAuthorization_whenKeyPresent() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_setsBearerAuthorization_whenKeyPresent() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "sk-abc", jsonMode: false, temperature: nil)
         XCTAssertEqual(r.value(forHTTPHeaderField: "Authorization"), "Bearer sk-abc")
     }
 
-    func test_makeRequest_omitsAuthorizationHeader_whenKeyEmpty() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_omitsAuthorizationHeader_whenKeyEmpty() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "", jsonMode: false, temperature: nil)
         XCTAssertNil(r.value(forHTTPHeaderField: "Authorization"))
     }
 
     /// AC-REQ-04 — a single `user` message holding the composed prompt.
-    func test_makeRequest_bodyMessages_singleUserMessageWithComposedPrompt() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_bodyMessages_singleUserMessageWithComposedPrompt() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "Summarize.", transcript: "hello world",
                                          summary: "gist", apiKey: "k", jsonMode: false, temperature: nil)
         let body = bodyJSON(r)
@@ -333,50 +333,101 @@ final class OpenAIRequestBuilderTests: XCTestCase {
     }
 
     /// AC-REQ-05 — model name is trimmed.
-    func test_makeRequest_bodyModel_equalsTrimmedModelName() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "  gpt-4o-mini  ",
+    func test_makeRequest_bodyModel_equalsTrimmedModelName() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "  gpt-4o-mini  ",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: nil)
         XCTAssertEqual(bodyJSON(r)["model"] as? String, "gpt-4o-mini")
     }
 
     /// AC-REQ-06 — response_format present iff jsonMode.
-    func test_makeRequest_includesResponseFormat_whenJSONModeRequested() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_includesResponseFormat_whenJSONModeRequested() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: true, temperature: nil)
         let rf = bodyJSON(r)["response_format"] as? [String: String]
         XCTAssertEqual(rf?["type"], "json_object")
     }
 
-    func test_makeRequest_omitsResponseFormat_whenJSONModeNotRequested() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_omitsResponseFormat_whenJSONModeNotRequested() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: nil)
         XCTAssertNil(bodyJSON(r)["response_format"])
     }
 
     /// AC-REQ-07 — non-streaming only.
-    func test_makeRequest_streamAlwaysFalse() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_streamAlwaysFalse() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: true, temperature: nil)
         XCTAssertEqual(bodyJSON(r)["stream"] as? Bool, false)
     }
 
     /// AC-REQ-09 — temperature included iff non-nil.
-    func test_makeRequest_includesTemperature_whenSet() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_includesTemperature_whenSet() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: 0.2)
         XCTAssertEqual(bodyJSON(r)["temperature"] as? Double, 0.2)
     }
 
-    func test_makeRequest_omitsTemperature_whenNil() {
-        let r = OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
+    func test_makeRequest_omitsTemperature_whenNil() throws {
+        let r = try OpenAIClient.makeRequest(baseURL: "https://x/v1", model: "m",
                                          prompt: "p", transcript: "t", summary: "",
                                          apiKey: "k", jsonMode: false, temperature: nil)
         XCTAssertNil(bodyJSON(r)["temperature"])
+    }
+
+    /// AC-REQ-11 (issue celarent7/mila#1) — a malformed base URL must surface
+    /// a typed `invalidEndpoint` error instead of crashing the app via a
+    /// force-unwrap. An internal space (not just leading/trailing) makes
+    /// `URL(string:)` return nil.
+    func test_makeRequest_throwsInvalidEndpoint_forMalformedBaseURL() {
+        XCTAssertThrowsError(try OpenAIClient.makeRequest(baseURL: "https://api.open ai.com/v1",
+                                                          model: "m", prompt: "p",
+                                                          transcript: "t", summary: "",
+                                                          apiKey: "k", jsonMode: false,
+                                                          temperature: nil)) { error in
+            XCTAssertEqual(error as? OpenAIRequestError, .invalidEndpoint("https://api.open ai.com/v1"))
+        }
+    }
+
+    /// AC-REQ-12 (issue celarent7/mila#1) — `runOpenAICompatible` must surface
+    /// the typed `invalidEndpoint` error (readable in the rename / Send sheet)
+    /// rather than crashing, when the base URL is malformed.
+    func test_runOpenAICompatible_throwsInvalidEndpoint_forMalformedBaseURL() async throws {
+        struct AlwaysReach: OpenAITransport {
+            func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
+                throw URLError(.badServerResponse)
+            }
+        }
+        do {
+            _ = try await LLMRunner.runOpenAICompatible(
+                prompt: "p", transcript: "t", summary: "", model: "m",
+                timeout: 30, baseURL: "https://api.open ai.com/v1",
+                apiKey: "k", jsonMode: false, temperature: nil,
+                transport: AlwaysReach())
+            XCTFail("Expected invalidEndpoint for a malformed base URL")
+        } catch let error as OpenAIRequestError {
+            XCTAssertEqual(error, .invalidEndpoint("https://api.open ai.com/v1"))
+        } catch {
+            XCTFail("Expected OpenAIRequestError.invalidEndpoint, got \(error)")
+        }
+    }
+
+    /// AC-REQ-13 (issue celarent7/mila#1) — `diagnoseOpenAICompatible` is
+    /// non-throwing, so a malformed base URL must land in `setupError` (and
+    /// NOT set `didLaunch`), not crash.
+    func test_diagnoseOpenAICompatible_reportsInvalidEndpoint_asSetupError() async {
+        let result = await LLMRunner.diagnoseOpenAICompatible(
+            prompt: "p", transcript: "t", summary: "", model: "m",
+            timeout: 30, baseURL: "https://api.open ai.com/v1",
+            apiKey: "k", jsonMode: false, transport: nil)
+        XCTAssertFalse(result.didLaunch, "An invalid endpoint must not count as a launch")
+        XCTAssertNotNil(result.setupError)
+        XCTAssertTrue(result.setupError?.contains("not a valid endpoint URL") ?? false,
+                      "setupError should name the invalid endpoint: \(result.setupError ?? "")")
     }
 
     /// AC-REQ-10 — the HTTP tool contributes no argv; the runner's HTTP branch
@@ -453,7 +504,8 @@ final class OpenAIProviderTests: XCTestCase {
     /// AC-PRESET-04 — picking a preset fills empty base URL + model fields.
     func test_selectingPreset_fillsBaseURLAndModel_whenFieldsEmpty() {
         let s = makeSettings()
-        s.applyPreset(.openai)
+        // First selection: provider starts at the `.custom` default.
+        s.applyPreset(.openai, previous: .custom)
         XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.openai.baseURL)
         XCTAssertEqual(s.openAIModelName, OpenAIProvider.openai.defaultModelName)
         XCTAssertEqual(s.openAIProvider, .openai)
@@ -464,7 +516,7 @@ final class OpenAIProviderTests: XCTestCase {
         let s = makeSettings()
         s.openAIBaseURL = "https://my-hosted.example/v1"
         s.openAIModelName = "my-model"
-        s.applyPreset(.groq)
+        s.applyPreset(.groq, previous: .custom)
         XCTAssertEqual(s.openAIBaseURL, "https://my-hosted.example/v1",
                        "A custom base URL must not be overwritten by a preset")
         XCTAssertEqual(s.openAIModelName, "my-model",
@@ -476,11 +528,37 @@ final class OpenAIProviderTests: XCTestCase {
     /// default values but not a user edit.
     func test_selectingPreset_overwritesPreviousPresetDefault() {
         let s = makeSettings()
-        s.applyPreset(.openai)            // fills openai defaults
+        s.applyPreset(.openai, previous: .custom)   // fills openai defaults
         XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.openai.baseURL)
-        s.applyPreset(.groq)              // openai defaults → groq defaults
+        s.applyPreset(.groq, previous: .openai)     // openai defaults → groq defaults
         XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.groq.baseURL)
         XCTAssertEqual(s.openAIModelName, OpenAIProvider.groq.defaultModelName)
+    }
+
+    /// AC-PRESET-06 (issue celarent7/mila#2) — switching presets via the
+    /// Settings `Picker` must actually update the base URL + model. The
+    /// `Picker` binding sets `openAIProvider` to the new value *before*
+    /// `.onChange` fires, so this test reproduces that exact order (set the
+    /// provider to the new preset first, then call `applyPreset(new,
+    /// previous: old)`). With the old `let previous = openAIProvider` read,
+    /// `previous` would be `.groq` (already updated) and the fields would
+    /// NOT change — the endpoint would stay pointed at OpenAI.
+    func test_selectingPreset_viaBindingOrder_updatesBaseURLAndModel() {
+        let s = makeSettings()
+        // Start on OpenAI, fields holding openai defaults (as a real first
+        // pick would leave them).
+        s.openAIProvider = .openai
+        s.openAIBaseURL = OpenAIProvider.openai.baseURL
+        s.openAIModelName = OpenAIProvider.openai.defaultModelName
+        // Picker binding updates openAIProvider FIRST ...
+        s.openAIProvider = .groq
+        // ... then .onChange fires with old=.openai, new=.groq.
+        s.applyPreset(.groq, previous: .openai)
+        XCTAssertEqual(s.openAIProvider, .groq)
+        XCTAssertEqual(s.openAIBaseURL, OpenAIProvider.groq.baseURL,
+                       "Switching OpenAI→Groq must update the base URL")
+        XCTAssertEqual(s.openAIModelName, OpenAIProvider.groq.defaultModelName,
+                       "Switching OpenAI→Groq must update the model name")
     }
 
     /// AC-PRESET-05 — OpenAI fields survive a settings re-creation (same defaults).

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -74,6 +74,65 @@ final class LLMSettingsOpenAIReadinessTests: XCTestCase {
         XCTAssertTrue(s.isConfigured)
     }
 
+    /// AC-READY-05 (CodeRabbit #3) — a *named hosted* preset with no API key is
+    /// not ready: every request would come back 401, so auto-title / auto-summary
+    /// must not fire at all. Mirrors `RemoteTranscriptionSettings.isConfigured`,
+    /// which likewise refuses to call OpenAI's endpoint without a token.
+    func test_isConfigured_falseForHostedPreset_whenAPIKeyMissing() {
+        let key = "LLMSettingsOpenAI.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAI.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAI.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        s.tool = .openaiCompatible
+        s.applyPreset(.openai, previous: .custom)   // fills base URL + model
+        XCTAssertFalse(s.isConfigured,
+                       "A hosted preset without an API key is enabled, not ready")
+        s.openAIAPIKey = "sk-live"
+        XCTAssertTrue(s.isConfigured,
+                      "Supplying the key completes the hosted preset")
+    }
+
+    /// AC-READY-05 — the key requirement must not lock out anonymous endpoints:
+    /// a local Ollama and a `.custom` (self-hosted / LAN) endpoint stay ready
+    /// without one, because we can't know whether they enforce auth.
+    func test_isConfigured_trueWithoutAPIKey_forLocalAndCustomEndpoints() {
+        let key = "LLMSettingsOpenAI.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        defer { KeychainHelper.delete(key: key) }
+        let suite = UserDefaults(suiteName: "LLMSettingsOpenAI.\(#function)")!
+        suite.removePersistentDomain(forName: "LLMSettingsOpenAI.\(#function)")
+        let s = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+
+        s.tool = .openaiCompatible
+        s.applyPreset(.ollamaLocal, previous: .custom)
+        XCTAssertTrue(s.isConfigured, "A local Ollama needs no API key")
+
+        s.openAIProvider = .custom
+        s.openAIBaseURL = "http://llm.corp.internal:8000/v1"
+        s.openAIModelName = "internal-model"
+        XCTAssertTrue(s.isConfigured,
+                      "A self-hosted custom endpoint is assumed open unless a key is given")
+    }
+
+    /// The readiness rule itself, pinned directly so the intent survives a
+    /// refactor of `isConfigured`.
+    func test_requiresAPIKeyForReadiness_hostedYes_localAndCustomNo() {
+        XCTAssertTrue(LLMSettings.requiresAPIKeyForReadiness(
+            provider: .openai, baseURL: "https://api.openai.com/v1"))
+        XCTAssertTrue(LLMSettings.requiresAPIKeyForReadiness(
+            provider: .groq, baseURL: "https://api.groq.com/openai/v1"))
+        XCTAssertFalse(LLMSettings.requiresAPIKeyForReadiness(
+            provider: .ollamaLocal, baseURL: "http://localhost:11434/v1"))
+        XCTAssertFalse(LLMSettings.requiresAPIKeyForReadiness(
+            provider: .custom, baseURL: "https://anything.example/v1"))
+        // A named preset repointed at a local proxy needs no key either.
+        XCTAssertFalse(LLMSettings.requiresAPIKeyForReadiness(
+            provider: .openai, baseURL: "http://localhost:8080/v1"))
+    }
+
     /// AC-READY — the existing CLI tools stay configured regardless of OpenAI state.
     func test_isConfigured_trueForClaude_regardlessOfOpenAIFields() {
         let s = makeSettings()
@@ -419,6 +478,49 @@ final class OpenAIRequestBuilderTests: XCTestCase {
                                                           apiKey: "k", jsonMode: false,
                                                           temperature: nil)) { error in
             XCTAssertEqual(error as? OpenAIRequestError, .invalidEndpoint("https://api.open ai.com/v1"))
+        }
+    }
+
+    /// AC-REQ-11 (CodeRabbit #4) — `URL(string:)` happily parses a scheme-less
+    /// string as a *relative* URL with no host, which then dies deep inside
+    /// `URLSession` as an opaque "unsupported URL". Require an absolute
+    /// http(s) URL with a host so the user gets the actionable Settings message
+    /// instead.
+    func test_makeRequest_throwsInvalidEndpoint_forSchemeLessOrNonHTTPBaseURL() {
+        for bad in ["api.openai.com/v1",          // no scheme ⇒ no host
+                    "/v1",                        // path only
+                    "ftp://example.com/v1",       // wrong scheme
+                    "file:///tmp/v1",             // wrong scheme, no host
+                    "https:///v1"] {              // scheme but empty host
+            XCTAssertThrowsError(
+                try OpenAIClient.makeRequest(baseURL: bad, model: "m", prompt: "p",
+                                             transcript: "t", summary: "",
+                                             apiKey: "k", jsonMode: false,
+                                             temperature: nil),
+                "\(bad) must be rejected as an invalid endpoint") { error in
+                    guard let typed = error as? OpenAIRequestError,
+                          case .invalidEndpoint = typed else {
+                        XCTFail("expected .invalidEndpoint for \(bad), got \(error)")
+                        return
+                    }
+                }
+        }
+    }
+
+    /// The validation must not reject legitimate endpoints — http and https,
+    /// with or without a port or a path prefix.
+    func test_makeRequest_acceptsValidHTTPAndHTTPSBaseURLs() throws {
+        for good in ["http://localhost:11434/v1",
+                     "https://api.groq.com/openai/v1",
+                     "http://192.168.1.10:8000/v1",
+                     "https://example.com"] {
+            let r = try OpenAIClient.makeRequest(baseURL: good, model: "m", prompt: "p",
+                                                 transcript: "t", summary: "",
+                                                 apiKey: "k", jsonMode: false,
+                                                 temperature: nil)
+            XCTAssertEqual(r.url?.absoluteString, "\(good)/chat/completions")
+            XCTAssertFalse(r.httpBody?.isEmpty ?? true,
+                           "a valid endpoint must still get a JSON body")
         }
     }
 
@@ -1204,13 +1306,19 @@ final class OpenAILiveAISplitTests: XCTestCase {
         await waitUntilIdle(session)
 
         XCTAssertEqual(log.calls.count, 1)
-        XCTAssertTrue(log.calls[0].jsonMode,
+        // `XCTAssertEqual` doesn't halt, so subscripting `[0]` would trap on a
+        // regression that fires zero ticks. Unwrap first. (CodeRabbit #5.)
+        guard let call = log.calls.first else {
+            XCTFail("expected exactly one tick call, got \(log.calls.count)")
+            return
+        }
+        XCTAssertTrue(call.jsonMode,
                       "Live AI OpenAI ticks must request JSON mode for reliable envelopes.")
-        XCTAssertEqual(log.calls[0].temperature, 0.2,
+        XCTAssertEqual(call.temperature, 0.2,
                        "Live AI OpenAI ticks must use a low temperature (0.2) for stable output.")
         // The OpenAI config is threaded from llmSettings into the LLMCall.
-        XCTAssertEqual(log.calls[0].openAIBaseURL, "http://localhost:11434/v1")
-        XCTAssertEqual(log.calls[0].model, "test-model")
+        XCTAssertEqual(call.openAIBaseURL, "http://localhost:11434/v1")
+        XCTAssertEqual(call.model, "test-model")
     }
 
     // MARK: - AC-LIVEAI-05 — parser tolerates ```json fences from local models

--- a/MilaTests/OpenAICompatibleTests.swift
+++ b/MilaTests/OpenAICompatibleTests.swift
@@ -626,7 +626,20 @@ final class OpenAIProviderTests: XCTestCase {
 /// `release()` if one was staged — so the "cancel wins over a late response"
 /// assertion is expressible).
 final class RecordingTransport: OpenAITransport, @unchecked Sendable {
-    private(set) var requests: [URLRequest] = []
+    // `requests` and `hang` are touched from the `send` task and, for `hang`,
+    // from the cancellation handler / `release()` — which run on different
+    // contexts. The lock serializes all of those accesses so the
+    // `@unchecked Sendable` conformance is honest and a cancellation race can
+    // neither miss the wakeup nor double-resume the `CheckedContinuation`
+    // (a double resume is a fatal error). `cannedResponse`/`cannedError`/
+    // `hangUntilCancelled` are set before the `send` task starts and only read
+    // inside it, so they need no guard.
+    private let lock = NSLock()
+    private var _requests: [URLRequest] = []
+    var requests: [URLRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return _requests
+    }
     var cannedResponse: (HTTPURLResponse, Data)?
     var cannedError: Error?
     var hangUntilCancelled = false
@@ -641,18 +654,27 @@ final class RecordingTransport: OpenAITransport, @unchecked Sendable {
     deinit {}
 
     func send(_ request: URLRequest) async throws -> (HTTPURLResponse, Data) {
-        requests.append(request)
+        lock.lock()
+        _requests.append(request)
+        lock.unlock()
         if let cannedError { throw cannedError }
         if hangUntilCancelled {
             let cancelled: Bool = await withTaskCancellationHandler {
                 await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                    if Task.isCancelled { cont.resume(); return }
+                    self.lock.lock()
+                    if Task.isCancelled {
+                        self.lock.unlock()
+                        cont.resume(); return
+                    }
                     self.hang = cont
+                    self.lock.unlock()
                 }
                 return Task.isCancelled
             } onCancel: {
-                self.hang?.resume()
-                self.hang = nil
+                // Route through `release()` so there's a single resume path;
+                // the lock + nil-after-extract makes a double resume impossible
+                // even if cancellation and a manual `release()` both fire.
+                self.release()
             }
             if cancelled || Task.isCancelled { throw URLError(.cancelled) }
             // Resumed by `release()` with a staged response.
@@ -663,10 +685,16 @@ final class RecordingTransport: OpenAITransport, @unchecked Sendable {
         return cannedResponse
     }
 
-    /// Release a hanging `send` (for the "late response" assertion).
+    /// Release a hanging `send` (for the "late response" assertion). Extracts
+    /// the continuation under the lock and resumes *after* unlocking, so a
+    /// concurrent cancellation (or a second `release()`) finds `hang == nil`
+    /// and no-ops instead of double-resuming.
     func release() {
-        hang?.resume()
+        lock.lock()
+        let cont = hang
         hang = nil
+        lock.unlock()
+        cont?.resume()
     }
 }
 

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -251,7 +251,90 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         XCTAssertFalse(coordinator.isSending(rec.id))
     }
 
+    // MARK: - OpenAI-compatible model threading (issue celarent7/mila#3)
+
+    /// `sendToLLM` must thread `openAIModelName` as the `model` argument for
+    /// the OpenAI-compatible path — otherwise the HTTP request POSTs an empty
+    /// model name and the endpoint rejects it. We inject a `runLLM` stub that
+    /// records the `model` it was handed and returns canned text, so the
+    /// assertion needs no network or CLI.
+    func test_sendToLLM_threadsOpenAIModelName_forOpenAICompatible() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.openai.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.openai.\(#function)")
+        let key = "PostRecordingCoordinatorSendTests.openai.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        let llm = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        llm.tool = .openaiCompatible
+        llm.openAIBaseURL = "https://api.openai.com/v1"
+        llm.openAIModelName = "gpt-4o-mini"
+
+        var capturedModel: String? = nil
+        var callCount = 0
+        let openAICoordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _ in
+                capturedModel = model
+                callCount += 1
+                return "OPENAI ANSWER"
+            })
+
+        let rec = addCompletedRecording(text: "the transcript text")
+        openAICoordinator.sendToLLM(recordingID: rec.id,
+                                    tool: .openaiCompatible,
+                                    prompt: "Summarize",
+                                    transcript: "the transcript text",
+                                    summary: "",
+                                    executableOverride: nil)
+        try await waitFor(callCount > 0)
+        XCTAssertEqual(capturedModel, "gpt-4o-mini",
+                       "The OpenAI path must thread openAIModelName, not an empty model")
+    }
+
+    /// The CLI path must keep passing `nil` for `model` (the CLI picks its
+    /// own) — the OpenAI-model threading must not leak into `.claude`/`.cursor`.
+    func test_sendToLLM_passesNilModel_forCLIPath() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.cli.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.cli.\(#function)")
+        let key = "PostRecordingCoordinatorSendTests.cli.\(#function).apiKey"
+        KeychainHelper.delete(key: key)
+        let llm = LLMSettings(defaults: suite, apiKeyKeychainKey: key)
+        llm.tool = .claude
+
+        var capturedModel: String? = "SENTINEL"
+        var callCount = 0
+        let cliCoordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _ in
+                capturedModel = model
+                callCount += 1
+                return "CLI ANSWER"
+            })
+
+        let rec = addCompletedRecording(text: "the transcript text")
+        cliCoordinator.sendToLLM(recordingID: rec.id,
+                                 tool: .claude,
+                                 prompt: "Summarize",
+                                 transcript: "the transcript text",
+                                 summary: "",
+                                 executableOverride: nil)
+        try await waitFor(callCount > 0)
+        XCTAssertNil(capturedModel,
+                     "The CLI path must leave model nil (the CLI chooses its own)")
+    }
+
     // MARK: - Helpers
+
+    /// Wait up to `timeoutSeconds` (default 5) for `condition` to hold, polling
+    /// every 50 ms. Fails the test on timeout — used by the OpenAI seam tests.
+    private func waitFor(_ condition: @autoclosure () async -> Bool,
+                         timeoutSeconds: TimeInterval = 5) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting on an injected runLLM stub to fire")
+    }
 
     /// Add a `.completed` recording with the given transcript text, with a
     /// placeholder audio file so `RecordingStore.add` is happy.

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -324,7 +324,7 @@ final class QuickActionsControllerTests: XCTestCase {
         let summarizer = RecordingSummarizer(store: store,
                                              llmSettings: llm,
                                              liveAISettings: liveAI,
-                                             runLLM: { _, _, transcript, _, _, _, _ in
+                                             runLLM: { _, _, transcript, _, _, _, _, _, _, _, _ in
             "COMPLETE: \(transcript)"
         })
         controller.llmSettings = llm

--- a/MilaTests/RecordingSummarizerBackfillTests.swift
+++ b/MilaTests/RecordingSummarizerBackfillTests.swift
@@ -60,7 +60,7 @@ final class RecordingSummarizerBackfillTests: XCTestCase {
     /// one go so a future regression that loosens any of them is caught.
     func test_backfill_only_targets_completed_non_trashed_missing_summary() async throws {
         llm.tool = .claude
-        useStubRunner { _, _, _, _, _, _, _ in "FILLED" }
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "FILLED" }
 
         // Eligible: completed, non-empty text, no summary, not trashed.
         let target = try addRecording(title: "Target",
@@ -108,7 +108,7 @@ final class RecordingSummarizerBackfillTests: XCTestCase {
     func test_backfill_noops_when_llm_not_configured() async throws {
         llm.tool = .none
         var called = false
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             called = true
             return "NOPE"
         }
@@ -134,7 +134,7 @@ final class RecordingSummarizerBackfillTests: XCTestCase {
     /// to relaunch the app or wait for a fresh recording to see summaries
     /// fill in.
     func test_backfill_runs_on_llm_config_flip() async throws {
-        useStubRunner { _, _, _, _, _, _, _ in "AUTO" }
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "AUTO" }
 
         // LLM starts unconfigured.
         XCTAssertEqual(llm.tool, .none)
@@ -163,7 +163,7 @@ final class RecordingSummarizerBackfillTests: XCTestCase {
     /// observable.
     func test_backfill_throttles_to_max_concurrent() async throws {
         let probe = ConcurrencyProbe()
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             await probe.enterAndWait()
             return "DONE"
         }
@@ -209,7 +209,7 @@ final class RecordingSummarizerBackfillTests: XCTestCase {
     /// parallel calls "first started" is the wrong question.
     func test_backfill_processes_newest_first() async throws {
         var order: [String] = []
-        useStubRunner { _, prompt, transcript, _, _, _, _ in
+        useStubRunner { _, prompt, transcript, _, _, _, _, _, _, _, _ in
             // The transcript text is the only thing that varies between our
             // recordings — record which marker this call carried.
             let blob = prompt + transcript

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -471,6 +471,41 @@ final class RecordingSummarizerTests: XCTestCase {
                        "isSummarizing should clear after CLI returns")
     }
 
+    // MARK: - OpenAI-compatible model threading (issue celarent7/mila#4)
+
+    /// The OpenAI-compatible summarizer must send `openAIModelName` (the
+    /// user's configured endpoint model), NOT `liveAISettings.model` (a Live
+    /// AI CLI override such as "claude-sonnet-4-6"). The latter 404's at the
+    /// endpoint as model-not-found. Mirrors `LiveAISession.kick`'s
+    /// tool-conditional selection.
+    func test_summarize_threadsOpenAIModelName_forOpenAICompatible() async throws {
+        llm.tool = .openaiCompatible
+        llm.openAIBaseURL = "https://api.openai.com/v1"
+        llm.openAIModelName = "gpt-4o-mini"
+        // Live AI's model is intentionally a *different* name — if the
+        // summarizer used it (the bug), the stub would record it here.
+        liveAI.model = "claude-sonnet-4-6"
+
+        var capturedModel: String? = ""
+        useStubRunner { _, _, _, _, model, _, _, _, _, _, _ in
+            capturedModel = model
+            return "A concise summary."
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Meeting")
+        try Data("not-audio".utf8).write(to: audioURL)
+        let rec = Recording(title: "Meeting", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent,
+                            fullText: "we discussed the roadmap")
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        XCTAssertEqual(capturedModel, "gpt-4o-mini",
+                       "The OpenAI summary path must send openAIModelName, not the Live AI model")
+    }
+
     // MARK: - Helpers
 
     /// Rebuild `summarizer` with a deterministic `runLLM` stub so the

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -124,7 +124,7 @@ final class RecordingSummarizerTests: XCTestCase {
     func test_summarize_stores_output_on_recording_and_writes_sidecar() async throws {
         llm.tool = .claude
         liveAI.model = ""
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             "A concise summary of the meeting."
         }
 
@@ -172,7 +172,7 @@ final class RecordingSummarizerTests: XCTestCase {
         // argv this way proves the one-shot `-p` shape without a subprocess.
         var capturedArgs: [String] = []
         var callCount = 0
-        useStubRunner { tool, prompt, transcript, _, model, extraArgs, _ in
+        useStubRunner { tool, prompt, transcript, _, model, extraArgs, _, _, _, _, _ in
             callCount += 1
             let composed = LLMRunner.composedPrompt(prompt, transcript: transcript)
             capturedArgs = tool.arguments(prompt: composed, model: model) + extraArgs
@@ -213,7 +213,7 @@ final class RecordingSummarizerTests: XCTestCase {
         llm.tool = .claude
         // Stub returns empty output — the production runner trims stdout, so
         // an empty return models a CLI that printed nothing useful.
-        useStubRunner { _, _, _, _, _, _, _ in "" }
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "" }
 
         let audioURL = store.freshAudioURL(suggestedName: "Empty")
         try Data("x".utf8).write(to: audioURL)
@@ -240,7 +240,7 @@ final class RecordingSummarizerTests: XCTestCase {
         llm.tool = .claude
 
         let gate = TestGate()
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             // Block until the test has patched the store, then return the
             // (now stale) CLI output.
             await gate.wait()
@@ -282,7 +282,7 @@ final class RecordingSummarizerTests: XCTestCase {
         llm.tool = .claude
         llm.summaryEnabled = false
         var called = false
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             called = true
             return "SHOULD NOT RUN"
         }
@@ -315,7 +315,7 @@ final class RecordingSummarizerTests: XCTestCase {
     func test_regenerate_works_even_when_auto_summary_disabled() async throws {
         llm.tool = .claude
         llm.summaryEnabled = false
-        useStubRunner { _, _, _, _, _, _, _ in "ON DEMAND" }
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "ON DEMAND" }
 
         let audioURL = store.freshAudioURL(suggestedName: "Manual")
         try Data("x".utf8).write(to: audioURL)
@@ -352,7 +352,7 @@ final class RecordingSummarizerTests: XCTestCase {
     /// synchronously and the assertion is deterministic.
     func test_regenerate_overwrites_existing_summary() async throws {
         llm.tool = .claude
-        useStubRunner { _, _, _, _, _, _, _ in "REGENERATED" }
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "REGENERATED" }
 
         let audioURL = store.freshAudioURL(suggestedName: "Regen")
         try Data("x".utf8).write(to: audioURL)
@@ -378,7 +378,7 @@ final class RecordingSummarizerTests: XCTestCase {
     func test_regenerate_noops_when_llm_not_configured() async throws {
         llm.tool = .none
         var called = false
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             called = true
             return "should not reach here"
         }
@@ -407,7 +407,7 @@ final class RecordingSummarizerTests: XCTestCase {
     func test_regenerate_noops_when_transcript_empty() async throws {
         llm.tool = .claude
         var called = false
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             called = true
             return "should not reach here"
         }
@@ -441,7 +441,7 @@ final class RecordingSummarizerTests: XCTestCase {
     func test_is_summarizing_tracks_in_flight_state() async throws {
         llm.tool = .claude
         let gate = TestGate()
-        useStubRunner { _, _, _, _, _, _, _ in
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
             await gate.wait()
             return "done"
         }


### PR DESCRIPTION
## Summary

Adds a native OpenAI-compatible `/v1/chat/completions` path alongside the existing `claude` / `cursor-agent` CLI integration, so users can point Mila at any OpenAI-compatible provider — Ollama Cloud, OpenAI, Groq, OpenRouter, DeepSeek, a local Ollama, or a custom endpoint — instead of requiring a local LLM CLI.

Designed and executed via a TDD plan (RED → GREEN → REFACTOR per phase); ~40 new tests cover the pure request/response layers, settings/keychain, transport injection, diagnose panel, UI predicates, host-locality, and the Live AI local/remote split. The CLI path is provably unchanged (Phase 10 regression guards).

## Architecture

- **Pure layers (no network needed to test):** `OpenAIClient.makeRequest` builds the `URLRequest`; `OpenAIClient.parse` decodes `(Data, HTTPURLResponse)` into content or a typed `OpenAIRequestError` (auth / notFound / server / emptyOutput).
- **Injectable transport:** `OpenAITransport` protocol + `URLSessionTransport`. Only `transport` is caller-transparent; `baseURL` / `apiKey` / `jsonMode` / `temperature` are threaded explicitly at every `run` / `diagnose` call site.
- **`LLMRunner.run` / `diagnose`:** an early `.openaiCompatible` branch (ahead of CLI resolution) composes the three layers and maps `URLError.cancelled` / `.timedOut` back onto `LLMRunnerError` so callers see the same error vocabulary the CLI path produces.

## Settings

- New `OpenAIProvider` preset enum (ollamaLocal / ollamaCloud / openai / openrouter / groq / deepseek / custom) with per-preset base URL + default model.
- API key stored in **Keychain** (mirrors `RemoteTranscriptionSettings`: write-through `didSet`, restore-on-init, isolated key for tests).
- `isConfigured` readiness gate for `.openaiCompatible` (base URL non-empty) — per `.claude/rules/feature-gates.md`.
- `LLMTestResult` extended with `url` / `httpStatus` / `requestBody`; `didLaunch` is now true when an HTTP response was received.

## UI (`SettingsView`)

Provider picker, base URL / model / API key fields, a remote-host privacy disclaimer (reuses `OpenAILocality.isLocal`), and an HTTP-aware test panel showing the request body + response status. CLI-only fields (executable path, extra args) hide on the OpenAI path.

## Live AI (Option C)

Local OpenAI endpoints run the existing **stateless** `kick()` branch (full transcript each tick, JSON mode, `temperature: 0.2` for envelope reliability). **Remote** OpenAI endpoints disable Live AI via a `liveAIDisabledByRemoteOpenAI` predicate on `LLMSettings` (remote re-bills the full transcript every stateless tick with no prompt-cache discount), consumed at both `aiActive` sites (`LiveAIRecordingView`, `MilaApp`) with defense-in-depth guards in `LiveAISession.scheduleKick` / `kick`. `LLMSession` is always `.none` on the HTTP path.

## Verification

- `make test`: full unit suite green except 2 pre-existing real-CLI smoke tests (`test_claude_cli…` / `test_cursor_cli…`) that require an authenticated `claude` / `cursor-agent` on the host — they call the unchanged CLI path with no OpenAI params and fail identically on `main` (401 / `agent login`), unrelated to this change.
- Release build installed to `/Applications/Mila.app` (1.9.0-beta.1, build 52).
- **Live cloud integration test** run against Ollama Cloud (`deepseek-v4-flash:cloud`): `run` returns a title (`"Staging ECR Migration by Friday"`); `diagnose` reports HTTP 200 with the response body. (Probe run from a temporary, uncommitted test reading creds from a local file — not included in this PR.)

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible HTTP endpoint support (provider presets, custom base URL/model, API-key storage, JSON mode, temperature).
  * Updated settings, UI test panel, and flows (Live AI, title/rename/summarization, and “Send to LLM”) to use the HTTP path when selected.
* **Bug Fixes**
  * Preserved local CLI behavior when HTTP settings are present.
  * Improved HTTP/CLI result reporting (request/response details) plus cancellation and timeout handling; Live AI runs only for local endpoints.
* **Tests**
  * Added coverage for OpenAI-compatible requests, parsing, and end-to-end Live AI behavior.
* **Chores**
  * Ignored local-only LLM scratch artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->