### PR TITLE
Speaker name editing, directory, and cross-recording voice recognition

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -705,6 +705,39 @@ final class QuickActionsController: ObservableObject {
         // Snapshot final state. Safe to read now because `.idle`
         // handler is skipping its `transcriber.stop()` /
         // `diarizer.stop()` while `isFinalizingRecording` is true.
+        // `currentProfiles()` returns EVERY pool entry, including ones
+        // `seedPool` pre-loaded from stored voice profiles at recording
+        // start (see MilaApp) that were never matched to a real utterance.
+        // Only speakers that actually spoke — i.e. that produced at least
+        // one diarized interval — count as recognised/observed for this
+        // recording. Otherwise a seeded-but-silent profile would tag the
+        // recording with someone who never spoke and, worse, feed its stale
+        // seed centroid back into that person's profile on the next update.
+        let usedSpeakerIDs: Set<String> = Set((liveDiarizer?.intervals ?? []).map(\.speaker))
+        // Auto-populate speakerNames for speakers recognised from stored
+        // voice profiles. The live diarizer pool entries that were seeded
+        // from a profile carry `profileName`; map those back to the
+        // recording's speakerNames so the user sees real names immediately.
+        let recognisedSpeakerNames: [String: String] = {
+            guard let diar = liveDiarizer else { return [:] }
+            var names: [String: String] = [:]
+            for entry in diar.currentProfiles() where usedSpeakerIDs.contains(entry.id) {
+                if let profileName = entry.profileName {
+                    names[entry.id] = profileName
+                }
+            }
+            return names
+        }()
+        // Snapshot live pool embeddings for the recording so naming a
+        // speaker later (on an older recording) can still save a voice profile.
+        let liveEmbeddings: [String: [Float]] = {
+            guard let diar = liveDiarizer else { return [:] }
+            var embs: [String: [Float]] = [:]
+            for entry in diar.currentProfiles() where usedSpeakerIDs.contains(entry.id) {
+                embs[entry.id] = entry.centroid
+            }
+            return embs
+        }()
         let finalLiveSegments = liveTranscriber?.segments ?? []
         let finalSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -782,6 +815,15 @@ final class QuickActionsController: ObservableObject {
         updated.fullText = hasLiveSegments ? finalFullText : ""
         updated.summary = finalSummary.isEmpty ? nil : finalSummary
         updated.actionItems = finalItems.isEmpty ? nil : finalItems
+        // Auto-assign names from recognised voice profiles — but only for
+        // speakers the user did NOT already name mid-recording. A manual
+        // rename always wins over a silent auto-ID guess (a wrong guess is
+        // worse than no label).
+        for (rawID, name) in recognisedSpeakerNames where updated.speakerNames[rawID] == nil {
+            updated.speakerNames[rawID] = name
+        }
+        // Store live pool embeddings on the recording.
+        updated.speakerEmbeddings.merge(liveEmbeddings) { _, new in new }
         updated.status = liveTranscriptIsAuthoritative ? .completed : .pending
         store.update(updated)
 

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -255,6 +255,10 @@ struct MilaApp: App {
     /// Applies double-clicked `.milaconfig` files (with a confirmation sheet).
     @StateObject private var configImporter: MilaConfigImporter
     @StateObject private var updater = UpdaterViewModel()
+    /// Cross-recording voice-recognition profiles. Constructed in `init()`
+    /// via `_speakerProfileStore = StateObject(wrappedValue:)` like every
+    /// other app-wide store, per the project's Environment Objects convention.
+    @StateObject private var speakerProfileStore: SpeakerProfileStore
 
     init() {
         // RecordingStore's no-arg init handles the legacy migration and
@@ -510,6 +514,7 @@ struct MilaApp: App {
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
         _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
         _configImporter = StateObject(wrappedValue: configImporter)
+        _speakerProfileStore = StateObject(wrappedValue: SpeakerProfileStore())
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,
@@ -539,6 +544,7 @@ struct MilaApp: App {
                 .environmentObject(liveAISettings)
                 .environmentObject(liveTranscriber)
                 .environmentObject(liveSpeakerDiarizer)
+                .environmentObject(speakerProfileStore)
                 .environmentObject(liveAISession)
                 .environmentObject(updater)
                 .frame(minWidth: 1000, minHeight: 640)
@@ -639,6 +645,7 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
                 .environmentObject(configImporter)
+                .environmentObject(speakerProfileStore)
         }
     }
 
@@ -1183,6 +1190,7 @@ struct MilaApp: App {
                 // By the time this runs, the session has already been freshly
                 // started for this recording.
                 diarizer.reset()
+                diarizer.seedPool(with: speakerProfileStore.seedEntries())
                 diarizer.similarityThreshold = aiSettings.speakerSimilarityThreshold
                 // Detach the diarizer start so a quick stop-after-start
                 // doesn't block the state observer on pyannote cold-init.

--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -65,6 +65,19 @@ struct Recording: Identifiable, Codable, Hashable {
     /// microphone-only or system-wide system-audio captures.
     var appName: String?
 
+    /// User-assigned display names for diarized speakers. Maps raw
+    /// diarizer IDs (`SPEAKER_00`, `SPEAKER_01`, …) to custom names
+    /// ("John", "Sarah"). Empty when no speakers have been renamed.
+    /// Raw IDs stay in `TranscriptSegment.speaker` for color stability
+    /// and tooling compatibility; this dictionary is the override layer.
+    var speakerNames: [String: String] = [:]
+
+    /// Per-speaker voice embeddings (256-dim centroids). Populated from the
+    /// live diarizer pool at end of recording, or extracted after batch
+    /// diarization. Used to create voice profiles when the user names a
+    /// speaker, even on older recordings.
+    var speakerEmbeddings: [String: [Float]] = [:]
+
     /// Rolling Live-AI summary captured at the moment recording stopped.
     /// nil for any recording that ran without Live AI mode active.
     var summary: String?
@@ -93,13 +106,6 @@ struct Recording: Identifiable, Codable, Hashable {
     /// upgrade can't mass-delete a user's older imports.
     var voiceMemoFolderUUID: String?
 
-    /// User-assigned display names for diarized speakers, keyed by the raw
-    /// diarizer ID (`SPEAKER_00` → "Daniel"). Segments keep their raw IDs —
-    /// this map is a display overlay resolved at render/export time, so
-    /// re-clustering tooling and the color palette stay keyed on stable IDs.
-    /// Empty for recordings whose speakers were never renamed.
-    var speakerNames: [String: String]
-
     /// Sentinel stored in `voiceMemoFolderUUID` for memos imported from the
     /// Voice Memos "Unfiled" bucket, which has no real folder UUID. Keeps
     /// "imported from Unfiled" distinguishable from a legacy import whose
@@ -125,7 +131,8 @@ struct Recording: Identifiable, Codable, Hashable {
          actionItems: [ActionItem]? = nil,
          voiceMemoUniqueID: String? = nil,
          voiceMemoFolderUUID: String? = nil,
-         speakerNames: [String: String] = [:]) {
+         speakerNames: [String: String] = [:],
+         speakerEmbeddings: [String: [Float]] = [:]) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -140,14 +147,22 @@ struct Recording: Identifiable, Codable, Hashable {
         self.deletedAt = deletedAt
         self.folder = folder
         self.appName = appName
+        self.speakerNames = speakerNames
+        self.speakerEmbeddings = speakerEmbeddings
         self.summary = summary
         self.actionItems = actionItems
         self.voiceMemoUniqueID = voiceMemoUniqueID
         self.voiceMemoFolderUUID = voiceMemoFolderUUID
-        self.speakerNames = speakerNames
     }
 
     var isTrashed: Bool { deletedAt != nil }
+
+    /// Resolved display name for a raw speaker ID. Returns the user's
+    /// custom name from `speakerNames` if set, otherwise falls back to
+    /// the locale-aware friendly label ("Speaker A" / "דובר א׳").
+    func displayName(for rawSpeaker: String, language: String) -> String {
+        speakerNames[rawSpeaker] ?? rawSpeaker.friendlySpeakerLabel(language: language)
+    }
 
     /// File name (relative to recordings directory) of the sidecar `.txt`
     /// holding the plain-text transcript. Derived from `audioFileName` so a
@@ -179,8 +194,8 @@ struct Recording: Identifiable, Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,
-             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID,
-             speakerNames
+             speakerNames, speakerEmbeddings,
+             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID
         // `fullText` deliberately excluded — lives in a sidecar .txt file.
         // Legacy records that had it inline are decoded via the custom init.
         case fullText
@@ -201,11 +216,12 @@ struct Recording: Identifiable, Codable, Hashable {
         self.deletedAt = try c.decodeIfPresent(Date.self, forKey: .deletedAt)
         self.folder = try c.decodeIfPresent(String.self, forKey: .folder)
         self.appName = try c.decodeIfPresent(String.self, forKey: .appName)
+        self.speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
+        self.speakerEmbeddings = try c.decodeIfPresent([String: [Float]].self, forKey: .speakerEmbeddings) ?? [:]
         self.summary = try c.decodeIfPresent(String.self, forKey: .summary)
         self.actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
         self.voiceMemoUniqueID = try c.decodeIfPresent(String.self, forKey: .voiceMemoUniqueID)
         self.voiceMemoFolderUUID = try c.decodeIfPresent(String.self, forKey: .voiceMemoFolderUUID)
-        self.speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
         // Legacy records still have fullText inline; new records leave it
         // empty here and RecordingStore loads it from the sidecar .txt.
         self.fullText = try c.decodeIfPresent(String.self, forKey: .fullText) ?? ""
@@ -226,13 +242,16 @@ struct Recording: Identifiable, Codable, Hashable {
         try c.encodeIfPresent(deletedAt, forKey: .deletedAt)
         try c.encodeIfPresent(folder, forKey: .folder)
         try c.encodeIfPresent(appName, forKey: .appName)
+        if !speakerNames.isEmpty {
+            try c.encode(speakerNames, forKey: .speakerNames)
+        }
+        if !speakerEmbeddings.isEmpty {
+            try c.encode(speakerEmbeddings, forKey: .speakerEmbeddings)
+        }
         try c.encodeIfPresent(summary, forKey: .summary)
         try c.encodeIfPresent(actionItems, forKey: .actionItems)
         try c.encodeIfPresent(voiceMemoUniqueID, forKey: .voiceMemoUniqueID)
         try c.encodeIfPresent(voiceMemoFolderUUID, forKey: .voiceMemoFolderUUID)
-        if !speakerNames.isEmpty {
-            try c.encode(speakerNames, forKey: .speakerNames)
-        }
         // fullText intentionally omitted — sidecar .txt is the source of truth.
     }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -379,6 +379,10 @@ final class RecordingStore: ObservableObject {
     /// `SPEAKER_NN` IDs — the name is a display overlay resolved at
     /// render/export time. Regenerates the `.srt` sidecar for completed
     /// recordings so the on-disk export matches what the UI shows.
+    ///
+    /// This is the primary rename entry point (used by the #88 speaker
+    /// picker). The voice-recognition layer additionally saves a voice
+    /// profile at the call site when an embedding is available.
     func setSpeakerName(_ name: String?, forSpeaker rawID: String, recordingID: UUID) {
         guard let idx = recordings.firstIndex(where: { $0.id == recordingID }) else { return }
         let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -393,6 +397,54 @@ final class RecordingStore: ObservableObject {
         if recordings[idx].status == .completed {
             TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
         }
+    }
+
+    /// Reassign a single segment to a different speaker. Used when the
+    /// diarizer wrongly grouped two different people under the same ID.
+    /// If `newSpeaker` doesn't exist in the recording yet, it's created
+    /// as the next `SPEAKER_NN` ID.
+    func reassignSegment(in recording: Recording, segmentID: UUID, to newSpeaker: String) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recording.id }) else { return }
+        guard let segIdx = recordings[idx].segments.firstIndex(where: { $0.id == segmentID }) else { return }
+        recordings[idx].segments[segIdx].speaker = newSpeaker
+        persist()
+    }
+
+    /// Create a new speaker ID for a recording (next available SPEAKER_NN).
+    func nextSpeakerID(in recording: Recording) -> String {
+        let existing = Set(recording.segments.compactMap(\.speaker))
+        var n = 0
+        while existing.contains(String(format: "SPEAKER_%02d", n)) { n += 1 }
+        return String(format: "SPEAKER_%02d", n)
+    }
+
+    /// All custom speaker names the user has assigned across every
+    /// recording, sorted alphabetically. Powers the autocomplete when
+    /// renaming a speaker and the Speakers directory view.
+    var allSpeakerNames: [String] {
+        let names = Set(recordings.flatMap(\.speakerNames.values))
+        return names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    /// Rename a speaker globally across all recordings. Every recording
+    /// that has `oldName` in its `speakerNames` values gets updated to
+    /// `newName`. A single `persist()` call flushes all changes at once.
+    func renameSpeakerGlobally(from oldName: String, to newName: String) {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != oldName else { return }
+        var changed = false
+        for idx in recordings.indices {
+            for (rawID, name) in recordings[idx].speakerNames where name == oldName {
+                recordings[idx].speakerNames[rawID] = trimmed
+                changed = true
+            }
+        }
+        if changed { persist() }
+    }
+
+    /// Recordings that contain a specific named speaker.
+    func recordings(forSpeaker name: String) -> [Recording] {
+        recordings.filter { $0.speakerNames.values.contains(name) }
     }
 
     /// Move a recording into a folder (or unfile it with nil). Auto-creates

--- a/Mila/Models/SpeakerProfile.swift
+++ b/Mila/Models/SpeakerProfile.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// Persistent voice profile for cross-recording speaker recognition.
+/// Stores the speaker's name alongside a centroid embedding (256-dim
+/// vector from wespeaker ECAPA-TDNN via pyannote). The centroid is a
+/// running mean of all embeddings observed for this speaker — the more
+/// recordings, the tighter the distribution.
+struct SpeakerProfile: Codable, Identifiable, Hashable {
+    var id: UUID
+    var name: String
+    /// 256-dimensional centroid embedding (running mean).
+    var embedding: [Float]
+    /// Number of utterances folded into the centroid.
+    var sampleCount: Int
+    var createdAt: Date
+    var lastSeenAt: Date
+
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: SpeakerProfile, rhs: SpeakerProfile) -> Bool { lhs.id == rhs.id }
+}
+
+/// Manages persistent speaker voice profiles for cross-recording
+/// recognition. Profiles are created when a user names a speaker
+/// that has an embedding in the live diarizer pool.
+@MainActor
+final class SpeakerProfileStore: ObservableObject {
+    @Published private(set) var profiles: [SpeakerProfile] = []
+
+    /// Tracks which speakers are currently having their voice profiles
+    /// updated (re-diarizing recordings to extract embeddings). Keyed
+    /// by speaker name so the UI can show progress per-speaker and
+    /// survive navigation away and back.
+    @Published var updatingProfiles: [String: ProfileUpdateState] = [:]
+
+    struct ProfileUpdateState {
+        var progress: Double = 0
+        var status: String?
+        var isRunning: Bool = true
+    }
+
+    private let fileManager = FileManager.default
+    private var storeURL: URL {
+        // Non-throwing resolution with a temp-dir fallback so a missing
+        // Application Support directory can't crash the app at launch —
+        // matches SpeakerDirectory's pattern (island-io/mila#88 review).
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory,
+                                          in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return appSupport
+            .appendingPathComponent("Mila", isDirectory: true)
+            .appendingPathComponent("speaker-profiles.json")
+    }
+
+    init() {
+        load()
+    }
+
+    // MARK: - CRUD
+
+    /// Upsert a speaker profile by name. If a profile with the same name
+    /// exists, merge the new embedding into its centroid via weighted
+    /// average. Otherwise create a new profile.
+    func updateProfile(name: String, embedding: [Float], sampleCount: Int) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !embedding.isEmpty else { return }
+
+        if let idx = profiles.firstIndex(where: { $0.name == trimmed }) {
+            // Weighted merge of centroids.
+            let existing = profiles[idx]
+            let totalCount = existing.sampleCount + sampleCount
+            var merged = [Float](repeating: 0, count: embedding.count)
+            for i in 0..<merged.count {
+                merged[i] = (existing.embedding[i] * Float(existing.sampleCount)
+                           + embedding[i] * Float(sampleCount)) / Float(totalCount)
+            }
+            profiles[idx].embedding = merged
+            profiles[idx].sampleCount = totalCount
+            profiles[idx].lastSeenAt = Date()
+            save()
+        } else {
+            let profile = SpeakerProfile(
+                id: UUID(),
+                name: trimmed,
+                embedding: embedding,
+                sampleCount: sampleCount,
+                createdAt: Date(),
+                lastSeenAt: Date()
+            )
+            profiles.append(profile)
+            save()
+        }
+    }
+
+    func deleteProfile(id: UUID) {
+        profiles.removeAll { $0.id == id }
+        save()
+    }
+
+    func deleteProfile(name: String) {
+        profiles.removeAll { $0.name == name }
+        save()
+    }
+
+    /// Check if a profile with the given name exists.
+    func profileExists(name: String) -> Bool {
+        profiles.contains { $0.name == name }
+    }
+
+    /// Find the profile for a given name.
+    func profile(named: String) -> SpeakerProfile? {
+        profiles.first { $0.name == named }
+    }
+
+    /// Rename a profile, propagating across all stored profiles.
+    func renameProfile(from oldName: String, to newName: String) {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != oldName else { return }
+        if let idx = profiles.firstIndex(where: { $0.name == oldName }) {
+            profiles[idx].name = trimmed
+            save()
+        }
+    }
+
+    /// Merge two profiles: keep the `keep` profile, absorb the `absorb`
+    /// profile's centroid via weighted average, then delete `absorb`.
+    /// Returns the merged profile.
+    @discardableResult
+    func mergeProfiles(keep keepName: String, absorb absorbName: String) -> SpeakerProfile? {
+        guard let keepIdx = profiles.firstIndex(where: { $0.name == keepName }),
+              let absorbIdx = profiles.firstIndex(where: { $0.name == absorbName }),
+              keepIdx != absorbIdx else { return nil }
+
+        let keep = profiles[keepIdx]
+        let absorb = profiles[absorbIdx]
+        let totalCount = keep.sampleCount + absorb.sampleCount
+        let dim = min(keep.embedding.count, absorb.embedding.count)
+        var merged = [Float](repeating: 0, count: dim)
+        for i in 0..<dim {
+            merged[i] = (keep.embedding[i] * Float(keep.sampleCount)
+                       + absorb.embedding[i] * Float(absorb.sampleCount)) / Float(totalCount)
+        }
+        profiles[keepIdx].embedding = merged
+        profiles[keepIdx].sampleCount = totalCount
+        profiles[keepIdx].lastSeenAt = max(keep.lastSeenAt, absorb.lastSeenAt)
+
+        // Remove absorb (index may have shifted if keepIdx < absorbIdx).
+        profiles.removeAll { $0.id == absorb.id }
+        save()
+        return profiles.first { $0.id == keep.id }
+    }
+
+    /// Match an embedding against all stored profiles. Returns the best
+    /// match above the threshold, or nil.
+    func match(embedding: [Float], threshold: Double = 0.55) -> SpeakerProfile? {
+        var best: (profile: SpeakerProfile, sim: Double)?
+        for profile in profiles {
+            let sim = cosineSimilarity(embedding, profile.embedding)
+            if sim >= threshold, best == nil || sim > best!.sim {
+                best = (profile, sim)
+            }
+        }
+        return best?.profile
+    }
+
+    /// Entries suitable for seeding the live diarizer pool.
+    func seedEntries() -> [(id: String, name: String, centroid: [Float], sampleCount: Int)] {
+        profiles.map { p in
+            (id: p.name, name: p.name, centroid: p.embedding, sampleCount: p.sampleCount)
+        }
+    }
+
+    // MARK: - Voice Profile Update (with re-diarization)
+
+    /// Re-extract embeddings from all recordings for a speaker, then
+    /// build/update the voice profile. Runs diarization on recordings
+    /// that lack embeddings. Progress is tracked in `updatingProfiles`
+    /// so the UI survives navigation.
+    func updateVoiceProfile(
+        speakerName: String,
+        store: RecordingStore,
+        pythonPath: String
+    ) {
+        guard updatingProfiles[speakerName]?.isRunning != true else { return }
+        updatingProfiles[speakerName] = ProfileUpdateState()
+
+        Task { @MainActor in
+            let recs = store.recordings(forSpeaker: speakerName)
+            var collectedEmbeddings: [([Float], Int)] = []
+            var recsNeedingExtraction: [Recording] = []
+
+            for rec in recs {
+                var hasEmbedding = false
+                for (rawID, name) in rec.speakerNames where name == speakerName {
+                    if let emb = rec.speakerEmbeddings[rawID], !emb.isEmpty {
+                        collectedEmbeddings.append((emb, 1))
+                        hasEmbedding = true
+                    }
+                }
+                if !hasEmbedding {
+                    recsNeedingExtraction.append(rec)
+                }
+            }
+
+            let total = recsNeedingExtraction.count
+            if total == 0, collectedEmbeddings.isEmpty {
+                updatingProfiles[speakerName] = ProfileUpdateState(
+                    progress: 1, status: "No voice data could be extracted.", isRunning: false)
+                return
+            }
+
+            for (i, rec) in recsNeedingExtraction.enumerated() {
+                updatingProfiles[speakerName]?.progress = Double(i) / Double(max(total, 1))
+                let wavURL = store.audioURL(for: rec)
+                guard FileManager.default.fileExists(atPath: wavURL.path) else {
+                    // Audio file gone (moved/deleted) — skip this recording.
+                    continue
+                }
+                do {
+                    let embeddings = try await SpeakerDiarizer.extractEmbeddings(
+                        wavURL: wavURL, pythonPath: pythonPath)
+                    if var current = store.recordings.first(where: { $0.id == rec.id }) {
+                        current.speakerEmbeddings.merge(embeddings) { _, new in new }
+                        store.update(current)
+                        for (rawID, name) in current.speakerNames where name == speakerName {
+                            if let emb = current.speakerEmbeddings[rawID], !emb.isEmpty {
+                                collectedEmbeddings.append((emb, 1))
+                            }
+                        }
+                    }
+                } catch {
+                    // Best-effort per recording: an extraction failure here
+                    // just means this recording contributes no voice sample.
+                }
+            }
+            updatingProfiles[speakerName]?.progress = 1.0
+
+            if collectedEmbeddings.isEmpty {
+                updatingProfiles[speakerName] = ProfileUpdateState(
+                    progress: 1, status: "No voice data could be extracted.", isRunning: false)
+                return
+            }
+
+            let dim = collectedEmbeddings[0].0.count
+            var centroid = [Float](repeating: 0, count: dim)
+            var totalCount = 0
+            for (emb, count) in collectedEmbeddings {
+                guard emb.count == dim else { continue }
+                for i in 0..<dim { centroid[i] += emb[i] * Float(count) }
+                totalCount += count
+            }
+            if totalCount > 0 {
+                for i in 0..<dim { centroid[i] /= Float(totalCount) }
+            }
+
+            deleteProfile(name: speakerName)
+            updateProfile(name: speakerName, embedding: centroid, sampleCount: totalCount)
+            let msg = "Updated from \(collectedEmbeddings.count) recording\(collectedEmbeddings.count == 1 ? "" : "s")"
+            updatingProfiles[speakerName] = ProfileUpdateState(
+                progress: 1, status: msg, isRunning: false)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let url = storeURL
+            // Ensure the Application Support/Mila directory exists — the
+            // non-throwing storeURL no longer creates it eagerly.
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(),
+                                            withIntermediateDirectories: true)
+            let data = try encoder.encode(profiles)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            print("SpeakerProfileStore save error: \(error)")
+        }
+    }
+
+    private func load() {
+        guard fileManager.fileExists(atPath: storeURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: storeURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            profiles = try decoder.decode([SpeakerProfile].self, from: data)
+        } catch {
+            print("SpeakerProfileStore load error: \(error)")
+        }
+    }
+}

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -60,9 +60,13 @@ final class LiveSpeakerDiarizer: ObservableObject {
     private var processQueue: Task<Void, Never>?
 
     struct SpeakerProfile {
-        let id: String
+        var id: String
         var centroid: [Float]
         var sampleCount: Int
+        /// Name of the speaker from a stored profile, if this pool entry
+        /// was seeded from a known voice profile. Nil for speakers first
+        /// encountered in this recording.
+        var profileName: String?
     }
 
     private struct EmbedResponse: Decodable {
@@ -211,6 +215,29 @@ final class LiveSpeakerDiarizer: ObservableObject {
         intervals.removeAll()
     }
 
+    /// Pre-populate the pool with known speaker profiles so returning
+    /// speakers are auto-recognised. Call after `reset()` at recording
+    /// start. Each entry gets a fresh `SPEAKER_NN` ID (pool-order) and
+    /// a low `sampleCount` so the centroid can adapt to current-session
+    /// acoustics on the first few matches.
+    func seedPool(with entries: [(id: String, name: String, centroid: [Float], sampleCount: Int)]) {
+        for entry in entries {
+            let id = String(format: "SPEAKER_%02d", pool.count)
+            pool.append(SpeakerProfile(
+                id: id,
+                centroid: entry.centroid,
+                sampleCount: min(entry.sampleCount, 3),
+                profileName: entry.name
+            ))
+        }
+    }
+
+    /// Snapshot the current pool for persistence. Returns entries for
+    /// each speaker with their final centroid and sample count.
+    func currentProfiles() -> [(id: String, centroid: [Float], sampleCount: Int, profileName: String?)] {
+        pool.map { ($0.id, $0.centroid, $0.sampleCount, $0.profileName) }
+    }
+
     /// Fire-and-track variant of `process(...)`. Chains the call onto
     /// `processQueue` so the FIFO order matches the daemon's, and
     /// `awaitPending()` can join the tail. Use this from the live-
@@ -325,7 +352,7 @@ final class LiveSpeakerDiarizer: ObservableObject {
             return pool[chosen.idx].id
         }
         let nextID = String(format: "SPEAKER_%02d", pool.count)
-        pool.append(SpeakerProfile(id: nextID, centroid: embedding, sampleCount: 1))
+        pool.append(SpeakerProfile(id: nextID, centroid: embedding, sampleCount: 1, profileName: nil))
         return nextID
     }
 

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -304,6 +304,110 @@ enum SpeakerDiarizer {
         return try JSONDecoder().decode([SpeakerTurn].self, from: result.stdout)
     }
 
+    /// Extract per-speaker embeddings from a WAV file by running
+    /// diarization and then embedding each speaker's longest turn.
+    /// Returns a dictionary mapping speaker IDs to 256-dim embeddings.
+    static func extractEmbeddings(wavURL: URL, pythonPath: String) async throws -> [String: [Float]] {
+        guard let modelsPath = bundledModelsPath else { return [:] }
+        var pythonInputURL = wavURL
+        var tempWAVToCleanUp: URL?
+        if wavURL.pathExtension.lowercased() != "wav" {
+            pythonInputURL = try AudioCompressor.decodeToTempWAV(wavURL)
+            tempWAVToCleanUp = pythonInputURL
+        }
+        defer {
+            if let temp = tempWAVToCleanUp { try? FileManager.default.removeItem(at: temp) }
+        }
+        let resolvedPython = resolvePython(userConfigured: pythonPath)
+        let extraEnv = pythonEnvironment()
+
+        let script = """
+        import json, sys, os, types
+
+        try:
+            import speechbrain.utils.importutils as _sbiu
+            _orig_ensure = _sbiu.LazyModule.ensure_module
+            def _safe_ensure(self, *a, **kw):
+                try:
+                    return _orig_ensure(self, *a, **kw)
+                except ImportError:
+                    self.lazy_module = types.ModuleType(self.target)
+                    return self.lazy_module
+            _sbiu.LazyModule.ensure_module = _safe_ensure
+        except Exception:
+            pass
+
+        import torch
+        _orig_torch_load = torch.load
+        def _patched_torch_load(*args, **kwargs):
+            kwargs["weights_only"] = False
+            return _orig_torch_load(*args, **kwargs)
+        torch.load = _patched_torch_load
+
+        import soundfile as sf
+        import tempfile
+        from pyannote.audio import Pipeline
+
+        wav_path = sys.argv[1]
+        models_dir = sys.argv[2]
+
+        config_path = os.path.join(models_dir, "config.yaml")
+        with open(config_path) as f:
+            config_text = f.read().replace("__MODELS_DIR__", models_dir)
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(config_text)
+        tmp.close()
+
+        try:
+            pipeline = Pipeline.from_pretrained(tmp.name)
+            if torch.backends.mps.is_available():
+                pipeline.to(torch.device("mps"))
+
+            diar = pipeline(wav_path)
+            annotation = getattr(diar, "speaker_diarization", diar)
+
+            turns = []
+            for turn, _, speaker in annotation.itertracks(yield_label=True):
+                turns.append({"start": turn.start, "end": turn.end, "speaker": speaker})
+
+            embedder = getattr(pipeline, "_embedding", None)
+            embeddings = {}
+            if embedder is not None:
+                longest = {}
+                for t in turns:
+                    sp = t["speaker"]
+                    dur = t["end"] - t["start"]
+                    if sp not in longest or dur > (longest[sp]["end"] - longest[sp]["start"]):
+                        longest[sp] = t
+                samples, sr = sf.read(wav_path, dtype="float32")
+                if samples.ndim > 1:
+                    samples = samples.mean(axis=1)
+                for sp, t in longest.items():
+                    start_sample = int(t["start"] * sr)
+                    end_sample = int(t["end"] * sr)
+                    chunk = samples[start_sample:end_sample]
+                    if len(chunk) < sr * 0.3:
+                        continue
+                    wave = torch.from_numpy(chunk).unsqueeze(0).unsqueeze(0)
+                    emb = embedder(wave)
+                    arr = emb.detach().cpu().numpy().flatten()
+                    embeddings[sp] = arr.tolist()
+
+            json.dump(embeddings, sys.stdout)
+        finally:
+            os.unlink(tmp.name)
+        """
+
+        let result = try await runPython(
+            path: resolvedPython,
+            arguments: ["-c", script, pythonInputURL.path, modelsPath],
+            environment: extraEnv
+        )
+        guard result.exitCode == 0, !result.stdout.isEmpty else { return [:] }
+        return (try? JSONDecoder().decode([String: [Float]].self, from: result.stdout)) ?? [:]
+    }
+
     struct VerifyResult: Codable {
         let pyannoteInstalled: Bool
         let torchInstalled: Bool

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -301,6 +301,8 @@ struct ContentView: View {
             QueueView(selection: $selection)
         case .more:
             MoreView()
+        case .speakers:
+            SpeakersView(selection: $selection)
         case .category(let cat):
             HistoryListView(category: cat, search: search, selection: $selection)
         case .defaultFolder:

--- a/Mila/Views/RecordingContextMenu.swift
+++ b/Mila/Views/RecordingContextMenu.swift
@@ -138,10 +138,21 @@ private struct RecordingContextMenu: ViewModifier {
                 transcription.enqueue(prepared, isRetranscription: true)
             }
             .disabled(isBusy)
-            Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
-                retranscribe(recording, in: currentLang.other)
+            if currentLang == .auto {
+                Button("Re-transcribe in 🇬🇧 English") {
+                    retranscribe(recording, in: .english)
+                }
+                .disabled(isBusy)
+                Button("Re-transcribe in 🇮🇱 Hebrew") {
+                    retranscribe(recording, in: .hebrew)
+                }
+                .disabled(isBusy)
+            } else {
+                Button("Re-transcribe in \(currentLang.other.flagEmoji) \(currentLang.other.displayName)") {
+                    retranscribe(recording, in: currentLang.other)
+                }
+                .disabled(isBusy)
             }
-            .disabled(isBusy)
             if llm.isConfigured {
                 Divider()
                 Button("Send to \(llm.tool.displayName)…") {

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -11,6 +11,10 @@ struct RecordingDetailView: View {
     @EnvironmentObject private var modelManager: ModelManager
     @EnvironmentObject private var llmSettings: LLMSettings
     @EnvironmentObject private var summarizer: RecordingSummarizer
+    /// Cross-recording voice-recognition store. Naming a speaker via the
+    /// picker also upserts a voice profile from the recording's stored
+    /// embedding, so a returning speaker is auto-identified next time.
+    @EnvironmentObject private var profileStore: SpeakerProfileStore
 
     @State private var player: AVPlayer?
     @State private var currentTime: Double = 0
@@ -301,6 +305,15 @@ struct RecordingDetailView: View {
             }
         } else {
             VStack(spacing: 0) {
+                if transcription.diarizingRecordingID == recording.id {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.small)
+                        Text("Identifying speakers…")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 6)
+                }
                 // Transcript-area copy button, on the right just below the
                 // AI-overview banner's divider. Mirrors the consolidated
                 // copy model: this grabs the transcript; the header button
@@ -335,6 +348,7 @@ struct RecordingDetailView: View {
                         let hasMultipleSpeakers = recording.segments.hasMultipleSpeakers
                         ForEach(recording.segments) { seg in
                             SegmentRow(segment: seg,
+                                       recording: recording,
                                        isActive: currentTime >= seg.start && currentTime < seg.end,
                                        showSpeaker: hasSpeakers,
                                        useSpeakerColor: hasMultipleSpeakers,
@@ -344,6 +358,20 @@ struct RecordingDetailView: View {
                                        onAssignName: { raw, name in
                                            store.setSpeakerName(name, forSpeaker: raw,
                                                                 recordingID: recording.id)
+                                           // Voice-recognition layer: upsert a voice
+                                           // profile from this recording's stored
+                                           // embedding so the named speaker is
+                                           // auto-identified in future recordings.
+                                           // `updateProfile` merges by name, so
+                                           // assigning an existing name folds the
+                                           // new sample into that person's centroid.
+                                           if let name, !name.isEmpty,
+                                              let embedding = recording.speakerEmbeddings[raw],
+                                              !embedding.isEmpty {
+                                               profileStore.updateProfile(name: name,
+                                                                          embedding: embedding,
+                                                                          sampleCount: 1)
+                                           }
                                        })
                         }
                     }
@@ -564,6 +592,7 @@ private struct AIOverviewBanner: View {
 
 private struct SegmentRow: View {
     let segment: TranscriptSegment
+    let recording: Recording
     let isActive: Bool
     let showSpeaker: Bool
     /// Whether to color the speaker label per-speaker rather than the
@@ -581,6 +610,9 @@ private struct SegmentRow: View {
     /// Persists a rename picked from the label's popover:
     /// (raw speaker ID, chosen name or nil-to-reset).
     let onAssignName: (String, String?) -> Void
+
+    /// Store access for the segment-level Reassign / Split context menu.
+    @EnvironmentObject private var store: RecordingStore
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -613,5 +645,23 @@ private struct SegmentRow: View {
                     in: RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
         .onTapGesture { onTap() }
+        .contextMenu {
+            if let raw = segment.speaker, !raw.isEmpty {
+                let otherSpeakers = Array(Set(recording.segments.compactMap(\.speaker)).filter { $0 != raw }).sorted()
+                if !otherSpeakers.isEmpty {
+                    Menu("Reassign to") {
+                        ForEach(otherSpeakers, id: \.self) { other in
+                            Button(recording.displayName(for: other, language: language)) {
+                                store.reassignSegment(in: recording, segmentID: segment.id, to: other)
+                            }
+                        }
+                    }
+                }
+                Button("Split to new speaker") {
+                    let newID = store.nextSpeakerID(in: recording)
+                    store.reassignSegment(in: recording, segmentID: segment.id, to: newID)
+                }
+            }
+        }
     }
 }

--- a/Mila/Views/SidebarView.swift
+++ b/Mila/Views/SidebarView.swift
@@ -8,6 +8,7 @@ enum SidebarSelection: Hashable {
     /// Video) live behind a single "More" page so Home stays focused
     /// on the one big Record button.
     case more
+    case speakers
     case category(HistoryCategory)
     /// Catch-all view for recordings the user hasn't filed anywhere
     /// yet — labelled "All Transcriptions" in the sidebar so users
@@ -60,6 +61,8 @@ struct SidebarView: View {
                     .tag(SidebarSelection.queue)
                 Label("More", systemImage: "ellipsis.circle")
                     .tag(SidebarSelection.more)
+                Label("Speakers", systemImage: "person.3")
+                    .tag(SidebarSelection.speakers)
             }
 
             Section("Folders") {

--- a/Mila/Views/SpeakersView.swift
+++ b/Mila/Views/SpeakersView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// Directory of all named speakers across the user's recordings.
+/// Shows each speaker with their recording count and most recent
+/// appearance, and lets the user drill into a speaker's recordings.
+struct SpeakersView: View {
+    @Binding var selection: SidebarSelection?
+    @EnvironmentObject private var store: RecordingStore
+
+    var body: some View {
+        Group {
+            let speakers = store.allSpeakerNames
+            if speakers.isEmpty {
+                ContentUnavailableView(
+                    "No named speakers",
+                    systemImage: "person.3",
+                    description: Text("Click a speaker label in any transcription to assign a name. Named speakers will appear here.")
+                )
+            } else {
+                List {
+                    ForEach(speakers, id: \.self) { name in
+                        let recs = store.recordings(forSpeaker: name)
+                        SpeakerRow(
+                            name: name,
+                            recordingCount: recs.count,
+                            lastRecordingDate: recs.map(\.createdAt).max(),
+                            recordings: recs,
+                            selection: $selection
+                        )
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle("Speakers")
+    }
+}
+
+private struct SpeakerRow: View {
+    let name: String
+    let recordingCount: Int
+    let lastRecordingDate: Date?
+    let recordings: [Recording]
+    @Binding var selection: SidebarSelection?
+
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var profileStore: SpeakerProfileStore
+    @State private var isExpanded = false
+    @State private var isEditing = false
+    @EnvironmentObject private var diarizationSettings: DiarizationSettings
+    @State private var nameDraft = ""
+    @FocusState private var nameFieldFocused: Bool
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            ForEach(recordings) { rec in
+                Button {
+                    selection = .recording(rec.id)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(rec.title)
+                                .font(.callout)
+                                .lineLimit(1)
+                            Text(rec.createdAt,
+                                 format: .dateTime.month().day().year().hour().minute())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(formatDuration(rec.duration))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        } label: {
+            HStack {
+                Image(systemName: "person.fill")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    if isEditing {
+                        TextField("Speaker name", text: $nameDraft)
+                            .font(.body.weight(.medium))
+                            .textFieldStyle(.roundedBorder)
+                            .focused($nameFieldFocused)
+                            .onSubmit { commitName() }
+                            .onExitCommand { cancelEdit() }
+                            .onChange(of: nameFieldFocused) { _, focused in
+                                if !focused { commitName() }
+                            }
+                            .accessibilityIdentifier("speakers.rename.field")
+                    } else {
+                        Text(name)
+                            .font(.body.weight(.medium))
+                            .contentShape(Rectangle())
+                            .onTapGesture { beginEdit() }
+                            .help("Click to rename speaker")
+                    }
+                    HStack(spacing: 12) {
+                        if let state = profileStore.updatingProfiles[name], state.isRunning {
+                            VStack(alignment: .leading, spacing: 4) {
+                                ProgressView(value: state.progress) {
+                                    Text("Extracting voice data…")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .progressViewStyle(.linear)
+                                Text("\(Int(state.progress * 100))%")
+                                    .font(.caption2.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
+                            .frame(maxWidth: 200)
+                        } else if let state = profileStore.updatingProfiles[name], let status = state.status {
+                            Text(status)
+                                .font(.caption)
+                                .foregroundStyle(status.contains("No") ? .orange : .teal)
+                                .onAppear {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                        profileStore.updatingProfiles.removeValue(forKey: name)
+                                    }
+                                }
+                        } else {
+                            if profileStore.profileExists(name: name) {
+                                Label("Voice profile", systemImage: "waveform.badge.person.crop")
+                                    .font(.caption)
+                                    .foregroundStyle(.teal)
+                            }
+                            Text("\(recordingCount) recording\(recordingCount == 1 ? "" : "s")")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            if let date = lastRecordingDate {
+                                Text("Last: \(date, format: .dateTime.month().day())")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+                Spacer()
+            }
+            .padding(.vertical, 4)
+            .contextMenu {
+                Button("Update Voice Profile") {
+                    profileStore.updateVoiceProfile(
+                        speakerName: name,
+                        store: store,
+                        pythonPath: diarizationSettings.pythonPath
+                    )
+                }
+                .disabled(profileStore.updatingProfiles[name]?.isRunning == true)
+                if profileStore.profileExists(name: name) {
+                    Button("Delete Voice Profile", role: .destructive) {
+                        profileStore.deleteProfile(name: name)
+                    }
+                }
+            }
+        }
+    }
+
+    private func beginEdit() {
+        nameDraft = name
+        isEditing = true
+        DispatchQueue.main.async { nameFieldFocused = true }
+    }
+
+    private func commitName() {
+        guard isEditing else { return }
+        let trimmed = nameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Reject a rename onto a name another speaker already uses. Both
+        // RecordingStore and SpeakerProfileStore key merges/lookups on exact
+        // name equality, so renaming onto an existing name would silently fold
+        // two different people's recordings together and leave two profiles
+        // sharing one name (breaking updateProfile's name-uniqueness). Merging
+        // speakers is a deliberate action, not a side effect of a typo'd rename.
+        if !trimmed.isEmpty, trimmed != name, !store.allSpeakerNames.contains(trimmed) {
+            store.renameSpeakerGlobally(from: name, to: trimmed)
+            profileStore.renameProfile(from: name, to: trimmed)
+        }
+        isEditing = false
+    }
+
+    private func cancelEdit() {
+        isEditing = false
+        nameDraft = name
+    }
+
+}


### PR DESCRIPTION
Closes #96

## Summary

- **Speaker name editing**: click any speaker label to rename inline (same UX as title editing), with autocomplete from previously-named speakers. Custom names flow through to clipboard copy, SRT export, and LLM prompts.
- **Speakers directory**: new sidebar tab listing all named speakers with recording counts, inline rename (propagates globally), voice profile badge, and "Update Voice Profile" action.
- **Cross-recording voice recognition**: persist 256-dim speaker embeddings as voice profiles. New recordings are seeded with known profiles — returning speakers are auto-identified silently. Each interaction (naming, merging, recording) improves the centroid.
- **Speaker merge & split**: merge prompt when assigning duplicate names ("Same person?") combines voice data. Right-click context menu to reassign segments or split to a new speaker.
- **Re-transcribe options**: auto-detected recordings now offer both English and Hebrew re-transcribe in the context menu.

## Files changed

| Area | Files |
|------|-------|
| Data model | `Recording.swift` (speakerNames, speakerEmbeddings), `RecordingStore.swift` (rename/merge/reassign methods), `SpeakerProfile.swift` (NEW - profile store) |
| Transcription | `LiveSpeakerDiarizer.swift` (pool seeding/snapshot), `SpeakerDiarizer.swift` (extractEmbeddings), `TranscriptFormatter.swift`, `TranscriptExporter.swift` |
| Views | `RecordingDetailView.swift` (inline edit, merge alert, split context menu), `SpeakersView.swift` (NEW - directory), `SidebarView.swift`, `ContentView.swift`, `RecordingContextMenu.swift` |
| App wiring | `MilaApp.swift` (SpeakerProfileStore + pool seeding), `QuickActionsController.swift` (auto-populate names + embeddings on stop) |
| Other | `CLAUDE.md` (updated), `SendToLLMSheet.swift`, `RenameRecordingSheet.swift`, `PostRecordingCoordinator.swift` |

## Test plan

- [ ] Name a speaker → verify all segments with that raw ID update
- [ ] Autocomplete suggests previously-named speakers as you type
- [ ] Speakers tab shows named speakers with recording counts
- [ ] Rename from Speakers tab propagates across all recordings
- [ ] Merge prompt appears when assigning a name already in use
- [ ] Right-click segment → "Split to new speaker" creates new speaker
- [ ] Right-click segment → "Reassign to" moves segment to existing speaker
- [ ] Voice profile badge appears after naming a speaker with live embeddings
- [ ] New recording auto-identifies returning speakers
- [ ] Re-transcribe context menu shows both languages for auto recordings
- [ ] make build succeeds, make test passes (existing tests unaffected)

🤖 Generated with [Claude Code](https://claude.ai/code)

---

## Rebase update (integrated on top of #88)

Rebased onto `main`, which now carries the manual speaker-naming foundation from **#88**. Per the plan in the review discussion, this PR now contributes **only the cross-recording voice-recognition layer on top of #88** rather than duplicating the naming UI.

- **Kept from #88 (main), not re-implemented:** the speaker rename popover picker (`SpeakerLabelButton` / `SpeakerNamePicker`), `TranscriptFormatter`/`TranscriptExporter` name overlay, `SpeakerNameRemapper` (name survival across offline re-diarize), and `speakerColor(names:)` merge-by-name coloring.
- **This PR adds:** `SpeakerProfile`/`SpeakerProfileStore` (persisted 256-dim voice profiles), `Recording.speakerEmbeddings`, live-pool seeding + silent auto-ID of returning speakers, batch `extractEmbeddings`, the Speakers directory (`SpeakersView`), the segment-level Reassign/Split context menu, and a hook so naming a speaker via #88's picker also upserts a voice profile.
- **Dropped in favor of #88:** the standalone inline speaker editor, the "Same person?" merge-confirm alert, and duplicate `TranscriptFormatter`/`TranscriptExporter` plumbing. Voice-data merge now happens automatically (`updateProfile` merges centroids by name).
- **Precedence:** a manual mid-recording rename always wins over a silent auto-ID guess.

Also addresses #24 (cross-recording speaker recognition).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Speakers section for viewing, renaming, and managing recognized speakers across recordings.
  * Added voice profiles to improve speaker recognition, including profile creation, updates, matching, and deletion.
  * Added per-segment speaker reassignment and the ability to create new speaker labels.
  * Automatically saves recognized speaker names and voice data after recording.
  * Added speaker-identification progress indicators and voice-profile status updates.
* **Bug Fixes**
  * Re-transcription now offers separate English and Hebrew options when the recording language is set to automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci: re-trigger linked-issue check -->
