### PR TITLE
Obsidian support and live-recording UX improvements

### DIFF
--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -53,6 +53,7 @@ make dmg VERSION="$VERSION"
 ## Verifying the signature
 
 A correct local build is signed with the Mila Local Dev cert (or ad-hoc if that cert was never created) and carries the app entitlements:
+
 ```bash
 codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature|Authority"
 # Identifier=io.island.whisper.IslandWhisper
@@ -81,9 +82,13 @@ Ad-hoc-signed apps copied (not downloaded) have no quarantine flag, so they laun
 
 ```bash
 SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
-      ~/Library/Keychains/login.keychain-db | awk '/SHA-1 hash/ {print $NF}' | head -1)
-codesign --force --sign "$SHA" \
-  --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+      ~/Library/Keychains/login.keychain-db 2>/dev/null | awk '/SHA-1 hash/ {print $NF}' | head -1)
+if [ -z "$SHA" ]; then
+  echo "no 'Mila Local Dev' cert — run scripts/install-debug.sh once to create it" >&2
+else
+  codesign --force --sign "$SHA" \
+    --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+fi
 ```
 
 If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it (or accept ad-hoc + per-install re-prompts).
@@ -93,5 +98,5 @@ If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it 
 - **Running `make dmg` without `VERSION=`** → the `MARKETING_VERSION: command not found` failure above. Always pass it.
 - **Editing `Mila.xcodeproj` directly** → overwritten on next `make project`. Edit `project.yml` instead.
 - **Hardcoding a version in `Info.plist`** → it must stay `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`; bump versions only in `project.yml`.
-- **Expecting a Developer-ID / notarized build** → not available locally; this repo only ad-hoc signs.
+- **Expecting a Developer-ID / notarized build** → not available locally; local builds sign with the Mila Local Dev cert or ad-hoc. (`CODESIGN_IDENTITY=- make dmg` forces ad-hoc, e.g. to test the Gatekeeper first-launch prompt.)
 - **`rm`-ing an old `/Applications/Mila.app`** → use `trash` so it's recoverable.

--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -7,7 +7,7 @@ description: Use when building, compiling, or running the Mila app locally from 
 
 ## Overview
 
-Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are **ad-hoc signed** ("Sign to Run Locally") — that is the only "self-signed" path this repo supports. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
+Mila builds via **XcodeGen** (`project.yml` is the source of truth, NOT the `.xcodeproj`) driven by a `Makefile`. Local builds are signed with the persistent self-signed **"Mila Local Dev"** cert when it exists in the login keychain (created on first run of `scripts/install-debug.sh`), falling back to **ad-hoc** ("Sign to Run Locally") otherwise. The stable cert matters: macOS TCC keys mic/screen-recording grants on the signing identity, so ad-hoc builds re-prompt for recording permission after every install. Notarized Developer-ID builds come from a separate private pipeline and are out of scope here.
 
 All build commands run from the repo root (wherever your checkout lives).
 
@@ -19,7 +19,7 @@ All build commands run from the repo root (wherever your checkout lives).
 | Debug build | `make build` | `build/Build/Products/Debug/Mila.app` |
 | Build **and launch** | `make run` | builds Debug, then `open`s it |
 | Release build | `make release-build` | `build-release/Build/Products/Release/Mila.app` |
-| Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (ad-hoc signed) |
+| Self-signed DMG | `make dmg VERSION=<x.y.z>` | `Mila-<x.y.z>.dmg` (Mila Local Dev cert if present, else ad-hoc) |
 | Run tests | `make test` | XCTest run |
 | Clean | `make clean` | removes `Mila.xcodeproj`, `build`, `build-release`, `*.dmg` |
 
@@ -52,11 +52,13 @@ make dmg VERSION="$VERSION"
 
 ## Verifying the signature
 
-A correct local build is ad-hoc signed:
+A correct local build is signed with the Mila Local Dev cert (or ad-hoc if that cert was never created) and carries the app entitlements:
 ```bash
-codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature"
+codesign -dv /Applications/Mila.app 2>&1 | grep -E "Identifier|Signature|Authority"
 # Identifier=io.island.whisper.IslandWhisper
-# Signature=adhoc
+# Authority=Mila Local Dev        (or Signature=adhoc as fallback)
+codesign -d --entitlements - /Applications/Mila.app 2>/dev/null | grep audio-input
+# must list com.apple.security.device.audio-input — if missing, re-sign (below)
 ```
 
 ## Installing a local build into /Applications
@@ -74,6 +76,17 @@ open -a /Applications/Mila.app    # verify it launches
 ```
 
 Ad-hoc-signed apps copied (not downloaded) have no quarantine flag, so they launch without the Gatekeeper right-click dance. If the app WAS downloaded, Gatekeeper shows a "right-click → Open" prompt on first launch.
+
+**TCC / recording-permission survival — re-sign if needed.** macOS keys mic and screen-recording grants on the app's signing identity + entitlements. `make dmg` already signs with the "Mila Local Dev" cert and `Mila/Resources/Mila.entitlements` when the cert exists in the login keychain, so a fresh DMG installs cleanly over a `scripts/install-debug.sh` install without re-prompting. But if the installed app is ad-hoc signed or missing entitlements (older DMG, cert created after the DMG was built — symptom: macOS asks for recording permission on every use), re-sign it in place:
+
+```bash
+SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+      ~/Library/Keychains/login.keychain-db | awk '/SHA-1 hash/ {print $NF}' | head -1)
+codesign --force --sign "$SHA" \
+  --entitlements Mila/Resources/Mila.entitlements /Applications/Mila.app
+```
+
+If the cert doesn't exist yet, run `scripts/install-debug.sh` once to create it (or accept ad-hoc + per-install re-prompts).
 
 ## Common Mistakes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,13 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
   literals there.
 - Tags are `v`-prefixed: `v1.2.8`. `CURRENT_PROJECT_VERSION` (the build
   number) must increase monotonically — Sparkle keys updates on it.
-- A local DMG for testing: `make dmg`. It signs with the persistent
+- A local DMG for testing: `make dmg VERSION=<x.y.z>` (the explicit
+  `VERSION=` is required — see the build skill). It signs with the persistent
   "Mila Local Dev" cert when that cert exists in the login keychain (created
   by `scripts/install-debug.sh`; keeps TCC mic/recording grants across
   installs) and falls back to ad-hoc otherwise. To force an ad-hoc build —
   e.g. to test the Gatekeeper right-click → Open first-launch prompt — run
-  `CODESIGN_IDENTITY=- make dmg`.
+  `CODESIGN_IDENTITY=- make dmg VERSION=<x.y.z>`.
 - Notarized, signed release builds and Sparkle appcast publishing are produced
   by a separate, private signing pipeline maintained by the original authors;
   that toolchain is not part of this repository. Forks that want notarized

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,12 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
   literals there.
 - Tags are `v`-prefixed: `v1.2.8`. `CURRENT_PROJECT_VERSION` (the build
   number) must increase monotonically — Sparkle keys updates on it.
-- A local, unsigned DMG for testing: `make dmg` (ad-hoc signed; Gatekeeper
-  shows the right-click → Open prompt on first launch).
+- A local DMG for testing: `make dmg`. It signs with the persistent
+  "Mila Local Dev" cert when that cert exists in the login keychain (created
+  by `scripts/install-debug.sh`; keeps TCC mic/recording grants across
+  installs) and falls back to ad-hoc otherwise. To force an ad-hoc build —
+  e.g. to test the Gatekeeper right-click → Open first-launch prompt — run
+  `CODESIGN_IDENTITY=- make dmg`.
 - Notarized, signed release builds and Sparkle appcast publishing are produced
   by a separate, private signing pipeline maintained by the original authors;
   that toolchain is not part of this repository. Forks that want notarized

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ A macOS (Swift/SwiftUI) local transcription app built on whisper.cpp, with optio
   - `Mila/Resources/DiarizationModels/` — bundled pyannote speaker diarization model weights (~31 MB)
   - `MilaTests/` — unit tests
   - `Packages/TranscriptionCore/` — cross-platform Swift package: WhisperEngine (whisper.cpp bindings), WAVReader, WER calculator, and E2E transcription test fixtures
+  - `Packages/MilaKit/` — zero-dependency Swift package shared by the app and the `mila-mcp` helper: TranscriptFormatter, the read-only `StoredRecording` mirror of recordings.json, `MilaStoreReader`, the live-transcript snapshot schema, and the MCP tool handlers
+  - `MilaMCP/` — the `mila-mcp` executable (MCP stdio server over Mila's transcriptions), embedded at `Mila.app/Contents/MacOS/mila-mcp`; see `docs/mcp.md`
   - `scripts/` — release/build scripts (make-dmg.sh, etc.)
 
 ## Conventions
@@ -46,9 +48,14 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
 - For verification/setup state that should survive app restarts, persist a `verified` flag alongside the verified parameter values (path). On launch, restore only if current values match the persisted ones.
 - Computed `status` properties must check `verificationStatus` before `lastVerifyResult` -- the persisted verified state should take precedence over nil in-memory verify results on launch.
 
+### MCP server (mila-mcp) and MilaKit
+- The app persists two cross-process contracts for the embedded MCP helper: `store-location.json` (written by `RecordingStore` on init + relocate — where recordings.json currently lives) and `live/current.json` (the live-transcript sidecar written during recording by `LiveTranscriptSidecarWriter`). Both live at the DEFAULT app-support root and deliberately do not travel with a relocated recordings folder.
+- **Any change to what `Recording.encode(to:)` writes into recordings.json must be mirrored in MilaKit's `StoredRecording`** — `StoredRecordingDriftTests` in MilaTests is the tripwire. Keep `StoredRecording` decoding lenient (`decodeIfPresent` + defaults) so an older helper survives a newer app's schema.
+- MilaKit must stay dependency-free (in particular: no TranscriptionCore) — it links into `mila-mcp`, which must not drag in the whisper xcframework. Tool logic lives in `MilaMCPToolHandlers` (pure JSON), not in the executable.
+
 ### Tests
 - `TranscriptionService` now requires a `diarizationSettings:` parameter. In tests, always pass `DiarizationSettings(defaults: .init(suiteName: "TestClassName.diarization")!)` to isolate from user defaults.
-- Run tests with `make test` or via Xcode.
+- Run tests with `make test` or via Xcode. Package tests: `make package-test` (TranscriptionCore + MilaKit).
 
 ## Release Process
 - **Release notes are REQUIRED, first.** Every release must add

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "  models-coreml-tiny - Download ggml-tiny + sibling -encoder.mlmodelc into ~/.cache/whisper-coreml-test/ (for CI ANE verification test)"
 	@echo "  dmg           - Build a release DMG (VERSION=<x.y.z>) suitable for upload"
 	@echo "  e2e           - Run E2E transcription tests (requires ggml-tiny.bin)"
-	@echo "  package-test  - Run TranscriptionCore package unit tests"
+	@echo "  package-test  - Run TranscriptionCore + MilaKit package unit tests"
 	@echo "  bundle-diarization - Produce the bundled Python + pyannote.audio runtime under Mila/Resources/PythonRuntime/"
 	@echo "  clean         - Remove generated project and build artifacts"
 
@@ -118,6 +118,7 @@ models-coreml-tiny:
 
 package-test:
 	cd Packages/TranscriptionCore && swift test
+	cd Packages/MilaKit && swift test
 
 # Produces Mila/Resources/PythonRuntime/ — a relocatable Python
 # 3.11 with pyannote.audio (and deps) pre-installed, minus torch which

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -349,9 +349,10 @@ enum LLMRunner {
         process.arguments = arguments
 
         // Inherit `$PATH` etc. so the CLI can find any helpers it shells out
-        // to. Spawning a Process from a sandboxed-style minimal environment
+        // to, but AUGMENT PATH so node-shebang CLIs find their interpreter.
+        // Spawning a Process from a sandboxed-style minimal environment
         // surprises users whose claude/cursor wrappers source nvm/asdf/etc.
-        process.environment = ProcessInfo.processInfo.environment
+        process.environment = childEnvironment(for: executable)
 
         // CRITICAL: spawn in a fresh, empty temp directory. macOS attributes
         // any file access by the child process to *our* bundle ID, so if
@@ -567,34 +568,82 @@ enum LLMRunner {
 
     /// Walk the user's `$PATH` plus a few common shell-managed locations
     /// (`~/.local/bin`, `/opt/homebrew/bin`, …). GUI apps on macOS inherit
-    /// a stripped-down PATH from launchd, so claude/cursor installed by
+    /// a stripped-down PATH from launchd, so claude/cursor/gemini installed by
     /// Homebrew or a node version manager are typically *not* on the
     /// inherited PATH — falling back to the well-known directories prevents
     /// the "works in Terminal, not in Mila" footgun.
     private static func lookupOnPath(_ name: String) -> URL? {
-        var searchDirs: [String] = []
-        if let path = ProcessInfo.processInfo.environment["PATH"] {
-            searchDirs += path.split(separator: ":").map(String.init)
-        }
-        let home = NSHomeDirectory()
-        searchDirs += [
-            "\(home)/.local/bin",
-            "\(home)/bin",
-            "\(home)/.cargo/bin",
-            "\(home)/.bun/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin"
-        ]
         let fm = FileManager.default
-        for dir in searchDirs {
+        for dir in searchDirectories() {
             let candidate = (dir as NSString).appendingPathComponent(name)
             if fm.isExecutableFile(atPath: candidate) {
                 return URL(fileURLWithPath: candidate)
             }
         }
         return nil
+    }
+
+    /// Environment for the spawned CLI. We inherit Mila's environment (so the
+    /// CLI still sees HOME, npm config, API-key vars, etc.) but *augment* PATH
+    /// so a node-shebang CLI can find its interpreter. `gemini`'s shebang is
+    /// `#!/usr/bin/env node`; a Finder-launched app gets a stripped PATH from
+    /// launchd, so without this it dies with `env: node: No such file or
+    /// directory`. We prepend the resolved executable's own directory (its
+    /// sibling `node` lives there for nvm/npm installs) plus the well-known
+    /// version-manager bins, then the inherited PATH — de-duped, order kept.
+    static func childEnvironment(
+        for executable: URL,
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var env = base
+        let inherited = base["PATH"]?.split(separator: ":").map(String.init) ?? []
+        var ordered: [String] = [executable.deletingLastPathComponent().path]
+        ordered += searchDirectories(pathEnv: nil)
+        ordered += inherited
+        var seen = Set<String>()
+        let merged = ordered.filter { !$0.isEmpty && seen.insert($0).inserted }
+        env["PATH"] = merged.joined(separator: ":")
+        return env
+    }
+
+    /// Ordered candidate directories for `lookupOnPath`: the inherited `$PATH`
+    /// first, then well-known shell/version-manager `bin` dirs. Node-based CLIs
+    /// (claude, cursor-agent, gemini) are commonly installed as global npm
+    /// packages under a version manager, so those roots are enumerated too.
+    /// Exposed (internal) so the version-manager enumeration is unit-testable.
+    static func searchDirectories(
+        home: String = NSHomeDirectory(),
+        pathEnv: String? = ProcessInfo.processInfo.environment["PATH"],
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var dirs: [String] = []
+        if let pathEnv {
+            dirs += pathEnv.split(separator: ":").map(String.init)
+        }
+        dirs += [
+            "\(home)/.local/bin",
+            "\(home)/bin",
+            "\(home)/.cargo/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.volta/bin",        // Volta
+            "\(home)/.asdf/shims",       // asdf
+            "\(home)/.npm-global/bin",   // custom npm prefix
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin"
+        ]
+        // nvm installs each Node version under
+        // ~/.nvm/versions/node/<version>/bin. A global npm package (claude,
+        // cursor-agent, gemini) lands in whichever version was active at
+        // install time, so search every installed version, newest first.
+        let nvmRoot = "\(home)/.nvm/versions/node"
+        if let versions = try? fileManager.contentsOfDirectory(atPath: nvmRoot) {
+            dirs += versions
+                .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+                .map { "\(nvmRoot)/\($0)/bin" }
+        }
+        return dirs
     }
 }
 

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -3,13 +3,14 @@ import Combine
 
 /// Which local LLM CLI Mila will shell out to for naming
 /// recordings and running post-recording actions. We deliberately keep this
-/// to a closed set of two so the Settings UI can show working defaults +
-/// concrete examples — supporting arbitrary CLIs would force the user to
-/// know shell-quoting rules.
+/// to a closed set of known CLIs so the Settings UI can show working
+/// defaults + concrete examples — supporting arbitrary CLIs would force the
+/// user to know shell-quoting rules.
 enum LLMTool: String, CaseIterable, Identifiable, Codable {
     case none
     case claude
     case cursor
+    case gemini
 
     var id: String { rawValue }
 
@@ -18,6 +19,7 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         case .none:   return "Off"
         case .claude: return "Claude (claude CLI)"
         case .cursor: return "Cursor (cursor-agent CLI)"
+        case .gemini: return "Gemini (gemini CLI)"
         }
     }
 
@@ -27,6 +29,7 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         case .none:   return ""
         case .claude: return "claude"
         case .cursor: return "cursor-agent"
+        case .gemini: return "gemini"
         }
     }
 
@@ -83,6 +86,21 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
                 args.append(contentsOf: ["--model", m])
             }
             // session intentionally ignored — see doc above.
+            return args
+        case .gemini:
+            // `gemini -p <prompt>` runs one-shot and streams the answer to
+            // stdout. `--skip-trust` is the gemini analogue of cursor's `-f`:
+            // we always launch in an isolated, empty sandbox dir (for TCC
+            // safety) which gemini treats as an untrusted workspace and
+            // otherwise refuses to run in headless mode. `-m` pins a model
+            // (e.g. gemini-2.5-flash); the CLI's configured default is used
+            // when omitted.
+            var args: [String] = ["-p", prompt, "--skip-trust"]
+            if hasModel, let m = trimmedModel {
+                args.append(contentsOf: ["-m", m])
+            }
+            // session intentionally ignored — gemini's -p mode has no
+            // documented conversation-resume flag.
             return args
         }
     }

--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MilaKit
+
+/// Writes a completed recording into the configured Obsidian vault as a
+/// Markdown note, then optionally kicks the git sync.
+///
+/// Content is **summary + action items** when a summary exists; when it
+/// doesn't (summaries off, LLM unconfigured, or generation failed) it falls
+/// back to **transcript + action items** so export stays independent of the
+/// LLM. One `.md` per recording, `<date> <title>.md`, into `vault/subfolder`.
+///
+/// Idempotency: a per-recording seen-index (Drive-importer discipline) maps the
+/// recording ID to its last-written relative path, so a re-transcription (or a
+/// title edit) overwrites/renames the same note instead of leaving duplicates.
+///
+/// The `pending` set is the sequencing gate: a fresh completion is marked
+/// pending, and the actual write happens from `RecordingSummarizer`'s
+/// completion hook once the summary is final. Backfilled recordings are never
+/// marked pending, so a launch-time summary sweep can't spam the vault.
+@MainActor
+final class ObsidianExporter: ObservableObject {
+    static let writtenIndexKey = "obsidian.writtenIndex"
+
+    private let settings: ObsidianVaultSettings
+    private let gitSyncer: ObsidianGitSyncer
+    private let defaults: UserDefaults
+    private let fileManager: FileManager
+
+    private var pending: Set<UUID> = []
+
+    init(settings: ObsidianVaultSettings,
+         gitSyncer: ObsidianGitSyncer = ObsidianGitSyncer(),
+         defaults: UserDefaults = .standard,
+         fileManager: FileManager = .default) {
+        self.settings = settings
+        self.gitSyncer = gitSyncer
+        self.defaults = defaults
+        self.fileManager = fileManager
+    }
+
+    // MARK: - Pending gate
+
+    func markPending(_ id: UUID) { pending.insert(id) }
+    func isPending(_ id: UUID) -> Bool { pending.contains(id) }
+    func clearPending(_ id: UUID) { pending.remove(id) }
+
+    // MARK: - Export
+
+    /// Write `recording` into the vault. No-op (returns nil) when the feature
+    /// is disabled, no vault is picked, or the recording has nothing worth
+    /// filing. Returns the written file URL on success.
+    @discardableResult
+    func export(_ recording: Recording) -> URL? {
+        guard settings.enabled, let vault = settings.vaultURL else { return nil }
+        guard let write = writeNote(recording, vault: vault) else { return nil }
+
+        if settings.gitSyncEnabled {
+            let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = "Add transcript: \(title.isEmpty ? "Untitled recording" : title)"
+            kickGitSync(vault: vault, changedPaths: write.changedPaths, commitMessage: message)
+        }
+        return write.written
+    }
+
+    /// Backfill: write every provided recording into the vault, then kick a
+    /// single git sync covering all of them. Used by "Sync existing
+    /// transcripts". Returns the count of notes actually written.
+    @discardableResult
+    func exportAll(_ recordings: [Recording]) -> Int {
+        guard settings.enabled, let vault = settings.vaultURL else { return 0 }
+
+        var changed: [URL] = []
+        for recording in recordings {
+            guard let write = writeNote(recording, vault: vault) else { continue }
+            changed.append(contentsOf: write.changedPaths)
+        }
+        guard !changed.isEmpty else { return 0 }
+
+        if settings.gitSyncEnabled {
+            let message = "Sync \(changed.count) Mila transcript\(changed.count == 1 ? "" : "s")"
+            kickGitSync(vault: vault, changedPaths: changed, commitMessage: message)
+        }
+        return changed.count
+    }
+
+    /// File `recording` into the vault (no git). Returns the written file plus
+    /// the paths that changed on disk (the new file and any old file removed by
+    /// a rename), or nil when there's nothing to write / the write fails.
+    private func writeNote(_ recording: Recording,
+                           vault: URL) -> (written: URL, changedPaths: [URL])? {
+        guard Self.hasContent(recording), let destDir = destinationDirectory(for: recording) else {
+            return nil
+        }
+
+        do {
+            try fileManager.createDirectory(at: destDir, withIntermediateDirectories: true)
+        } catch {
+            print("ObsidianExporter: failed to create \(destDir.path): \(error)")
+            return nil
+        }
+
+        let target = destDir.appendingPathComponent(Self.fileName(for: recording))
+        let newRelative = Self.relativePath(of: target, vault: vault)
+        var changedPaths: [URL] = [target]
+
+        // Overwrite discipline: if we wrote a differently-named file for this
+        // recording before (title changed / moved to another folder), remove it.
+        var index = writtenIndex()
+        let key = recording.id.uuidString
+        if let prevRelative = index[key], prevRelative != newRelative {
+            let old = vault.appendingPathComponent(prevRelative)
+            try? fileManager.removeItem(at: old)
+            changedPaths.append(old)
+        }
+
+        do {
+            try Self.markdown(for: recording).write(to: target, atomically: true, encoding: .utf8)
+        } catch {
+            print("ObsidianExporter: failed to write \(target.path): \(error)")
+            return nil
+        }
+        index[key] = newRelative
+        setWrittenIndex(index)
+        return (target, changedPaths)
+    }
+
+    /// The vault destination for `recording`: the configured subfolder, plus a
+    /// nested folder mirroring the recording's Mila folder when it has one.
+    private func destinationDirectory(for recording: Recording) -> URL? {
+        guard let base = settings.destinationDirectory else { return nil }
+        let folder = (recording.folder ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !folder.isEmpty else { return base }
+        let safe = Self.sanitizedTitle(folder)
+        guard !safe.isEmpty else { return base }
+        return base.appendingPathComponent(safe, isDirectory: true)
+    }
+
+    private func kickGitSync(vault: URL, changedPaths: [URL], commitMessage: String) {
+        let rawBranch = settings.gitBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = rawBranch.isEmpty ? ObsidianVaultSettings.defaultBranch : rawBranch
+        let syncer = gitSyncer
+        Task { @MainActor in
+            let error = await syncer.sync(vault: vault,
+                                          changedPaths: changedPaths,
+                                          branch: branch,
+                                          commitMessage: commitMessage)
+            self.settings.lastSyncError = error
+        }
+    }
+
+    // MARK: - Seen-index
+
+    private func writtenIndex() -> [String: String] {
+        defaults.dictionary(forKey: Self.writtenIndexKey) as? [String: String] ?? [:]
+    }
+
+    private func setWrittenIndex(_ index: [String: String]) {
+        defaults.set(index, forKey: Self.writtenIndexKey)
+    }
+
+    private static func relativePath(of url: URL, vault: URL) -> String {
+        let base = vault.path.hasSuffix("/") ? vault.path : vault.path + "/"
+        if url.path.hasPrefix(base) { return String(url.path.dropFirst(base.count)) }
+        return url.lastPathComponent
+    }
+
+    // MARK: - Formatting (pure, unit-tested)
+
+    /// True when the recording has anything worth writing (a summary,
+    /// transcript text, or action items).
+    static func hasContent(_ recording: Recording) -> Bool {
+        if !(recording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if !recording.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if let items = recording.actionItems, !items.isEmpty { return true }
+        return false
+    }
+
+    /// Build the note body: `# title`, then the summary (or a `## Transcript`
+    /// fallback), then a `## Action items` checklist when present.
+    static func markdown(for recording: Recording) -> String {
+        let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        var out = "# \(title.isEmpty ? "Untitled recording" : title)\n"
+
+        let summary = (recording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !summary.isEmpty {
+            out += "\n\(summary)\n"
+        } else {
+            let transcript = TranscriptFormatter.plainText(
+                segments: recording.segments,
+                fallback: recording.fullText,
+                names: recording.speakerNames
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !transcript.isEmpty {
+                out += "\n## Transcript\n\n\(transcript)\n"
+            }
+        }
+
+        if let items = recording.actionItems, !items.isEmpty {
+            out += "\n## Action items\n\n"
+            out += items.map { "- [ ] \($0.text)" }.joined(separator: "\n")
+            out += "\n"
+        }
+        return out
+    }
+
+    /// `<yyyy-MM-dd> <title>.md`, sanitized for the filesystem.
+    static func fileName(for recording: Recording) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let datePart = formatter.string(from: recording.createdAt)
+        let safeTitle = sanitizedTitle(recording.title)
+        let base = safeTitle.isEmpty ? datePart : "\(datePart) \(safeTitle)"
+        return base + ".md"
+    }
+
+    /// Strip path-hostile characters and collapse whitespace so the title is a
+    /// safe single-line filename component.
+    static func sanitizedTitle(_ title: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/\\:*?\"<>|")
+            .union(.newlines)
+            .union(.controlCharacters)
+        let stripped = title.components(separatedBy: invalid).joined(separator: " ")
+        return stripped
+            .split(whereSeparator: { $0 == " " || $0 == "\t" })
+            .joined(separator: " ")
+    }
+}

--- a/Mila/Actions/ObsidianGitSyncer.swift
+++ b/Mila/Actions/ObsidianGitSyncer.swift
@@ -1,0 +1,207 @@
+import Foundation
+import os
+
+/// Result of a single `git` invocation.
+struct GitCommandResult: Sendable {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+    let timedOut: Bool
+
+    var succeeded: Bool { !timedOut && exitCode == 0 }
+    /// Prefer stderr (git writes progress/errors there); fall back to stdout.
+    var message: String {
+        let e = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return e.isEmpty ? stdout.trimmingCharacters(in: .whitespacesAndNewlines) : e
+    }
+}
+
+/// Seam so tests can assert the exact command sequence without spawning git.
+protocol GitCommandRunning: Sendable {
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult
+}
+
+/// Commits + rebases + pushes an Obsidian vault git repo after a note is
+/// written. Modelled on the confirmed flow:
+///
+///   1. `git add <file>`
+///   2. `git commit -m <msg>`   (skipped cleanly when nothing changed)
+///   3. `git pull --rebase origin <branch>`
+///   4. `git push origin HEAD:<branch>`
+///
+/// On a rebase conflict we `git rebase --abort` so the vault is never left
+/// mid-conflict — the local commit is preserved and pushes on the next
+/// successful sync. All steps are non-interactive (see `ProcessGitCommandRunner`)
+/// and the whole thing is an `actor`, so concurrent recording completions can't
+/// interleave git commands in the same repo.
+actor ObsidianGitSyncer {
+    private let runner: GitCommandRunning
+
+    init(runner: GitCommandRunning = ProcessGitCommandRunner()) {
+        self.runner = runner
+    }
+
+    /// Run the sync. Returns nil on success, or a human-readable error string
+    /// to surface in Settings (the caller stores it on
+    /// `ObsidianVaultSettings.lastSyncError`).
+    ///
+    /// `changedPaths` are staged with `git add --all --` so note additions,
+    /// modifications, AND deletions (from a rename/overwrite) are all captured
+    /// while leaving the user's unrelated vault files untouched.
+    @discardableResult
+    func sync(vault: URL,
+              changedPaths: [URL],
+              branch: String,
+              commitMessage: String) async -> String? {
+        // Locate the repo toplevel from the vault dir. Doubles as the
+        // "is this a git repo?" guard.
+        let top = await runner.run(["rev-parse", "--show-toplevel"], in: vault)
+        guard top.succeeded else {
+            return "The Obsidian vault is not a git repository (git rev-parse failed)."
+        }
+        let toplevelPath = top.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let toplevel = toplevelPath.isEmpty ? vault : URL(fileURLWithPath: toplevelPath)
+
+        let add = await runner.run(["add", "--all", "--"] + changedPaths.map(\.path), in: toplevel)
+        guard add.succeeded else { return "git add failed: \(add.message)" }
+
+        let commit = await runner.run(["commit", "-m", commitMessage], in: toplevel)
+        if !commit.succeeded {
+            // A re-export of unchanged content leaves nothing to commit —
+            // that's fine, we still want to pull/push. Anything else is a
+            // real failure.
+            let lower = commit.message.lowercased()
+            let nothingToCommit = lower.contains("nothing to commit")
+                || lower.contains("no changes added")
+                || lower.contains("working tree clean")
+            if !nothingToCommit { return "git commit failed: \(commit.message)" }
+        }
+
+        let pull = await runner.run(["pull", "--rebase", "origin", branch], in: toplevel)
+        guard pull.succeeded else {
+            // Never leave the vault mid-rebase.
+            _ = await runner.run(["rebase", "--abort"], in: toplevel)
+            return "git pull --rebase failed (aborted): \(pull.message)"
+        }
+
+        let push = await runner.run(["push", "origin", "HEAD:\(branch)"], in: toplevel)
+        guard push.succeeded else { return "git push failed: \(push.message)" }
+
+        return nil
+    }
+}
+
+/// Production `GitCommandRunning` — spawns the real `git` binary with a bounded
+/// timeout and a non-interactive environment (no credential/host prompts that
+/// would hang a background sync).
+struct ProcessGitCommandRunner: GitCommandRunning {
+    var timeout: TimeInterval = 120
+
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult {
+        let timeout = self.timeout
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: Self.runSync(arguments, in: directory, timeout: timeout))
+            }
+        }
+    }
+
+    /// Resolve `git`: prefer the system binary shipped with the Command Line
+    /// Tools, then fall back to the same version-manager dirs `LLMRunner`
+    /// searches (a Finder-launched app has a stripped PATH).
+    static func gitExecutable() -> URL? {
+        let fm = FileManager.default
+        if fm.isExecutableFile(atPath: "/usr/bin/git") {
+            return URL(fileURLWithPath: "/usr/bin/git")
+        }
+        for dir in LLMRunner.searchDirectories() {
+            let candidate = (dir as NSString).appendingPathComponent("git")
+            if fm.isExecutableFile(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+
+    private static func runSync(_ arguments: [String],
+                                in directory: URL,
+                                timeout: TimeInterval) -> GitCommandResult {
+        guard let git = gitExecutable() else {
+            return GitCommandResult(exitCode: -1, stdout: "",
+                                    stderr: "git executable not found on PATH", timedOut: false)
+        }
+        let process = Process()
+        process.executableURL = git
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+
+        // Augment PATH so git finds any helpers, then force non-interactive:
+        //  * GIT_TERMINAL_PROMPT=0 — never prompt for username/password.
+        //  * GIT_SSH_COMMAND BatchMode — SSH fails fast instead of prompting
+        //    for a passphrase / unknown-host confirmation.
+        // A missing credential thus errors quickly rather than hanging the
+        // background sync forever.
+        var env = LLMRunner.childEnvironment(for: git)
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+        process.environment = env
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return GitCommandResult(exitCode: -1, stdout: "",
+                                    stderr: "failed to launch git: \(error.localizedDescription)",
+                                    timedOut: false)
+        }
+        try? stdinPipe.fileHandleForWriting.close()
+
+        // Drain both pipes on background threads so a chatty git can't
+        // deadlock by filling the OS pipe buffer while we wait for exit.
+        let outBox = OSAllocatedUnfairLock(initialState: Data())
+        let errBox = OSAllocatedUnfairLock(initialState: Data())
+        let drain = DispatchGroup()
+        for (pipe, box) in [(stdoutPipe, outBox), (stderrPipe, errBox)] {
+            drain.enter()
+            DispatchQueue.global().async {
+                let handle = pipe.fileHandleForReading
+                while true {
+                    let chunk = handle.availableData
+                    if chunk.isEmpty { break }
+                    box.withLock { $0.append(chunk) }
+                }
+                drain.leave()
+            }
+        }
+
+        let running = DispatchGroup()
+        running.enter()
+        DispatchQueue.global().async {
+            process.waitUntilExit()
+            running.leave()
+        }
+        let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
+        let timedOut = running.wait(timeout: deadline) == .timedOut
+        if timedOut {
+            process.terminate()
+            if running.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = running.wait(timeout: .now() + 3)
+            }
+        }
+        _ = drain.wait(timeout: .now() + 5)
+
+        let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""
+        let stderr = String(data: errBox.withLock { $0 }, encoding: .utf8) ?? ""
+        return GitCommandResult(exitCode: timedOut ? -1 : process.terminationStatus,
+                                stdout: stdout,
+                                stderr: stderr,
+                                timedOut: timedOut)
+    }
+}

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -316,7 +316,8 @@ final class PostRecordingCoordinator: ObservableObject {
             }
             if rec.status != .pending && rec.status != .running {
                 let text = TranscriptFormatter.plainText(segments: rec.segments,
-                                                         fallback: rec.fullText)
+                                                         fallback: rec.fullText,
+                                                         names: rec.speakerNames)
                 return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ? nil
                     : text

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import OSLog
+import MilaKit
 
 private let postRecordingLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
                                       category: "PostRecordingCoordinator")

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -625,7 +625,8 @@ final class QuickActionsController: ObservableObject {
             fullText: initialTranscriptSegments.map(\.text).joined(separator: " "),
             appName: appName,
             summary: initialSummary.isEmpty ? nil : initialSummary,
-            actionItems: initialItems.isEmpty ? nil : initialItems
+            actionItems: initialItems.isEmpty ? nil : initialItems,
+            speakerNames: liveTranscriber?.speakerNames ?? [:]
         )
         store.add(recording)
         activeJob = .none
@@ -769,6 +770,11 @@ final class QuickActionsController: ObservableObject {
             return
         }
         updated.segments = finalTranscriptSegments
+        // Mid-recording speaker renames from the live pane. Snapshotted
+        // here (before `liveTranscriber?.stop()` below) alongside the
+        // segments they label; `finalizeTail` remaps them if the offline
+        // re-diarize pass re-keys the speaker IDs.
+        updated.speakerNames = liveTranscriber?.speakerNames ?? [:]
         // Always preserve fullText when we have live segments — the
         // sheet should show what the user just saw on screen, even
         // for chunk mode while the batch diarization pass is still
@@ -869,9 +875,19 @@ final class QuickActionsController: ObservableObject {
                         wavURL: self.store.audioURL(for: updated),
                         segments: updated.segments,
                         recordingID: id) {
+                        let preRediarize = updated.segments
                         updated.segments = rediarized
                         if var current = self.store.recordings.first(where: { $0.id == id }) {
                             current.segments = rediarized
+                            // The offline pass re-keyed every SPEAKER_NN, so
+                            // names assigned mid-recording (or in the detail
+                            // view while this pass ran — hence the re-fetched
+                            // row's map, not the snapshot's) must follow the
+                            // utterances they labeled onto the new IDs.
+                            current.speakerNames = SpeakerNameRemapper.remap(
+                                names: current.speakerNames,
+                                from: preRediarize,
+                                to: rediarized)
                             self.store.update(current)
                             updated = current
                         }

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -598,11 +598,7 @@ final class QuickActionsController: ObservableObject {
         // live pane. Now the dialog pops up instantly; the
         // background drain below updates the Recording (and thus
         // the sheet, which observes the store) as more data lands.
-        let initialSegments = liveTranscriber?.segments ?? []
-        let initialTranscriptSegments: [TranscriptSegment] = initialSegments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
+        let initialTranscriptSegments = liveTranscriber?.transcriptSegments ?? []
         let initialSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let initialItems = liveAISession?.actionItems ?? []
@@ -613,7 +609,7 @@ final class QuickActionsController: ObservableObject {
         // the drain task. Mirrors `useLiveTranscript` below: both VAD
         // and chunk modes produce live segments we want to preserve,
         // so the initial-status gate is segment-presence, not mode.
-        let initialStatus: TranscriptionStatus = initialSegments.isEmpty ? .pending : .running
+        let initialStatus: TranscriptionStatus = initialTranscriptSegments.isEmpty ? .pending : .running
         let recording = Recording(
             title: title,
             duration: duration,

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -704,7 +704,7 @@ final class QuickActionsController: ObservableObject {
         // Snapshot final state. Safe to read now because `.idle`
         // handler is skipping its `transcriber.stop()` /
         // `diarizer.stop()` while `isFinalizingRecording` is true.
-        let finalLiveSegments = liveTranscriber?.segments ?? []
+        let finalTranscriptSegments = liveTranscriber?.transcriptSegments ?? []
         let finalSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let finalItems = liveAISession?.actionItems ?? []
@@ -750,12 +750,8 @@ final class QuickActionsController: ObservableObject {
         //
         // `vadActive` here is whatever was passed in by the caller —
         // typically `liveAISettings.useVAD && liveAISettings.enabled`.
-        let hasLiveSegments = !finalLiveSegments.isEmpty
+        let hasLiveSegments = !finalTranscriptSegments.isEmpty
         let liveTranscriptIsAuthoritative = hasLiveSegments && vadActive
-        let finalTranscriptSegments: [TranscriptSegment] = finalLiveSegments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
         let finalFullText = finalTranscriptSegments.map(\.text).joined(separator: " ")
 
         guard var updated = store.recordings.first(where: { $0.id == recording.id }) else {

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -124,6 +124,11 @@ final class QuickActionsController: ObservableObject {
     /// diarizer work so the final utterance's speaker label lands
     /// before the transcript is saved.
     var liveDiarizer: LiveSpeakerDiarizer?
+    /// Set after init by MilaApp. `stopRecording` closes the on-disk
+    /// live-transcript sidecar with the saved recording's id so external
+    /// pollers (mila-mcp) can hand off from the live feed to the stored
+    /// transcript.
+    var liveSidecarWriter: LiveTranscriptSidecarWriter?
 
     /// True only while `stopRecording` is running its inline LIVE-PIPELINE
     /// drain — the short, bounded window where it flushes the transcriber
@@ -550,6 +555,7 @@ final class QuickActionsController: ObservableObject {
             // recording. Cursor (PRRT_kwDOSY2m-s6GOIj-) flagged it.
             liveTranscriber?.stop()
             liveDiarizer?.stop()
+            liveSidecarWriter?.finish(recordingID: nil)
             isFinalizingRecording = false
             activeJob = .none
             return
@@ -625,6 +631,11 @@ final class QuickActionsController: ObservableObject {
             speakerNames: liveTranscriber?.speakerNames ?? [:]
         )
         store.add(recording)
+        // The recording is persisted — close the live sidecar with its id
+        // so an external poller's next get_live_transcript sees
+        // `completed` + the handoff id (the inline drain below keeps
+        // updating the STORED recording, which is what the handoff reads).
+        liveSidecarWriter?.finish(recordingID: recording.id)
         activeJob = .none
         if sleepReason != nil {
             sleepInterruption = SleepInterruption(

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -64,6 +64,21 @@ final class QuickActionsController: ObservableObject {
     /// new app and the user has to re-grant access.
     @Published var microphonePermissionMissing = false
 
+    /// Mila folder the *next* recording is filed into (nil = All Transcriptions).
+    /// Always defaults to All Transcriptions on launch — the choice is
+    /// per-session only and deliberately NOT persisted across launches, so a
+    /// folder picked for one session never silently becomes the default for
+    /// the next one. Set from the Home record controls; applied when the
+    /// recording is saved in `stopRecording`.
+    @Published var nextRecordingFolder: String?
+
+    /// User-entered meeting name for the *next* recording (empty = use the
+    /// auto-generated date-stamped title). Set from the Home controls and
+    /// the live recording screen; applied when the recording is saved in
+    /// `stopRecording`, then cleared so a name typed for one meeting never
+    /// silently carries into the next one.
+    @Published var nextRecordingTitle: String = ""
+
     /// Populated when a recording was force-stopped because the Mac went
     /// to sleep (lid close on battery, low-battery sleep, etc.). Surfaced
     /// to ContentView as an alert on the next wake so the user knows why
@@ -591,6 +606,12 @@ final class QuickActionsController: ObservableObject {
             }
         }()
 
+        // A user-entered meeting name (from Home or the live recording
+        // screen) overrides the auto-generated date-stamped title. Cleared
+        // below once the recording is built so it doesn't carry over.
+        let finalTitle = Self.resolvedRecordingTitle(userProvided: nextRecordingTitle,
+                                                     defaultTitle: title)
+
         // A mic-only recording that captured zero frames produces an empty
         // WAV → empty transcript → silent ".failed". Tell the user why
         // (the recording itself is still saved, so the rename sheet appears
@@ -624,7 +645,7 @@ final class QuickActionsController: ObservableObject {
         // so the initial-status gate is segment-presence, not mode.
         let initialStatus: TranscriptionStatus = initialTranscriptSegments.isEmpty ? .pending : .running
         let recording = Recording(
-            title: title,
+            title: finalTitle,
             duration: duration,
             source: source,
             audioFileName: outputURL.lastPathComponent,
@@ -632,12 +653,22 @@ final class QuickActionsController: ObservableObject {
             language: languageSettings.current.rawValue,
             segments: initialTranscriptSegments,
             fullText: initialTranscriptSegments.map(\.text).joined(separator: " "),
+            folder: nextRecordingFolder,
             appName: appName,
             summary: initialSummary.isEmpty ? nil : initialSummary,
             actionItems: initialItems.isEmpty ? nil : initialItems,
             speakerNames: liveTranscriber?.speakerNames ?? [:]
         )
         store.add(recording)
+        // Clear the one-shot meeting name so the next recording starts with
+        // a fresh, auto-generated title unless the user names it again.
+        nextRecordingTitle = ""
+        // Register the chosen folder in the store's folder list (and dedup
+        // case-insensitively) so the recording isn't orphaned out of both
+        // "All Transcriptions" and the folder.
+        if nextRecordingFolder != nil {
+            store.assign(recording, toFolder: nextRecordingFolder)
+        }
         // The recording is persisted — close the live sidecar with its id
         // so an external poller's next get_live_transcript sees
         // `completed` + the handoff id (the inline drain below keeps
@@ -1109,22 +1140,6 @@ final class QuickActionsController: ObservableObject {
         }
     }
 
-    var elapsed: TimeInterval { session.elapsed }
-    var micLevel: Float { session.micLevel }
-    var systemLevel: Float { session.systemLevel }
-
-    private func defaultTitle(prefix: String) -> String {
-        let f = DateFormatter()
-        f.dateStyle = .medium
-        f.timeStyle = .short
-        return "\(prefix) · \(f.string(from: Date()))"
-    }
-
-    private func audioDuration(at url: URL) -> Double {
-        guard let file = try? AVAudioFile(forReading: url) else { return 0 }
-        return Double(file.length) / file.processingFormat.sampleRate
-    }
-}
     /// True while an active recording is paused. Reads straight off the
     /// session's published state so the UI's Pause/Resume affordances stay
     /// in sync without a separate mirrored flag.
@@ -1159,3 +1174,28 @@ final class QuickActionsController: ObservableObject {
         }
     }
 
+    var elapsed: TimeInterval { session.elapsed }
+    var micLevel: Float { session.micLevel }
+    var systemLevel: Float { session.systemLevel }
+
+    /// Resolve the title a recording should be saved with: the user-entered
+    /// meeting name (trimmed) when they typed one, otherwise the
+    /// auto-generated date-stamped default. Pure + `static` so it's
+    /// unit-testable without a real recording session.
+    static func resolvedRecordingTitle(userProvided: String, defaultTitle: String) -> String {
+        let trimmed = userProvided.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultTitle : trimmed
+    }
+
+    private func defaultTitle(prefix: String) -> String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return "\(prefix) · \(f.string(from: Date()))"
+    }
+
+    private func audioDuration(at url: URL) -> Double {
+        guard let file = try? AVAudioFile(forReading: url) else { return 0 }
+        return Double(file.length) / file.processingFormat.sampleRate
+    }
+}

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -1125,3 +1125,37 @@ final class QuickActionsController: ObservableObject {
         return Double(file.length) / file.processingFormat.sampleRate
     }
 }
+    /// True while an active recording is paused. Reads straight off the
+    /// session's published state so the UI's Pause/Resume affordances stay
+    /// in sync without a separate mirrored flag.
+    var isPaused: Bool { session.state == .paused }
+
+    /// Pause the active recording. While paused the session drops all
+    /// incoming audio (see `RecordingSession.pause()`), so nothing said
+    /// during the pause is written to the WAV or the live transcript. The
+    /// VAD utterance in progress is flushed so it doesn't span the gap.
+    /// No-op if not recording or already finalizing.
+    func pauseRecording() {
+        guard isRecording, !isFinalizingRecording, !isPaused else { return }
+        session.pause()
+        liveTranscriber?.pauseBoundary()
+    }
+
+    /// Resume a paused recording. Capture picks back up where it left off;
+    /// the paused span is absent from the recording and excluded from the
+    /// elapsed clock. No-op if not currently paused.
+    func resumeRecording() {
+        guard isPaused else { return }
+        session.resume()
+    }
+
+    /// Toggle between paused and recording. Bound to the Pause/Resume UI
+    /// controls and safe to call from a keyboard shortcut / menu.
+    func togglePause() {
+        if isPaused {
+            resumeRecording()
+        } else {
+            pauseRecording()
+        }
+    }
+

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -166,6 +166,13 @@ final class QuickActionsController: ObservableObject {
     /// Existing / in-progress recordings are never touched.
     var storageSettings: RecordingStorageSettings?
 
+    /// Late-bound by MilaApp. Obsidian vault destination + exporter. The
+    /// live-transcript save path (below) mirrors the batch path's Obsidian
+    /// wiring: mark the fresh completion pending so the summarizer's
+    /// completion hook writes the note once the summary is ready.
+    var obsidianSettings: ObsidianVaultSettings?
+    var obsidianExporter: ObsidianExporter?
+
     /// Active silence-watch task — cancelled when the recording stops so
     /// we never fire the warning for a recording that's already over.
     private var silenceWatchTask: Task<Void, Never>?
@@ -908,10 +915,17 @@ final class QuickActionsController: ObservableObject {
                 // enabled + configured conditions. `summarizeIfNeeded` covers
                 // the Live-AI-off case under the normal auto-summary gate.
                 TranscriptExporter.writeSRT(for: updated, in: self.store.recordingsDirectory)
+                // Mark this fresh completion pending for Obsidian export (if
+                // enabled) BEFORE kicking the summarizer, since a skip fires
+                // the completion hook synchronously.
+                let obsidianOn = (self.obsidianSettings?.enabled == true)
+                    && (self.obsidianSettings?.vaultURL != nil)
                 if self.liveAISettings?.enabled == true,
                    self.llmSettings?.isConfigured == true {
+                    if obsidianOn { self.obsidianExporter?.markPending(updated.id) }
                     self.summarizer?.regenerate(updated)
                 } else {
+                    if obsidianOn { self.obsidianExporter?.markPending(updated.id) }
                     self.summarizer?.summarizeIfNeeded(updated)
                 }
                 // Shrink storage: the live transcript is authoritative and the

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -67,6 +67,18 @@ final class RecordingSummarizer: ObservableObject {
     @Published private(set) var inFlightIDs: Set<UUID> = []
     private var inFlight: [UUID: Task<Void, Never>] = [:]
 
+    /// Fired once per summarize attempt, after the recording's summary state
+    /// is final — i.e. after a summary was generated, or synchronously when
+    /// generation was skipped (disabled / not configured / already summarized
+    /// / empty transcript), or when it failed. Passes the latest recording.
+    ///
+    /// The Obsidian exporter uses this to write a note only once the summary +
+    /// action items are ready, falling back to the transcript when no summary
+    /// was produced. It is NOT fired for the dedup early-return (a duplicate
+    /// call while one is already in flight — the in-flight task fires instead)
+    /// or when the recording has been deleted mid-flight (nothing to export).
+    var onSummaryFinished: ((Recording) -> Void)?
+
     /// Recordings the backfill scan has identified as needing a summary
     /// but hasn't started yet — held here so `maxConcurrent` is enforced
     /// across the whole batch instead of letting all candidates spawn at
@@ -192,6 +204,9 @@ final class RecordingSummarizer: ObservableObject {
     func summarizeIfNeeded(_ recording: Recording) {
         guard shouldSummarize(recording) else {
             logSkip(recording, force: false)
+            // No summary will be generated — signal completion now so a
+            // pending Obsidian export falls back to the transcript.
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         runSummary(for: recording, force: false)
@@ -209,12 +224,14 @@ final class RecordingSummarizer: ObservableObject {
     func regenerate(_ recording: Recording) {
         guard llmSettings.isConfigured else {
             summarizerLog.log("regenerate \(self.shortID(recording.id), privacy: .public): skipped — LLM not configured")
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         let transcript = recording.fullText
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !transcript.isEmpty else {
             summarizerLog.log("regenerate \(self.shortID(recording.id), privacy: .public): skipped — transcript empty")
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         runSummary(for: recording, force: true)
@@ -371,6 +388,9 @@ final class RecordingSummarizer: ObservableObject {
                 let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !cleaned.isEmpty else {
                     summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
+                    // No summary landed — let a pending export fall back to
+                    // the transcript rather than waiting forever.
+                    if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
                     return
                 }
                 // The recording may have been deleted between enqueue
@@ -379,20 +399,28 @@ final class RecordingSummarizer: ObservableObject {
                 guard let self else { return }
                 guard var current = self.store.recordings.first(where: { $0.id == id }) else {
                     summarizerLog.log("skipped \(self.shortID(id), privacy: .public): recording is gone")
+                    // Deleted mid-flight — nothing to export, so no signal.
                     return
                 }
                 let existing = (current.summary ?? "")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if !force, !existing.isEmpty {
                     summarizerLog.log("skipped \(self.shortID(id), privacy: .public): a summary landed mid-flight")
+                    // A summary is present (just from another path) — the
+                    // recording is ready to export.
+                    self.onSummaryFinished?(current)
                     return
                 }
                 current.summary = cleaned
                 self.store.update(current)
                 let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
                 summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(cleaned.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
+                self.onSummaryFinished?(current)
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // Failed generation — signal so a pending export can still
+                // write the transcript fallback.
+                if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
             }
         }
         inFlight[id] = task
@@ -427,5 +455,12 @@ final class RecordingSummarizer: ObservableObject {
 
     private func shortID(_ id: UUID) -> String {
         String(id.uuidString.prefix(8))
+    }
+
+    /// The freshest copy of a recording from the store, or `fallback` when
+    /// it's no longer there. Used so `onSummaryFinished` hands out the
+    /// up-to-date row (which may carry a just-written summary).
+    private func latestRecording(_ id: UUID, fallback: Recording) -> Recording {
+        store.recordings.first(where: { $0.id == id }) ?? fallback
     }
 }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -249,6 +249,9 @@ struct MilaApp: App {
     @StateObject private var recordingSummarizer: RecordingSummarizer
     @StateObject private var voiceMemosSettings: VoiceMemosSettings
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
+    /// Persistent, app-wide list of speaker names — the pick-list behind
+    /// the transcript's speaker rename popover.
+    @StateObject private var speakerDirectory = SpeakerDirectory()
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -545,6 +548,7 @@ struct MilaApp: App {
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
+                .environmentObject(speakerDirectory)
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -598,6 +602,7 @@ struct MilaApp: App {
                 .environmentObject(liveAISettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
+                .environmentObject(speakerDirectory)
         }
     }
 

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -252,6 +252,10 @@ struct MilaApp: App {
     /// Persistent, app-wide list of speaker names — the pick-list behind
     /// the transcript's speaker rename popover.
     @StateObject private var speakerDirectory: SpeakerDirectory
+    /// Mirrors the live transcript to `live/current.json` for external
+    /// tools (mila-mcp). Not observed by any view; held as a StateObject
+    /// purely so it survives SwiftUI re-inits like the other singletons.
+    @StateObject private var liveSidecarWriter: LiveTranscriptSidecarWriter
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -457,6 +461,12 @@ struct MilaApp: App {
         actions.liveDiarizer = liveDiar
         actions.summarizer = summarizer
         actions.storageSettings = storage
+        // Live-transcript sidecar for external tools (mila-mcp). Anchored
+        // to the store's original root so tests / UI-test temp stores stay
+        // isolated from the user's real app-support directory.
+        let sidecarWriter = LiveTranscriptSidecarWriter(root: store.originalRootDirectory)
+        sidecarWriter.cleanupAtLaunch()
+        actions.liveSidecarWriter = sidecarWriter
         let meetingSettings = MeetingDetectionSettings()
         let detector = MeetingDetector()
         let promptCoordinator = MeetingPromptCoordinator(
@@ -498,6 +508,7 @@ struct MilaApp: App {
         _voiceMemosSettings = StateObject(wrappedValue: vmSettings)
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
         _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
+        _liveSidecarWriter = StateObject(wrappedValue: sidecarWriter)
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,
@@ -1029,6 +1040,7 @@ struct MilaApp: App {
         // drain belongs here (sleep/lock/quit path) or to
         // `stopRecording` (Stop-button path).
         let actionsRef: QuickActionsController? = actions
+        let sidecarWriter = liveSidecarWriter
 
         var feedTask: Task<Void, Never>?
         var aiEnabledCancellable: AnyCancellable?
@@ -1084,10 +1096,19 @@ struct MilaApp: App {
                     // to a recording that never ran the LLM loop.
                     // Cursor flagged on c95d2bb.
                     aiSession.cancel()
+                    // Still surface the recording to external pollers
+                    // (mila-mcp): they get an honest "recording, but no
+                    // live text on this hardware" status instead of
+                    // silence.
+                    sidecarWriter.begin(title: nil, source: nil, liveAvailable: false)
                     os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
                         .log("wireLiveAIPipeline: .recording skipped — hardware below Live AI bar (model=\(aiSettings.capabilities.marketingName, privacy: .public))")
                     continue
                 }
+                // Open the live-transcript sidecar for this recording so
+                // external tools (mila-mcp) can follow the meeting; the
+                // feed loop below streams content into it.
+                sidecarWriter.begin(title: nil, source: nil, liveAvailable: true)
                 // Live transcription runs on every recording — it's how
                 // the recording UI shows the live transcript pane even
                 // when AI mode is off. Apply the user's tick-interval
@@ -1176,7 +1197,7 @@ struct MilaApp: App {
                     }
 
                 feedTask?.cancel()
-                feedTask = Task { @MainActor [weak transcriber, weak diarizer, weak aiSession, aiSettings, llmSettingsRef] in
+                feedTask = Task { @MainActor [weak transcriber, weak diarizer, weak aiSession, weak sidecarWriter, aiSettings, llmSettingsRef] in
                     var lastFed = ""
                     guard let transcriber else { return }
                     for await _ in transcriber.$segments.values {
@@ -1196,6 +1217,10 @@ struct MilaApp: App {
                         if let diarizer {
                             transcriber.applySpeakerLabels(diarizer.intervals)
                         }
+                        // Mirror the tick to the on-disk live sidecar
+                        // (throttled + deduped inside the writer).
+                        sidecarWriter?.update(segments: transcriber.transcriptSegments,
+                                              speakerNames: transcriber.speakerNames)
                         if aiActive {
                             let text = transcriber.formattedTranscript
                             if text != lastFed, !text.isEmpty {
@@ -1264,6 +1289,11 @@ struct MilaApp: App {
                     // utterance would lose its speaker label.
                     await diarizer.awaitPending()
                     diarizer.stop()
+                    // Close the live sidecar with no handoff id — this
+                    // teardown path (sleep/lock/quit/cancelAll) has no
+                    // saved Recording yet; the Stop-button path closes
+                    // it from stopRecording with the real id instead.
+                    sidecarWriter.finish(recordingID: nil)
                 }
                 // Note: don't cancel aiSession here — QuickActionsController
                 // still needs to read .summary and .actionItems out of

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -251,7 +251,7 @@ struct MilaApp: App {
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
     /// Persistent, app-wide list of speaker names — the pick-list behind
     /// the transcript's speaker rename popover.
-    @StateObject private var speakerDirectory = SpeakerDirectory()
+    @StateObject private var speakerDirectory: SpeakerDirectory
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -497,6 +497,7 @@ struct MilaApp: App {
                                             languageSettings: langSettings)
         _voiceMemosSettings = StateObject(wrappedValue: vmSettings)
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
+        _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1427,6 +1427,11 @@ struct MilaApp: App {
                 // than stranding the row at `.failed` (no self-serve recovery
                 // path). `.running` is reset to `.pending`; an already
                 // `.pending` row is re-enqueued as-is.
+                // A crash skips AVAudioFile.close(), so the WAV header still
+                // advertises 0 audio frames — the transcription reader would
+                // see an empty file. Rewrite the size fields from the physical
+                // length first so the recovered run actually gets the audio.
+                WAVHeaderRepair.repairIfNeeded(at: wavURL)
                 if fixed.status != .pending {
                     fixed.status = .pending
                     statusChanged.append(fixed)
@@ -1454,6 +1459,9 @@ struct MilaApp: App {
         guard !ids.isEmpty else { return }
         for id in ids {
             guard let recording = store.recordings.first(where: { $0.id == id }) else { continue }
+            // Orphan WAVs from a crash have an unfinalized header (see the
+            // reenqueue branch above) — repair it before the batch run reads it.
+            WAVHeaderRepair.repairIfNeeded(at: store.audioURL(for: recording))
             print("MilaApp: re-enqueuing recovered recording \(recording.audioFileName)")
             transcription.enqueue(recording)
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1477,9 +1477,23 @@ struct MilaApp: App {
     /// button, and any too-eager Record press during the window finds
     /// the model already loaded.
     private func prewarmDefaultModel() {
+        // Skip prewarm under UI tests. No UI test relies on a launch-time
+        // warm — the transcription E2E tests pass `--ui-test-tiny-model-path=`
+        // and load on demand — so warming the (potentially multi-GB) default
+        // model here just burns CPU/IO on every UI-test launch and creates a
+        // whisper/Metal context that XCTest never frees (it exits via
+        // `exit()`, bypassing `gracefulShutdown()`), which is what prints the
+        // ggml-metal teardown backtrace at process exit.
+        guard !isRunningUITests else { return }
         // No local weights to warm when the remote backend is selected.
         guard !remoteTranscriptionSettings.isActive else { return }
         transcription.prewarm(language: languageSettings.current.rawValue)
+    }
+
+    /// True when the process was launched by an XCUITest run. Keyed off the
+    /// `--uitests` / `--ui-test-*` launch arguments the UI test targets pass.
+    private var isRunningUITests: Bool {
+        CommandLine.arguments.contains { $0 == "--uitests" || $0.hasPrefix("--ui-test") }
     }
 
     /// Pre-download the two default models on first launch:

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -864,7 +864,7 @@ struct MilaApp: App {
                     }
                     await Self.pumpFixtureWAVOnce(path: wavPath, to: sessionRef, agcEnabled: true)
                 }
-            case .stopping:
+            case .paused, .stopping:
                 break
             case .idle:
                 pumpTask?.cancel()
@@ -1104,9 +1104,18 @@ struct MilaApp: App {
         // The state observer below runs forever now; the `.recording`
         // branch is where we gate on `aiSettings.isLiveAIAvailable`.
 
+        var priorLiveState: RecordingSession.State = .idle
         for await state in sessionRef.$state.values {
+            let previousLiveState = priorLiveState
+            priorLiveState = state
             switch state {
             case .recording:
+                // Resume from pause: the live pipeline is already wired and
+                // the accumulated transcript is intact. Re-running the setup
+                // below would call `transcriber.start()`, which resets
+                // `segments` / `fullText` and wipes everything the user has
+                // seen so far. A pause→resume must be a no-op here.
+                if previousLiveState == .paused { break }
                 guard aiSettings.isLiveAIAvailable else {
                     // Hardware below the Live AI bar AND no override
                     // flipped. Recording still runs via RecordingSession;
@@ -1267,6 +1276,13 @@ struct MilaApp: App {
                         }
                     }
                 }
+            case .paused:
+                // A pause suspends capture but keeps the whole live
+                // pipeline intact — RecordingSession simply drops incoming
+                // audio while paused, so the transcriber / diarizer / feed
+                // loop just see a gap and pick back up on resume. No
+                // teardown (that only happens on `.idle`).
+                break
             case .stopping:
                 // Don't tear down yet — RecordingSession.stop() still
                 // flushes the buffered system-audio tail during

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -247,6 +247,11 @@ struct MilaApp: App {
     /// SwiftUI redraws and so its in-flight task table survives
     /// alongside everything else.
     @StateObject private var recordingSummarizer: RecordingSummarizer
+    /// Obsidian vault destination + its exporter. The exporter is held as a
+    /// StateObject purely so it stays alive — the completion hooks capture it
+    /// weakly.
+    @StateObject private var obsidianVaultSettings: ObsidianVaultSettings
+    @StateObject private var obsidianExporter: ObsidianExporter
     @StateObject private var voiceMemosSettings: VoiceMemosSettings
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
     /// Persistent, app-wide list of speaker names — the pick-list behind
@@ -419,6 +424,19 @@ struct MilaApp: App {
         let summarizer = RecordingSummarizer(store: store,
                                              llmSettings: llm,
                                              liveAISettings: liveAI)
+        // Obsidian vault destination. When enabled, a completed recording is
+        // written into the vault as a Markdown note (summary + action items,
+        // transcript fallback) once its summary is ready, then optionally
+        // committed + pushed to git. Off by default.
+        let obsidianSettings = ObsidianVaultSettings()
+        let obsidian = ObsidianExporter(settings: obsidianSettings)
+        // Write the note once the summary state is final. Gated on `pending`
+        // so a launch-time backfill sweep never re-files the back-catalogue.
+        summarizer.onSummaryFinished = { [weak obsidian] rec in
+            guard let obsidian, obsidian.isPending(rec.id) else { return }
+            obsidian.export(rec)
+            obsidian.clearPending(rec.id)
+        }
         // Wire the post-transcription summary hook. Fires for every
         // recording that the queue successfully completes — the
         // summarizer's own `shouldSummarize` gate skips work if a
@@ -429,16 +447,27 @@ struct MilaApp: App {
         // summary referring to the previous transcript; we force-
         // regenerate so the user doesn't end up with a stale summary
         // that disagrees with what the segments now say.
-        svc.onTranscriptionCompleted = { [weak summarizer, weak llm] rec, wasRetranscription in
+        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian] rec, wasRetranscription in
+            // Obsidian export is driven off the summarizer's completion hook.
+            // Mark this fresh completion pending so the hook knows to write it
+            // (backfilled recordings are never marked, hence never re-filed).
+            let obsidianOn = (obsidianSettings?.enabled == true) && (obsidianSettings?.vaultURL != nil)
             if wasRetranscription {
                 // `regenerate` bypasses the "already has a summary" gate by
                 // design (it's also the manual on-demand path), so it does
                 // NOT consult `summaryEnabled` itself. Guard the AUTOMATIC
                 // re-transcription trigger here so a transcript-only user
                 // doesn't get a summary regenerated behind their back.
-                guard llm?.summaryEnabled ?? true else { return }
+                guard llm?.summaryEnabled ?? true else {
+                    // No summary will be regenerated — export immediately with
+                    // the transcript fallback (no summarizer hook to wait for).
+                    if obsidianOn { obsidian?.export(rec) }
+                    return
+                }
+                if obsidianOn { obsidian?.markPending(rec.id) }
                 summarizer?.regenerate(rec)
             } else {
+                if obsidianOn { obsidian?.markPending(rec.id) }
                 summarizer?.summarizeIfNeeded(rec)
             }
         }
@@ -461,6 +490,8 @@ struct MilaApp: App {
         actions.liveDiarizer = liveDiar
         actions.summarizer = summarizer
         actions.storageSettings = storage
+        actions.obsidianSettings = obsidianSettings
+        actions.obsidianExporter = obsidian
         // Live-transcript sidecar for external tools (mila-mcp). Anchored
         // to the store's original root so tests / UI-test temp stores stay
         // isolated from the user's real app-support directory.
@@ -496,6 +527,8 @@ struct MilaApp: App {
         _liveSpeakerDiarizer = StateObject(wrappedValue: liveDiar)
         _liveAISession = StateObject(wrappedValue: liveSession)
         _recordingSummarizer = StateObject(wrappedValue: summarizer)
+        _obsidianVaultSettings = StateObject(wrappedValue: obsidianSettings)
+        _obsidianExporter = StateObject(wrappedValue: obsidian)
         // Voice Memos (iPhone) folder integration. Settings are opt-in and
         // default-off; the importer wires up its FSEvents watcher + initial
         // backfill from its `start()` launch task (below), so constructing
@@ -561,6 +594,8 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(obsidianVaultSettings)
+                .environmentObject(obsidianExporter)
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -615,6 +650,8 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(obsidianVaultSettings)
+                .environmentObject(obsidianExporter)
         }
     }
 

--- a/Mila/Audio/AdaptiveGainController.swift
+++ b/Mila/Audio/AdaptiveGainController.swift
@@ -16,9 +16,21 @@ import Accelerate
 /// feed and the saved WAV (single source of truth).
 ///
 /// ## Behaviour
-/// - **Update gate**: gain only adapts on frames whose RMS exceeds the VAD
-///   noise floor. Pure silence is passed through at the last-known gain so
-///   the noise floor never gets amplified into garbage.
+/// - **Update gate**: gain only adapts on frames whose RMS clearly exceeds
+///   the *observed* room noise floor (a minimum-statistics tracker: seeded
+///   from the first frame, snaps down to any quieter frame, drifts slowly
+///   upward). Quiet-but-real speech — bursty, with pauses that keep the
+///   floor pinned at room tone — adapts; sustained hum becomes its own
+///   floor and gates itself off, so it is never amplified into the VAD's
+///   trigger range. Pure silence is passed through at the last-known gain
+///   so the noise floor never gets amplified into garbage.
+///
+///   The gate was previously a static 0.012 — the same value as the live
+///   VAD's speech cutoff — which made the controller useless in exactly
+///   the scenario it was built for: speech quieter than 0.012 never
+///   adapted the gain, so it stayed below the VAD cutoff forever and the
+///   live transcript sat empty for the whole recording (observed on a
+///   MacBook Pro built-in mic at ~0.004-0.010 RMS speech).
 /// - **Attack** (signal louder than target, gain too high): ~200 ms time
 ///   constant — fast enough to prevent clipping on sudden voice onsets.
 /// - **Release** (signal quieter than target, gain too low): ~2 s time
@@ -47,11 +59,23 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// Minimum gain. 1.0 means "never attenuate" — a loud speaker passes
     /// through unchanged.
     static let defaultMinGain: Float = 1.0
-    /// Threshold below which we treat the frame as silence and *hold* the
-    /// last gain instead of adapting. Matches the live VAD's static cutoff
-    /// (`UtteranceDetector.rmsThreshold`) so we adapt on the same frames
-    /// the VAD treats as speech.
-    static let defaultSilenceFloor: Float = 0.012
+    /// Absolute minimum RMS below which a frame can never adapt the gain,
+    /// regardless of how quiet the observed noise floor is. Keeps a dead-
+    /// silent room (floor ≈ 0) from letting sub-audible rumble adapt.
+    /// Deliberately far below the VAD cutoff (0.012): frames between the
+    /// two are exactly the quiet speech this controller exists to boost.
+    static let defaultSilenceFloor: Float = 0.002
+    /// The adaptation gate is `max(silenceFloor, noiseFloor × this)`. 6×
+    /// sits between room tone (the floor itself) and quiet speech
+    /// (typically ≥ 10× the floor) — hum near the floor holds the gain,
+    /// speech adapts it.
+    static let defaultNoiseFloorMultiplier: Float = 6.0
+    /// Upward drift of the minimum-statistics noise floor: it doubles
+    /// once per this many seconds unless a quieter frame snaps it back
+    /// down. Fast enough that steady hum becomes its own floor within a
+    /// recording's first minute, slow enough that a long monologue
+    /// (pauses keep snapping the floor down) never out-drifts speech.
+    static let defaultNoiseFloorDoublingSeconds: Double = 20.0
     /// Attack time-constant in seconds. ~200 ms — fast enough to bring the
     /// gain back down when speech turns out louder than expected.
     static let defaultAttackSeconds: Double = 0.2
@@ -67,6 +91,8 @@ final class AdaptiveGainController: @unchecked Sendable {
     let maxGain: Float
     let minGain: Float
     let silenceFloor: Float
+    let noiseFloorMultiplier: Float
+    let noiseFloorDoublingSeconds: Double
     let attackSeconds: Double
     let releaseSeconds: Double
     let softClipThreshold: Float
@@ -76,6 +102,12 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// safe to read from another thread for display because Swift `Float`
     /// loads/stores are atomic and we tolerate one-frame staleness.
     private(set) var currentGain: Float = 1.0
+    /// Minimum-statistics estimate of the room's background RMS. Negative
+    /// sentinel = "no frame seen yet"; seeded from the first frame so a
+    /// recording that starts inside steady hum treats that hum as floor
+    /// from sample one (rather than boosting it while a low initial guess
+    /// catches up). Read-only outside for tests/diagnostics.
+    private(set) var observedNoiseFloor: Float = -1
     /// `false` disables all adaptation and bypasses the soft clipper —
     /// output equals input bit-for-bit. Settings toggle.
     var enabled: Bool
@@ -86,6 +118,8 @@ final class AdaptiveGainController: @unchecked Sendable {
         maxGain: Float = defaultMaxGain,
         minGain: Float = defaultMinGain,
         silenceFloor: Float = defaultSilenceFloor,
+        noiseFloorMultiplier: Float = defaultNoiseFloorMultiplier,
+        noiseFloorDoublingSeconds: Double = defaultNoiseFloorDoublingSeconds,
         attackSeconds: Double = defaultAttackSeconds,
         releaseSeconds: Double = defaultReleaseSeconds,
         softClipThreshold: Float = defaultSoftClipThreshold,
@@ -96,6 +130,8 @@ final class AdaptiveGainController: @unchecked Sendable {
         self.maxGain = maxGain
         self.minGain = minGain
         self.silenceFloor = silenceFloor
+        self.noiseFloorMultiplier = noiseFloorMultiplier
+        self.noiseFloorDoublingSeconds = noiseFloorDoublingSeconds
         self.attackSeconds = attackSeconds
         self.releaseSeconds = releaseSeconds
         self.softClipThreshold = softClipThreshold
@@ -106,6 +142,7 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// gain doesn't begin where the previous session left off.
     func reset() {
         currentGain = 1.0
+        observedNoiseFloor = -1
     }
 
     /// Apply gain in-place to a mono Float32 channel buffer. Computes the
@@ -130,11 +167,27 @@ final class AdaptiveGainController: @unchecked Sendable {
         //    keeps this safe to call on the audio render thread).
         var rms: Float = 0
         vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
+        let frameDuration = Double(count) / sampleRate
 
-        // 2) Adapt the gain only when there's signal — never amplify pure
-        //    room hum. If the frame is below the silence floor, hold the
-        //    last gain and skip straight to applying it.
-        if rms >= silenceFloor {
+        // 2) Track the room's noise floor (minimum statistics): follow the
+        //    quietest recent frame, drifting slowly upward so a signal
+        //    that never pauses — hum, fan, AC — becomes its own floor.
+        //    Speech always has inter-word gaps that snap the floor back
+        //    down to true room tone, so it keeps clearing the gate.
+        let clampedRMS = max(rms, 1e-6)
+        if observedNoiseFloor < 0 {
+            observedNoiseFloor = clampedRMS
+        } else {
+            let drift = Float(exp2(frameDuration / max(noiseFloorDoublingSeconds, 1e-3)))
+            observedNoiseFloor = min(clampedRMS, observedNoiseFloor * drift)
+        }
+
+        // 3) Adapt the gain only when the frame is clearly above the
+        //    observed floor — never amplify room hum toward the VAD's
+        //    trigger range. Below the gate, hold the last gain and skip
+        //    straight to applying it.
+        let adaptGate = max(silenceFloor, observedNoiseFloor * noiseFloorMultiplier)
+        if rms >= adaptGate {
             let desired = clamp(targetRMS / max(rms, 1e-6),
                                 lower: minGain,
                                 upper: maxGain)
@@ -142,7 +195,6 @@ final class AdaptiveGainController: @unchecked Sendable {
             // (desired > currentGain, signal too quiet). Convert the
             // time-constant into a 0…1 blend factor using the frame's
             // wall-clock duration: alpha = 1 - exp(-dt / tau).
-            let frameDuration = Double(count) / sampleRate
             let tau = (desired < currentGain) ? attackSeconds : releaseSeconds
             let alpha = Float(1.0 - exp(-frameDuration / max(tau, 1e-6)))
             currentGain += (desired - currentGain) * alpha
@@ -152,14 +204,14 @@ final class AdaptiveGainController: @unchecked Sendable {
             currentGain = clamp(currentGain, lower: minGain, upper: maxGain)
         }
 
-        // 3) Apply the gain. With min=1, gain==1 is a no-op so skip the
+        // 4) Apply the gain. With min=1, gain==1 is a no-op so skip the
         //    multiply (most loud-speaker frames hit this path).
         let g = currentGain
         if g != 1.0 {
             vDSP_vsmul(samples, 1, [g], samples, 1, vDSP_Length(count))
         }
 
-        // 4) Soft-clip any sample whose magnitude exceeds the threshold.
+        // 5) Soft-clip any sample whose magnitude exceeds the threshold.
         //    The bulk of speech frames won't trigger this; we pay the loop
         //    only on the few transients that need protection.
         let threshold = softClipThreshold

--- a/Mila/Audio/AdaptiveGainController.swift
+++ b/Mila/Audio/AdaptiveGainController.swift
@@ -17,13 +17,14 @@ import Accelerate
 ///
 /// ## Behaviour
 /// - **Update gate**: gain only adapts on frames whose RMS clearly exceeds
-///   the *observed* room noise floor (a minimum-statistics tracker: seeded
-///   from the first frame, snaps down to any quieter frame, drifts slowly
-///   upward). Quiet-but-real speech — bursty, with pauses that keep the
-///   floor pinned at room tone — adapts; sustained hum becomes its own
-///   floor and gates itself off, so it is never amplified into the VAD's
-///   trigger range. Pure silence is passed through at the last-known gain
-///   so the noise floor never gets amplified into garbage.
+///   the *observed* room noise floor (seeded from the first frame, snaps
+///   down to any quieter frame, rises toward louder sustained signal with
+///   a ~10 s time constant). Quiet-but-real speech — bursty, with pauses
+///   that keep the floor pinned at room tone — adapts; sustained hum
+///   becomes its own floor within seconds and gates itself off, so it is
+///   never amplified into the VAD's trigger range. Pure silence is passed
+///   through at the last-known gain so the noise floor never gets
+///   amplified into garbage.
 ///
 ///   The gate was previously a static 0.012 — the same value as the live
 ///   VAD's speech cutoff — which made the controller useless in exactly
@@ -31,6 +32,15 @@ import Accelerate
 ///   adapted the gain, so it stayed below the VAD cutoff forever and the
 ///   live transcript sat empty for the whole recording (observed on a
 ///   MacBook Pro built-in mic at ~0.004-0.010 RMS speech).
+///
+/// - **Sustained-noise relaxation**: hum that starts mid-recording (AC
+///   kicking in after a quiet stretch) briefly clears the gate while the
+///   floor catches up, picking up some gain. Any gain acquired that way
+///   must not stick: after `noiseRelaxAfterSeconds` of *continuous*
+///   below-gate (but non-silent) signal, the gain decays back toward 1
+///   with a `noiseRelaxSeconds` time constant. Ordinary speech pauses are
+///   far shorter than the trigger, so hold semantics are preserved for
+///   conversation; only genuinely sustained noise unwinds the gain.
 /// - **Attack** (signal louder than target, gain too high): ~200 ms time
 ///   constant — fast enough to prevent clipping on sudden voice onsets.
 /// - **Release** (signal quieter than target, gain too low): ~2 s time
@@ -70,12 +80,28 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// (typically ≥ 10× the floor) — hum near the floor holds the gain,
     /// speech adapts it.
     static let defaultNoiseFloorMultiplier: Float = 6.0
-    /// Upward drift of the minimum-statistics noise floor: it doubles
-    /// once per this many seconds unless a quieter frame snaps it back
-    /// down. Fast enough that steady hum becomes its own floor within a
-    /// recording's first minute, slow enough that a long monologue
-    /// (pauses keep snapping the floor down) never out-drifts speech.
-    static let defaultNoiseFloorDoublingSeconds: Double = 20.0
+    /// Time constant of the noise floor's rise toward louder sustained
+    /// signal (exponential approach; downward snaps are instant). 10 s
+    /// finds a hum that starts after a silent stretch within ~2 s (the
+    /// gate needs floor ≥ hum/multiplier, i.e. ~1/6 of the way up),
+    /// while a burst of speech between pauses only drags the floor a
+    /// fraction of the way up before the next pause snaps it back down.
+    /// The previous doubling-based drift took minutes to climb from a
+    /// silence-seeded floor to a real hum level.
+    static let defaultNoiseFloorRiseSeconds: Double = 10.0
+    /// How long the signal must sit continuously below the adaptation
+    /// gate (but above dead silence) before the gain starts relaxing
+    /// back toward 1. Longer than any conversational pause or single
+    /// utterance, shorter than "the AC has clearly been on for a while".
+    static let defaultNoiseRelaxAfterSeconds: Double = 15.0
+    /// Time constant of that relaxation once it engages. ~20 s unwinds
+    /// a hum-acquired gain within half a minute without audible pumping.
+    static let defaultNoiseRelaxSeconds: Double = 20.0
+    /// RMS below which a frame counts as dead silence: the gain holds
+    /// and the sustained-noise run is reset (silence is not noise). Well
+    /// below any real room tone; digital zero-fill and muted inputs land
+    /// here.
+    static let defaultDeadSilenceFloor: Float = 1e-4
     /// Attack time-constant in seconds. ~200 ms — fast enough to bring the
     /// gain back down when speech turns out louder than expected.
     static let defaultAttackSeconds: Double = 0.2
@@ -92,7 +118,10 @@ final class AdaptiveGainController: @unchecked Sendable {
     let minGain: Float
     let silenceFloor: Float
     let noiseFloorMultiplier: Float
-    let noiseFloorDoublingSeconds: Double
+    let noiseFloorRiseSeconds: Double
+    let noiseRelaxAfterSeconds: Double
+    let noiseRelaxSeconds: Double
+    let deadSilenceFloor: Float
     let attackSeconds: Double
     let releaseSeconds: Double
     let softClipThreshold: Float
@@ -108,6 +137,10 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// from sample one (rather than boosting it while a low initial guess
     /// catches up). Read-only outside for tests/diagnostics.
     private(set) var observedNoiseFloor: Float = -1
+    /// Seconds of *continuous* below-gate, above-dead-silence signal seen
+    /// so far. Crossing `noiseRelaxAfterSeconds` engages the gain
+    /// relaxation; any speech frame or dead-silence frame resets it.
+    private var sustainedNoiseSeconds: Double = 0
     /// `false` disables all adaptation and bypasses the soft clipper —
     /// output equals input bit-for-bit. Settings toggle.
     var enabled: Bool
@@ -119,7 +152,10 @@ final class AdaptiveGainController: @unchecked Sendable {
         minGain: Float = defaultMinGain,
         silenceFloor: Float = defaultSilenceFloor,
         noiseFloorMultiplier: Float = defaultNoiseFloorMultiplier,
-        noiseFloorDoublingSeconds: Double = defaultNoiseFloorDoublingSeconds,
+        noiseFloorRiseSeconds: Double = defaultNoiseFloorRiseSeconds,
+        noiseRelaxAfterSeconds: Double = defaultNoiseRelaxAfterSeconds,
+        noiseRelaxSeconds: Double = defaultNoiseRelaxSeconds,
+        deadSilenceFloor: Float = defaultDeadSilenceFloor,
         attackSeconds: Double = defaultAttackSeconds,
         releaseSeconds: Double = defaultReleaseSeconds,
         softClipThreshold: Float = defaultSoftClipThreshold,
@@ -131,7 +167,10 @@ final class AdaptiveGainController: @unchecked Sendable {
         self.minGain = minGain
         self.silenceFloor = silenceFloor
         self.noiseFloorMultiplier = noiseFloorMultiplier
-        self.noiseFloorDoublingSeconds = noiseFloorDoublingSeconds
+        self.noiseFloorRiseSeconds = noiseFloorRiseSeconds
+        self.noiseRelaxAfterSeconds = noiseRelaxAfterSeconds
+        self.noiseRelaxSeconds = noiseRelaxSeconds
+        self.deadSilenceFloor = deadSilenceFloor
         self.attackSeconds = attackSeconds
         self.releaseSeconds = releaseSeconds
         self.softClipThreshold = softClipThreshold
@@ -143,6 +182,7 @@ final class AdaptiveGainController: @unchecked Sendable {
     func reset() {
         currentGain = 1.0
         observedNoiseFloor = -1
+        sustainedNoiseSeconds = 0
     }
 
     /// Apply gain in-place to a mono Float32 channel buffer. Computes the
@@ -169,25 +209,35 @@ final class AdaptiveGainController: @unchecked Sendable {
         vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
         let frameDuration = Double(count) / sampleRate
 
-        // 2) Track the room's noise floor (minimum statistics): follow the
-        //    quietest recent frame, drifting slowly upward so a signal
-        //    that never pauses — hum, fan, AC — becomes its own floor.
-        //    Speech always has inter-word gaps that snap the floor back
-        //    down to true room tone, so it keeps clearing the gate.
+        // 2) Track the room's noise floor: snap down instantly to any
+        //    quieter frame, rise toward louder sustained signal with a
+        //    ~10 s time constant. A signal that never pauses — hum, fan,
+        //    AC — becomes its own floor within seconds even after a
+        //    silent stretch seeded the floor near zero; speech's
+        //    inter-word gaps keep snapping the floor back down to true
+        //    room tone, so it keeps clearing the gate.
         let clampedRMS = max(rms, 1e-6)
         if observedNoiseFloor < 0 {
             observedNoiseFloor = clampedRMS
+        } else if clampedRMS < observedNoiseFloor {
+            observedNoiseFloor = clampedRMS
         } else {
-            let drift = Float(exp2(frameDuration / max(noiseFloorDoublingSeconds, 1e-3)))
-            observedNoiseFloor = min(clampedRMS, observedNoiseFloor * drift)
+            let alpha = Float(1.0 - exp(-frameDuration / max(noiseFloorRiseSeconds, 1e-3)))
+            observedNoiseFloor += (clampedRMS - observedNoiseFloor) * alpha
         }
 
         // 3) Adapt the gain only when the frame is clearly above the
         //    observed floor — never amplify room hum toward the VAD's
-        //    trigger range. Below the gate, hold the last gain and skip
-        //    straight to applying it.
+        //    trigger range. Below the gate: hold the last gain through
+        //    ordinary speech pauses, but if the signal sits below the
+        //    gate CONTINUOUSLY for noiseRelaxAfterSeconds while staying
+        //    above dead silence (i.e. it's sustained noise, not a
+        //    pause), relax the gain back toward 1 — this unwinds any
+        //    gain picked up in the brief window where a mid-recording
+        //    hum onset cleared the gate before the floor caught up.
         let adaptGate = max(silenceFloor, observedNoiseFloor * noiseFloorMultiplier)
         if rms >= adaptGate {
+            sustainedNoiseSeconds = 0
             let desired = clamp(targetRMS / max(rms, 1e-6),
                                 lower: minGain,
                                 upper: maxGain)
@@ -202,6 +252,16 @@ final class AdaptiveGainController: @unchecked Sendable {
             // errors from drifting outside [minGain, maxGain] over a long
             // recording.
             currentGain = clamp(currentGain, lower: minGain, upper: maxGain)
+        } else if rms >= deadSilenceFloor {
+            sustainedNoiseSeconds += frameDuration
+            if sustainedNoiseSeconds >= noiseRelaxAfterSeconds, currentGain > minGain {
+                let alpha = Float(1.0 - exp(-frameDuration / max(noiseRelaxSeconds, 1e-6)))
+                currentGain += (minGain - currentGain) * alpha
+            }
+        } else {
+            // Dead silence: hold the gain and reset the noise run —
+            // silence is not sustained noise.
+            sustainedNoiseSeconds = 0
         }
 
         // 4) Apply the gain. With min=1, gain==1 is a no-op so skip the

--- a/Mila/Audio/AdaptiveGainController.swift
+++ b/Mila/Audio/AdaptiveGainController.swift
@@ -199,13 +199,15 @@ final class AdaptiveGainController: @unchecked Sendable {
     }
 
     /// Apply gain in-place to a mono Float32 channel buffer. Computes the
-    /// frame's RMS, updates the smoothed gain (if signal is above the
-    /// silence floor), and writes the gained + soft-clipped samples back
-    /// into `samples`.
+    /// frame's RMS, updates the windowed-minimum noise floor and the
+    /// adaptation gate derived from it, updates the smoothed gain (adapting
+    /// toward target when the gate is cleared, relaxing back toward 1
+    /// after sustained below-gate noise, holding through everything else),
+    /// and writes the gained + soft-clipped samples back into `samples`.
     ///
-    /// `frameDurationSeconds` is the elapsed wall-clock time the frame
-    /// represents; used to convert the attack/release time-constants into
-    /// per-frame smoothing coefficients. For a 30 ms frame this is `0.030`.
+    /// The frame's wall-clock duration — `count / sampleRate` — converts
+    /// the floor-window/attack/release/relax time-constants into per-frame
+    /// smoothing coefficients. For a 30 ms frame this is `0.030`.
     func process(_ samples: UnsafeMutablePointer<Float>, count: Int) {
         guard count > 0 else { return }
         if !enabled {

--- a/Mila/Audio/AdaptiveGainController.swift
+++ b/Mila/Audio/AdaptiveGainController.swift
@@ -17,14 +17,18 @@ import Accelerate
 ///
 /// ## Behaviour
 /// - **Update gate**: gain only adapts on frames whose RMS clearly exceeds
-///   the *observed* room noise floor (seeded from the first frame, snaps
-///   down to any quieter frame, rises toward louder sustained signal with
-///   a ~10 s time constant). Quiet-but-real speech — bursty, with pauses
-///   that keep the floor pinned at room tone — adapts; sustained hum
-///   becomes its own floor within seconds and gates itself off, so it is
-///   never amplified into the VAD's trigger range. Pure silence is passed
-///   through at the last-known gain so the noise floor never gets
-///   amplified into garbage.
+///   the *observed* room noise floor — the MINIMUM frame RMS over the
+///   last `noiseFloorWindowSeconds` (two half-window buckets, classic
+///   minimum statistics). The minimum is the right statistic: speech
+///   pauses within any window pin the floor at true room tone no matter
+///   how loud or continuous the talking is, so quiet speech keeps
+///   clearing the gate — while sustained hum, which never pauses, becomes
+///   the window minimum within one window and gates itself off. (An
+///   earlier EMA-toward-signal variant regressed the quiet-mic fix: in a
+///   room with elevated tone it settled at the AVERAGE level and parked
+///   the gate on top of quiet speech.) Pure silence is passed through at
+///   the last-known gain so the noise floor never gets amplified into
+///   garbage.
 ///
 ///   The gate was previously a static 0.012 — the same value as the live
 ///   VAD's speech cutoff — which made the controller useless in exactly
@@ -75,20 +79,19 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// Deliberately far below the VAD cutoff (0.012): frames between the
     /// two are exactly the quiet speech this controller exists to boost.
     static let defaultSilenceFloor: Float = 0.002
-    /// The adaptation gate is `max(silenceFloor, noiseFloor × this)`. 6×
-    /// sits between room tone (the floor itself) and quiet speech
-    /// (typically ≥ 10× the floor) — hum near the floor holds the gain,
-    /// speech adapts it.
-    static let defaultNoiseFloorMultiplier: Float = 6.0
-    /// Time constant of the noise floor's rise toward louder sustained
-    /// signal (exponential approach; downward snaps are instant). 10 s
-    /// finds a hum that starts after a silent stretch within ~2 s (the
-    /// gate needs floor ≥ hum/multiplier, i.e. ~1/6 of the way up),
-    /// while a burst of speech between pauses only drags the floor a
-    /// fraction of the way up before the next pause snaps it back down.
-    /// The previous doubling-based drift took minutes to climb from a
-    /// silence-seeded floor to a real hum level.
-    static let defaultNoiseFloorRiseSeconds: Double = 10.0
+    /// The adaptation gate is `max(silenceFloor, noiseFloor × this)`. 4×
+    /// sits between room tone (the floor itself, fluctuating up to ~2-3×
+    /// its own minimum) and quiet speech (≥ 5-10× the floor) — hum near
+    /// the floor holds the gain, speech adapts it. Observed field values
+    /// that must stay separated: room-tone minimum ~0.0005-0.0015 on a
+    /// MacBook Pro built-in mic vs quiet-speech frames ~0.004-0.010.
+    static let defaultNoiseFloorMultiplier: Float = 4.0
+    /// Length of the minimum-statistics window. Hum that starts after a
+    /// silent stretch owns the floor once the window has fully rotated
+    /// past the silence — ≤ 12 s — bounding how long its onset can keep
+    /// adapting the gain. Conversation always pauses within any 12 s
+    /// span, so speech never becomes its own floor.
+    static let defaultNoiseFloorWindowSeconds: Double = 12.0
     /// How long the signal must sit continuously below the adaptation
     /// gate (but above dead silence) before the gain starts relaxing
     /// back toward 1. Longer than any conversational pause or single
@@ -118,7 +121,7 @@ final class AdaptiveGainController: @unchecked Sendable {
     let minGain: Float
     let silenceFloor: Float
     let noiseFloorMultiplier: Float
-    let noiseFloorRiseSeconds: Double
+    let noiseFloorWindowSeconds: Double
     let noiseRelaxAfterSeconds: Double
     let noiseRelaxSeconds: Double
     let deadSilenceFloor: Float
@@ -131,12 +134,19 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// safe to read from another thread for display because Swift `Float`
     /// loads/stores are atomic and we tolerate one-frame staleness.
     private(set) var currentGain: Float = 1.0
-    /// Minimum-statistics estimate of the room's background RMS. Negative
-    /// sentinel = "no frame seen yet"; seeded from the first frame so a
-    /// recording that starts inside steady hum treats that hum as floor
-    /// from sample one (rather than boosting it while a low initial guess
-    /// catches up). Read-only outside for tests/diagnostics.
+    /// Minimum-statistics estimate of the room's background RMS: the
+    /// minimum frame RMS over the last `noiseFloorWindowSeconds`, via two
+    /// half-window buckets. Negative sentinel = "no frame seen yet";
+    /// seeded from the first frame so a recording that starts inside
+    /// steady hum treats that hum as floor from sample one. Read-only
+    /// outside for tests/diagnostics.
     private(set) var observedNoiseFloor: Float = -1
+    /// Current and previous half-window minimum buckets backing
+    /// `observedNoiseFloor`, plus how much of the current half-window
+    /// has elapsed. `.infinity` = bucket empty.
+    private var windowMin: Float = .infinity
+    private var prevWindowMin: Float = .infinity
+    private var windowElapsed: Double = 0
     /// Seconds of *continuous* below-gate, above-dead-silence signal seen
     /// so far. Crossing `noiseRelaxAfterSeconds` engages the gain
     /// relaxation; any speech frame or dead-silence frame resets it.
@@ -152,7 +162,7 @@ final class AdaptiveGainController: @unchecked Sendable {
         minGain: Float = defaultMinGain,
         silenceFloor: Float = defaultSilenceFloor,
         noiseFloorMultiplier: Float = defaultNoiseFloorMultiplier,
-        noiseFloorRiseSeconds: Double = defaultNoiseFloorRiseSeconds,
+        noiseFloorWindowSeconds: Double = defaultNoiseFloorWindowSeconds,
         noiseRelaxAfterSeconds: Double = defaultNoiseRelaxAfterSeconds,
         noiseRelaxSeconds: Double = defaultNoiseRelaxSeconds,
         deadSilenceFloor: Float = defaultDeadSilenceFloor,
@@ -167,7 +177,7 @@ final class AdaptiveGainController: @unchecked Sendable {
         self.minGain = minGain
         self.silenceFloor = silenceFloor
         self.noiseFloorMultiplier = noiseFloorMultiplier
-        self.noiseFloorRiseSeconds = noiseFloorRiseSeconds
+        self.noiseFloorWindowSeconds = noiseFloorWindowSeconds
         self.noiseRelaxAfterSeconds = noiseRelaxAfterSeconds
         self.noiseRelaxSeconds = noiseRelaxSeconds
         self.deadSilenceFloor = deadSilenceFloor
@@ -182,6 +192,9 @@ final class AdaptiveGainController: @unchecked Sendable {
     func reset() {
         currentGain = 1.0
         observedNoiseFloor = -1
+        windowMin = .infinity
+        prevWindowMin = .infinity
+        windowElapsed = 0
         sustainedNoiseSeconds = 0
     }
 
@@ -209,22 +222,25 @@ final class AdaptiveGainController: @unchecked Sendable {
         vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
         let frameDuration = Double(count) / sampleRate
 
-        // 2) Track the room's noise floor: snap down instantly to any
-        //    quieter frame, rise toward louder sustained signal with a
-        //    ~10 s time constant. A signal that never pauses — hum, fan,
-        //    AC — becomes its own floor within seconds even after a
-        //    silent stretch seeded the floor near zero; speech's
-        //    inter-word gaps keep snapping the floor back down to true
-        //    room tone, so it keeps clearing the gate.
+        // 2) Track the room's noise floor as the MINIMUM frame RMS over
+        //    the last window (two half-window buckets). Speech pauses
+        //    within any window pin the floor at true room tone — the
+        //    floor must NOT follow the average signal (an earlier EMA
+        //    variant did, and in a room with elevated tone it parked
+        //    the gate on top of quiet speech). A signal that never
+        //    pauses — hum, fan, AC — owns the window minimum once the
+        //    window rotates past whatever preceded it, so a
+        //    mid-recording hum onset gates itself off within
+        //    `noiseFloorWindowSeconds`.
         let clampedRMS = max(rms, 1e-6)
-        if observedNoiseFloor < 0 {
-            observedNoiseFloor = clampedRMS
-        } else if clampedRMS < observedNoiseFloor {
-            observedNoiseFloor = clampedRMS
-        } else {
-            let alpha = Float(1.0 - exp(-frameDuration / max(noiseFloorRiseSeconds, 1e-3)))
-            observedNoiseFloor += (clampedRMS - observedNoiseFloor) * alpha
+        windowMin = min(windowMin, clampedRMS)
+        windowElapsed += frameDuration
+        if windowElapsed >= noiseFloorWindowSeconds / 2 {
+            prevWindowMin = windowMin
+            windowMin = clampedRMS
+            windowElapsed = 0
         }
+        observedNoiseFloor = min(windowMin, prevWindowMin)
 
         // 3) Adapt the gain only when the frame is clearly above the
         //    observed floor — never amplify room hum toward the VAD's

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import OSLog
 import TranscriptionCore
+import MilaKit
 
 private let liveLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveTranscriber")
 

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -61,6 +61,12 @@ final class LiveTranscriber: ObservableObject {
     /// flat string (e.g. the LLM feed via `formattedTranscript`).
     @Published private(set) var segments: [LiveSegment] = []
 
+    /// User-assigned display names for live speakers (raw `SPEAKER_NN`
+    /// → name), set from the live pane's rename popover mid-recording.
+    /// Copied into the saved `Recording` at stop (QuickActionsController),
+    /// where the post-stop re-diarize remaps them onto the re-keyed IDs.
+    @Published var speakerNames: [String: String] = [:]
+
     var chunkSeconds: Double = 30.0
     var windowSeconds: Double = 30.0
     /// When true, route incoming audio through `UtteranceDetector` and
@@ -135,6 +141,7 @@ final class LiveTranscriber: ObservableObject {
         self.samplesDropped = 0
         self.fullText = ""
         self.segments = []
+        self.speakerNames = [:]
         self.lastError = nil
         self.epoch &+= 1
         liveLog.log("LiveTranscriber.start lang=\(language, privacy: .public) chunk=\(self.chunkSeconds, privacy: .public)s window=\(self.windowSeconds, privacy: .public)s useVAD=\(self.useVAD, privacy: .public) epoch=\(self.epoch, privacy: .public)")

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -279,6 +279,27 @@ final class LiveTranscriber: ObservableObject {
         }.joined(separator: "\n")
     }
 
+    /// The live segments as `TranscriptSegment`s — the shape the
+    /// formatter/exporter share with finished recordings, so copy and
+    /// SRT export mid-recording produce the same output the detail view
+    /// would for the same content.
+    var transcriptSegments: [TranscriptSegment] {
+        segments.map {
+            TranscriptSegment(start: $0.startSeconds, end: $0.endSeconds,
+                              text: $0.text, speaker: $0.speaker)
+        }
+    }
+
+    /// Clipboard rendering of the in-progress transcript — same format
+    /// as the detail view's "Copy transcript" (speaker-prefixed turns
+    /// once live diarization has labelled anyone, plain joined text
+    /// otherwise), so copying mid-recording and copying after the fact
+    /// produce the same text.
+    var clipboardText: String {
+        TranscriptFormatter.plainText(segments: transcriptSegments,
+                                      fallback: fullText)
+    }
+
     /// VAD path: enqueue a transcribe for a complete utterance. New
     /// utterances chain on top of the previous task so whisper runs
     /// strictly serially (the engine actor enforces this anyway, but

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -304,7 +304,8 @@ final class LiveTranscriber: ObservableObject {
     /// produce the same text.
     var clipboardText: String {
         TranscriptFormatter.plainText(segments: transcriptSegments,
-                                      fallback: fullText)
+                                      fallback: fullText,
+                                      names: speakerNames)
     }
 
     /// VAD path: enqueue a transcribe for a complete utterance. New

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -112,6 +112,13 @@ final class LiveTranscriber: ObservableObject {
     /// amount so `windowAbsoluteStart` in `runOnce` keeps producing
     /// correct absolute timestamps for the segment merge.
     private var samplesDropped: Int = 0
+    /// Absolute time ranges of segments the user deleted from the live
+    /// pane. Incoming whisper output overlapping any of these is dropped so
+    /// a just-deleted line can't reappear on a later tick — the fixed-window
+    /// path re-transcribes a rolling buffer and would otherwise re-emit the
+    /// deleted content. The VAD path emits each utterance once, so this is
+    /// mostly a safety net there. Cleared on `start()`.
+    private var deletedRanges: [(start: Double, end: Double)] = []
     private var inFlight: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
     private var language: String = "he"
@@ -140,6 +147,7 @@ final class LiveTranscriber: ObservableObject {
         self.language = language
         self.buffer.removeAll(keepingCapacity: true)
         self.samplesDropped = 0
+        self.deletedRanges = []
         self.fullText = ""
         self.segments = []
         self.speakerNames = [:]
@@ -211,6 +219,45 @@ final class LiveTranscriber: ObservableObject {
         } else {
             buffer.append(contentsOf: samples)
         }
+    }
+
+    /// Called when the recording is paused. In VAD mode, close the current
+    /// utterance at the pause point — otherwise resume would append post-pause
+    /// audio onto the same utterance, gluing the two sides of the gap into a
+    /// single segment with a bogus duration. Uses `flushForPause()` (not
+    /// `flush()`) so the detector's recording clock is preserved: post-resume
+    /// utterances keep their absolute timestamps instead of restarting at 0.
+    /// The fixed-window path keeps a plain rolling buffer with no in-flight
+    /// utterance to close, so this is a no-op there (paused audio simply
+    /// never arrives via `ingest`).
+    func pauseBoundary() {
+        detector?.flushForPause()
+    }
+
+    /// Delete a line from the live transcript. Records the segment's time
+    /// range so a later whisper tick (fixed-window mode re-transcribes a
+    /// rolling buffer) can't re-emit it, removes it from `segments`, and
+    /// recomputes `fullText`. Because `segments` is `@Published`, the app's
+    /// feed loop picks the change up automatically (MCP sidecar + LLM
+    /// re-feed), and the Stop-time snapshot excludes the deleted line.
+    func removeSegment(id: UUID) {
+        guard let idx = segments.firstIndex(where: { $0.id == id }) else { return }
+        let seg = segments[idx]
+        deletedRanges.append((start: seg.startSeconds, end: seg.endSeconds))
+        segments.remove(at: idx)
+        fullText = segments.map(\.text).joined(separator: " ")
+        liveLog.log("LiveTranscriber.removeSegment start=\(seg.startSeconds, privacy: .public) end=\(seg.endSeconds, privacy: .public) remaining=\(self.segments.count, privacy: .public)")
+    }
+
+    /// Whether an incoming segment's absolute time range overlaps a range
+    /// the user deleted. Any positive overlap counts — the intent of a
+    /// delete is "drop what was said in that span," so re-emitted content
+    /// there should stay gone.
+    private func isSuppressed(start: Double, end: Double) -> Bool {
+        for r in deletedRanges where start < r.end && end > r.start {
+            return true
+        }
+        return false
     }
 
     func transcribeNow() async {
@@ -415,10 +462,14 @@ final class LiveTranscriber: ObservableObject {
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { continue }
             guard s.start < originalDuration else { continue }
+            let absStart = startSec + s.start
+            let absEnd = startSec + s.end
+            // Skip anything the user deleted from this time span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { continue }
             segments.append(LiveSegment(
                 id: UUID(),
-                startSeconds: startSec + s.start,
-                endSeconds: startSec + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true
@@ -473,10 +524,14 @@ final class LiveTranscriber: ObservableObject {
         let absoluteSegs: [LiveSegment] = whisperSegs.compactMap { s in
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
+            let absStart = windowAbsoluteStart + s.start
+            let absEnd = windowAbsoluteStart + s.end
+            // Don't resurrect a line the user deleted from this span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { return nil }
             return LiveSegment(
                 id: UUID(),
-                startSeconds: windowAbsoluteStart + s.start,
-                endSeconds: windowAbsoluteStart + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -10,7 +10,7 @@ private let recLog = Logger(subsystem: "io.island.whisper.IslandWhisper", catego
 /// Orchestrates microphone + system audio capture into a single mono 16kHz WAV file.
 @MainActor
 final class RecordingSession: ObservableObject {
-    enum State { case idle, recording, stopping }
+    enum State { case idle, recording, paused, stopping }
     @Published private(set) var state: State = .idle
     @Published private(set) var elapsed: TimeInterval = 0
     @Published private(set) var micLevel: Float = 0
@@ -39,6 +39,17 @@ final class RecordingSession: ObservableObject {
     private(set) var fileURL: URL?
     private var audioFile: AVAudioFile?
     private var startTime: Date?
+    /// Wall-clock instant the current pause began. `nil` unless
+    /// `state == .paused`. Used to accumulate `totalPaused` on resume so
+    /// `elapsed` never counts paused time.
+    private var pausedAt: Date?
+    /// Total wall-clock time spent paused so far this session. Subtracted
+    /// from the raw `now - startTime` so `elapsed` reflects only the audio
+    /// that actually made it into the WAV (paused spans are dropped by the
+    /// capture-gate in `consumeMic` / `consumeSystem`), keeping `elapsed`
+    /// aligned with both the on-disk duration and the live segment
+    /// timestamps.
+    private var totalPaused: TimeInterval = 0
     private var timerTask: Task<Void, Never>?
     private var micTask: Task<Void, Never>?
     private var systemTask: Task<Void, Never>?
@@ -141,15 +152,66 @@ final class RecordingSession: ObservableObject {
         }
 
         startTime = Date()
+        pausedAt = nil
+        totalPaused = 0
         state = .recording
+        startElapsedTimer()
+    }
+
+    /// Drives the `elapsed` clock while a session is active. Kept running
+    /// across pauses (`state == .paused`) but only advances the published
+    /// value while `.recording`, so a pause freezes the timer instead of
+    /// letting it jump forward by the paused span on resume.
+    private func startElapsedTimer() {
+        timerTask?.cancel()
         timerTask = Task { @MainActor [weak self] in
-            while let self, self.state == .recording {
-                if let start = self.startTime {
-                    self.elapsed = Date().timeIntervalSince(start)
+            while let self, self.state == .recording || self.state == .paused {
+                if self.state == .recording, let start = self.startTime {
+                    self.elapsed = Self.elapsed(now: Date(), startTime: start,
+                                                totalPaused: self.totalPaused)
                 }
                 try? await Task.sleep(nanoseconds: 200_000_000)
             }
         }
+    }
+
+    /// Pure elapsed-time computation: raw wall clock since `startTime`
+    /// minus the time already spent paused. Factored out so the
+    /// pause-accounting math is unit-testable without an audio engine.
+    static func elapsed(now: Date, startTime: Date, totalPaused: TimeInterval) -> TimeInterval {
+        max(0, now.timeIntervalSince(startTime) - totalPaused)
+    }
+
+    /// Suspend capture without tearing down the engine. While paused,
+    /// `consumeMic` / `consumeSystem` drop every incoming buffer, so nothing
+    /// is written to the WAV or forwarded to the live transcriber — the
+    /// paused span is genuinely absent from the recording. The mic /
+    /// system-audio engines keep running (we just discard their output)
+    /// rather than stopping, which avoids the fragile fresh-engine-per-
+    /// session bring-up on resume.
+    func pause() {
+        guard state == .recording else { return }
+        pausedAt = Date()
+        // Drop any system-audio the jitter buffer parked before the pause so
+        // it isn't mixed in on resume — otherwise a pre-pause tail would be
+        // glued onto post-pause audio with the paused gap collapsed out.
+        pendingSystem.removeAll(keepingCapacity: false)
+        state = .paused
+        recLog.log("pause: source=\(self.source.rawValue, privacy: .public) elapsed=\(self.elapsed, privacy: .public)")
+    }
+
+    /// Resume a paused session. Accumulates the just-finished pause into
+    /// `totalPaused` so `elapsed` skips it, and clears any system-audio that
+    /// arrived while paused before capture resumes.
+    func resume() {
+        guard state == .paused else { return }
+        if let pausedAt {
+            totalPaused += Date().timeIntervalSince(pausedAt)
+        }
+        pausedAt = nil
+        pendingSystem.removeAll(keepingCapacity: false)
+        state = .recording
+        recLog.log("resume: source=\(self.source.rawValue, privacy: .public) totalPaused=\(self.totalPaused, privacy: .public)")
     }
 
     /// UI-test seam: flip state to .recording without spinning up
@@ -170,19 +232,14 @@ final class RecordingSession: ObservableObject {
         // Skip AVAudioFile setup — the test injects samples directly
         // into onLiveSamples; nothing should be writing to disk.
         startTime = Date()
+        pausedAt = nil
+        totalPaused = 0
         state = .recording
-        timerTask = Task { @MainActor [weak self] in
-            while let self, self.state == .recording {
-                if let start = self.startTime {
-                    self.elapsed = Date().timeIntervalSince(start)
-                }
-                try? await Task.sleep(nanoseconds: 200_000_000)
-            }
-        }
+        startElapsedTimer()
     }
 
     func stop() async -> URL? {
-        guard state == .recording else { return fileURL }
+        guard state == .recording || state == .paused else { return fileURL }
         state = .stopping
         // Snapshot the mic frame count BEFORE teardown so the caller can tell
         // a genuinely-empty mic session apart from a normal one. A fake
@@ -205,6 +262,8 @@ final class RecordingSession: ObservableObject {
         audioFile = nil
         fileURL = nil
         startTime = nil
+        pausedAt = nil
+        totalPaused = 0
         elapsed = 0
         isFakeForTesting = false
         state = .idle
@@ -225,6 +284,8 @@ final class RecordingSession: ObservableObject {
         audioFile = nil
         fileURL = nil
         startTime = nil
+        pausedAt = nil
+        totalPaused = 0
         elapsed = 0
         isFakeForTesting = false
         pendingSystem.removeAll(keepingCapacity: false)
@@ -234,6 +295,10 @@ final class RecordingSession: ObservableObject {
     // MARK: - Mixing
 
     private func consumeMic(_ buffer: AVAudioPCMBuffer) async {
+        // Paused: discard the buffer entirely so nothing reaches the WAV or
+        // the live transcriber. The engine keeps running; we just drop its
+        // output until `resume()`.
+        guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
         await MainActor.run { self.micLevel = AudioMeter.level(from: buffer) }
         if source == .microphone {
@@ -257,6 +322,10 @@ final class RecordingSession: ObservableObject {
     }
 
     private func consumeSystem(_ buffer: AVAudioPCMBuffer) async {
+        // Paused: drop system audio too (both the inline `.systemAudio`
+        // write and the `.meeting` jitter-buffer append) so the paused span
+        // is absent from the recording.
+        guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
         await MainActor.run { self.systemLevel = AudioMeter.level(from: buffer) }
         if source == .systemAudio {

--- a/Mila/Audio/UtteranceDetector.swift
+++ b/Mila/Audio/UtteranceDetector.swift
@@ -112,6 +112,13 @@ final class UtteranceDetector {
     private var partial: [Float] = []
     private var samplesIngested: Int = 0
     private var currentStartSample: Int = 0
+    /// Absolute recording-time seconds already elapsed BEFORE the current
+    /// `samplesIngested` counter (which restarts at 0 after a pause
+    /// boundary). Added to every emitted `startSec` so timestamps stay on
+    /// one continuous recording clock across pause/resume. Paused audio is
+    /// never ingested (RecordingSession drops it), so this stays aligned
+    /// with the gapless WAV — no gap is introduced for the paused span.
+    private var clockOffset: Double = 0
     /// Rolling estimate of the room's background RMS, tracked only
     /// during `.silence`. The effective absolute cutoff is
     /// `max(rmsThreshold, noiseFloor * noiseFloorMultiplier)` — so a
@@ -195,6 +202,23 @@ final class UtteranceDetector {
         clearAllState()
     }
 
+    /// Pause boundary: force-emit any in-progress utterance (so post-resume
+    /// audio isn't glued onto it across the paused gap) but PRESERVE the
+    /// recording clock. Unlike `flush()`, which zeroes the sample counter for
+    /// end-of-recording, this folds the audio ingested so far into
+    /// `clockOffset` before the state wipe, so utterances emitted after the
+    /// resume keep their absolute recording-time timestamps. Paused audio is
+    /// never ingested (RecordingSession drops it while paused), so the clock
+    /// stays aligned with the gapless WAV — no gap is introduced.
+    func flushForPause() {
+        let elapsed = clockOffset + Double(samplesIngested) / sampleRate
+        if state == .speech, speechFramesInCurrent >= minUtteranceFrames {
+            emit()
+        }
+        clearAllState()
+        clockOffset = elapsed
+    }
+
     /// Shared state-wipe used by both `reset()` and `flush()`. Wipes
     /// the state machine, in-progress utterance, pre-roll ring buffer,
     /// pending-speech onset buffer, partial-frame accumulator, sample
@@ -211,6 +235,7 @@ final class UtteranceDetector {
         partial.removeAll(keepingCapacity: true)
         samplesIngested = 0
         currentStartSample = 0
+        clockOffset = 0
         noiseFloor = 0.001
         signalEnvelope = 0
         pendingSpeechFrames = 0
@@ -389,7 +414,7 @@ final class UtteranceDetector {
     }
 
     private func emit() {
-        let startSec = max(0, Double(currentStartSample) / sampleRate)
+        let startSec = max(0, clockOffset + Double(currentStartSample) / sampleRate)
         let dur = Double(current.count) / sampleRate
         vadLog.log("VAD emit utterance: startSec=\(startSec, privacy: .public) dur=\(dur, privacy: .public)s noiseFloor=\(self.noiseFloor, privacy: .public) envelope=\(self.signalEnvelope, privacy: .public) speechFrames=\(self.speechFramesInCurrent, privacy: .public)")
         onUtterance?(current, startSec)

--- a/Mila/Audio/WAVHeaderRepair.swift
+++ b/Mila/Audio/WAVHeaderRepair.swift
@@ -1,0 +1,147 @@
+import Foundation
+import OSLog
+
+private let wavRepairLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                  category: "WAVHeaderRepair")
+
+/// Repairs WAV files whose header size fields were never finalized because the
+/// app was killed mid-recording.
+///
+/// `AVAudioFile` streams the PCM frames to disk as they arrive, but only
+/// backfills the `RIFF` chunk size and the `data` chunk size when the file is
+/// `close()`d — which only happens on a clean Stop. A crash / force-quit skips
+/// `close()`, so the header is frozen at its initial placeholder (`data`
+/// size = 0). Every decoder — including Mila's own transcription reader —
+/// then honors that header and treats the file as empty, even though the audio
+/// is physically present. Rewriting the two size fields from the actual file
+/// length makes the recording readable again.
+///
+/// The decision (`plan`) is a pure function over the header bytes + file size
+/// so it can be unit-tested without touching the filesystem; `repairIfNeeded`
+/// applies it in place.
+enum WAVHeaderRepair {
+
+    /// A concrete repair to apply: which little-endian `UInt32` fields to
+    /// overwrite and with what values.
+    struct Plan: Equatable {
+        /// Offset of the `RIFF` chunk size field — always 4 for a real WAV.
+        let riffSizeOffset: Int
+        let newRiffSize: UInt32
+        /// Offset of the `data` chunk's size field (chunk offset + 4).
+        let dataSizeOffset: Int
+        let newDataSize: UInt32
+    }
+
+    /// Decide whether `header` describes an unfinalized WAV that needs its
+    /// `RIFF`/`data` size fields rewritten. Returns `nil` when the header is
+    /// already finalized, isn't a WAV we recognize, or the file is too small —
+    /// callers treat "no plan" as "leave the file untouched".
+    ///
+    /// - Parameters:
+    ///   - header: the first bytes of the file (the RIFF header + chunk table
+    ///     live in the first few KB; pass a generous prefix, e.g. 64 KB).
+    ///   - fileSize: the physical file size in bytes.
+    static func plan(header: [UInt8], fileSize: Int) -> Plan? {
+        // Minimum: RIFF(8) + WAVE(4) + fmt(24) + data header(8) = 44.
+        guard fileSize > 44, header.count >= 12 else { return nil }
+        guard header[0] == 0x52, header[1] == 0x49, header[2] == 0x46, header[3] == 0x46, // "RIFF"
+              header[8] == 0x57, header[9] == 0x41, header[10] == 0x56, header[11] == 0x45 // "WAVE"
+        else { return nil }
+
+        func u32(_ offset: Int) -> UInt32? {
+            guard offset >= 0, offset + 4 <= header.count else { return nil }
+            return UInt32(header[offset])
+                | (UInt32(header[offset + 1]) << 8)
+                | (UInt32(header[offset + 2]) << 16)
+                | (UInt32(header[offset + 3]) << 24)
+        }
+        func tag(_ offset: Int, _ a: UInt8, _ b: UInt8, _ c: UInt8, _ d: UInt8) -> Bool {
+            offset + 4 <= header.count
+                && header[offset] == a && header[offset + 1] == b
+                && header[offset + 2] == c && header[offset + 3] == d
+        }
+
+        // Walk the chunk table to find `data` (and `fmt ` for block alignment).
+        var offset = 12
+        var blockAlign = 0
+        var dataChunkOffset: Int?
+        while offset + 8 <= header.count {
+            guard let size = u32(offset + 4) else { break }
+            if tag(offset, 0x64, 0x61, 0x74, 0x61) {          // "data"
+                dataChunkOffset = offset
+                break
+            }
+            if tag(offset, 0x66, 0x6d, 0x74, 0x20),           // "fmt "
+               offset + 8 + 14 <= header.count {
+                // fmt content: audioFormat(2) numChannels(2) sampleRate(4)
+                // byteRate(4) blockAlign(2)@12 bitsPerSample(2)@14.
+                blockAlign = Int(header[offset + 8 + 12])
+                    | (Int(header[offset + 8 + 13]) << 8)
+            }
+            // Chunks are word-aligned: an odd size carries a trailing pad byte.
+            offset += 8 + Int(size) + (Int(size) & 1)
+        }
+
+        guard let dataChunkOffset else { return nil }
+        let dataStart = dataChunkOffset + 8
+        guard dataStart <= fileSize else { return nil }
+
+        var available = fileSize - dataStart
+        // Floor to a whole frame so a torn final frame (crash mid-write) doesn't
+        // leave a fractional sample the reader could choke on.
+        if blockAlign > 1 { available -= available % blockAlign }
+        guard available > 0 else { return nil }
+
+        // Only repair a clearly-unfinalized header: the declared `data` size is
+        // smaller than what's physically present (0 on a crash). If it already
+        // matches — or over-claims, a different problem we won't invent data
+        // for — leave it alone. This makes the call idempotent.
+        let declared = u32(dataChunkOffset + 4) ?? 0
+        guard Int(declared) < available else { return nil }
+
+        // WAV size fields are UInt32; a >4 GiB file can't be described by the
+        // format anyway, so bail rather than truncate.
+        guard available <= Int(UInt32.max), (fileSize - 8) <= Int(UInt32.max) else { return nil }
+
+        return Plan(riffSizeOffset: 4,
+                    newRiffSize: UInt32(fileSize - 8),
+                    dataSizeOffset: dataChunkOffset + 4,
+                    newDataSize: UInt32(available))
+    }
+
+    /// Repair the WAV at `url` in place if its header is unfinalized. Returns
+    /// `true` iff a fix was written. Safe to call on any file: non-WAVs,
+    /// already-finalized WAVs, and unreadable paths are no-ops.
+    @discardableResult
+    static func repairIfNeeded(at url: URL) -> Bool {
+        let fileSize = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard fileSize > 44 else { return false }
+        guard let handle = try? FileHandle(forUpdating: url) else { return false }
+        defer { try? handle.close() }
+
+        // The RIFF header + chunk table sit in the first few KB; 64 KB is
+        // comfortably beyond any realistic fmt/JUNK/FLLR padding.
+        guard let prefix = try? handle.read(upToCount: 64 * 1024),
+              let plan = plan(header: [UInt8](prefix), fileSize: fileSize)
+        else { return false }
+
+        func write(_ value: UInt32, at offset: Int) -> Bool {
+            var le = value.littleEndian
+            let bytes = Data(bytes: &le, count: 4)
+            do {
+                try handle.seek(toOffset: UInt64(offset))
+                try handle.write(contentsOf: bytes)
+                return true
+            } catch {
+                wavRepairLog.error("WAV header write failed at \(offset): \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        }
+
+        let okRiff = write(plan.newRiffSize, at: plan.riffSizeOffset)
+        let okData = write(plan.newDataSize, at: plan.dataSizeOffset)
+        guard okRiff && okData else { return false }
+        wavRepairLog.log("repaired unfinalized WAV header for \(url.lastPathComponent, privacy: .public) (data size -> \(plan.newDataSize))")
+        return true
+    }
+}

--- a/Mila/MCP/LiveTranscriptSidecarWriter.swift
+++ b/Mila/MCP/LiveTranscriptSidecarWriter.swift
@@ -1,0 +1,159 @@
+import Foundation
+import OSLog
+import TranscriptionCore
+import MilaKit
+
+private let sidecarLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                category: "LiveTranscriptSidecar")
+
+/// Mirrors the in-progress recording's live transcript to
+/// `<app-support>/Mila/live/current.json` so external tools (mila-mcp)
+/// can follow the meeting in real time. The live transcript otherwise
+/// exists only in `LiveTranscriber`'s memory until Stop.
+///
+/// Writes are throttled (content ticks arrive per whisper pass) and
+/// atomic (temp + rename via `.atomic`), so a concurrent reader always
+/// sees a complete document. A heartbeat refreshes `updatedAt` every few
+/// seconds while recording so a reader can distinguish "meeting is quiet"
+/// from "app died mid-meeting".
+@MainActor
+final class LiveTranscriptSidecarWriter: ObservableObject {
+
+    private let root: URL
+    private let minWriteInterval: TimeInterval
+    private let heartbeatInterval: TimeInterval
+
+    private var snapshot: LiveTranscriptSnapshot?
+    private var lastWriteAt: Date = .distantPast
+    private var trailingWriteTask: Task<Void, Never>?
+    private var heartbeatTask: Task<Void, Never>?
+
+    /// `root` is the directory holding the `live/` subdirectory — the
+    /// default app-support root in production, a temp dir in tests.
+    init(root: URL = StoreLocationPointer.defaultRoot(),
+         minWriteInterval: TimeInterval = 1.5,
+         heartbeatInterval: TimeInterval = 5) {
+        self.root = root
+        self.minWriteInterval = minWriteInterval
+        self.heartbeatInterval = heartbeatInterval
+    }
+
+    /// Call once at app launch: a leftover `recording` snapshot means the
+    /// app died mid-recording — rewrite it as `interrupted` so a poller
+    /// doesn't sit on a transcript that will never grow. (Crash recovery
+    /// re-transcribes the orphan WAV through the normal batch queue.)
+    func cleanupAtLaunch() {
+        guard var stale = LiveTranscriptSnapshot.read(root: root),
+              stale.state == .recording else { return }
+        stale.state = .interrupted
+        stale.revision += 1
+        stale.updatedAt = Date()
+        do {
+            try stale.write(root: root)
+            sidecarLog.log("marked leftover live snapshot interrupted (session \(stale.sessionID, privacy: .public))")
+        } catch {
+            sidecarLog.error("cleanupAtLaunch write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Start a new session snapshot. `liveAvailable: false` records that
+    /// the capture is running but no live transcript will appear (the
+    /// low-end-hardware gate) — external pollers get an honest status
+    /// instead of a silent, forever-empty transcript.
+    func begin(title: String?, source: String?, liveAvailable: Bool) {
+        cancelTimers()
+        let now = Date()
+        snapshot = LiveTranscriptSnapshot(liveTranscriptAvailable: liveAvailable,
+                                          recordingStartedAt: now,
+                                          updatedAt: now,
+                                          title: title,
+                                          source: source?.isEmpty == false ? source : nil)
+        writeNow()
+        startHeartbeat()
+    }
+
+    /// Content tick: replace segments + speaker names. Bumps `revision`
+    /// only when something actually changed (the `$segments` feed fires
+    /// on every reassignment, changed or not), and coalesces bursts down
+    /// to one write per `minWriteInterval` with a guaranteed trailing
+    /// write so the last tick of a burst always lands.
+    func update(segments: [TranscriptSegment], speakerNames: [String: String]) {
+        guard var current = snapshot, current.state == .recording else { return }
+        let mapped = segments.map {
+            LiveTranscriptSnapshot.Segment(start: $0.start, end: $0.end,
+                                           text: $0.text, speaker: $0.speaker)
+        }
+        guard mapped != current.segments || speakerNames != current.speakerNames else { return }
+        current.segments = mapped
+        current.speakerNames = speakerNames
+        current.revision += 1
+        snapshot = current
+        scheduleWrite()
+    }
+
+    /// Final write for this session. Pass the saved recording's id on the
+    /// normal Stop path (poller handoff to `get_transcript`); nil when
+    /// there's nothing to hand off (failed stop, sleep/lock teardown).
+    /// The completed snapshot stays on disk until the next `begin`.
+    func finish(recordingID: UUID?) {
+        cancelTimers()
+        guard var current = snapshot, current.state == .recording else { return }
+        current.state = .completed
+        current.finalRecordingID = recordingID
+        current.revision += 1
+        snapshot = current
+        writeNow()
+        snapshot = nil
+    }
+
+    // MARK: - Write scheduling
+
+    private func scheduleWrite() {
+        let elapsed = Date().timeIntervalSince(lastWriteAt)
+        if elapsed >= minWriteInterval {
+            trailingWriteTask?.cancel()
+            trailingWriteTask = nil
+            writeNow()
+        } else if trailingWriteTask == nil {
+            let delay = minWriteInterval - elapsed
+            trailingWriteTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                self.trailingWriteTask = nil
+                self.writeNow()
+            }
+        }
+    }
+
+    private func writeNow() {
+        guard var current = snapshot else { return }
+        current.updatedAt = Date()
+        snapshot = current
+        lastWriteAt = Date()
+        do {
+            try current.write(root: root)
+        } catch {
+            sidecarLog.error("live snapshot write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func startHeartbeat() {
+        heartbeatTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let interval = self?.heartbeatInterval else { return }
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                guard !Task.isCancelled, let self, self.snapshot?.state == .recording else { continue }
+                // Refresh updatedAt (liveness) without touching revision
+                // (content cursor) — quiet meetings stay cheap to poll.
+                self.writeNow()
+            }
+        }
+    }
+
+    private func cancelTimers() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        trailingWriteTask?.cancel()
+        trailingWriteTask = nil
+    }
+}

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Combine
+
+/// User-configurable Obsidian vault destination. When enabled, Mila writes a
+/// Markdown note (summary + action items, with a transcript fallback) into the
+/// chosen vault folder after every recording finishes — and, optionally,
+/// commits + pushes the vault git repo.
+///
+/// Mirrors `RecordingStorageSettings`: the vault folder is persisted as a
+/// **security-scoped bookmark** (not a raw path) so it survives moves/renames
+/// and keeps working if/when the app is sandboxed. The
+/// `com.apple.security.files.user-selected.read-write` entitlement is already
+/// declared, so bookmark access is granted at pick time and held for the app's
+/// lifetime.
+@MainActor
+final class ObsidianVaultSettings: ObservableObject {
+    static let enabledKey = "obsidian.enabled"
+    static let bookmarkKey = "obsidian.vaultBookmark"
+    static let subfolderKey = "obsidian.subfolder"
+    static let gitEnabledKey = "obsidian.git.enabled"
+    static let gitBranchKey = "obsidian.git.branch"
+
+    /// Default subfolder within the vault. Blank means "vault root".
+    static let defaultSubfolder = "Transcripts"
+    static let defaultBranch = "main"
+
+    /// Master switch. Off by default — the feature is opt-in and the
+    /// existing local-only experience is unchanged unless the user turns
+    /// this on and picks a vault.
+    @Published var enabled: Bool {
+        didSet {
+            guard enabled != oldValue else { return }
+            defaults.set(enabled, forKey: Self.enabledKey)
+        }
+    }
+
+    /// Relative folder inside the vault that notes are written into (e.g.
+    /// `Transcripts`). Blank = the vault root.
+    @Published var subfolder: String {
+        didSet {
+            guard subfolder != oldValue else { return }
+            defaults.set(subfolder, forKey: Self.subfolderKey)
+        }
+    }
+
+    /// When on, each written note is committed and pushed to the vault's
+    /// git remote (`add + commit -> pull --rebase -> push`). Requires the
+    /// vault to be a working git repo with credentials pre-configured
+    /// (SSH key / credential helper) — Mila runs git non-interactively.
+    @Published var gitSyncEnabled: Bool {
+        didSet {
+            guard gitSyncEnabled != oldValue else { return }
+            defaults.set(gitSyncEnabled, forKey: Self.gitEnabledKey)
+        }
+    }
+
+    /// Branch the sync pushes to (default `main`).
+    @Published var gitBranch: String {
+        didSet {
+            guard gitBranch != oldValue else { return }
+            defaults.set(gitBranch, forKey: Self.gitBranchKey)
+        }
+    }
+
+    /// Human-readable message from the last git sync, or nil when the last
+    /// one succeeded / none has run. Surfaced in the Obsidian settings tab.
+    /// Deliberately NOT persisted — a stale error across launches would be
+    /// misleading.
+    @Published var lastSyncError: String?
+
+    /// The resolved vault folder, or nil when none is picked. Published so
+    /// the settings UI re-renders on pick/clear.
+    @Published private(set) var vaultURL: URL?
+
+    /// Set when the persisted bookmark resolved stale (folder moved) so the
+    /// UI can show a "refreshed the reference" badge.
+    @Published private(set) var lastResolutionWasStale: Bool = false
+
+    private let defaults: UserDefaults
+    private var accessingURL: URL?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.enabled = defaults.bool(forKey: Self.enabledKey)
+        self.subfolder = defaults.string(forKey: Self.subfolderKey) ?? Self.defaultSubfolder
+        self.gitSyncEnabled = defaults.bool(forKey: Self.gitEnabledKey)
+        self.gitBranch = defaults.string(forKey: Self.gitBranchKey) ?? Self.defaultBranch
+        resolveAndStartAccessing()
+    }
+
+    /// The directory notes are written into: the vault root plus the
+    /// configured subfolder. nil when no vault is picked.
+    var destinationDirectory: URL? {
+        guard let vaultURL else { return nil }
+        let clean = subfolder
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return clean.isEmpty ? vaultURL : vaultURL.appendingPathComponent(clean, isDirectory: true)
+    }
+
+    /// Resolve the persisted bookmark into a URL and start accessing it.
+    /// Idempotent — safe to re-call after `setVault` / `clearVault`.
+    private func resolveAndStartAccessing() {
+        if let url = accessingURL {
+            url.stopAccessingSecurityScopedResource()
+            accessingURL = nil
+        }
+        vaultURL = nil
+        lastResolutionWasStale = false
+
+        guard let data = defaults.data(forKey: Self.bookmarkKey) else { return }
+        var isStale = false
+        let resolved: URL
+        do {
+            resolved = try URL(
+                resolvingBookmarkData: data,
+                options: [.withSecurityScope],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+        } catch {
+            print("ObsidianVaultSettings: failed to resolve bookmark: \(error)")
+            defaults.removeObject(forKey: Self.bookmarkKey)
+            return
+        }
+        if isStale {
+            lastResolutionWasStale = true
+            if let refreshed = try? resolved.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) {
+                defaults.set(refreshed, forKey: Self.bookmarkKey)
+            } else {
+                defaults.removeObject(forKey: Self.bookmarkKey)
+                return
+            }
+        }
+        let started = resolved.startAccessingSecurityScopedResource()
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: resolved.path, isDirectory: &isDir)
+        if !exists || !isDir.boolValue {
+            if started { resolved.stopAccessingSecurityScopedResource() }
+            defaults.removeObject(forKey: Self.bookmarkKey)
+            return
+        }
+        accessingURL = resolved
+        vaultURL = resolved
+    }
+
+    /// Persist a freshly-picked vault folder. Returns true on success.
+    @discardableResult
+    func setVault(_ url: URL) -> Bool {
+        do {
+            let data = try url.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+            defaults.set(data, forKey: Self.bookmarkKey)
+            resolveAndStartAccessing()
+            return vaultURL != nil
+        } catch {
+            print("ObsidianVaultSettings: failed to mint bookmark for \(url.path): \(error)")
+            return false
+        }
+    }
+
+    /// Forget the chosen vault.
+    func clearVault() {
+        defaults.removeObject(forKey: Self.bookmarkKey)
+        resolveAndStartAccessing()
+    }
+}

--- a/Mila/Models/Recording.swift
+++ b/Mila/Models/Recording.swift
@@ -93,6 +93,13 @@ struct Recording: Identifiable, Codable, Hashable {
     /// upgrade can't mass-delete a user's older imports.
     var voiceMemoFolderUUID: String?
 
+    /// User-assigned display names for diarized speakers, keyed by the raw
+    /// diarizer ID (`SPEAKER_00` → "Daniel"). Segments keep their raw IDs —
+    /// this map is a display overlay resolved at render/export time, so
+    /// re-clustering tooling and the color palette stay keyed on stable IDs.
+    /// Empty for recordings whose speakers were never renamed.
+    var speakerNames: [String: String]
+
     /// Sentinel stored in `voiceMemoFolderUUID` for memos imported from the
     /// Voice Memos "Unfiled" bucket, which has no real folder UUID. Keeps
     /// "imported from Unfiled" distinguishable from a legacy import whose
@@ -117,7 +124,8 @@ struct Recording: Identifiable, Codable, Hashable {
          summary: String? = nil,
          actionItems: [ActionItem]? = nil,
          voiceMemoUniqueID: String? = nil,
-         voiceMemoFolderUUID: String? = nil) {
+         voiceMemoFolderUUID: String? = nil,
+         speakerNames: [String: String] = [:]) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -136,6 +144,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.actionItems = actionItems
         self.voiceMemoUniqueID = voiceMemoUniqueID
         self.voiceMemoFolderUUID = voiceMemoFolderUUID
+        self.speakerNames = speakerNames
     }
 
     var isTrashed: Bool { deletedAt != nil }
@@ -170,7 +179,8 @@ struct Recording: Identifiable, Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, title, createdAt, duration, source, audioFileName,
              status, language, modelName, segments, deletedAt, folder, appName,
-             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID
+             summary, actionItems, voiceMemoUniqueID, voiceMemoFolderUUID,
+             speakerNames
         // `fullText` deliberately excluded — lives in a sidecar .txt file.
         // Legacy records that had it inline are decoded via the custom init.
         case fullText
@@ -195,6 +205,7 @@ struct Recording: Identifiable, Codable, Hashable {
         self.actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
         self.voiceMemoUniqueID = try c.decodeIfPresent(String.self, forKey: .voiceMemoUniqueID)
         self.voiceMemoFolderUUID = try c.decodeIfPresent(String.self, forKey: .voiceMemoFolderUUID)
+        self.speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
         // Legacy records still have fullText inline; new records leave it
         // empty here and RecordingStore loads it from the sidecar .txt.
         self.fullText = try c.decodeIfPresent(String.self, forKey: .fullText) ?? ""
@@ -219,6 +230,9 @@ struct Recording: Identifiable, Codable, Hashable {
         try c.encodeIfPresent(actionItems, forKey: .actionItems)
         try c.encodeIfPresent(voiceMemoUniqueID, forKey: .voiceMemoUniqueID)
         try c.encodeIfPresent(voiceMemoFolderUUID, forKey: .voiceMemoFolderUUID)
+        if !speakerNames.isEmpty {
+            try c.encode(speakerNames, forKey: .speakerNames)
+        }
         // fullText intentionally omitted — sidecar .txt is the source of truth.
     }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -374,6 +374,27 @@ final class RecordingStore: ObservableObject {
         persist()
     }
 
+    /// Assign (or clear, with nil/empty) a display name for one raw
+    /// diarizer speaker ID on a recording. Segments keep their raw
+    /// `SPEAKER_NN` IDs — the name is a display overlay resolved at
+    /// render/export time. Regenerates the `.srt` sidecar for completed
+    /// recordings so the on-disk export matches what the UI shows.
+    func setSpeakerName(_ name: String?, forSpeaker rawID: String, recordingID: UUID) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recordingID }) else { return }
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, !trimmed.isEmpty {
+            guard recordings[idx].speakerNames[rawID] != trimmed else { return }
+            recordings[idx].speakerNames[rawID] = trimmed
+        } else {
+            guard recordings[idx].speakerNames[rawID] != nil else { return }
+            recordings[idx].speakerNames.removeValue(forKey: rawID)
+        }
+        persist()
+        if recordings[idx].status == .completed {
+            TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
+        }
+    }
+
     /// Move a recording into a folder (or unfile it with nil). Auto-creates
     /// the folder so callers can drag into a brand-new name without a
     /// separate `createFolder` round-trip. Dedup is case-insensitive — if

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import OSLog
+import MilaKit
 
 private let recStoreLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "RecordingStore")
 
@@ -131,6 +132,7 @@ final class RecordingStore: ObservableObject {
         load()
         loadFolders()
         loadTombstones()
+        writeStoreLocationPointer()
     }
 
     /// Switch the recordings directory to `newDirectory`. Clears the
@@ -168,6 +170,25 @@ final class RecordingStore: ObservableObject {
         self.pendingRecoveryIDs = []
         load()
         loadFolders()
+        writeStoreLocationPointer()
+    }
+
+    /// Mirror the resolved store paths into `store-location.json` at the
+    /// original root so external tools (mila-mcp) can find the store even
+    /// when the user relocated the recordings directory — the relocation
+    /// itself lives in a security-scoped bookmark another process can't
+    /// resolve. Always written at the ORIGINAL root: on the default path
+    /// that's Application Support/Mila, and test instances (temp roots)
+    /// stay isolated automatically.
+    private func writeStoreLocationPointer() {
+        let pointer = StoreLocationPointer(recordingsDirectory: recordingsDirectory.path,
+                                           storeFile: storeURL.path,
+                                           updatedAt: Date())
+        do {
+            try pointer.write(to: originalRootDirectory)
+        } catch {
+            recStoreLog.error("failed to write store-location pointer: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func audioURL(for recording: Recording) -> URL {

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -114,8 +114,11 @@ final class RecordingStore: ObservableObject {
     /// `relocateRecordings(to: nil)` can revert to the original
     /// default-path layout (json files sit alongside the `Recordings/`
     /// subdir, matching the historical shape that pre-v1.7 builds
-    /// shipped).
-    private let originalRootDirectory: URL
+    /// shipped). Exposed (read-only) so app-state siblings that must NOT
+    /// travel with a relocated recordings folder — the store-location
+    /// pointer, the live-transcript sidecar — anchor to the same root,
+    /// keeping test instances (temp roots) isolated automatically.
+    let originalRootDirectory: URL
 
     init(rootDirectory: URL) {
         self.originalRootDirectory = rootDirectory

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -562,6 +562,37 @@ final class RecordingStore: ObservableObject {
         }
     }
 
+    /// Permanently delete every trashed recording in one pass — the bulk
+    /// "Empty Trash" action. Applies the same per-recording cleanup as
+    /// `permanentlyDelete(_:)` (audio + `.txt`/`.summary.txt`/`.srt` sidecars,
+    /// plus a Voice-Memos tombstone so a deleted import doesn't resync), but
+    /// batches the store + tombstone writes so a full bin doesn't trigger one
+    /// persist per row. Returns the number of recordings removed; a no-op that
+    /// skips persisting when the trash is already empty.
+    @discardableResult
+    func emptyTrash() -> Int {
+        let trashed = recordings.filter { $0.isTrashed }
+        guard !trashed.isEmpty else { return 0 }
+
+        var tombstonedAny = false
+        for recording in trashed {
+            try? fileManager.removeItem(at: audioURL(for: recording))
+            try? fileManager.removeItem(at: transcriptURL(for: recording))
+            try? fileManager.removeItem(at: summaryURL(for: recording))
+            try? fileManager.removeItem(at: subtitleURL(for: recording))
+            if let memoID = recording.voiceMemoUniqueID {
+                voiceMemoTombstones.insert(memoID)
+                tombstonedAny = true
+            }
+        }
+
+        let trashedIDs = Set(trashed.map(\.id))
+        recordings.removeAll { trashedIDs.contains($0.id) }
+        if tombstonedAny { persistTombstones() }
+        persist()
+        return trashed.count
+    }
+
     func recordings(in category: HistoryCategory) -> [Recording] {
         switch category {
         case .recentlyDeleted:

--- a/Mila/Models/SpeakerDirectory.swift
+++ b/Mila/Models/SpeakerDirectory.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// App-wide directory of speaker names the user has assigned across
+/// recordings — the pick-list behind the speaker rename popover. Most
+/// people recur across meetings, so the list persists to
+/// `speaker-names.json` at the Application Support/Mila root. Like the
+/// voice-memo tombstones (and unlike `folders.json`), it deliberately
+/// does NOT travel with a relocated recordings folder: it's app state,
+/// not per-folder content.
+///
+/// Per-recording assignments live in `Recording.speakerNames` as plain
+/// string copies — removing a name here never touches recordings it was
+/// already assigned to.
+@MainActor
+final class SpeakerDirectory: ObservableObject {
+
+    @Published private(set) var names: [String] = []
+
+    private let fileURL: URL
+
+    /// `directory` is the folder that holds `speaker-names.json`.
+    /// Injectable so tests can point at a temp directory.
+    init(directory: URL) {
+        self.fileURL = directory.appendingPathComponent("speaker-names.json")
+        load()
+    }
+
+    /// Production init: same Application Support/Mila root the
+    /// RecordingStore resolves.
+    convenience init() {
+        // Mirror RecordingStore: UI tests must never read or write the
+        // user's real directory.
+        if CommandLine.arguments.contains("--ui-test-clean-store") {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("Mila-UITest-Speakers-\(UUID())", isDirectory: true)
+            self.init(directory: tmp)
+            return
+        }
+        let appSupport = try! FileManager.default.url(for: .applicationSupportDirectory,
+                                                      in: .userDomainMask,
+                                                      appropriateFor: nil,
+                                                      create: true)
+        self.init(directory: appSupport.appendingPathComponent("Mila", isDirectory: true))
+    }
+
+    /// Add a name to the directory. Trims whitespace, rejects empty input,
+    /// and dedupes case-insensitively — adding "daniel" when "Daniel"
+    /// exists returns the existing canonical spelling instead of a
+    /// duplicate. Returns the canonical name that's now in the list, or
+    /// nil when the input was blank.
+    @discardableResult
+    func add(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let existing = names.first(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return existing
+        }
+        names.append(trimmed)
+        names.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        persist()
+        return trimmed
+    }
+
+    func remove(_ name: String) {
+        let before = names.count
+        names.removeAll { $0.caseInsensitiveCompare(name) == .orderedSame }
+        if names.count != before { persist() }
+    }
+
+    /// Names matching a type-to-filter query (case-insensitive contains).
+    /// An empty/whitespace query returns the full list.
+    func matches(for query: String) -> [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return names }
+        return names.filter { $0.localizedCaseInsensitiveContains(trimmed) }
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else { return }
+        names = decoded.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func persist() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(names)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("SpeakerDirectory persist error: \(error)")
+        }
+    }
+}

--- a/Mila/Models/SpeakerDirectory.swift
+++ b/Mila/Models/SpeakerDirectory.swift
@@ -36,10 +36,12 @@ final class SpeakerDirectory: ObservableObject {
             self.init(directory: tmp)
             return
         }
-        let appSupport = try! FileManager.default.url(for: .applicationSupportDirectory,
-                                                      in: .userDomainMask,
-                                                      appropriateFor: nil,
-                                                      create: true)
+        // Non-throwing lookup + temp-dir fallback: a missing Application
+        // Support directory shouldn't crash the app at launch — worst case
+        // the directory just doesn't persist across reboots.
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
         self.init(directory: appSupport.appendingPathComponent("Mila", isDirectory: true))
     }
 

--- a/Mila/Transcription/SpeakerColor.swift
+++ b/Mila/Transcription/SpeakerColor.swift
@@ -27,6 +27,19 @@ extension String {
         }
         return speakerColorPalette[index % speakerColorPalette.count]
     }
+
+    /// Speaker color that honors user-assigned names: when two raw IDs
+    /// share the same assigned name (the user's fix for an over-split
+    /// speaker), both take the color of the lowest raw ID carrying that
+    /// name so they read as one person. Unnamed IDs keep their own color.
+    func speakerColor(names: [String: String]) -> Color {
+        guard let name = names[self] else { return speakerColor }
+        let canonical = names
+            .filter { $0.value == name }
+            .keys
+            .min() ?? self
+        return canonical.speakerColor
+    }
 }
 
 /// Segment types that carry a diarizer speaker ID — `TranscriptSegment`

--- a/Mila/Transcription/SpeakerLabel.swift
+++ b/Mila/Transcription/SpeakerLabel.swift
@@ -4,13 +4,27 @@ import Foundation
 /// identifiers into a label the user actually wants to see — `Speaker A`
 /// in English, `דובר א׳` in Hebrew.
 ///
-/// The raw labels stay in the internal data model (segment metadata,
-/// SRT exports, post-recording sidecar text) because they're stable
-/// across runs and tooling outside Mila (pyannote, third-party
-/// re-clustering scripts) expects them. The conversion only happens
-/// at display time and when feeding text to the LLM, so the LLM sees
-/// the same labels the user sees and emits them back the same way.
+/// The raw labels stay in the internal data model (segment metadata)
+/// because they're stable across runs and tooling outside Mila
+/// (pyannote, third-party re-clustering scripts) expects them. The
+/// conversion happens at display/export time and when feeding text to
+/// the LLM, so the LLM sees the same labels the user sees and emits
+/// them back the same way. When the user has assigned a real name to a
+/// speaker (`Recording.speakerNames`), that name wins everywhere —
+/// UI, clipboard, `.srt` sidecar, LLM feed — via
+/// `displaySpeakerName(names:language:)`.
 extension String {
+    /// The label to show/export for this raw speaker ID: the
+    /// user-assigned name when one exists, otherwise the friendly
+    /// "Speaker A" / "דובר א׳" fallback.
+    func displaySpeakerName(names: [String: String], language: String) -> String {
+        if let name = names[self]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return name
+        }
+        return friendlySpeakerLabel(language: language)
+    }
+
     func friendlySpeakerLabel(language: String) -> String {
         guard self.hasPrefix("SPEAKER_") else { return self }
         let suffix = self.dropFirst("SPEAKER_".count)

--- a/Mila/Transcription/SpeakerNameRemapper.swift
+++ b/Mila/Transcription/SpeakerNameRemapper.swift
@@ -1,0 +1,50 @@
+import Foundation
+import TranscriptionCore
+
+/// Carries user-assigned speaker names across the post-stop offline
+/// re-diarization, which re-keys every `SPEAKER_NN` label (global
+/// clustering assigns IDs by first-speaking order, unrelated to the
+/// live diarizer's IDs). Without the remap, a name assigned to live
+/// `SPEAKER_03` could silently land on — or vanish from — a different
+/// person in the finalized recording.
+///
+/// Works because `TranscriptionService.rediarizeSegments` only
+/// reassigns `.speaker` on the SAME segment array: `old[i]` and
+/// `new[i]` are the same utterance, so per-index pairs tell us which
+/// old speaker each new speaker was.
+enum SpeakerNameRemapper {
+
+    /// For each new speaker ID, find the old ID that dominates it by
+    /// summed segment duration and carry that old ID's name over.
+    /// Handles the offline pass merging over-segmented live speakers
+    /// (dominant name wins) and splitting one live speaker into two
+    /// (the name propagates to both halves).
+    static func remap(names: [String: String],
+                      from old: [TranscriptSegment],
+                      to new: [TranscriptSegment]) -> [String: String] {
+        guard !names.isEmpty else { return [:] }
+
+        // votes[newID][oldID] = summed duration of segments where the
+        // utterance carried oldID before and newID after. The small
+        // floor keeps zero-duration segments counted (degrades to a
+        // per-segment vote instead of dropping them).
+        var votes: [String: [String: Double]] = [:]
+        for (o, n) in zip(old, new) {
+            guard let oldID = o.speaker, let newID = n.speaker else { continue }
+            let duration = max(n.end - n.start, 0.001)
+            votes[newID, default: [:]][oldID, default: 0] += duration
+        }
+
+        var remapped: [String: String] = [:]
+        for (newID, tally) in votes {
+            let dominant = tally.max { a, b in
+                if a.value != b.value { return a.value < b.value }
+                return a.key > b.key  // deterministic tie-break: lower old ID wins
+            }?.key
+            if let dominant, let name = names[dominant] {
+                remapped[newID] = name
+            }
+        }
+        return remapped
+    }
+}

--- a/Mila/Transcription/TranscriptExporter.swift
+++ b/Mila/Transcription/TranscriptExporter.swift
@@ -28,15 +28,16 @@ enum TranscriptExporter {
     /// history context menu so users can drop subtitles next to a source
     /// video file. Throws so the caller can surface failures via NSAlert.
     static func writeSRT(for recording: Recording, to url: URL) throws {
-        try writeSRT(segments: recording.segments, to: url)
+        try writeSRT(segments: recording.segments, to: url, names: recording.speakerNames)
     }
 
     /// Raw-segments variant: write an SRT for a segment list that isn't
     /// (yet) attached to a saved `Recording`. Used by the mid-recording
     /// "Export SRT…" button in the live transcript pane, which snapshots
     /// `LiveTranscriber.segments` while the recording is still running.
-    static func writeSRT(segments: [TranscriptSegment], to url: URL) throws {
-        let body = srtBody(for: segments)
+    static func writeSRT(segments: [TranscriptSegment], to url: URL,
+                         names: [String: String] = [:]) throws {
+        let body = srtBody(for: segments, names: names)
         guard !body.isEmpty else {
             throw NSError(domain: "TranscriptExporter", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "No transcript segments to export."])
@@ -47,13 +48,15 @@ enum TranscriptExporter {
     /// Format the SRT content for `recording`. Returns empty string when
     /// there's nothing to write (no segments, or every segment is blank).
     static func srtBody(for recording: Recording) -> String {
-        srtBody(for: recording.segments)
+        srtBody(for: recording.segments, names: recording.speakerNames)
     }
 
     /// Format SRT content for a raw segment list. Returns empty string
     /// when there's nothing to write (no segments, or every segment is
-    /// blank).
-    static func srtBody(for segments: [TranscriptSegment]) -> String {
+    /// blank). `names` substitutes user-assigned speaker names for raw
+    /// diarizer IDs in the cue prefix; unnamed speakers keep the raw ID.
+    static func srtBody(for segments: [TranscriptSegment],
+                        names: [String: String] = [:]) -> String {
         guard !segments.isEmpty else { return "" }
 
         var entries: [String] = []
@@ -62,7 +65,7 @@ enum TranscriptExporter {
             guard !text.isEmpty else { continue }
 
             let seqNum = entries.count + 1
-            let prefix = seg.speaker.map { $0 + ": " } ?? ""
+            let prefix = seg.speaker.map { (names[$0] ?? $0) + ": " } ?? ""
             entries.append("\(seqNum)\n\(formatSRTTime(seg.start)) --> \(formatSRTTime(seg.end))\n\(prefix)\(text)")
         }
         return entries.isEmpty ? "" : entries.joined(separator: "\n\n") + "\n\n"

--- a/Mila/Transcription/TranscriptFormatter.swift
+++ b/Mila/Transcription/TranscriptFormatter.swift
@@ -5,14 +5,20 @@ enum TranscriptFormatter {
 
     /// Plain-text rendering of `segments` suitable for the clipboard or for
     /// piping into an LLM prompt. When any segment carries a speaker label
-    /// (diarization ran), each turn is prefixed `SPEAKER_XX: ` and
+    /// (diarization ran), each turn is prefixed with the speaker's label and
     /// consecutive segments from the same speaker collapse into one
     /// paragraph. When no segment has a speaker, falls back to `fallback`
     /// — the trimmed full-text join the rest of the app stores.
     ///
+    /// `names` maps raw diarizer IDs (`SPEAKER_00`) to user-assigned names;
+    /// unnamed speakers keep the raw ID. Turns collapse on the RESOLVED
+    /// label, so two raw IDs the user named identically (their fix for an
+    /// over-split speaker) merge into one paragraph.
+    ///
     /// Matches the SRT exporter's prefix format so the clipboard text and
     /// the on-disk `.srt` use the same speaker labels.
-    static func plainText(segments: [TranscriptSegment], fallback: String) -> String {
+    static func plainText(segments: [TranscriptSegment], fallback: String,
+                          names: [String: String] = [:]) -> String {
         guard segments.contains(where: { $0.speaker != nil }) else { return fallback }
 
         var lines: [String] = []
@@ -22,7 +28,7 @@ enum TranscriptFormatter {
         for seg in segments {
             let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { continue }
-            let speaker = seg.speaker
+            let speaker = seg.speaker.map { names[$0] ?? $0 }
 
             if currentSpeaker == .none {
                 currentSpeaker = .some(speaker)

--- a/Mila/Transcription/TranscriptSegment+Formatter.swift
+++ b/Mila/Transcription/TranscriptSegment+Formatter.swift
@@ -1,0 +1,4 @@
+import TranscriptionCore
+import MilaKit
+
+extension TranscriptSegment: SpeakerTextSegment {}

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -725,6 +725,12 @@ final class TranscriptionService: ObservableObject {
             print("Transcribe done: \(working.title) -> \(enrichedSegments.count) segments, \(text.count) chars")
 
             working.segments = enrichedSegments
+            // The batch pass minted fresh speaker IDs (new clustering, new
+            // segment boundaries) with no alignment to the old ones, so any
+            // user-assigned names are now keyed to meaningless IDs — clear
+            // them rather than mislabel a different voice. Only explicit
+            // re-transcribes of a renamed recording hit this in practice.
+            working.speakerNames = [:]
             working.fullText = text
             if let lastEnd = enrichedSegments.last?.end, lastEnd > 0 {
                 working.duration = lastEnd

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -656,6 +656,15 @@ final class TranscriptionService: ObservableObject {
                 }
             }()
 
+            // Per-run coalescer: whisper fires its progress callback many
+            // times/sec from a background compute thread. Funnelling each tick
+            // through its own `Task { @MainActor }` flooded the main actor (one
+            // @Published mutation + full re-render per tick) and applied values
+            // out of order. The coalescer bounds outstanding work to a single
+            // pending main-actor flush and keeps `progress` monotonic. Local to
+            // this run so there's no cross-recording state to reset.
+            let progressCoalescer = ProgressCoalescer()
+
             async let transcribeTask = activeEngine.transcribe(
                 samples: samples,
                 language: working.language,
@@ -669,11 +678,15 @@ final class TranscriptionService: ObservableObject {
                 // e2e short-clip case (en_numbers_and_dates 5.17s,
                 // 0.29 → 0.36 on ggml-tiny).
                 audioCtx: 0,
-                progress: { [weak self] p in
-                    Task { @MainActor [weak self] in
-                        guard let self else { return }
-                        guard self.activeRecordingID == recordingID else { return }
-                        self.progress = Double(p)
+                progress: { [weak self, progressCoalescer] p in
+                    // Cheap, lock-guarded, no allocation on the hot path.
+                    // Only schedule a main-actor flush when one isn't already
+                    // pending — that's what caps the flood.
+                    guard progressCoalescer.offer(Double(p)) else { return }
+                    Task { @MainActor [weak self, progressCoalescer] in
+                        let latest = progressCoalescer.flush()
+                        guard let self, self.activeRecordingID == recordingID else { return }
+                        self.progress = latest
                     }
                 },
                 // Polled by whisper.cpp's abort_callback between every
@@ -831,6 +844,40 @@ final class TranscriptionService: ObservableObject {
         print("Transcribe: auto-dropping \(recording.title) [\(recording.id.uuidString.prefix(8))] — \(duration)s + empty transcript (issue #61)")
         store.permanentlyDelete(recording)
         return true
+    }
+}
+
+/// Coalesces high-frequency progress callbacks (fired from whisper.cpp's
+/// background compute thread) into at most one pending main-actor update, and
+/// keeps the reported value monotonic.
+///
+/// The previous code spawned a fresh `Task { @MainActor }` per whisper tick — an
+/// unbounded flood of main-actor hops, each mutating `@Published progress` and
+/// re-rendering every observing view. Worse, independent `Task`s have no
+/// ordering guarantee, so a late-running earlier value could clobber a later
+/// one, freezing the bar short of 100%. This bounds outstanding work to one
+/// flush and applies `max`, so progress only ever moves forward.
+///
+/// `offer` runs on the compute thread and returns `true` when the caller should
+/// schedule a main-actor flush (none pending). `flush` runs on the main actor,
+/// returns the latest value, and clears the pending flag.
+final class ProgressCoalescer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latest: Double = 0
+    private var scheduled = false
+
+    func offer(_ value: Double) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        latest = max(latest, value)
+        if scheduled { return false }
+        scheduled = true
+        return true
+    }
+
+    func flush() -> Double {
+        lock.lock(); defer { lock.unlock() }
+        scheduled = false
+        return latest
     }
 }
 

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -473,10 +473,13 @@ private struct RecordingChip: View {
     var body: some View {
         HStack(spacing: 10) {
             Circle()
-                .fill(Color.red)
+                .fill(session.state == .paused ? Color.orange : Color.red)
                 .frame(width: 8, height: 8)
             Text(formatDuration(session.elapsed))
                 .font(.callout.monospacedDigit())
+                .foregroundStyle(session.state == .paused ? .orange : .primary)
+            RecordingPauseButton(compact: true)
+                .buttonStyle(.borderless)
             Button {
                 Task { await actions.stopRecording() }
             } label: {

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -58,6 +58,14 @@ struct ContentView: View {
                 }
             }
             .toolbar {
+                // Empty Trash sits on the leading side and only while the
+                // Recently Deleted view is open — a destructive bulk action
+                // has no place in the toolbar of a normal recordings list.
+                if isViewingTrash {
+                    ToolbarItem(placement: .destructiveAction) {
+                        EmptyTrashButton()
+                    }
+                }
                 ToolbarItem(placement: .primaryAction) {
                     InputDevicePickerToolbarItem()
                 }
@@ -209,6 +217,14 @@ struct ContentView: View {
             // flicker.
             NotificationCenter.default.post(name: .milaSidebarVisibilityDidChange, object: nil)
         }
+    }
+
+    /// True while the detail pane is showing the "Recently Deleted" list —
+    /// gates the toolbar's "Empty Trash" action so it doesn't appear over
+    /// any other view.
+    private var isViewingTrash: Bool {
+        if case .category(.recentlyDeleted) = selection { return true }
+        return false
     }
 
     /// True iff the detail pane is currently rendering `LiveAIRecordingView`

--- a/Mila/Views/HistoryListView.swift
+++ b/Mila/Views/HistoryListView.swift
@@ -18,10 +18,16 @@ struct HistoryListView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                Text(category.displayName)
-                    .font(.title2.weight(.semibold))
-                    .padding(.horizontal, 24)
-                    .padding(.top, 16)
+                HStack {
+                    Text(category.displayName)
+                        .font(.title2.weight(.semibold))
+                    if category == .recentlyDeleted {
+                        Spacer()
+                        EmptyTrashButton()
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
 
                 BucketedRecordingsView(
                     recordings: store.recordings(in: category),
@@ -244,6 +250,39 @@ private struct HistoryRow: View {
         if t.count <= 140 { return t }
         let end = t.index(t.startIndex, offsetBy: 140)
         return String(t[..<end]) + "…"
+    }
+}
+
+/// Bulk "Empty Trash" action shared by the "Recently Deleted" list header
+/// and the window toolbar (both placements so the affordance is easy to
+/// find). Gated behind a confirmation dialog — like the per-row "Delete
+/// Permanently", there's no undo. Disabled while the trash is empty.
+struct EmptyTrashButton: View {
+    @EnvironmentObject private var store: RecordingStore
+    @State private var confirming = false
+
+    var body: some View {
+        let count = store.recordings(in: .recentlyDeleted).count
+        Button(role: .destructive) {
+            confirming = true
+        } label: {
+            Label("Empty Trash", systemImage: "trash.slash")
+        }
+        .disabled(count == 0)
+        .help("Permanently delete everything in the trash")
+        .accessibilityIdentifier("trash.empty")
+        .confirmationDialog(
+            "Empty Trash?",
+            isPresented: $confirming,
+            titleVisibility: .visible
+        ) {
+            Button("Delete \(count) Recording\(count == 1 ? "" : "s")", role: .destructive) {
+                store.emptyTrash()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("The audio files and any transcripts will be permanently deleted. This can't be undone.")
+        }
     }
 }
 

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 /// the toolbar now, recordings live in the All Transcriptions folder.
 struct HomeView: View {
     @EnvironmentObject private var actions: QuickActionsController
-    @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var languageSettings: RecordingLanguageSettings
     @EnvironmentObject private var hotkeys: HotkeySettings
     @EnvironmentObject private var liveAISettings: LiveAISettings
@@ -186,9 +185,9 @@ struct HomeView: View {
             Image(systemName: "text.cursor")
                 .font(.callout)
                 .foregroundStyle(.secondary)
-            TextField("Meeting name (optional)", text: $actions.nextRecordingTitle)
+            NextRecordingMeetingNameField(placeholder: "Meeting name (optional)",
+                                          accessibilityID: "home.record.meetingName")
                 .textFieldStyle(.roundedBorder)
-                .accessibilityIdentifier("home.record.meetingName")
         }
         .controlSize(.small)
         .frame(maxWidth: 280)
@@ -207,24 +206,7 @@ struct HomeView: View {
             Text("Save to")
                 .font(.callout)
                 .foregroundStyle(.secondary)
-            Menu {
-                Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
-                    actions.nextRecordingFolder = nil
-                }
-                if !store.folders.isEmpty {
-                    Divider()
-                    ForEach(store.folders, id: \.self) { folder in
-                        Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
-                            actions.nextRecordingFolder = folder
-                        }
-                    }
-                }
-            } label: {
-                Text(actions.nextRecordingFolder ?? "All Transcriptions")
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .accessibilityIdentifier("home.record.folder.menu")
+            NextRecordingFolderPicker(accessibilityID: "home.record.folder.menu")
         }
         .controlSize(.small)
     }

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -53,8 +53,7 @@ struct HomeView: View {
                         .controlSize(.large)
                 }
                 sourceToggles
-                meetingNameField
-                folderPicker
+                recordingDestination
                 dictationHint
             }
             .padding(.horizontal, 24)
@@ -165,6 +164,17 @@ struct HomeView: View {
         .toggleStyle(.switch)
         .controlSize(.small)
         .disabled(isRecording)
+        .frame(maxWidth: 280, alignment: .leading)
+    }
+
+    /// Destination controls for the next recording: the folder on top and the
+    /// meeting name directly under it, both left-aligned to a shared width so
+    /// their leading edges line up.
+    private var recordingDestination: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            folderPicker
+            meetingNameField
+        }
         .frame(maxWidth: 280, alignment: .leading)
     }
 

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// the toolbar now, recordings live in the All Transcriptions folder.
 struct HomeView: View {
     @EnvironmentObject private var actions: QuickActionsController
+    @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var languageSettings: RecordingLanguageSettings
     @EnvironmentObject private var hotkeys: HotkeySettings
     @EnvironmentObject private var liveAISettings: LiveAISettings
@@ -44,7 +45,6 @@ struct HomeView: View {
             VStack(spacing: 24) {
                 header
                 heroAction
-                sourceToggles
                 if actions.isRecording {
                     // Pause/Resume sits under the hero Record/Stop button so
                     // it's reachable even in Live AI background mode, where
@@ -52,6 +52,9 @@ struct HomeView: View {
                     RecordingPauseButton()
                         .controlSize(.large)
                 }
+                sourceToggles
+                meetingNameField
+                folderPicker
                 dictationHint
             }
             .padding(.horizontal, 24)
@@ -163,6 +166,57 @@ struct HomeView: View {
         .controlSize(.small)
         .disabled(isRecording)
         .frame(maxWidth: 280, alignment: .leading)
+    }
+
+    /// Optional meeting name for the next recording. Empty falls back to the
+    /// auto-generated date-stamped title. Editable during a recording too,
+    /// since it's applied when the recording is saved.
+    private var meetingNameField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "text.cursor")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            TextField("Meeting name (optional)", text: $actions.nextRecordingTitle)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("home.record.meetingName")
+        }
+        .controlSize(.small)
+        .frame(maxWidth: 280)
+    }
+
+    /// Optional destination folder for the next recording. Sticky across
+    /// launches (stored on the controller). "None" lands in All Transcriptions,
+    /// where the user can still drag it into a folder later. Editable during a
+    /// recording too — the folder is applied when the recording is saved, so
+    /// changing it mid-capture takes effect.
+    private var folderPicker: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text("Save to")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Menu {
+                Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
+                    actions.nextRecordingFolder = nil
+                }
+                if !store.folders.isEmpty {
+                    Divider()
+                    ForEach(store.folders, id: \.self) { folder in
+                        Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
+                            actions.nextRecordingFolder = folder
+                        }
+                    }
+                }
+            } label: {
+                Text(actions.nextRecordingFolder ?? "All Transcriptions")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .accessibilityIdentifier("home.record.folder.menu")
+        }
+        .controlSize(.small)
     }
 
     /// Discrete reminder of the two global dictation hotkeys. Reads live

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -45,6 +45,13 @@ struct HomeView: View {
                 header
                 heroAction
                 sourceToggles
+                if actions.isRecording {
+                    // Pause/Resume sits under the hero Record/Stop button so
+                    // it's reachable even in Live AI background mode, where
+                    // the app stays on Home instead of the split-pane view.
+                    RecordingPauseButton()
+                        .controlSize(.large)
+                }
                 dictationHint
             }
             .padding(.horizontal, 24)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -322,6 +322,10 @@ struct LiveAIRecordingView: View {
                 .buttonStyle(.borderless)
                 .disabled(transcriber.segments.isEmpty)
                 .help("Copy transcript")
+                // Icon-only button: `help` is the hover tooltip and the
+                // identifier is test-only — VoiceOver needs its own
+                // user-facing name.
+                .accessibilityLabel("Copy transcript")
                 .accessibilityIdentifier("liveTranscript.copy")
                 // Mid-recording SRT export (issue #65): save whatever the
                 // live transcript has accumulated so far, without stopping

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -308,6 +308,21 @@ struct LiveAIRecordingView: View {
                 if transcriber.isTranscribing {
                     ProgressView().controlSize(.small)
                 }
+                // Mid-recording clipboard copy: same format as the
+                // detail view's transcript copy (speaker-prefixed turns
+                // once live diarization has labelled anyone) so the two
+                // read as one feature.
+                Button {
+                    let text = transcriber.clipboardText
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .disabled(transcriber.segments.isEmpty)
+                .help("Copy transcript")
+                .accessibilityIdentifier("liveTranscript.copy")
                 // Mid-recording SRT export (issue #65): save whatever the
                 // live transcript has accumulated so far, without stopping
                 // the recording. The finished recording still gets its
@@ -397,10 +412,7 @@ struct LiveAIRecordingView: View {
     /// failure); the suggested filename matches the date-stamped default
     /// title a stopped recording would get.
     private func exportLiveSRT() {
-        let snapshot = transcriber.segments.map { ls in
-            TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
-                              text: ls.text, speaker: ls.speaker)
-        }
+        let snapshot = transcriber.transcriptSegments
         guard !snapshot.isEmpty else { return }
         let panel = NSSavePanel()
         panel.title = "Export Subtitles"

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -205,7 +205,8 @@ struct LiveAIRecordingView: View {
             sectionHeader(icon: "checklist", title: "Action items", isRTL: isRTL)
             VStack(alignment: isRTL ? .trailing : .leading, spacing: 4) {
                 ForEach(aiSession.actionItems) { item in
-                    ActionItemRow(item: item, language: language, isRTL: isRTL)
+                    ActionItemRow(item: item, language: language, isRTL: isRTL,
+                                  speakerNames: transcriber.speakerNames)
                 }
             }
         }
@@ -350,7 +351,16 @@ struct LiveAIRecordingView: View {
                             // tint color.
                             let hasMultipleSpeakers = transcriber.segments.hasMultipleSpeakers
                             ForEach(transcriber.segments) { seg in
-                                TranscriptLineView(segment: seg, language: language, useSpeakerColor: hasMultipleSpeakers)
+                                TranscriptLineView(segment: seg, language: language,
+                                                   useSpeakerColor: hasMultipleSpeakers,
+                                                   speakerNames: transcriber.speakerNames,
+                                                   onAssignName: { raw, name in
+                                                       if let name {
+                                                           transcriber.speakerNames[raw] = name
+                                                       } else {
+                                                           transcriber.speakerNames.removeValue(forKey: raw)
+                                                       }
+                                                   })
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
                                 // inside TranscriptLineView (where SwiftUI
@@ -411,7 +421,8 @@ struct LiveAIRecordingView: View {
         panel.nameFieldStringValue = "Recording · \(f.string(from: Date())).srt"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
-            try TranscriptExporter.writeSRT(segments: snapshot, to: url)
+            try TranscriptExporter.writeSRT(segments: snapshot, to: url,
+                                            names: transcriber.speakerNames)
         } catch {
             NSAlert(error: error).runModal()
         }
@@ -451,6 +462,9 @@ private struct ActionItemRow: View {
     /// / open sidebar and shoved Hebrew action items to the left, which
     /// is the bug this replaces.
     var isRTL: Bool = false
+    /// Live speaker names so the metadata line shows the same label the
+    /// transcript pane does after a mid-recording rename.
+    var speakerNames: [String: String] = [:]
 
     var body: some View {
         let align: Alignment = isRTL ? .trailing : .leading
@@ -478,7 +492,7 @@ private struct ActionItemRow: View {
     @ViewBuilder private var metadataRow: some View {
         HStack(spacing: 8) {
             if let speaker = item.speaker {
-                Text(speaker.friendlySpeakerLabel(language: language))
+                Text(speaker.displaySpeakerName(names: speakerNames, language: language))
                     .font(.caption2.monospaced())
                     .foregroundStyle(.secondary)
             }
@@ -529,6 +543,11 @@ private struct TranscriptLineView: View {
     /// default tint — set by the caller once it's seen more than one
     /// distinct speaker across the live transcript.
     var useSpeakerColor: Bool = false
+    /// User-assigned live speaker names (raw ID → name).
+    var speakerNames: [String: String] = [:]
+    /// Persists a rename picked from the label's popover mid-recording:
+    /// (raw speaker ID, chosen name or nil-to-reset).
+    var onAssignName: (String, String?) -> Void = { _, _ in }
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -541,10 +560,15 @@ private struct TranscriptLineView: View {
         let lineRTL = segment.text.isPredominantlyHebrew || language == "he"
         HStack(alignment: .top, spacing: 8) {
             if let sp = segment.speaker {
-                Text(sp.friendlySpeakerLabel(language: language))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? sp.speakerColor : Color.accentColor)
-                    .frame(minWidth: 96, alignment: .leading)
+                SpeakerLabelButton(
+                    rawID: sp,
+                    names: speakerNames,
+                    language: language,
+                    color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
+                    font: .caption.weight(.semibold),
+                    onAssign: { name in onAssignName(sp, name) }
+                )
+                .frame(minWidth: 96, alignment: .leading)
             } else {
                 Color.clear.frame(width: 96, height: 1)
             }

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -12,6 +12,7 @@ import TranscriptionCore
 /// vs. transcript volumes can drag the divider to fit their preference.
 struct LiveAIRecordingView: View {
     @EnvironmentObject private var actions: QuickActionsController
+    @EnvironmentObject private var store: RecordingStore
     // NOTE: `session` is deliberately NOT observed here. RecordingSession
     // is a fat ObservableObject that also @Publishes micLevel/systemLevel
     // at ~50 Hz; holding it here re-evaluated this whole body (including
@@ -77,6 +78,16 @@ struct LiveAIRecordingView: View {
     // MARK: - Header
 
     private var header: some View {
+        VStack(spacing: 10) {
+            controlsRow
+            metaRow
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+    }
+
+    private var controlsRow: some View {
         HStack(spacing: 12) {
             Button {
                 Task { await actions.stopRecording() }
@@ -122,9 +133,51 @@ struct LiveAIRecordingView: View {
                 ThinkingIndicator(isThinking: aiSession.isThinking)
             }
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 12)
-        .background(.regularMaterial)
+    }
+
+    /// Meeting name + destination folder for the recording being captured.
+    /// Both are editable mid-recording — the name and folder are applied
+    /// when the recording is saved (`QuickActionsController.stopRecording`),
+    /// so changing them here at any point up to Stop takes effect.
+    private var metaRow: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 6) {
+                Image(systemName: "text.cursor")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("Meeting name", text: $actions.nextRecordingTitle)
+                    .textFieldStyle(.plain)
+                    .font(.callout)
+                    .accessibilityIdentifier("liveAI.meetingName")
+            }
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 6) {
+                Image(systemName: "folder")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Menu {
+                    Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
+                        actions.nextRecordingFolder = nil
+                    }
+                    if !store.folders.isEmpty {
+                        Divider()
+                        ForEach(store.folders, id: \.self) { folder in
+                            Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
+                                actions.nextRecordingFolder = folder
+                            }
+                        }
+                    }
+                } label: {
+                    Text(actions.nextRecordingFolder ?? "All Transcriptions")
+                        .font(.callout)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .accessibilityIdentifier("liveAI.folder.menu")
+            }
+        }
     }
 
     // MARK: - Action items pane
@@ -411,15 +464,40 @@ struct LiveAIRecordingView: View {
                     // queried in production.
                     Color.clear.frame(height: 1).id("bottom-anchor")
                 }
+                // Scroll on BOTH a new line (segments.count) and the
+                // in-progress last line growing in place (fullText, which is
+                // @Published and recomputed as that segment expands). Both
+                // route through `scrollToBottom`, which hops to the next
+                // runloop so the just-changed content is laid out FIRST —
+                // scrolling synchronously here targets the pre-update height
+                // and stops short of the newest words (worse under LazyVStack,
+                // whose just-appended row isn't measured yet at this instant).
                 .onChange(of: transcriber.segments.count) { _, _ in
-                    withAnimation(.easeOut(duration: 0.18)) {
-                        proxy.scrollTo("bottom-anchor", anchor: .bottom)
-                    }
+                    scrollToBottom(proxy)
+                }
+                .onChange(of: transcriber.fullText) { _, _ in
+                    scrollToBottom(proxy)
                 }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color.primary.opacity(0.02))
+    }
+
+    /// Pin the transcript to its newest line. Deferred to the next runloop
+    /// via `DispatchQueue.main.async` so the segment that just changed (an
+    /// appended line, or the in-progress last line that just grew) is laid
+    /// out BEFORE we scroll — a synchronous `scrollTo` inside `onChange`
+    /// runs in the same update cycle and lands on the stale, pre-update
+    /// content height, leaving the latest words below the fold. The
+    /// `bottom-anchor` sits after the LazyVStack (non-lazy, always
+    /// measured) so it's a stable scroll target once layout settles.
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            withAnimation(.easeOut(duration: 0.18)) {
+                proxy.scrollTo("bottom-anchor", anchor: .bottom)
+            }
+        }
     }
 
     /// Save the accumulated live transcript as an SRT to a user-chosen

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -10,6 +10,15 @@ import TranscriptionCore
 /// The pane heights default to a balanced 50/50 — we use a `VSplitView`
 /// rather than fixed fractions so users with very different action-item
 /// vs. transcript volumes can drag the divider to fit their preference.
+///
+/// IMPORTANT: this top-level view deliberately does NOT observe any of the
+/// high-frequency publishers (`LiveTranscriber`, `LiveSpeakerDiarizer`,
+/// `LiveAISession`). Those live inside the `LiveTranscriptPane` /
+/// `ActionItemsPane` / `LiveThinkingIndicator` leaves. If the parent
+/// observed them, its whole body — including the `header` that hosts the
+/// folder `Menu` — would re-render at transcript cadence, and reconciling
+/// an OPEN NSMenu-backed control mid-tracking beachballs the app. Keeping
+/// the flood out of the menu's ancestors is what stops that freeze.
 struct LiveAIRecordingView: View {
     @EnvironmentObject private var actions: QuickActionsController
     // NOTE: `session` is deliberately NOT observed here. RecordingSession
@@ -18,16 +27,9 @@ struct LiveAIRecordingView: View {
     // the growing transcript ForEach) on every mic-level tick. The
     // elapsed clock now lives in the `RecordingElapsedLabel` leaf so only
     // that tiny Text re-renders at audio cadence — not the transcript.
-    @EnvironmentObject private var transcriber: LiveTranscriber
-    @EnvironmentObject private var diarizer: LiveSpeakerDiarizer
-    @EnvironmentObject private var aiSession: LiveAISession
     @EnvironmentObject private var languageSettings: RecordingLanguageSettings
     @EnvironmentObject private var liveAISettings: LiveAISettings
     @EnvironmentObject private var llmSettings: LLMSettings
-
-    /// Debounce handle for the live transcript auto-scroll (see
-    /// `scrollToBottom`). Coalesces the per-tick scroll requests.
-    @State private var pendingScroll: DispatchWorkItem?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,13 +41,13 @@ struct LiveAIRecordingView: View {
             // Mila is hearing in real time.
             if aiActive {
                 VSplitView {
-                    actionItemsPane
+                    ActionItemsPane(language: language)
                         .frame(minHeight: 140)
-                    liveTranscriptPane
+                    LiveTranscriptPane(language: language)
                         .frame(minHeight: 140)
                 }
             } else {
-                liveTranscriptPane
+                LiveTranscriptPane(language: language)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -54,29 +56,7 @@ struct LiveAIRecordingView: View {
     /// Recording's current language. Drives RTL handling for the
     /// transcript pane + friendly speaker labels.
     private var language: String { languageSettings.current.rawValue }
-    private var isRTL: Bool { language == "he" }
     private var aiActive: Bool { liveAISettings.enabled && llmSettings.isConfigured }
-
-    /// RTL for the AI pane (summary + action items). The AI output is its
-    /// own language setting; for `.auto` we detect from the actual emitted
-    /// text — summary + ALL item texts combined — so a short individual
-    /// item with an embedded English name ("…ל-Cursor") doesn't mis-detect
-    /// while its neighbours are clearly Hebrew. One verdict for the whole
-    /// pane keeps every row aligned the same way. Drives EXPLICIT
-    /// `.trailing` alignment (never `\.layoutDirection`) — see the live
-    /// transcript pane: flipping layoutDirection mis-measured inside the
-    /// split view / open sidebar and shoved Hebrew to the left.
-    private var aiOutputIsRTL: Bool {
-        switch liveAISettings.outputLanguage {
-        case .hebrew: return true
-        case .english: return false
-        case .auto:
-            if language == "he" { return true }
-            let combined = aiSession.summary + " "
-                + aiSession.actionItems.map(\.text).joined(separator: " ")
-            return combined.isPredominantlyHebrew
-        }
-    }
 
     // MARK: - Header
 
@@ -133,7 +113,7 @@ struct LiveAIRecordingView: View {
             }
 
             if aiActive {
-                ThinkingIndicator(isThinking: aiSession.isThinking)
+                LiveThinkingIndicator()
             }
         }
     }
@@ -166,10 +146,56 @@ struct LiveAIRecordingView: View {
         }
     }
 
-    // MARK: - Action items pane
+    /// Split a rolling summary paragraph into one bullet per sentence.
+    /// Falls back to the whole string as a single bullet when no
+    /// sentence boundary is found — better than showing nothing.
+    ///
+    /// Uses Foundation's `.bySentences` tokenizer (same as
+    /// `AIOverviewSection.summaryAttributed`, so the live pane and the
+    /// detail pane split the same summary identically). The previous
+    /// naive split on every '.', '!', '?' character turned "Budget is
+    /// 3.5 million." into two bullets — and, despite its comment, never
+    /// actually included the Hebrew full stop in the separator set.
+    ///
+    /// Kept static on `LiveAIRecordingView` (rather than on the pane leaf)
+    /// so `MilaTests/LiveAIBulletsTests` can exercise it without building
+    /// the view.
+    static func bulletsFromSummary(_ s: String) -> [String] {
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let sourceLines: [String]
+        if trimmed.contains("\n") {
+            // Already has line structure (often the LLM's own bullets).
+            sourceLines = trimmed.components(separatedBy: "\n")
+        } else {
+            var sentences: [String] = []
+            trimmed.enumerateSubstrings(in: trimmed.startIndex..<trimmed.endIndex,
+                                        options: [.bySentences, .localized]) { sub, _, _, _ in
+                let sentence = (sub ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                if !sentence.isEmpty { sentences.append(sentence) }
+            }
+            sourceLines = sentences
+        }
+        let parts = sourceLines
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return parts.isEmpty ? [trimmed] : parts
+    }
+}
 
-    @ViewBuilder
-    private var actionItemsPane: some View {
+// MARK: - Action items pane
+
+/// Summary + action-items pane. Owns the ONLY parent-side dependency on
+/// `LiveAISession` (and on `LiveTranscriber` for live speaker names), so
+/// the AI/transcript flood re-renders this leaf instead of the whole
+/// `LiveAIRecordingView` body (which hosts the folder `Menu`).
+private struct ActionItemsPane: View {
+    @EnvironmentObject private var aiSession: LiveAISession
+    @EnvironmentObject private var liveAISettings: LiveAISettings
+    @EnvironmentObject private var transcriber: LiveTranscriber
+    let language: String
+
+    var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Image(systemName: "sparkles")
@@ -218,6 +244,27 @@ struct LiveAIRecordingView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
+    /// RTL for the AI pane (summary + action items). The AI output is its
+    /// own language setting; for `.auto` we detect from the actual emitted
+    /// text — summary + ALL item texts combined — so a short individual
+    /// item with an embedded English name ("…ל-Cursor") doesn't mis-detect
+    /// while its neighbours are clearly Hebrew. One verdict for the whole
+    /// pane keeps every row aligned the same way. Drives EXPLICIT
+    /// `.trailing` alignment (never `\.layoutDirection`) — see the live
+    /// transcript pane: flipping layoutDirection mis-measured inside the
+    /// split view / open sidebar and shoved Hebrew to the left.
+    private var aiOutputIsRTL: Bool {
+        switch liveAISettings.outputLanguage {
+        case .hebrew: return true
+        case .english: return false
+        case .auto:
+            if language == "he" { return true }
+            let combined = aiSession.summary + " "
+                + aiSession.actionItems.map(\.text).joined(separator: " ")
+            return combined.isPredominantlyHebrew
+        }
+    }
+
     /// Render the LLM's rolling summary as a bulleted list. The LLM
     /// usually returns one paragraph (1-3 sentences); we split on
     /// sentence boundaries so each sentence becomes its own bullet
@@ -225,7 +272,7 @@ struct LiveAIRecordingView: View {
     /// for, without forcing a prompt change that would risk
     /// breaking JSON parsing.
     private func summarySection(isRTL: Bool) -> some View {
-        let bullets = Self.bulletsFromSummary(aiSession.summary)
+        let bullets = LiveAIRecordingView.bulletsFromSummary(aiSession.summary)
         return VStack(alignment: isRTL ? .trailing : .leading, spacing: 6) {
             sectionHeader(icon: "text.alignleft", title: "Summary", isRTL: isRTL)
             VStack(alignment: isRTL ? .trailing : .leading, spacing: 4) {
@@ -270,38 +317,6 @@ struct LiveAIRecordingView: View {
         .frame(maxWidth: .infinity, alignment: isRTL ? .trailing : .leading)
     }
 
-    /// Split a rolling summary paragraph into one bullet per sentence.
-    /// Falls back to the whole string as a single bullet when no
-    /// sentence boundary is found — better than showing nothing.
-    ///
-    /// Uses Foundation's `.bySentences` tokenizer (same as
-    /// `AIOverviewSection.summaryAttributed`, so the live pane and the
-    /// detail pane split the same summary identically). The previous
-    /// naive split on every '.', '!', '?' character turned "Budget is
-    /// 3.5 million." into two bullets — and, despite its comment, never
-    /// actually included the Hebrew full stop in the separator set.
-    static func bulletsFromSummary(_ s: String) -> [String] {
-        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-        let sourceLines: [String]
-        if trimmed.contains("\n") {
-            // Already has line structure (often the LLM's own bullets).
-            sourceLines = trimmed.components(separatedBy: "\n")
-        } else {
-            var sentences: [String] = []
-            trimmed.enumerateSubstrings(in: trimmed.startIndex..<trimmed.endIndex,
-                                        options: [.bySentences, .localized]) { sub, _, _, _ in
-                let sentence = (sub ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                if !sentence.isEmpty { sentences.append(sentence) }
-            }
-            sourceLines = sentences
-        }
-        let parts = sourceLines
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        return parts.isEmpty ? [trimmed] : parts
-    }
-
     private var emptyState: some View {
         VStack(spacing: 8) {
             Image(systemName: "ear")
@@ -320,10 +335,23 @@ struct LiveAIRecordingView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.bottom, 24)
     }
+}
 
-    // MARK: - Live transcript pane
+// MARK: - Live transcript pane
 
-    private var liveTranscriptPane: some View {
+/// Live transcript pane. Owns the ONLY parent-side dependency on
+/// `LiveTranscriber`, so the partial-transcript flood re-renders this leaf
+/// instead of the whole `LiveAIRecordingView` body (which hosts the folder
+/// `Menu`). Also owns the per-tick auto-scroll debounce state.
+private struct LiveTranscriptPane: View {
+    @EnvironmentObject private var transcriber: LiveTranscriber
+    let language: String
+
+    /// Debounce handle for the live transcript auto-scroll (see
+    /// `scrollToBottom`). Coalesces the per-tick scroll requests.
+    @State private var pendingScroll: DispatchWorkItem?
+
+    var body: some View {
         // Detect Hebrew from the accumulated transcript text — much
         // more reliable than the language dropdown, which the user
         // may not have flipped before pressing Record.
@@ -339,7 +367,6 @@ struct LiveAIRecordingView: View {
         // alignment, each Text just stays pinned to whichever edge
         // we name, regardless of how the parent is sized.
         let textAlignment: Alignment = paneIsRTL ? .trailing : .leading
-        let multilineAlignment: TextAlignment = paneIsRTL ? .trailing : .leading
         return VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Image(systemName: "text.quote")
@@ -520,6 +547,18 @@ struct LiveAIRecordingView: View {
         } catch {
             NSAlert(error: error).runModal()
         }
+    }
+}
+
+/// Header "Thinking… / Idle" indicator. Isolated as a leaf that owns the
+/// `LiveAISession` dependency so the AI thinking-state flips (and every
+/// other `LiveAISession` @Published tick) re-render only this small view
+/// rather than the `header` that hosts the folder `Menu`.
+private struct LiveThinkingIndicator: View {
+    @EnvironmentObject private var aiSession: LiveAISession
+
+    var body: some View {
+        ThinkingIndicator(isThinking: aiSession.isThinking)
     }
 }
 

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -12,7 +12,6 @@ import TranscriptionCore
 /// vs. transcript volumes can drag the divider to fit their preference.
 struct LiveAIRecordingView: View {
     @EnvironmentObject private var actions: QuickActionsController
-    @EnvironmentObject private var store: RecordingStore
     // NOTE: `session` is deliberately NOT observed here. RecordingSession
     // is a fat ObservableObject that also @Publishes micLevel/systemLevel
     // at ~50 Hz; holding it here re-evaluated this whole body (including
@@ -25,6 +24,10 @@ struct LiveAIRecordingView: View {
     @EnvironmentObject private var languageSettings: RecordingLanguageSettings
     @EnvironmentObject private var liveAISettings: LiveAISettings
     @EnvironmentObject private var llmSettings: LLMSettings
+
+    /// Debounce handle for the live transcript auto-scroll (see
+    /// `scrollToBottom`). Coalesces the per-tick scroll requests.
+    @State private var pendingScroll: DispatchWorkItem?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -145,10 +148,10 @@ struct LiveAIRecordingView: View {
                 Image(systemName: "text.cursor")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                TextField("Meeting name", text: $actions.nextRecordingTitle)
+                NextRecordingMeetingNameField(placeholder: "Meeting name",
+                                              accessibilityID: "liveAI.meetingName")
                     .textFieldStyle(.plain)
                     .font(.callout)
-                    .accessibilityIdentifier("liveAI.meetingName")
             }
 
             Spacer(minLength: 12)
@@ -157,25 +160,8 @@ struct LiveAIRecordingView: View {
                 Image(systemName: "folder")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Menu {
-                    Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
-                        actions.nextRecordingFolder = nil
-                    }
-                    if !store.folders.isEmpty {
-                        Divider()
-                        ForEach(store.folders, id: \.self) { folder in
-                            Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
-                                actions.nextRecordingFolder = folder
-                            }
-                        }
-                    }
-                } label: {
-                    Text(actions.nextRecordingFolder ?? "All Transcriptions")
-                        .font(.callout)
-                }
-                .menuStyle(.borderlessButton)
-                .fixedSize()
-                .accessibilityIdentifier("liveAI.folder.menu")
+                NextRecordingFolderPicker(accessibilityID: "liveAI.folder.menu")
+                    .font(.callout)
             }
         }
     }
@@ -493,11 +479,20 @@ struct LiveAIRecordingView: View {
     /// `bottom-anchor` sits after the LazyVStack (non-lazy, always
     /// measured) so it's a stable scroll target once layout settles.
     private func scrollToBottom(_ proxy: ScrollViewProxy) {
-        DispatchQueue.main.async {
+        // Debounce: `fullText` changes on every partial-transcript tick (many
+        // per second as the in-progress line grows). Firing a fresh
+        // `withAnimation` scroll per tick stacks animations and adds
+        // main-thread work to the transcript re-render storm. Coalesce to one
+        // scroll per short window; deferring via `asyncAfter` also lets the
+        // just-changed content lay out first so we land on the newest line.
+        pendingScroll?.cancel()
+        let work = DispatchWorkItem {
             withAnimation(.easeOut(duration: 0.18)) {
                 proxy.scrollTo("bottom-anchor", anchor: .bottom)
             }
         }
+        pendingScroll = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: work)
     }
 
     /// Save the accumulated live transcript as an SRT to a user-chosen

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -100,6 +100,8 @@ struct LiveAIRecordingView: View {
             // the Home Record button to confirm it isn't stuck "Finalizing").
             .accessibilityIdentifier("liveAI.stop")
 
+            RecordingPauseButton()
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(aiActive ? "Recording — Live AI" : "Recording")
                     .font(.callout.weight(.semibold))
@@ -379,6 +381,9 @@ struct LiveAIRecordingView: View {
                                                        } else {
                                                            transcriber.speakerNames.removeValue(forKey: raw)
                                                        }
+                                                   },
+                                                   onDelete: { id in
+                                                       transcriber.removeSegment(id: id)
                                                    })
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
@@ -546,9 +551,55 @@ private struct RecordingElapsedLabel: View {
 
     var body: some View {
         let t = Int(session.elapsed.rounded())
-        Text(String(format: "%02d:%02d", t / 60, t % 60))
+        let clock = String(format: "%02d:%02d", t / 60, t % 60)
+        // Show "Paused" alongside the (frozen) clock so the user gets clear
+        // feedback that capture is suspended. This leaf already observes the
+        // session, so folding the paused state in here keeps the larger
+        // view body from re-rendering.
+        Text(session.state == .paused ? "Paused · \(clock)" : clock)
             .font(.caption.monospacedDigit())
-            .foregroundStyle(.secondary)
+            .foregroundStyle(session.state == .paused ? .orange : .secondary)
+    }
+}
+
+/// Pause / Resume control for the active recording. Isolated as a leaf that
+/// observes `RecordingSession` so its paused-state flip doesn't re-render
+/// larger views (which the session's high-frequency level updates would
+/// otherwise churn). Pausing drops all audio until resume, so nothing said
+/// during the pause is recorded. Used by the Live AI header, Home, and the
+/// floating recording chip.
+struct RecordingPauseButton: View {
+    @EnvironmentObject private var actions: QuickActionsController
+    @EnvironmentObject private var session: RecordingSession
+    /// Icon-only rendering for the compact floating chip; labeled pill
+    /// everywhere else.
+    var compact: Bool = false
+
+    var body: some View {
+        let paused = session.state == .paused
+        Button {
+            actions.togglePause()
+        } label: {
+            if compact {
+                Image(systemName: paused ? "play.fill" : "pause.fill")
+                    .foregroundStyle(paused ? Color.accentColor : .primary)
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: paused ? "play.fill" : "pause.fill")
+                    Text(paused ? "Resume" : "Pause")
+                        .font(.callout.weight(.semibold))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.primary.opacity(0.08),
+                            in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(actions.isFinalizingRecording)
+        .help(paused ? "Resume recording" : "Pause recording (audio during the pause isn't recorded)")
+        .accessibilityLabel(paused ? "Resume recording" : "Pause recording")
+        .accessibilityIdentifier(paused ? "recording.resume" : "recording.pause")
     }
 }
 
@@ -564,6 +615,11 @@ private struct TranscriptLineView: View {
     /// Persists a rename picked from the label's popover mid-recording:
     /// (raw speaker ID, chosen name or nil-to-reset).
     var onAssignName: (String, String?) -> Void = { _, _ in }
+    /// Deletes this line from the live transcript. Wired to
+    /// `LiveTranscriber.removeSegment(id:)`.
+    var onDelete: (UUID) -> Void = { _ in }
+
+    @State private var hovering = false
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -600,8 +656,41 @@ private struct TranscriptLineView: View {
                 // outer wrapper-level identifier was a no-op (SwiftUI
                 // didn't materialize an a11y node there).
                 .accessibilityIdentifier("liveTranscript.segment")
+            // Hover-revealed delete button. Kept out of the layout-direction
+            // flip (its own LTR) so the trash icon sits on the trailing edge
+            // regardless of the line's script. Always present but near-
+            // invisible until hover so rows don't jump when the button
+            // appears.
+            deleteButton
+                .opacity(hovering ? 1 : 0)
+                .environment(\.layoutDirection, .leftToRight)
         }
         .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        // Right-click / control-click also offers delete, for when the
+        // hover button is easy to miss.
+        .contextMenu {
+            Button(role: .destructive) {
+                onDelete(segment.id)
+            } label: {
+                Label("Delete line", systemImage: "trash")
+            }
+        }
+    }
+
+    private var deleteButton: some View {
+        Button {
+            onDelete(segment.id)
+        } label: {
+            Image(systemName: "trash")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.borderless)
+        .help("Delete this line from the transcript")
+        .accessibilityLabel("Delete line")
+        .accessibilityIdentifier("liveTranscript.deleteLine")
     }
 }
 

--- a/Mila/Views/ObsidianSettingsSection.swift
+++ b/Mila/Views/ObsidianSettingsSection.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+import AppKit
+
+/// Obsidian vault section, embedded in the Storage settings tab. Lets the user
+/// route finished recordings into an Obsidian vault as Markdown notes (summary
+/// + action items, transcript fallback), and optionally commit + push the vault
+/// git repo after each write.
+///
+/// The vault folder is persisted via a security-scoped bookmark; see
+/// `ObsidianVaultSettings` for the resolution / fallback rules. Notes are
+/// written after the AI summary lands (falling back to the transcript when
+/// summaries are off), so nothing here blocks recording.
+struct ObsidianSettingsSection: View {
+    @EnvironmentObject private var settings: ObsidianVaultSettings
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var exporter: ObsidianExporter
+
+    @State private var lastError: String?
+    @State private var backfillResult: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            enableCard
+            if settings.enabled {
+                vaultCard
+                gitCard
+                if settings.vaultURL != nil {
+                    backfillCard
+                }
+            }
+            if settings.lastResolutionWasStale {
+                staleBookmarkNotice
+            }
+            if let lastError {
+                Text(lastError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Obsidian vault")
+                .font(.title3.weight(.semibold))
+            Text("When a recording finishes, Mila writes a Markdown note into your vault — the AI summary plus any action items, falling back to the transcript when summaries are off. Notes are written after the summary lands, so this never blocks recording.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var enableCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("Save transcripts to an Obsidian vault", isOn: $settings.enabled)
+                .accessibilityIdentifier("obsidian.enabled.toggle")
+            if settings.enabled && settings.vaultURL == nil {
+                Text("Pick a vault folder below to start filing notes.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var vaultCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(settings.vaultURL.map(displayPath) ?? "No vault chosen")
+                        .font(.callout.monospaced())
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                    Text(settings.vaultURL == nil ? "Not set" : "Vault folder")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            HStack(spacing: 8) {
+                Button("Choose…") { chooseFolder() }
+                    .accessibilityIdentifier("obsidian.chooseFolder.button")
+                if settings.vaultURL != nil {
+                    Button("Reveal in Finder") { revealInFinder() }
+                }
+                Spacer()
+                Button("Clear") { settings.clearVault() }
+                    .disabled(settings.vaultURL == nil)
+                    .accessibilityIdentifier("obsidian.clear.button")
+            }
+            Divider()
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    TextField("Subfolder in vault (blank = vault root)", text: $settings.subfolder)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("obsidian.subfolder.field")
+                    Button("Browse…") { browseSubfolder() }
+                        .disabled(settings.vaultURL == nil)
+                        .help("Pick a folder inside the vault")
+                        .accessibilityIdentifier("obsidian.subfolderBrowse.button")
+                }
+                Text("Notes are written into this folder inside the vault (created if needed). One note per recording, named by date and title; re-transcribing overwrites the same note.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var gitCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Commit & push to git after writing", isOn: $settings.gitSyncEnabled)
+                .accessibilityIdentifier("obsidian.gitSync.toggle")
+            if settings.gitSyncEnabled {
+                HStack(spacing: 8) {
+                    Text("Branch")
+                        .font(.callout)
+                    TextField("main", text: $settings.gitBranch)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 200)
+                        .accessibilityIdentifier("obsidian.gitBranch.field")
+                }
+                Text("After each note, Mila runs git add + commit, pulls with rebase, and pushes to this branch. Your vault must already be a git repo with credentials configured (SSH key or credential helper) — Mila runs git non-interactively and won't prompt for passwords.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let syncError = settings.lastSyncError {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Last sync failed: \(syncError)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(10)
+                    .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var backfillCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Existing transcripts")
+                .font(.callout.weight(.semibold))
+            Text("Obsidian was set up after some recordings already existed. Sync them into the vault now — each is filed under its Mila folder (created if needed) and existing notes are overwritten in place.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Button("Sync existing transcripts") { syncExisting() }
+                    .accessibilityIdentifier("obsidian.backfill.button")
+                if let backfillResult {
+                    Text(backfillResult)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var staleBookmarkNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("The vault folder you chose was moved or renamed. Mila refreshed the saved reference — if notes stop appearing, pick the folder again.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func displayPath(_ url: URL) -> String {
+        let home = NSHomeDirectory()
+        let path = url.path
+        if path.hasPrefix(home) { return "~" + path.dropFirst(home.count) }
+        return path
+    }
+
+    private func chooseFolder() {
+        lastError = nil
+        let panel = NSOpenPanel()
+        panel.title = "Choose your Obsidian vault folder"
+        panel.prompt = "Choose"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = settings.vaultURL
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard settings.setVault(url) else {
+            lastError = "Couldn't save that folder. Try a different location (some network/cloud volumes can't be bookmarked)."
+            return
+        }
+    }
+
+    private func revealInFinder() {
+        guard let url = settings.vaultURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Backfill: write every non-trashed recording that has content into the
+    /// vault. `exportAll` skips empty ones and kicks a single git sync.
+    private func syncExisting() {
+        lastError = nil
+        let recordings = store.recordings.filter { !$0.isTrashed }
+        let count = exporter.exportAll(recordings)
+        backfillResult = count == 0
+            ? "Nothing to sync."
+            : "Synced \(count) note\(count == 1 ? "" : "s")."
+    }
+
+    /// Pick the destination subfolder with a folder panel constrained to the
+    /// vault. Stores the path RELATIVE to the vault (blank when the vault root
+    /// is chosen); rejects a folder outside the vault.
+    private func browseSubfolder() {
+        guard let vault = settings.vaultURL else { return }
+        lastError = nil
+        let panel = NSOpenPanel()
+        panel.title = "Choose a subfolder inside the vault"
+        panel.prompt = "Choose"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = settings.destinationDirectory ?? vault
+        guard panel.runModal() == .OK, let chosen = panel.url else { return }
+
+        // Resolve symlinks on both sides so an NSOpenPanel path (which can be
+        // /private-prefixed) compares cleanly against the bookmark-resolved
+        // vault URL.
+        let vaultPath = vault.resolvingSymlinksInPath().path
+        let chosenPath = chosen.resolvingSymlinksInPath().path
+        if chosenPath == vaultPath {
+            settings.subfolder = ""
+            return
+        }
+        let prefix = vaultPath.hasSuffix("/") ? vaultPath : vaultPath + "/"
+        guard chosenPath.hasPrefix(prefix) else {
+            lastError = "Choose a folder inside the vault (\(vault.lastPathComponent))."
+            return
+        }
+        settings.subfolder = String(chosenPath.dropFirst(prefix.count))
+    }
+}

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -339,7 +339,12 @@ struct RecordingDetailView: View {
                                        showSpeaker: hasSpeakers,
                                        useSpeakerColor: hasMultipleSpeakers,
                                        language: recording.language,
-                                       onTap: { seek(to: seg.start) })
+                                       speakerNames: recording.speakerNames,
+                                       onTap: { seek(to: seg.start) },
+                                       onAssignName: { raw, name in
+                                           store.setSpeakerName(name, forSpeaker: raw,
+                                                                recordingID: recording.id)
+                                       })
                         }
                     }
                     .padding()
@@ -411,7 +416,8 @@ struct RecordingDetailView: View {
 
     private func copyTranscript() {
         let text = TranscriptFormatter.plainText(segments: recording.segments,
-                                                 fallback: recording.fullText)
+                                                 fallback: recording.fullText,
+                                                 names: recording.speakerNames)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }
@@ -569,7 +575,12 @@ private struct SegmentRow: View {
     /// language — matching the labels the live view + post-recording
     /// action items already show.
     let language: String
+    /// User-assigned speaker names for this recording (raw ID → name).
+    let speakerNames: [String: String]
     let onTap: () -> Void
+    /// Persists a rename picked from the label's popover:
+    /// (raw speaker ID, chosen name or nil-to-reset).
+    let onAssignName: (String, String?) -> Void
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -578,10 +589,15 @@ private struct SegmentRow: View {
             // label "Speaker A" / "דובר א׳" and the actual content.
             // `fixedSize` keeps the label at its natural width.
             if showSpeaker, let raw = segment.speaker, !raw.isEmpty {
-                Text(raw.friendlySpeakerLabel(language: language) + ":")
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(useSpeakerColor ? raw.speakerColor : Color.accentColor)
-                    .fixedSize(horizontal: true, vertical: false)
+                SpeakerLabelButton(
+                    rawID: raw,
+                    names: speakerNames,
+                    language: language,
+                    color: useSpeakerColor ? raw.speakerColor(names: speakerNames) : Color.accentColor,
+                    suffix: ":",
+                    onAssign: { name in onAssignName(raw, name) }
+                )
+                .fixedSize(horizontal: true, vertical: false)
             }
             Text(segment.text)
                 .font(.body)

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -3,6 +3,7 @@ import AVKit
 import AppKit
 import TranscriptionCore
 import UniformTypeIdentifiers
+import MilaKit
 
 struct RecordingDetailView: View {
     let recording: Recording

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -19,8 +19,6 @@ struct RecordingDetailView: View {
     @State private var isEditingTitle = false
     @State private var titleDraft = ""
     @FocusState private var titleFieldFocused: Bool
-    @State private var showingNewFolderAlert = false
-    @State private var newFolderName = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -71,7 +69,8 @@ struct RecordingDetailView: View {
                     Text("·")
                     Text(formatDuration(recording.duration))
                     Text("·")
-                    folderMenu
+                    RecordingFolderMenu(recordingID: recording.id,
+                                        currentFolder: recording.folder)
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -80,48 +79,6 @@ struct RecordingDetailView: View {
             actionButtons
         }
         .padding()
-        .alert("New Folder", isPresented: $showingNewFolderAlert) {
-            TextField("Folder name", text: $newFolderName)
-            Button("Create") {
-                let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !name.isEmpty { store.assign(recording, toFolder: name) }
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            Text("File this recording into a new folder.")
-        }
-    }
-
-    /// Change the recording's Mila folder inline. Mirrors the sidebar
-    /// context-menu assignment but keeps it reachable from the open recording.
-    private var folderMenu: some View {
-        Menu {
-            Button(recording.folder == nil ? "✓ None" : "None") {
-                store.assign(recording, toFolder: nil)
-            }
-            if !store.folders.isEmpty {
-                Divider()
-                ForEach(store.folders, id: \.self) { folder in
-                    Button(recording.folder == folder ? "✓ \(folder)" : folder) {
-                        store.assign(recording, toFolder: folder)
-                    }
-                }
-            }
-            Divider()
-            Button("New Folder…") {
-                newFolderName = ""
-                showingNewFolderAlert = true
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "folder")
-                Text(recording.folder ?? "No folder")
-            }
-        }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
-        .help("Choose the folder this recording is filed under")
-        .accessibilityIdentifier("detail.folder.menu")
     }
 
     /// Click-to-edit title. Pressing Return or losing focus commits the new

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -19,6 +19,8 @@ struct RecordingDetailView: View {
     @State private var isEditingTitle = false
     @State private var titleDraft = ""
     @FocusState private var titleFieldFocused: Bool
+    @State private var showingNewFolderAlert = false
+    @State private var newFolderName = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -68,6 +70,8 @@ struct RecordingDetailView: View {
                     Text(recording.createdAt, format: .dateTime)
                     Text("·")
                     Text(formatDuration(recording.duration))
+                    Text("·")
+                    folderMenu
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -76,6 +80,48 @@ struct RecordingDetailView: View {
             actionButtons
         }
         .padding()
+        .alert("New Folder", isPresented: $showingNewFolderAlert) {
+            TextField("Folder name", text: $newFolderName)
+            Button("Create") {
+                let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !name.isEmpty { store.assign(recording, toFolder: name) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("File this recording into a new folder.")
+        }
+    }
+
+    /// Change the recording's Mila folder inline. Mirrors the sidebar
+    /// context-menu assignment but keeps it reachable from the open recording.
+    private var folderMenu: some View {
+        Menu {
+            Button(recording.folder == nil ? "✓ None" : "None") {
+                store.assign(recording, toFolder: nil)
+            }
+            if !store.folders.isEmpty {
+                Divider()
+                ForEach(store.folders, id: \.self) { folder in
+                    Button(recording.folder == folder ? "✓ \(folder)" : folder) {
+                        store.assign(recording, toFolder: folder)
+                    }
+                }
+            }
+            Divider()
+            Button("New Folder…") {
+                newFolderName = ""
+                showingNewFolderAlert = true
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "folder")
+                Text(recording.folder ?? "No folder")
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Choose the folder this recording is filed under")
+        .accessibilityIdentifier("detail.folder.menu")
     }
 
     /// Click-to-edit title. Pressing Return or losing focus commits the new

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -8,10 +8,16 @@ import MilaKit
 struct RecordingDetailView: View {
     let recording: Recording
     @EnvironmentObject private var store: RecordingStore
-    @EnvironmentObject private var transcription: TranscriptionService
-    @EnvironmentObject private var modelManager: ModelManager
     @EnvironmentObject private var llmSettings: LLMSettings
     @EnvironmentObject private var summarizer: RecordingSummarizer
+    // NOTE: `TranscriptionService` is deliberately NOT observed here. Its
+    // `progress` @Published floods at whisper-tick cadence during an active
+    // transcription; holding it at this level re-rendered the whole body —
+    // including `header`, which hosts the folder `Menu` — on every tick, and
+    // reconciling an OPEN NSMenu-backed control mid-tracking beachballs the
+    // app. The two consumers now live in the `RecordingDetailActionButtons`
+    // and `RecordingTranscriptArea` leaves, so the flood never reaches the
+    // menu's ancestors.
 
     @State private var player: AVPlayer?
     @State private var currentTime: Double = 0
@@ -33,7 +39,9 @@ struct RecordingDetailView: View {
                     ? { summarizer.regenerate(recording) }
                     : nil
             )
-            transcriptArea
+            RecordingTranscriptArea(recording: recording,
+                                    currentTime: currentTime,
+                                    onSeek: { seek(to: $0) })
                 // Force the transcript area to take the remaining
                 // vertical space and scroll its OWN content rather than
                 // expanding to the segments' intrinsic height. Without
@@ -76,7 +84,7 @@ struct RecordingDetailView: View {
                 .foregroundStyle(.secondary)
             }
             Spacer()
-            actionButtons
+            RecordingDetailActionButtons(recording: recording)
         }
         .padding()
     }
@@ -130,7 +138,97 @@ struct RecordingDetailView: View {
         titleDraft = recording.title
     }
 
-    private var actionButtons: some View {
+    /// Whether the user can ask for a fresh summary right now. Gates the
+    /// "Regenerate summary" context-menu entry in `AIOverviewBanner` so
+    /// it never shows up for recordings without an LLM CLI configured
+    /// or without anything to summarise. Mirrors `RecordingSummarizer`'s
+    /// own predicate but adds the "force-allowed even if a summary
+    /// exists" piece — that's the whole point of the affordance.
+    private var canRegenerateSummary: Bool {
+        guard llmSettings.isConfigured else { return false }
+        return !recording.fullText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+    }
+
+    /// What the transcript area shows while a recording has no segments.
+    /// `nil` means no placeholder — the active-transcription progress view
+    /// owns that state.
+    enum EmptyTranscriptPlaceholder: Equatable {
+        /// Queued behind the active transcription — the Transcribe menu is
+        /// disabled (see `busy` in `RecordingDetailActionButtons`), so
+        /// pointing the user at it would be a dead end.
+        case waitingInQueue
+        /// Idle: invite the user to start a transcription themselves.
+        case clickTranscribe
+    }
+
+    /// Decision for the empty-segments placeholder, split out as a pure
+    /// function so RecordingDetailPlaceholderTests can pin the queued
+    /// case without building the view.
+    static func emptyTranscriptPlaceholder(isActive: Bool,
+                                           isQueued: Bool) -> EmptyTranscriptPlaceholder? {
+        if isActive { return nil }
+        return isQueued ? .waitingInQueue : .clickTranscribe
+    }
+
+    @ViewBuilder
+    private var playbackBar: some View {
+        if let player {
+            HStack {
+                PlayPauseButton(player: player)
+                Slider(value: Binding(get: { currentTime },
+                                      set: { seek(to: $0) }),
+                       in: 0...max(recording.duration, 0.1))
+                Text(formatDuration(currentTime))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 60, alignment: .trailing)
+            }
+            .padding()
+        }
+    }
+
+    private func configurePlayer() {
+        teardownPlayer()
+        let url = store.audioURL(for: recording)
+        let item = AVPlayerItem(url: url)
+        let p = AVPlayer(playerItem: item)
+        timeObserver = p.addPeriodicTimeObserver(forInterval: CMTime(value: 1, timescale: 30),
+                                                  queue: .main) { time in
+            currentTime = time.seconds.isFinite ? time.seconds : 0
+        }
+        player = p
+    }
+
+    private func teardownPlayer() {
+        if let player, let observer = timeObserver {
+            player.removeTimeObserver(observer)
+        }
+        timeObserver = nil
+        player?.pause()
+        player = nil
+    }
+
+    private func seek(to seconds: Double) {
+        let time = CMTime(seconds: seconds, preferredTimescale: 600)
+        player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+        currentTime = seconds
+    }
+}
+
+/// Header action buttons (re-transcribe, share, copy overview, export SRT).
+/// Owns the parent-side dependency on `TranscriptionService` for its `busy`
+/// gate + `enqueue` calls, so the transcription `progress` flood re-renders
+/// this leaf (a sibling of the folder `Menu`) instead of the `header` that
+/// hosts the menu. The re-transcribe `Menu` is `busy`-disabled during an
+/// active transcription, so it can't be open while this leaf re-renders.
+private struct RecordingDetailActionButtons: View {
+    let recording: Recording
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var transcription: TranscriptionService
+
+    var body: some View {
         let currentLang = RecordingLanguage.fromCode(recording.language)
         let busy = transcription.activeRecordingID == recording.id
                    || transcription.pendingIDs.contains(recording.id)
@@ -215,56 +313,54 @@ struct RecordingDetailView: View {
         transcription.enqueue(prepared, isRetranscription: true)
     }
 
-
-    /// Whether the user can ask for a fresh summary right now. Gates the
-    /// "Regenerate summary" context-menu entry in `AIOverviewBanner` so
-    /// it never shows up for recordings without an LLM CLI configured
-    /// or without anything to summarise. Mirrors `RecordingSummarizer`'s
-    /// own predicate but adds the "force-allowed even if a summary
-    /// exists" piece — that's the whole point of the affordance.
-    private var canRegenerateSummary: Bool {
-        guard llmSettings.isConfigured else { return false }
-        return !recording.fullText
+    /// Whether there's any AI overview content (summary or action items)
+    /// to copy. Gates the header's "Copy summary + action items" button.
+    private var hasOverviewToCopy: Bool {
+        let hasSummary = recording.summary?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty
+            .isEmpty == false
+        let hasItems = !(recording.actionItems ?? []).isEmpty
+        return hasSummary || hasItems
     }
 
-    /// Human-readable name of the whisper model that will run for the
-    /// recording's CURRENT language. Prefers `recording.modelName` once
-    /// transcription has started writing it back to the store (that's
-    /// what the engine actually used), otherwise falls back to the
-    /// model selected for the recording's language.
-    private var activeTranscriptionModelName: String {
-        if let name = recording.modelName, !name.isEmpty { return name }
-        if let model = modelManager.model(for: recording.language) {
-            return model.displayName
+    /// Copy the AI overview (summary + action items) as plain text: the
+    /// summary first, then — separated by a blank line — the action items
+    /// as `•\u{00A0}…` lines. Only the parts that actually exist are
+    /// included, so a summary-only or items-only recording copies cleanly.
+    private func copyOverview() {
+        var parts: [String] = []
+        if let summary = recording.summary?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !summary.isEmpty {
+            parts.append(summary)
         }
-        return modelManager.selectedModel()?.displayName ?? ""
+        let items = recording.actionItems ?? []
+        if !items.isEmpty {
+            parts.append(items.map { "•\u{00A0}\($0.text)" }.joined(separator: "\n"))
+        }
+        guard !parts.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(parts.joined(separator: "\n\n"), forType: .string)
     }
+}
 
-    /// What the transcript area shows while a recording has no segments.
-    /// `nil` means no placeholder — the active-transcription progress view
-    /// owns that state.
-    enum EmptyTranscriptPlaceholder: Equatable {
-        /// Queued behind the active transcription — the Transcribe menu is
-        /// disabled (see `busy` in `actionButtons`), so pointing the user
-        /// at it would be a dead end.
-        case waitingInQueue
-        /// Idle: invite the user to start a transcription themselves.
-        case clickTranscribe
-    }
+/// Transcript area: the active-transcription progress view, the empty-state
+/// placeholders, and the finished transcript list. Owns the parent-side
+/// dependency on `TranscriptionService` (progress + active/queued state), so
+/// the whisper-progress flood re-renders this leaf instead of the parent
+/// body / `header` that hosts the folder `Menu`.
+private struct RecordingTranscriptArea: View {
+    let recording: Recording
+    /// Playback head, owned by `RecordingDetailView`, used to highlight the
+    /// currently-playing segment.
+    let currentTime: Double
+    /// Seek callback into the parent's `AVPlayer`.
+    let onSeek: (Double) -> Void
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var transcription: TranscriptionService
+    @EnvironmentObject private var modelManager: ModelManager
 
-    /// Decision for the empty-segments placeholder, split out as a pure
-    /// function so RecordingDetailPlaceholderTests can pin the queued
-    /// case without building the view.
-    static func emptyTranscriptPlaceholder(isActive: Bool,
-                                           isQueued: Bool) -> EmptyTranscriptPlaceholder? {
-        if isActive { return nil }
-        return isQueued ? .waitingInQueue : .clickTranscribe
-    }
-
-    @ViewBuilder
-    private var transcriptArea: some View {
+    var body: some View {
         if transcription.activeRecordingID == recording.id {
             VStack(spacing: 12) {
                 Spacer()
@@ -286,7 +382,7 @@ struct RecordingDetailView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if recording.segments.isEmpty {
-            let placeholder = Self.emptyTranscriptPlaceholder(
+            let placeholder = RecordingDetailView.emptyTranscriptPlaceholder(
                 isActive: transcription.activeRecordingID == recording.id,
                 isQueued: transcription.pendingIDs.contains(recording.id)
             )
@@ -344,7 +440,7 @@ struct RecordingDetailView: View {
                                        useSpeakerColor: hasMultipleSpeakers,
                                        language: recording.language,
                                        speakerNames: recording.speakerNames,
-                                       onTap: { seek(to: seg.start) },
+                                       onTap: { onSeek(seg.start) },
                                        onAssignName: { raw, name in
                                            store.setSpeakerName(name, forSpeaker: raw,
                                                                 recordingID: recording.id)
@@ -374,48 +470,27 @@ struct RecordingDetailView: View {
         }
     }
 
-    @ViewBuilder
-    private var playbackBar: some View {
-        if let player {
-            HStack {
-                PlayPauseButton(player: player)
-                Slider(value: Binding(get: { currentTime },
-                                      set: { seek(to: $0) }),
-                       in: 0...max(recording.duration, 0.1))
-                Text(formatDuration(currentTime))
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 60, alignment: .trailing)
-            }
-            .padding()
+    /// Human-readable name of the whisper model that will run for the
+    /// recording's CURRENT language. Prefers `recording.modelName` once
+    /// transcription has started writing it back to the store (that's
+    /// what the engine actually used), otherwise falls back to the
+    /// model selected for the recording's language.
+    private var activeTranscriptionModelName: String {
+        if let name = recording.modelName, !name.isEmpty { return name }
+        if let model = modelManager.model(for: recording.language) {
+            return model.displayName
         }
+        return modelManager.selectedModel()?.displayName ?? ""
     }
 
-    private func configurePlayer() {
-        teardownPlayer()
-        let url = store.audioURL(for: recording)
-        let item = AVPlayerItem(url: url)
-        let p = AVPlayer(playerItem: item)
-        timeObserver = p.addPeriodicTimeObserver(forInterval: CMTime(value: 1, timescale: 30),
-                                                  queue: .main) { time in
-            currentTime = time.seconds.isFinite ? time.seconds : 0
-        }
-        player = p
-    }
-
-    private func teardownPlayer() {
-        if let player, let observer = timeObserver {
-            player.removeTimeObserver(observer)
-        }
-        timeObserver = nil
-        player?.pause()
-        player = nil
-    }
-
-    private func seek(to seconds: Double) {
-        let time = CMTime(seconds: seconds, preferredTimescale: 600)
-        player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
-        currentTime = seconds
+    /// Re-run the transcription pipeline with a different language model.
+    /// Updates the persisted `Recording.language` so the downstream
+    /// `TranscriptionService` picks the right model on its own.
+    private func retranscribe(in language: RecordingLanguage) {
+        guard let prepared = store.prepareForRetranscription(id: recording.id,
+                                                             language: language.rawValue)
+        else { return }
+        transcription.enqueue(prepared, isRetranscription: true)
     }
 
     private func copyTranscript() {
@@ -424,36 +499,6 @@ struct RecordingDetailView: View {
                                                  names: recording.speakerNames)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
-    }
-
-    /// Whether there's any AI overview content (summary or action items)
-    /// to copy. Gates the header's "Copy summary + action items" button.
-    private var hasOverviewToCopy: Bool {
-        let hasSummary = recording.summary?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty == false
-        let hasItems = !(recording.actionItems ?? []).isEmpty
-        return hasSummary || hasItems
-    }
-
-    /// Copy the AI overview (summary + action items) as plain text: the
-    /// summary first, then — separated by a blank line — the action items
-    /// as `•\u{00A0}…` lines. Only the parts that actually exist are
-    /// included, so a summary-only or items-only recording copies cleanly.
-    private func copyOverview() {
-        var parts: [String] = []
-        if let summary = recording.summary?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !summary.isEmpty {
-            parts.append(summary)
-        }
-        let items = recording.actionItems ?? []
-        if !items.isEmpty {
-            parts.append(items.map { "•\u{00A0}\($0.text)" }.joined(separator: "\n"))
-        }
-        guard !parts.isEmpty else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(parts.joined(separator: "\n\n"), forType: .string)
     }
 }
 

--- a/Mila/Views/RecordingFolderControls.swift
+++ b/Mila/Views/RecordingFolderControls.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Isolated leaf views for the recording folder / meeting-name controls.
+///
+/// These deliberately observe ONLY `RecordingStore` (for the folder list) and
+/// `QuickActionsController` (for the bindings) — never the high-frequency
+/// `LiveTranscriber` / `TranscriptionService` / `LiveAISession`. That isolation
+/// is the whole point: on the live recording screen, the detail view during an
+/// active transcription, and the post-stop rename sheet, those objects
+/// `@Publish` many times per second. When an interactive `Menu` (backed by a
+/// native NSMenu that runs a nested modal event-tracking runloop while open)
+/// lives in a body that re-renders at that cadence, the menu host gets
+/// reconciled mid-tracking and the whole app beachballs.
+///
+/// By pulling the controls into leaves whose inputs are constant/stable, the
+/// parent body can churn as much as it likes without ever re-invoking these
+/// bodies — so the open menu stays untouched. Same rationale as
+/// `RecordingElapsedLabel` isolating `RecordingSession`.
+
+/// Folder picker for the NEXT recording (Home + live recording screen). Binds
+/// to `QuickActionsController.nextRecordingFolder`, applied when the recording
+/// is saved.
+struct NextRecordingFolderPicker: View {
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var actions: QuickActionsController
+    let accessibilityID: String
+
+    var body: some View {
+        Menu {
+            Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
+                actions.nextRecordingFolder = nil
+            }
+            if !store.folders.isEmpty {
+                Divider()
+                ForEach(store.folders, id: \.self) { folder in
+                    Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
+                        actions.nextRecordingFolder = folder
+                    }
+                }
+            }
+        } label: {
+            Text(actions.nextRecordingFolder ?? "All Transcriptions")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+/// Optional meeting-name field for the NEXT recording (Home + live recording
+/// screen). Isolated so typing stays responsive even while the surrounding
+/// screen re-renders at transcript cadence. Callers apply `.textFieldStyle` /
+/// `.font` via modifiers (both propagate into the inner `TextField` through the
+/// environment).
+struct NextRecordingMeetingNameField: View {
+    @EnvironmentObject private var actions: QuickActionsController
+    let placeholder: String
+    let accessibilityID: String
+
+    var body: some View {
+        TextField(placeholder, text: $actions.nextRecordingTitle)
+            .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+/// Inline folder picker for an EXISTING recording (recording detail view).
+/// Files the recording via `store.assign` and offers a "New Folder…" flow. Takes
+/// the recording id + its current folder as stable inputs (both only change when
+/// the folder actually changes), so an active transcription's progress flood
+/// never re-invokes this body.
+struct RecordingFolderMenu: View {
+    @EnvironmentObject private var store: RecordingStore
+    let recordingID: UUID
+    let currentFolder: String?
+
+    @State private var showingNewFolderAlert = false
+    @State private var newFolderName = ""
+
+    var body: some View {
+        Menu {
+            Button(currentFolder == nil ? "✓ None" : "None") {
+                assign(nil)
+            }
+            if !store.folders.isEmpty {
+                Divider()
+                ForEach(store.folders, id: \.self) { folder in
+                    Button(currentFolder == folder ? "✓ \(folder)" : folder) {
+                        assign(folder)
+                    }
+                }
+            }
+            Divider()
+            Button("New Folder…") {
+                newFolderName = ""
+                showingNewFolderAlert = true
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "folder")
+                Text(currentFolder ?? "No folder")
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Choose the folder this recording is filed under")
+        .accessibilityIdentifier("detail.folder.menu")
+        .alert("New Folder", isPresented: $showingNewFolderAlert) {
+            TextField("Folder name", text: $newFolderName)
+            Button("Create") {
+                let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !name.isEmpty { assign(name) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("File this recording into a new folder.")
+        }
+    }
+
+    private func assign(_ folder: String?) {
+        guard let rec = store.recordings.first(where: { $0.id == recordingID }) else { return }
+        store.assign(rec, toFolder: folder)
+    }
+}

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import MilaKit
 
 /// Shown the moment a recording is added — i.e. as soon as recording stops,
 /// in parallel with transcription. The user can type a title and Save at any

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -53,7 +53,8 @@ struct RenameRecordingSheet: View {
     /// join when no segments carry speaker info.
     private var transcript: String {
         TranscriptFormatter.plainText(segments: liveRecording.segments,
-                                      fallback: liveRecording.fullText)
+                                      fallback: liveRecording.fullText,
+                                      names: liveRecording.speakerNames)
     }
     private var transcriptReady: Bool {
         !transcript.isEmpty && liveRecording.status != .running && liveRecording.status != .pending

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -20,6 +20,13 @@ struct RenameRecordingSheet: View {
     /// Mila folder the recording should be filed under (nil = unfiled).
     /// Seeded from the recording and applied on Save via `store.assign`.
     @State private var selectedFolder: String?
+    /// Mirrors `userEditedTitle` for the folder: while false, the picker
+    /// tracks the stored recording's folder (so a folder chosen on the
+    /// recording screen shows up here even when SwiftUI reuses this sheet's
+    /// `@State` across presentations and the init seed goes stale). Once the
+    /// user picks a folder in this sheet we stop mirroring so their choice
+    /// isn't clobbered.
+    @State private var userEditedFolder = false
     @State private var showingNewFolderField = false
     @State private var newFolderName = ""
     @State private var isFetchingName = false
@@ -230,6 +237,14 @@ struct RenameRecordingSheet: View {
         // back over the stored suggestion.
         .onAppear {
             if !userEditedTitle { title = liveRecording.title }
+            if !userEditedFolder { selectedFolder = liveRecording.folder }
+        }
+        // Keep the folder in sync with the stored recording until the user
+        // picks one here — mirrors the title mirroring above. This is what
+        // carries a folder chosen on the recording screen into the sheet even
+        // if the init-seeded `@State` was stale.
+        .onChange(of: liveRecording.folder) { _, newFolder in
+            if !userEditedFolder { selectedFolder = newFolder }
         }
         // Mirror a background auto-suggestion into the field as it lands —
         // but only until the user expresses their own preference. The
@@ -367,13 +382,13 @@ struct RenameRecordingSheet: View {
             HStack(spacing: 8) {
                 Menu {
                     Button(selectedFolder == nil ? "✓ None" : "None") {
-                        selectedFolder = nil
+                        chooseFolder(nil)
                     }
                     if !store.folders.isEmpty {
                         Divider()
                         ForEach(store.folders, id: \.self) { folder in
                             Button(selectedFolder == folder ? "✓ \(folder)" : folder) {
-                                selectedFolder = folder
+                                chooseFolder(folder)
                             }
                         }
                     }
@@ -407,8 +422,15 @@ struct RenameRecordingSheet: View {
     private func commitNewFolder() {
         let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else { return }
-        selectedFolder = name
+        chooseFolder(name)
         showingNewFolderField = false
+    }
+
+    /// Record an explicit in-sheet folder choice and stop mirroring the
+    /// stored recording's folder so the user's pick is never clobbered.
+    private func chooseFolder(_ folder: String?) {
+        selectedFolder = folder
+        userEditedFolder = true
     }
 
     private var header: some View {

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -17,6 +17,11 @@ struct RenameRecordingSheet: View {
     @EnvironmentObject private var summarizer: RecordingSummarizer
 
     @State private var title: String
+    /// Mila folder the recording should be filed under (nil = unfiled).
+    /// Seeded from the recording and applied on Save via `store.assign`.
+    @State private var selectedFolder: String?
+    @State private var showingNewFolderField = false
+    @State private var newFolderName = ""
     @State private var isFetchingName = false
     @State private var llmError: String?
     /// Set once the user types in the title field (or accepts a manual
@@ -40,6 +45,7 @@ struct RenameRecordingSheet: View {
     init(initialRecording: Recording) {
         self.initialRecording = initialRecording
         _title = State(initialValue: initialRecording.title)
+        _selectedFolder = State(initialValue: initialRecording.folder)
     }
 
     /// Live recording (transcript fills in here as Whisper finishes).
@@ -136,6 +142,8 @@ struct RenameRecordingSheet: View {
                         }
                     }
                 }
+
+                folderPicker
 
                 transcriptionStatus
             }
@@ -351,6 +359,58 @@ struct RenameRecordingSheet: View {
         }
     }
 
+    /// Pick the Mila folder this recording is filed under. Existing folders +
+    /// "None", plus an inline "New Folder…" field. Applied on Save.
+    private var folderPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Folder").font(.callout.weight(.semibold))
+            HStack(spacing: 8) {
+                Menu {
+                    Button(selectedFolder == nil ? "✓ None" : "None") {
+                        selectedFolder = nil
+                    }
+                    if !store.folders.isEmpty {
+                        Divider()
+                        ForEach(store.folders, id: \.self) { folder in
+                            Button(selectedFolder == folder ? "✓ \(folder)" : folder) {
+                                selectedFolder = folder
+                            }
+                        }
+                    }
+                    Divider()
+                    Button("New Folder…") {
+                        newFolderName = ""
+                        showingNewFolderField = true
+                    }
+                } label: {
+                    Label(selectedFolder ?? "No folder", systemImage: "folder")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .accessibilityIdentifier("rename.folder.menu")
+                Spacer()
+            }
+            if showingNewFolderField {
+                HStack(spacing: 8) {
+                    TextField("New folder name", text: $newFolderName)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { commitNewFolder() }
+                        .accessibilityIdentifier("rename.newFolder.field")
+                    Button("Add") { commitNewFolder() }
+                        .disabled(newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Button("Cancel") { showingNewFolderField = false }
+                }
+            }
+        }
+    }
+
+    private func commitNewFolder() {
+        let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        selectedFolder = name
+        showingNewFolderField = false
+    }
+
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Name this recording").font(.title3.weight(.semibold))
@@ -439,7 +499,19 @@ struct RenameRecordingSheet: View {
     }
 
     private func save() {
+        applyFolder()
         coordinator.dismiss(savingTitle: title)
+    }
+
+    /// File the recording under the chosen folder (auto-creates it) before the
+    /// sheet tears down. No-op when the folder is unchanged. Runs before the
+    /// Obsidian export (which fires off the summary hook) so the note nests
+    /// under the right Mila folder.
+    private func applyFolder() {
+        guard let rec = store.recordings.first(where: { $0.id == initialRecording.id }) else { return }
+        if rec.folder != selectedFolder {
+            store.assign(rec, toFolder: selectedFolder)
+        }
     }
 
     /// Save the title, dismiss the sheet, then run the action in the
@@ -466,6 +538,7 @@ struct RenameRecordingSheet: View {
         let summarySnapshot = summary
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let tool = llm.tool
+        applyFolder()
         coordinator.dismiss(savingTitle: title)
         coordinator.sendToLLM(recordingID: recordingID,
                               tool: tool,

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -13,7 +13,6 @@ struct RenameRecordingSheet: View {
     @EnvironmentObject private var coordinator: PostRecordingCoordinator
     @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var llm: LLMSettings
-    @EnvironmentObject private var transcription: TranscriptionService
     @EnvironmentObject private var summarizer: RecordingSummarizer
 
     @State private var title: String
@@ -95,28 +94,6 @@ struct RenameRecordingSheet: View {
             || summarizer.isSummarizing(liveRecording.id)
     }
 
-    /// "Transcribing…", "Identifying speakers…", "Done", "Failed",
-    /// "Waiting in queue" — drives the progress indicator inside the sheet.
-    private var transcriptionLabel: String {
-        let live = liveRecording
-        if transcription.activeRecordingID == live.id {
-            let pct = Int(transcription.progress * 100)
-            return "Transcribing… \(pct)%"
-        }
-        // The offline re-diarize pass: the transcript text is already final
-        // (status is .completed), so "Transcribing" would be wrong — the
-        // pyannote subprocess is only re-clustering speaker labels.
-        if transcription.diarizingRecordingID == live.id {
-            return "Identifying speakers…"
-        }
-        switch live.status {
-        case .pending:   return "Waiting to transcribe…"
-        case .running:   return "Transcribing…"
-        case .completed: return "Transcript ready"
-        case .failed:    return "Transcription failed"
-        }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Fixed top: identity + status. Never scrolls, so the title field
@@ -152,7 +129,7 @@ struct RenameRecordingSheet: View {
 
                 folderPicker
 
-                transcriptionStatus
+                RenameTranscriptionStatusRow(recordingID: initialRecording.id)
             }
             .padding(20)
 
@@ -482,44 +459,6 @@ struct RenameRecordingSheet: View {
             .isEmpty
     }
 
-    @ViewBuilder
-    private var transcriptionStatus: some View {
-        HStack(spacing: 10) {
-            statusIcon
-            Text(transcriptionLabel)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            if transcription.activeRecordingID == liveRecording.id {
-                ProgressView(value: transcription.progress)
-                    .progressViewStyle(.linear)
-                    .frame(maxWidth: 140)
-            }
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-    }
-
-    @ViewBuilder
-    private var statusIcon: some View {
-        // While the offline re-diarize is in flight the transcript is done
-        // but speaker labels aren't — show a spinner, not the green check,
-        // to match the "Identifying speakers…" label.
-        if transcription.diarizingRecordingID == liveRecording.id {
-            ProgressView().controlSize(.small)
-        } else {
-            switch liveRecording.status {
-            case .completed:
-                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-            case .failed:
-                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
-            default:
-                ProgressView().controlSize(.small)
-            }
-        }
-    }
-
     private func save() {
         applyFolder()
         coordinator.dismiss(savingTitle: title)
@@ -604,6 +543,82 @@ struct RenameRecordingSheet: View {
             // when withTaskCancellationHandler's onCancel beat us to it.
             if Task.isCancelled { return }
             llmError = error.localizedDescription
+        }
+    }
+}
+
+/// Isolated transcription-status row for the rename sheet.
+///
+/// This is the ONLY part of the sheet that observes `TranscriptionService`, so
+/// the high-frequency `progress` updates during batch transcription re-render
+/// just this small leaf — not the whole sheet. Previously the sheet held
+/// `@EnvironmentObject transcription`, so every progress tick rebuilt the
+/// entire body including the folder `Menu`; opening that menu mid-transcription
+/// then collided with the NSMenu's modal tracking loop and beachballed the app.
+private struct RenameTranscriptionStatusRow: View {
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var transcription: TranscriptionService
+    let recordingID: UUID
+
+    private var status: TranscriptionStatus {
+        store.recordings.first(where: { $0.id == recordingID })?.status ?? .pending
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if transcription.activeRecordingID == recordingID {
+                ProgressView(value: transcription.progress)
+                    .progressViewStyle(.linear)
+                    .frame(maxWidth: 140)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// "Transcribing… NN%", "Identifying speakers…", "Transcript ready",
+    /// "Transcription failed", "Waiting to transcribe…".
+    private var label: String {
+        if transcription.activeRecordingID == recordingID {
+            let pct = Int(transcription.progress * 100)
+            return "Transcribing… \(pct)%"
+        }
+        // The offline re-diarize pass: the transcript text is already final
+        // (status is .completed), so "Transcribing" would be wrong — the
+        // pyannote subprocess is only re-clustering speaker labels.
+        if transcription.diarizingRecordingID == recordingID {
+            return "Identifying speakers…"
+        }
+        switch status {
+        case .pending:   return "Waiting to transcribe…"
+        case .running:   return "Transcribing…"
+        case .completed: return "Transcript ready"
+        case .failed:    return "Transcription failed"
+        }
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        // While the offline re-diarize is in flight the transcript is done
+        // but speaker labels aren't — show a spinner, not the green check,
+        // to match the "Identifying speakers…" label.
+        if transcription.diarizingRecordingID == recordingID {
+            ProgressView().controlSize(.small)
+        } else {
+            switch status {
+            case .completed:
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+            case .failed:
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
+            default:
+                ProgressView().controlSize(.small)
+            }
         }
     }
 }

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -23,7 +23,8 @@ struct SendToLLMSheet: View {
 
     private var transcript: String {
         TranscriptFormatter.plainText(segments: liveRecording.segments,
-                                      fallback: liveRecording.fullText)
+                                      fallback: liveRecording.fullText,
+                                      names: liveRecording.speakerNames)
     }
 
     var body: some View {

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MilaKit
 
 /// Sheet shown when the user right-clicks a recording and picks
 /// "Send to <LLM>…". Surfaces the prompt that will be sent (editable for

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1157,6 +1157,10 @@ private struct DiarizationSettingsTabContent: View {
                 .accessibilityIdentifier("speakers.health.ok.probe")
                 .accessibilityLabel(diarization.healthCheckResult?.ok == true ? "ok" : "not_ok")
 
+            Divider()
+
+            KnownSpeakersSection()
+
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1279,6 +1283,65 @@ private struct DiarizationSettingsTabContent: View {
         if diarization.isHealthChecking { return "Checking…" }
         guard let result = diarization.healthCheckResult else { return "Not checked yet" }
         return result.ok ? "Speaker detection is working" : "Speaker detection unavailable"
+    }
+}
+
+/// "Known Speakers" — manage the persistent name list behind the
+/// transcript's speaker-rename popover. Names added here (or via the
+/// popover) are offered in every future recording's rename list.
+private struct KnownSpeakersSection: View {
+    @EnvironmentObject private var directory: SpeakerDirectory
+    @State private var newName = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Known speakers")
+                .font(.callout.weight(.semibold))
+            Text("Names you can assign to speakers by clicking their label in a transcript. Removing a name here doesn't change recordings it's already assigned to.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !directory.names.isEmpty {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(directory.names, id: \.self) { name in
+                            HStack {
+                                Text(name)
+                                Spacer()
+                                Button {
+                                    directory.remove(name)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Remove \"\(name)\" from the list")
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(maxHeight: 120)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            HStack(spacing: 8) {
+                TextField("Add a name…", text: $newName)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(addName)
+                Button("Add", action: addName)
+                    .disabled(newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private func addName() {
+        if directory.add(newName) != nil {
+            newName = ""
+        }
     }
 }
 

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1317,9 +1317,12 @@ private struct KnownSpeakersSection: View {
                                 }
                                 .buttonStyle(.borderless)
                                 .help("Remove \"\(name)\" from the list")
+                                .accessibilityIdentifier("speakers.known.remove.\(name)")
                             }
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
+                            .accessibilityElement(children: .contain)
+                            .accessibilityIdentifier("speakers.known.row.\(name)")
                         }
                     }
                     .padding(.vertical, 4)
@@ -1332,8 +1335,10 @@ private struct KnownSpeakersSection: View {
                 TextField("Add a name…", text: $newName)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(addName)
+                    .accessibilityIdentifier("speakers.known.addField")
                 Button("Add", action: addName)
                     .disabled(newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityIdentifier("speakers.known.addButton")
             }
         }
     }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -49,7 +49,9 @@ struct SettingsView: View {
                 .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
                 .tag(SettingsTab.updates)
         }
-        .frame(width: 560, height: 560)
+        // Wide enough that the full 10-tab bar fits and the last tab
+        // (Updates) stays clickable — at 560 it can clip off the right edge.
+        .frame(width: 640, height: 560)
         .padding(20)
         .onChange(of: SettingsNavigation.shared.pendingTab, initial: true) { _, newTab in
             if let tab = newTab {

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -809,7 +809,7 @@ private struct LLMSettingsTab: View {
                     .textFieldStyle(.roundedBorder)
             }
             .font(.callout)
-            Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
+            Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` / `gemini` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Mila/Views/SpeakerNamePicker.swift
+++ b/Mila/Views/SpeakerNamePicker.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// Popover content for renaming a diarized speaker: type-to-filter over
+/// the persistent `SpeakerDirectory`, an "Add" row for new names, and a
+/// reset row back to the default "Speaker A" label. Shared by the
+/// completed-recording detail view and the live transcript pane — the
+/// caller decides where the assignment lands via `onAssign`.
+struct SpeakerNamePicker: View {
+    /// Resolved default label ("Speaker A" / "דובר א׳") shown in the
+    /// reset row when a custom name is currently assigned.
+    let defaultLabel: String
+    /// Name currently assigned to this speaker, nil when unnamed.
+    let currentName: String?
+    /// Called with the chosen name, or nil to reset to the default label.
+    let onAssign: (String?) -> Void
+
+    @EnvironmentObject private var directory: SpeakerDirectory
+    @Environment(\.dismiss) private var dismiss
+    @State private var query = ""
+    @FocusState private var searchFocused: Bool
+
+    private var filtered: [String] {
+        directory.matches(for: query)
+    }
+
+    /// The typed query has no exact (case-insensitive) match in the
+    /// directory yet — offer to add it as a brand-new name.
+    private var canAddQuery: Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return !directory.names.contains { $0.caseInsensitiveCompare(trimmed) == .orderedSame }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            TextField("Name this speaker…", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .focused($searchFocused)
+                .onSubmit(submitQuery)
+                .padding(10)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered, id: \.self) { name in
+                        row {
+                            assign(name)
+                        } label: {
+                            HStack {
+                                Text(name).lineLimit(1)
+                                Spacer()
+                                if name == currentName {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                        }
+                    }
+                    if canAddQuery {
+                        row {
+                            assign(query)
+                        } label: {
+                            Label("Add \"\(query.trimmingCharacters(in: .whitespacesAndNewlines))\"",
+                                  systemImage: "plus.circle.fill")
+                                .lineLimit(1)
+                        }
+                    }
+                    if filtered.isEmpty && !canAddQuery {
+                        Text("Type a name to add it")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 180)
+
+            if currentName != nil {
+                Divider()
+                row {
+                    onAssign(nil)
+                    dismiss()
+                } label: {
+                    Label("Use default (\(defaultLabel))", systemImage: "arrow.uturn.backward")
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .frame(width: 260)
+        .onAppear { searchFocused = true }
+    }
+
+    /// Enter in the search field: exact match wins, otherwise the top
+    /// filtered suggestion, otherwise add the typed name.
+    private func submitQuery() {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if let exact = directory.names.first(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            assign(exact)
+        } else if let top = filtered.first {
+            assign(top)
+        } else {
+            assign(trimmed)
+        }
+    }
+
+    /// Route every assignment through the directory so names typed here
+    /// (not just ones picked from the list) persist for future recordings.
+    private func assign(_ name: String) {
+        guard let canonical = directory.add(name) else { return }
+        onAssign(canonical)
+        dismiss()
+    }
+
+    private func row<L: View>(action: @escaping () -> Void,
+                              @ViewBuilder label: () -> L) -> some View {
+        Button(action: action) {
+            label()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Clickable speaker label used by both transcript panes (recording
+/// detail + live). Shows the resolved display name, underlines on hover,
+/// and opens `SpeakerNamePicker` in an anchored popover on click. Its
+/// own tap gesture takes precedence over any enclosing row gesture
+/// (e.g. the detail view's seek-on-tap), so clicking the label never
+/// scrubs playback.
+struct SpeakerLabelButton: View {
+    let rawID: String
+    let names: [String: String]
+    let language: String
+    let color: Color
+    /// Text appended after the name — the detail view's tight-prefix
+    /// layout uses ":", the live pane's fixed column uses nothing.
+    var suffix: String = ""
+    var font: Font = .body.weight(.semibold)
+    /// Receives the chosen name (nil = reset to the default label);
+    /// the caller persists it wherever this transcript's names live.
+    let onAssign: (String?) -> Void
+
+    @State private var showingPicker = false
+    @State private var hovering = false
+
+    var body: some View {
+        Text(rawID.displaySpeakerName(names: names, language: language) + suffix)
+            .font(font)
+            .foregroundStyle(color)
+            .underline(hovering)
+            .contentShape(Rectangle())
+            .onHover { hovering = $0 }
+            .onTapGesture { showingPicker = true }
+            .popover(isPresented: $showingPicker, arrowEdge: .bottom) {
+                SpeakerNamePicker(
+                    defaultLabel: rawID.friendlySpeakerLabel(language: language),
+                    currentName: names[rawID],
+                    onAssign: onAssign
+                )
+            }
+            .help("Rename speaker")
+    }
+}

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -30,23 +30,30 @@ struct StorageSettingsTab: View {
     @State private var compressStatus: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            header
-            currentLocationCard
-            storageLimitCard
-            autoDropCard
-            if storage.lastResolutionWasStale {
-                staleBookmarkNotice
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                header
+                currentLocationCard
+                storageLimitCard
+                autoDropCard
+                if storage.lastResolutionWasStale {
+                    staleBookmarkNotice
+                }
+                if let lastError {
+                    Text(lastError)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Divider()
+                    .padding(.vertical, 4)
+                // Obsidian vault destination lives under Storage as its own
+                // section rather than a top-level tab (keeps the tab bar from
+                // overflowing).
+                ObsidianSettingsSection()
             }
-            if let lastError {
-                Text(lastError)
-                    .font(.callout)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var header: some View {

--- a/MilaMCP/MilaMCPMain.swift
+++ b/MilaMCP/MilaMCPMain.swift
@@ -13,7 +13,12 @@ import MilaKit
 struct MilaMCPMain {
 
     static func main() async throws {
-        let handlers = MilaMCPToolHandlers()
+        // MILA_ROOT overrides the app-support root — for tests and
+        // debugging against a fixture store; unset in normal use.
+        let root = ProcessInfo.processInfo.environment["MILA_ROOT"]
+            .map { URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? StoreLocationPointer.defaultRoot()
+        let handlers = MilaMCPToolHandlers(root: root)
 
         let tools: [Tool] = try MilaMCPToolHandlers.toolSpecs.map { spec in
             let schemaData = try JSONSerialization.data(withJSONObject: spec.inputSchema)

--- a/MilaMCP/MilaMCPMain.swift
+++ b/MilaMCP/MilaMCPMain.swift
@@ -1,0 +1,73 @@
+import Foundation
+import MCP
+import MilaKit
+
+/// mila-mcp — MCP stdio server exposing Mila's transcriptions to Claude
+/// (Claude Code / Claude Desktop). Register once with:
+///
+///     claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp
+///
+/// All tool logic lives in MilaKit's `MilaMCPToolHandlers` (pure
+/// JSON-in/JSON-out); this file is only the SDK/transport shell.
+@main
+struct MilaMCPMain {
+
+    static func main() async throws {
+        let handlers = MilaMCPToolHandlers()
+
+        let tools: [Tool] = try MilaMCPToolHandlers.toolSpecs.map { spec in
+            let schemaData = try JSONSerialization.data(withJSONObject: spec.inputSchema)
+            let schema = try JSONDecoder().decode(Value.self, from: schemaData)
+            return Tool(name: spec.name, description: spec.description, inputSchema: schema)
+        }
+
+        let server = Server(
+            name: "mila",
+            version: appVersion(),
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: tools)
+        }
+
+        await server.withMethodHandler(CallTool.self) { params in
+            do {
+                let arguments = try jsonObject(from: params.arguments)
+                let result = try handlers.handle(tool: params.name, arguments: arguments)
+                return CallTool.Result(content: [.text(result)], isError: false)
+            } catch {
+                return CallTool.Result(content: [.text(String(describing: error))],
+                                       isError: true)
+            }
+        }
+
+        try await server.start(transport: StdioTransport())
+        await server.waitUntilCompleted()
+    }
+
+    /// Bridge the SDK's `Value` arguments into the Foundation JSON tree
+    /// the handler layer consumes.
+    private static func jsonObject(from arguments: [String: Value]?) throws -> [String: Any] {
+        guard let arguments, !arguments.isEmpty else { return [:] }
+        let data = try JSONEncoder().encode(arguments)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return object as? [String: Any] ?? [:]
+    }
+
+    /// The helper ships inside Mila.app — report the app's version when
+    /// we can find it (…/Mila.app/Contents/MacOS/mila-mcp → Info.plist),
+    /// so `initialize` handshakes identify the build.
+    private static func appVersion() -> String {
+        let binary = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
+        let infoPlist = binary
+            .deletingLastPathComponent()   // MacOS
+            .deletingLastPathComponent()   // Contents
+            .appendingPathComponent("Info.plist")
+        if let info = NSDictionary(contentsOf: infoPlist),
+           let version = info["CFBundleShortVersionString"] as? String {
+            return version
+        }
+        return "dev"
+    }
+}

--- a/MilaTests/AdaptiveGainControllerTests.swift
+++ b/MilaTests/AdaptiveGainControllerTests.swift
@@ -55,13 +55,14 @@ final class AdaptiveGainControllerTests: XCTestCase {
                              bursts: Int,
                              voicedSeconds: Double = 1.0,
                              gapSeconds: Double = 0.5,
+                             gapChunk: [Float]? = nil,
                              sampleRate: Double = 16_000) -> [Float] {
-        let silence = [Float](repeating: 0, count: chunk.count)
+        let gap = gapChunk ?? [Float](repeating: 0, count: chunk.count)
         var lastVoiced: [Float] = []
         for _ in 0..<bursts {
             lastVoiced = drive(controller, chunk: chunk,
                                seconds: voicedSeconds, sampleRate: sampleRate)
-            _ = drive(controller, chunk: silence,
+            _ = drive(controller, chunk: gap,
                       seconds: gapSeconds, sampleRate: sampleRate)
         }
         return lastVoiced
@@ -129,6 +130,26 @@ final class AdaptiveGainControllerTests: XCTestCase {
 
         XCTAssertEqual(controller.currentGain, 1.0, accuracy: 1e-3,
                        "sustained hum must never adapt the gain (observed floor \(controller.observedNoiseFloor))")
+    }
+
+    /// Field regression for the windowed-minimum floor: quiet speech over
+    /// REAL room tone (~0.001 RMS between utterances — not digital
+    /// zeros). An earlier EMA-based floor rose toward the average signal,
+    /// settled above room tone, and parked the adaptation gate on top of
+    /// the speech itself — live transcription silently died in any room
+    /// with elevated tone. The windowed minimum must keep the floor at
+    /// the tone's minimum so speech keeps clearing the gate.
+    func test_quietSpeech_overRealRoomTone_getsAmplified() {
+        let controller = AdaptiveGainController()
+        let speech = sine(amplitude: 0.006 * sqrt(2), durationSeconds: 0.030)
+        let roomTone = sine(amplitude: 0.001 * sqrt(2), durationSeconds: 0.030)
+        let final = driveBursts(controller, chunk: speech, bursts: 8,
+                                gapChunk: roomTone)
+
+        XCTAssertGreaterThan(controller.currentGain, 2.0,
+                             "quiet speech over real room tone must adapt the gain (floor \(controller.observedNoiseFloor))")
+        XCTAssertGreaterThan(rms(final), 0.012,
+                             "boosted speech must clear the live VAD cutoff (0.012)")
     }
 
     /// Hum that starts only AFTER a silent stretch (AC kicking in

--- a/MilaTests/AdaptiveGainControllerTests.swift
+++ b/MilaTests/AdaptiveGainControllerTests.swift
@@ -45,6 +45,28 @@ final class AdaptiveGainControllerTests: XCTestCase {
         return last
     }
 
+    /// Drive `controller` with speech-shaped input: `bursts` repetitions
+    /// of (`voicedSeconds` of `chunk`, then `gapSeconds` of silence).
+    /// The gaps matter — the noise-floor tracker snaps down during them,
+    /// which is what lets the bursts clear the adaptation gate. Returns
+    /// the gained samples of the final *voiced* chunk.
+    private func driveBursts(_ controller: AdaptiveGainController,
+                             chunk: [Float],
+                             bursts: Int,
+                             voicedSeconds: Double = 1.0,
+                             gapSeconds: Double = 0.5,
+                             sampleRate: Double = 16_000) -> [Float] {
+        let silence = [Float](repeating: 0, count: chunk.count)
+        var lastVoiced: [Float] = []
+        for _ in 0..<bursts {
+            lastVoiced = drive(controller, chunk: chunk,
+                               seconds: voicedSeconds, sampleRate: sampleRate)
+            _ = drive(controller, chunk: silence,
+                      seconds: gapSeconds, sampleRate: sampleRate)
+        }
+        return lastVoiced
+    }
+
     /// Convert a linear RMS to dBFS. Returns `-inf` for zero input.
     private func dBFS(_ rmsValue: Float) -> Float {
         guard rmsValue > 0 else { return -.infinity }
@@ -53,26 +75,60 @@ final class AdaptiveGainControllerTests: XCTestCase {
 
     // MARK: - Tests
 
-    /// Constant low-level input (~-34 dBFS RMS, just above the silence
-    /// floor at 0.012) should be raised toward the -26 dBFS target.
-    /// Allow ±2 dB tolerance and ~4 release time-constants to settle.
-    func test_lowLevelSine_settlesNearTarget() {
+    /// Low-level speech-shaped input (~-34 dBFS RMS bursts with silence
+    /// gaps) should be raised toward the -26 dBFS target. Allow ±2 dB
+    /// tolerance and enough voiced time (~5 release time-constants,
+    /// excluding the seeded first burst) to settle.
+    func test_lowLevelBursts_settleNearTarget() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02 (well above the 0.012 silence floor so adaptation
-        // engages). amplitude = 0.02 * sqrt(2) for a sine of that RMS.
+        // RMS ≈ 0.02. amplitude = 0.02 * sqrt(2) for a sine of that RMS.
         let amplitude: Float = 0.02 * sqrt(2)
         // Use 30 ms chunks (matches the live VAD frame size) so the
         // attack/release dt mapping in `process` is realistic.
         let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
-        // Drive for 8 seconds (4× the release time-constant) so the
-        // smoother is well within ε of steady state.
-        let final = drive(controller, chunk: chunk, seconds: 8.0)
+        let final = driveBursts(controller, chunk: chunk, bursts: 12)
 
         let outRMS = rms(final)
         let outDb = dBFS(outRMS)
         let targetDb = dBFS(AdaptiveGainController.defaultTargetRMS)
         XCTAssertEqual(outDb, targetDb, accuracy: 2.0,
                        "settled RMS \(outDb) dBFS should be within ±2 dB of target \(targetDb) dBFS (gain=\(controller.currentGain))")
+    }
+
+    /// THE regression test for the quiet built-in-mic bug: speech at RMS
+    /// ~0.006 — well below the live VAD's 0.012 cutoff AND below the old
+    /// static adaptation gate (0.012) — must now be amplified above the
+    /// VAD cutoff. With the old gate this speech never adapted the gain,
+    /// the VAD never fired, and the live transcript stayed empty for the
+    /// whole recording (observed on a MacBook Pro built-in mic while a
+    /// headset mic worked).
+    func test_quietSpeechBursts_belowLegacyGate_getAmplifiedAboveVADCutoff() {
+        let controller = AdaptiveGainController()
+        let amplitude: Float = 0.006 * sqrt(2)   // sine RMS ≈ 0.006
+        let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
+        let final = driveBursts(controller, chunk: chunk, bursts: 8)
+
+        XCTAssertGreaterThan(controller.currentGain, 2.0,
+                             "quiet speech must adapt the gain upward")
+        XCTAssertGreaterThan(rms(final), 0.012,
+                             "boosted speech must clear the live VAD cutoff (0.012)")
+    }
+
+    /// Sustained hum — a signal that never pauses — must NOT be
+    /// amplified, even when it sits above the absolute silence floor.
+    /// The minimum-statistics tracker seeds the noise floor from the
+    /// first frame, so the hum is its own floor and never clears the
+    /// adaptation gate. Amplifying it would push room noise into the
+    /// VAD's trigger range and latch the live transcript into endless
+    /// noise "utterances".
+    func test_sustainedHum_holdsGainAtOne() {
+        let controller = AdaptiveGainController()
+        let amplitude: Float = 0.008 * sqrt(2)   // sine RMS ≈ 0.008
+        let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
+        _ = drive(controller, chunk: chunk, seconds: 20.0)
+
+        XCTAssertEqual(controller.currentGain, 1.0, accuracy: 1e-3,
+                       "sustained hum must never adapt the gain (observed floor \(controller.observedNoiseFloor))")
     }
 
     /// A full-scale signal should be passed through at gain == 1 —
@@ -120,15 +176,15 @@ final class AdaptiveGainControllerTests: XCTestCase {
     }
 
     /// Silence after a quiet signal should also hold (not continue ramping).
-    /// Pre-condition with a low-level signal (gain converges high), then
-    /// silence — gain must stay at the high value, NOT keep rising.
+    /// Pre-condition with low-level speech bursts (gain converges high),
+    /// then silence — gain must stay at the high value, NOT keep rising.
     func test_silence_doesNotKeepRising() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02 — above the silence floor (0.012) so adaptation
-        // engages and pushes the gain up toward target / RMS = 2.5×.
+        // Burst RMS ≈ 0.02 — adaptation pushes the gain up toward
+        // target / RMS = 2.5×.
         let lowSignal = sine(amplitude: 0.02 * sqrt(2),
                               durationSeconds: 0.030)
-        _ = drive(controller, chunk: lowSignal, seconds: 8.0)
+        _ = driveBursts(controller, chunk: lowSignal, bursts: 12)
         let gainAfterSpeech = controller.currentGain
         // Sanity: gain should be elevated (we were boosting low signal).
         XCTAssertGreaterThan(gainAfterSpeech, 2.0)
@@ -145,13 +201,14 @@ final class AdaptiveGainControllerTests: XCTestCase {
     /// the silence floor, then slam in a near-full-scale buffer; output
     /// must stay inside [-1, +1] thanks to the soft-clipper.
     func test_softClipper_keepsOutputInRange() {
-        // Use a custom controller with a very low silence floor so we can
-        // push the gain near the max with a small-amplitude signal. The
-        // production controller's silence floor (0.012) prevents
-        // amplifying ambient noise — that gate is verified by the
-        // silence tests; here we only care that the soft-clipper handles
-        // large-magnitude post-gain samples correctly.
-        let controller = AdaptiveGainController(silenceFloor: 0.0001)
+        // Use a custom controller with a very low silence floor and the
+        // noise-floor gate disabled (multiplier 0) so a constant
+        // small-amplitude signal can push the gain to the max. The
+        // production gates prevent amplifying ambient noise — verified by
+        // the silence/hum tests; here we only care that the soft-clipper
+        // handles large-magnitude post-gain samples correctly.
+        let controller = AdaptiveGainController(silenceFloor: 0.0001,
+                                                noiseFloorMultiplier: 0)
         let tinyChunk = sine(amplitude: 0.001, durationSeconds: 0.030)
         // Drive for ~10× the release time-constant (2.0s) so the smoother
         // gets to within 0.005% of the max gain. 10s only gets ~99.3% of
@@ -209,15 +266,17 @@ final class AdaptiveGainControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(controller.currentGain, 1.0)
     }
 
-    /// Reset wipes the gain back to 1 (fresh recording starts).
-    func test_reset_clearsGain() {
+    /// Reset wipes the gain back to 1 and forgets the observed noise
+    /// floor (fresh recording starts).
+    func test_reset_clearsGainAndNoiseFloor() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02, just above the silence floor so adaptation engages.
         let lowSignal = sine(amplitude: 0.02 * sqrt(2),
                               durationSeconds: 0.030)
-        _ = drive(controller, chunk: lowSignal, seconds: 8.0)
+        _ = driveBursts(controller, chunk: lowSignal, bursts: 12)
         XCTAssertGreaterThan(controller.currentGain, 1.5)
         controller.reset()
         XCTAssertEqual(controller.currentGain, 1.0)
+        XCTAssertLessThan(controller.observedNoiseFloor, 0,
+                          "reset must forget the previous session's noise floor")
     }
 }

--- a/MilaTests/AdaptiveGainControllerTests.swift
+++ b/MilaTests/AdaptiveGainControllerTests.swift
@@ -131,6 +131,27 @@ final class AdaptiveGainControllerTests: XCTestCase {
                        "sustained hum must never adapt the gain (observed floor \(controller.observedNoiseFloor))")
     }
 
+    /// Hum that starts only AFTER a silent stretch (AC kicking in
+    /// mid-recording) briefly clears the gate while the noise floor —
+    /// seeded near zero by the silence — catches up, picking up gain.
+    /// The floor must find the hum within seconds, and the
+    /// sustained-noise relaxation must then unwind the acquired gain so
+    /// the boosted hum ends up back below the VAD's 0.012 trigger
+    /// instead of latching the live transcript into noise "utterances".
+    func test_humAfterSilence_gainRelaxesBackDown() {
+        let controller = AdaptiveGainController()
+        let silence = [Float](repeating: 0, count: 480)   // 30 ms @ 16 kHz
+        _ = drive(controller, chunk: silence, seconds: 5.0)
+
+        let hum = sine(amplitude: 0.008 * sqrt(2), durationSeconds: 0.030)
+        let final = drive(controller, chunk: hum, seconds: 90.0)
+
+        XCTAssertLessThan(controller.currentGain, 1.5,
+                          "gain acquired during the hum onset must relax back down")
+        XCTAssertLessThan(rms(final), 0.012,
+                          "steady hum must not stay boosted into the VAD's trigger range")
+    }
+
     /// A full-scale signal should be passed through at gain == 1 —
     /// never attenuate, and never soft-clip a signal that's already at or
     /// below the soft-clip threshold.

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -267,14 +267,10 @@ final class LLMRunnerTests: XCTestCase {
     // this fix in the first place.
 
     private func resolve(_ name: String) -> String? {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        let dirs = path.split(separator: ":").map(String.init) + [
-            "\(NSHomeDirectory())/.local/bin",
-            "\(NSHomeDirectory())/.bun/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin"
-        ]
-        for d in dirs {
+        // Reuse the production lookup dirs (incl. nvm/Volta/asdf/npm-global) so
+        // these smoke tests find CLIs installed by a node version manager
+        // rather than spuriously skipping.
+        for d in LLMRunner.searchDirectories() {
             let p = (d as NSString).appendingPathComponent(name)
             if FileManager.default.isExecutableFile(atPath: p) { return p }
         }
@@ -472,5 +468,125 @@ final class LLMRunnerTests: XCTestCase {
                        "cursor-agent never saw the transcript — runner regressed: \(result)")
         XCTAssertFalse(result.lowercased().contains("could you paste"),
                        "cursor-agent never saw the transcript — runner regressed: \(result)")
+    }
+
+    // MARK: - Gemini CLI (LLMTool.gemini)
+
+    func test_gemini_metadata_matches_cli() {
+        XCTAssertEqual(LLMTool.gemini.executableName, "gemini")
+        XCTAssertEqual(LLMTool.gemini.displayName, "Gemini (gemini CLI)")
+        // Must be selectable in the Settings picker (ForEach over allCases).
+        XCTAssertTrue(LLMTool.allCases.contains(.gemini))
+    }
+
+    func test_gemini_arguments_are_prompt_and_skip_trust_by_default() {
+        // `--skip-trust` is always passed: we launch in an isolated sandbox
+        // dir which gemini would otherwise reject as an untrusted workspace.
+        XCTAssertEqual(LLMTool.gemini.arguments(prompt: "Summarize"),
+                       ["-p", "Summarize", "--skip-trust"])
+    }
+
+    func test_gemini_arguments_append_model_with_short_flag() {
+        // Gemini uses `-m`, unlike claude/cursor's `--model`.
+        XCTAssertEqual(
+            LLMTool.gemini.arguments(prompt: "Summarize", model: "gemini-2.5-flash"),
+            ["-p", "Summarize", "--skip-trust", "-m", "gemini-2.5-flash"])
+    }
+
+    func test_gemini_arguments_blank_model_is_omitted() {
+        XCTAssertEqual(LLMTool.gemini.arguments(prompt: "Summarize", model: "   "),
+                       ["-p", "Summarize", "--skip-trust"])
+    }
+
+    func test_gemini_arguments_ignore_session() {
+        // Gemini's -p mode has no conversation-resume flag; a session value
+        // must not leak flags into argv.
+        let args = LLMTool.gemini.arguments(prompt: "Summarize",
+                                            session: .new(UUID()))
+        XCTAssertEqual(args, ["-p", "Summarize", "--skip-trust"])
+    }
+
+    // MARK: - Executable lookup directories
+
+    func test_searchDirectories_includes_version_manager_bins() {
+        let dirs = LLMRunner.searchDirectories(home: "/Users/tester", pathEnv: nil)
+        XCTAssertTrue(dirs.contains("/Users/tester/.volta/bin"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/Users/tester/.asdf/shims"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/Users/tester/.npm-global/bin"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/opt/homebrew/bin"), "\(dirs)")
+    }
+
+    func test_searchDirectories_prepends_PATH_entries_in_order() {
+        let dirs = LLMRunner.searchDirectories(home: "/Users/tester",
+                                               pathEnv: "/a:/b")
+        XCTAssertEqual(Array(dirs.prefix(2)), ["/a", "/b"])
+    }
+
+    func test_searchDirectories_enumerates_nvm_versions_newest_first() throws {
+        // Build a fake home with two nvm node versions; the newer one must
+        // sort ahead so a global CLI installed under it wins.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-nvm-\(UUID().uuidString)")
+        let nodeRoot = home.appendingPathComponent(".nvm/versions/node")
+        for v in ["v20.1.0", "v22.15.0"] {
+            try FileManager.default.createDirectory(
+                at: nodeRoot.appendingPathComponent("\(v)/bin"),
+                withIntermediateDirectories: true)
+        }
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let dirs = LLMRunner.searchDirectories(home: home.path, pathEnv: nil)
+        let nvmDirs = dirs.filter { $0.contains("/.nvm/versions/node/") }
+        XCTAssertEqual(nvmDirs, [
+            "\(home.path)/.nvm/versions/node/v22.15.0/bin",
+            "\(home.path)/.nvm/versions/node/v20.1.0/bin",
+        ], "nvm version bins must be present, newest first: \(dirs)")
+    }
+
+    func test_childEnvironment_prepends_executable_dir_to_PATH() {
+        // node-shebang CLIs (gemini) need their sibling `node` on PATH; the
+        // resolved binary's own dir must come first so that install wins.
+        let exe = URL(fileURLWithPath: "/Users/tester/.nvm/versions/node/v22.15.0/bin/gemini")
+        let env = LLMRunner.childEnvironment(for: exe, base: ["PATH": "/usr/bin"])
+        let path = env["PATH"] ?? ""
+        let entries = path.split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.first, "/Users/tester/.nvm/versions/node/v22.15.0/bin",
+                       "executable dir must be first: \(path)")
+        XCTAssertTrue(entries.contains("/usr/bin"), "inherited PATH must survive: \(path)")
+        XCTAssertTrue(entries.contains("/opt/homebrew/bin"), "well-known dirs must be added: \(path)")
+    }
+
+    func test_childEnvironment_dedupes_and_preserves_other_vars() {
+        let exe = URL(fileURLWithPath: "/opt/homebrew/bin/claude")
+        let env = LLMRunner.childEnvironment(
+            for: exe, base: ["PATH": "/opt/homebrew/bin", "HOME": "/Users/tester"])
+        let entries = (env["PATH"] ?? "").split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.filter { $0 == "/opt/homebrew/bin" }.count, 1,
+                       "duplicate dirs must be collapsed: \(entries)")
+        XCTAssertEqual(env["HOME"], "/Users/tester", "other env vars must be inherited")
+    }
+
+    func test_searchDirectories_without_nvm_is_stable() {
+        // A home with no ~/.nvm must not crash or inject nvm dirs.
+        let dirs = LLMRunner.searchDirectories(
+            home: "/nonexistent-home-\(UUID().uuidString)", pathEnv: nil)
+        XCTAssertFalse(dirs.contains { $0.contains("/.nvm/versions/node/") })
+    }
+
+    func test_gemini_cli_returns_a_title_for_a_sample_transcript() async throws {
+        guard let geminiPath = resolve("gemini") else {
+            throw XCTSkip("gemini CLI not installed on this machine")
+        }
+        let transcript = "We agreed to migrate the staging ECR to the new account by Friday and Uri will open the PR."
+        let result = try await LLMRunner.run(
+            tool: .gemini,
+            prompt: LLMSettings.defaultNamePrompt,
+            transcript: transcript,
+            executablePathOverride: geminiPath,
+            timeout: 120
+        )
+        XCTAssertFalse(result.isEmpty, "gemini returned empty output")
+        XCTAssertLessThan(result.count, 200,
+                          "gemini reply looks like prose, not a title: \(result)")
     }
 }

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -61,6 +61,31 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    /// Mid-recording copy button: `clipboardText` must match the detail
+    /// view's copy format — the plain fullText join while nobody is
+    /// labelled, speaker-prefixed turns once live diarization kicks in.
+    func test_clipboardText_matches_detail_copy_format() async {
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "hello"),
+            TranscriptSegment(start: 2, end: 3, text: "hi there")
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+
+        // No speakers yet -> plain joined text, no prefixes.
+        XCTAssertEqual(transcriber.clipboardText, "hello hi there")
+
+        transcriber.applySpeakerLabels([
+            (start: 0, end: 1, speaker: "SPEAKER_00"),
+            (start: 2, end: 3, speaker: "SPEAKER_01")
+        ])
+        XCTAssertEqual(transcriber.clipboardText,
+                       "SPEAKER_00: hello\nSPEAKER_01: hi there")
+        _ = transcriber.stop()
+    }
+
     func test_successive_ticks_dedup_overlap_by_time() async {
         // Two ticks. Each whisper call sees the window starting at the
         // same absolute time (0s in this test because the buffer is

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -166,6 +166,97 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    /// Pausing mid-utterance must cut the current VAD utterance cleanly:
+    /// `pauseBoundary()` flushes the detector so the in-progress speech is
+    /// emitted at the pause point instead of being glued onto whatever is
+    /// said after resume. Without a boundary, the detector holds the speech
+    /// until it next sees ≥400ms of silence.
+    func test_pauseBoundary_emits_in_progress_VAD_utterance() async {
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "midway")])
+        transcriber.useVAD = true
+        transcriber.start(language: "en")
+        // 1.2s of speech energy with NO trailing silence — the detector
+        // holds it as an in-progress utterance that wouldn't emit on its own.
+        let speech = Array(repeating: Float(0.05), count: 16_000 * 12 / 10)
+        transcriber.ingest(ArraySlice(speech))
+        XCTAssertTrue(transcriber.segments.isEmpty,
+                      "utterance shouldn't emit before a silence/pause boundary")
+
+        transcriber.pauseBoundary()
+        // Await the transcribe the flush scheduled.
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["midway"],
+                       "pauseBoundary should flush the in-progress utterance to whisper")
+        _ = transcriber.stop()
+    }
+
+    // MARK: - Delete a live line
+
+    func test_removeSegment_removes_line_and_recomputes_fullText() async {
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "keep"),
+            TranscriptSegment(start: 2, end: 3, text: "remove me")
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep", "remove me"])
+
+        let victim = try! XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
+        transcriber.removeSegment(id: victim.id)
+
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep"])
+        XCTAssertEqual(transcriber.fullText, "keep")
+        _ = transcriber.stop()
+    }
+
+    /// A deleted line must not reappear when the fixed-window path
+    /// re-transcribes its rolling buffer on the next tick — the deleted
+    /// time range is suppressed.
+    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async {
+        // Both ticks emit the same two segments; after deleting "beta" it
+        // must stay gone even though tick 2 re-emits it.
+        await stub.setCannedQueue([
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ],
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ]
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha", "beta"])
+
+        let beta = try! XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
+        transcriber.removeSegment(id: beta.id)
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"])
+
+        // Next tick re-emits alpha (already present, skipped) + beta
+        // (suppressed by the deleted range).
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"],
+                       "deleted line reappeared after a re-transcription tick")
+        _ = transcriber.stop()
+    }
+
+    func test_removeSegment_unknown_id_is_a_noop() async {
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "only")])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        transcriber.removeSegment(id: UUID())
+        XCTAssertEqual(transcriber.segments.map(\.text), ["only"])
+        _ = transcriber.stop()
+    }
+
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "first"),

--- a/MilaTests/LiveTranscriptSidecarWriterTests.swift
+++ b/MilaTests/LiveTranscriptSidecarWriterTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import TranscriptionCore
+import MilaKit
+@testable import Mila
+
+@MainActor
+final class LiveTranscriptSidecarWriterTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUp() {
+        super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SidecarTests-\(UUID())", isDirectory: true)
+    }
+
+    override func tearDown() {
+        if let root { try? FileManager.default.removeItem(at: root) }
+        super.tearDown()
+    }
+
+    private func snapshot() -> LiveTranscriptSnapshot? {
+        LiveTranscriptSnapshot.read(root: root)
+    }
+
+    private func segs(_ texts: String...) -> [TranscriptSegment] {
+        texts.enumerated().map { i, t in
+            TranscriptSegment(start: Double(i), end: Double(i + 1), text: t,
+                              speaker: "SPEAKER_00")
+        }
+    }
+
+    func test_begin_writes_recording_snapshot() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: "meeting", liveAvailable: true)
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .recording)
+        XCTAssertTrue(snap.liveTranscriptAvailable)
+        XCTAssertEqual(snap.revision, 1)
+        XCTAssertEqual(snap.source, "meeting")
+        XCTAssertTrue(snap.segments.isEmpty)
+    }
+
+    func test_update_bumps_revision_and_writes_content() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: ["SPEAKER_00": "Dana"])
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.revision, 2)
+        XCTAssertEqual(snap.segments.map(\.text), ["hello"])
+        XCTAssertEqual(snap.speakerNames, ["SPEAKER_00": "Dana"])
+    }
+
+    func test_unchanged_update_does_not_bump_revision() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        XCTAssertEqual(try XCTUnwrap(snapshot()).revision, 2)
+    }
+
+    func test_trailing_write_lands_after_throttle_window() async throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0.15)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        // Two updates inside one throttle window: the second must land via
+        // the trailing write, not be dropped.
+        writer.update(segments: segs("one"), speakerNames: [:])
+        writer.update(segments: segs("one", "two"), speakerNames: [:])
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.segments.map(\.text), ["one", "two"])
+        XCTAssertEqual(snap.revision, 3)
+    }
+
+    func test_finish_marks_completed_with_handoff_id_and_stops_updates() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        let recordingID = UUID()
+        writer.finish(recordingID: recordingID)
+
+        var snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .completed)
+        XCTAssertEqual(snap.finalRecordingID, recordingID)
+
+        // Snapshot stays on disk (poller handoff) and later updates are ignored.
+        writer.update(segments: segs("late"), speakerNames: [:])
+        snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .completed)
+        XCTAssertEqual(snap.segments.map(\.text), ["hello"])
+    }
+
+    func test_gated_hardware_snapshot_reports_live_unavailable() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: false)
+        XCTAssertFalse(try XCTUnwrap(snapshot()).liveTranscriptAvailable)
+    }
+
+    func test_cleanup_at_launch_marks_leftover_recording_interrupted() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        // Simulate a crash: a fresh writer (new process) finds the stale file.
+        let relaunched = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        relaunched.cleanupAtLaunch()
+        XCTAssertEqual(try XCTUnwrap(snapshot()).state, .interrupted)
+    }
+
+    func test_new_session_gets_fresh_session_id() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        let first = try XCTUnwrap(snapshot()).sessionID
+        writer.finish(recordingID: nil)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        let second = try XCTUnwrap(snapshot()).sessionID
+        XCTAssertNotEqual(first, second)
+    }
+}

--- a/MilaTests/ObsidianExportSequencingTests.swift
+++ b/MilaTests/ObsidianExportSequencingTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Mila
+
+/// Verifies the sequencing contract between `RecordingSummarizer` and
+/// `ObsidianExporter`: a fresh completion is marked pending and exported only
+/// once the summary is ready, while a summary produced without being marked
+/// pending (e.g. launch-time backfill) is NOT exported — no vault spam.
+@MainActor
+final class ObsidianExportSequencingTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var vault: URL!
+    private var store: RecordingStore!
+    private var llmDefaults: UserDefaults!
+    private var liveDefaults: UserDefaults!
+    private var obsidianDefaults: UserDefaults!
+    private var suiteNames: [String] = []
+    private var llm: LLMSettings!
+    private var liveAI: LiveAISettings!
+    private var settings: ObsidianVaultSettings!
+    private var exporter: ObsidianExporter!
+    private var summarizer: RecordingSummarizer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianSeqTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        store = RecordingStore(rootDirectory: tempRoot.appendingPathComponent("AppSupport", isDirectory: true))
+
+        let llmSuite = "ObsidianSeq.llm.\(UUID())"
+        let liveSuite = "ObsidianSeq.live.\(UUID())"
+        let obsSuite = "ObsidianSeq.obs.\(UUID())"
+        suiteNames = [llmSuite, liveSuite, obsSuite]
+        llmDefaults = UserDefaults(suiteName: llmSuite)
+        liveDefaults = UserDefaults(suiteName: liveSuite)
+        obsidianDefaults = UserDefaults(suiteName: obsSuite)
+        llm = LLMSettings(defaults: llmDefaults)
+        llm.tool = .claude
+        liveAI = LiveAISettings(defaults: liveDefaults)
+        liveAI.model = ""
+
+        settings = ObsidianVaultSettings(defaults: obsidianDefaults)
+        settings.enabled = true
+        settings.subfolder = ""
+        XCTAssertTrue(settings.setVault(vault))
+        exporter = ObsidianExporter(settings: settings, defaults: obsidianDefaults)
+
+        // Wire the hook exactly like MilaApp does.
+        summarizer = RecordingSummarizer(store: store, llmSettings: llm, liveAISettings: liveAI,
+                                         runLLM: { _, _, _, _, _, _, _ in "A tidy summary." })
+        summarizer.onSummaryFinished = { [weak exporter] rec in
+            guard let exporter, exporter.isPending(rec.id) else { return }
+            exporter.export(rec)
+            exporter.clearPending(rec.id)
+        }
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        try await super.tearDown()
+    }
+
+    private func addRecording(fullText: String = "some transcript") -> Recording {
+        let audioURL = store.freshAudioURL(suggestedName: "Rec")
+        try? Data("x".utf8).write(to: audioURL)
+        let rec = Recording(title: "Rec", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent, fullText: fullText)
+        store.add(rec)
+        return rec
+    }
+
+    func test_pending_recording_is_exported_after_summary() async throws {
+        let rec = addRecording()
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path),
+                      "a pending recording should be written once its summary lands")
+        let contents = try String(contentsOf: expected, encoding: .utf8)
+        XCTAssertTrue(contents.contains("A tidy summary."))
+    }
+
+    func test_non_pending_summary_is_not_exported() async throws {
+        let rec = addRecording()
+        // No markPending — models a backfill sweep.
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a summary produced without a pending mark must not be filed")
+    }
+
+    func test_pending_export_falls_back_to_transcript_when_summaries_disabled() async throws {
+        llm.summaryEnabled = false   // no summary will be generated
+        let rec = addRecording(fullText: "the raw transcript body")
+        exporter.markPending(rec.id)
+        // summarizeIfNeeded skips synchronously and fires onSummaryFinished.
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path))
+        let contents = try String(contentsOf: expected, encoding: .utf8)
+        XCTAssertTrue(contents.contains("## Transcript"))
+        XCTAssertTrue(contents.contains("the raw transcript body"))
+    }
+}

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class ObsidianExporterTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var vault: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var settings: ObsidianVaultSettings!
+    private var exporter: ObsidianExporter!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianExporterTests-\(UUID())", isDirectory: true)
+        vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        suiteName = "ObsidianExporterTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+        settings = ObsidianVaultSettings(defaults: defaults)
+        settings.enabled = true
+        settings.subfolder = ""   // vault root for most tests
+        XCTAssertTrue(settings.setVault(vault))
+        exporter = ObsidianExporter(settings: settings, defaults: defaults)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    private func makeRecording(title: String = "Team Sync",
+                               createdAt: Date = Date(timeIntervalSince1970: 1_767_312_000), // 2026-01-02 UTC-ish
+                               summary: String? = nil,
+                               fullText: String = "",
+                               folder: String? = nil,
+                               actionItems: [ActionItem]? = nil) -> Recording {
+        var rec = Recording(title: title,
+                            createdAt: createdAt,
+                            source: .microphone,
+                            audioFileName: "a.wav",
+                            fullText: fullText)
+        rec.summary = summary
+        rec.actionItems = actionItems
+        rec.folder = folder
+        return rec
+    }
+
+    private func action(_ text: String) -> ActionItem {
+        ActionItem(id: UUID().uuidString, text: text, speaker: nil,
+                   timestampSeconds: 0, source: .llmInferred, addedAt: Date())
+    }
+
+    // MARK: - Formatting
+
+    func test_markdown_uses_summary_and_action_items() {
+        let rec = makeRecording(summary: "We decided to ship next week.",
+                                fullText: "long transcript here",
+                                actionItems: [action("Ship it"), action("Email Sam")])
+        let md = ObsidianExporter.markdown(for: rec)
+        XCTAssertTrue(md.contains("# Team Sync"))
+        XCTAssertTrue(md.contains("We decided to ship next week."))
+        XCTAssertTrue(md.contains("- [ ] Ship it"))
+        XCTAssertTrue(md.contains("- [ ] Email Sam"))
+        XCTAssertFalse(md.contains("## Transcript"),
+                       "When a summary exists the transcript body is omitted")
+    }
+
+    func test_markdown_falls_back_to_transcript_without_summary() {
+        let rec = makeRecording(summary: nil, fullText: "hello world transcript",
+                                actionItems: [action("Do thing")])
+        let md = ObsidianExporter.markdown(for: rec)
+        XCTAssertTrue(md.contains("## Transcript"))
+        XCTAssertTrue(md.contains("hello world transcript"))
+        XCTAssertTrue(md.contains("- [ ] Do thing"))
+    }
+
+    func test_hasContent_false_when_nothing_present() {
+        let empty = makeRecording(summary: nil, fullText: "", actionItems: nil)
+        XCTAssertFalse(ObsidianExporter.hasContent(empty))
+        XCTAssertTrue(ObsidianExporter.hasContent(makeRecording(fullText: "x")))
+    }
+
+    func test_fileName_is_date_and_sanitized_title() {
+        let rec = makeRecording(title: "My/Meeting: Q3?")
+        let name = ObsidianExporter.fileName(for: rec)
+        XCTAssertTrue(name.hasSuffix(".md"))
+        XCTAssertFalse(name.contains("/"))
+        XCTAssertFalse(name.contains(":"))
+        XCTAssertFalse(name.contains("?"))
+        XCTAssertTrue(name.contains("My Meeting Q3"))
+    }
+
+    // MARK: - Writing
+
+    func test_export_writes_note_into_vault() throws {
+        let rec = makeRecording(summary: "S", actionItems: [action("A")])
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(contents.contains("# Team Sync"))
+        XCTAssertTrue(contents.contains("- [ ] A"))
+    }
+
+    func test_export_creates_configured_subfolder() throws {
+        settings.subfolder = "Notes/Sub"
+        let rec = makeRecording(summary: "S")
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes/Sub").standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func test_export_noop_when_disabled() {
+        settings.enabled = false
+        XCTAssertNil(exporter.export(makeRecording(summary: "S")))
+    }
+
+    func test_export_noop_when_recording_is_empty() {
+        XCTAssertNil(exporter.export(makeRecording(summary: nil, fullText: "", actionItems: nil)))
+    }
+
+    func test_reexport_with_changed_title_removes_the_old_file() throws {
+        var rec = makeRecording(title: "First", summary: "S")
+        let firstURL = try XCTUnwrap(exporter.export(rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: firstURL.path))
+
+        rec.title = "Second"   // same id + date, new title
+        let secondURL = try XCTUnwrap(exporter.export(rec))
+        XCTAssertNotEqual(firstURL.path, secondURL.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: secondURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstURL.path),
+                       "The previously-written note for this recording must be removed")
+    }
+
+    func test_export_mirrors_mila_folder_under_subfolder() throws {
+        settings.subfolder = "Notes"
+        let rec = makeRecording(summary: "S", folder: "Client: Acme")
+        let url = try XCTUnwrap(exporter.export(rec))
+        // Folder name is sanitized (":" stripped) and nested under the subfolder.
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes/Client Acme").standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func test_export_unfiled_recording_lands_in_base_dir() throws {
+        settings.subfolder = "Notes"
+        let rec = makeRecording(summary: "S", folder: nil)
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes").standardizedFileURL)
+    }
+
+    // MARK: - Backfill (exportAll)
+
+    func test_exportAll_writes_all_with_content_and_skips_empty() throws {
+        let a = makeRecording(title: "Alpha", summary: "S")
+        let b = makeRecording(title: "Beta", fullText: "transcript", folder: "Work")
+        let empty = makeRecording(title: "Empty", summary: nil, fullText: "", actionItems: nil)
+        let count = exporter.exportAll([a, b, empty])
+        XCTAssertEqual(count, 2, "the empty recording should be skipped")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("2026-01-02 Alpha.md").path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("Work/2026-01-02 Beta.md").path),
+            "a filed recording should nest under its Mila folder")
+    }
+
+    func test_exportAll_noop_when_disabled() {
+        settings.enabled = false
+        XCTAssertEqual(exporter.exportAll([makeRecording(summary: "S")]), 0)
+    }
+
+    // MARK: - Pending gate
+
+    func test_pending_gate() {
+        let id = UUID()
+        XCTAssertFalse(exporter.isPending(id))
+        exporter.markPending(id)
+        XCTAssertTrue(exporter.isPending(id))
+        exporter.clearPending(id)
+        XCTAssertFalse(exporter.isPending(id))
+    }
+}

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Mila
+
+/// End-to-end git tests that run the REAL `git` binary (via the production
+/// `ProcessGitCommandRunner`) against a temporary working copy wired to a local
+/// bare "remote". Proves the actual add -> commit -> pull --rebase -> push flow
+/// lands commits on the remote, and that a non-conflicting remote change is
+/// rebased in rather than rejected. Skips cleanly when `git` isn't installed.
+final class ObsidianGitSyncerIntegrationTests: XCTestCase {
+
+    private var gitURL: URL!
+    private var tempRoot: URL!
+    private var home: URL!
+    private var remote: URL!
+    private var vault: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let git = ProcessGitCommandRunner.gitExecutable() else {
+            throw XCTSkip("git is not installed on this machine")
+        }
+        gitURL = git
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaGitIntegration-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        // Isolated HOME so setup commands don't read the developer's global
+        // git config (default branch name, gpg signing, hooks).
+        home = tempRoot.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+
+        remote = tempRoot.appendingPathComponent("remote.git", isDirectory: true)
+        vault = tempRoot.appendingPathComponent("vault", isDirectory: true)
+
+        // Bare remote whose default branch is `main`.
+        try runGit(["init", "--bare", remote.path], in: tempRoot)
+        try runGit(["symbolic-ref", "HEAD", "refs/heads/main"], in: remote)
+
+        // Working copy on `main` with identity + no gpg signing, an initial
+        // commit, and `origin` pointing at the bare remote.
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        try runGit(["init", vault.path], in: tempRoot)
+        try configureRepo(vault)
+        try runGit(["checkout", "-b", "main"], in: vault)
+        try write("# vault\n", to: vault.appendingPathComponent("README.md"))
+        try runGit(["add", "."], in: vault)
+        try runGit(["commit", "-m", "init"], in: vault)
+        try runGit(["remote", "add", "origin", remote.path], in: vault)
+        try runGit(["push", "-u", "origin", "main"], in: vault)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Tests
+
+    func test_sync_commits_and_pushes_note_to_remote() async throws {
+        let note = vault.appendingPathComponent("2026-01-02 Meeting.md")
+        try write("# Meeting\n\nSummary body.\n", to: note)
+
+        let syncer = ObsidianGitSyncer()   // real ProcessGitCommandRunner
+        let error = await syncer.sync(vault: vault,
+                                      changedPaths: [note],
+                                      branch: "main",
+                                      commitMessage: "Add transcript: Meeting")
+        XCTAssertNil(error, "expected a clean sync, got: \(error ?? "")")
+
+        // The remote now carries the commit and the file's content.
+        let log = try runGit(["log", "--oneline"], in: remote)
+        XCTAssertTrue(log.contains("Add transcript: Meeting"),
+                      "remote log should contain the note commit; got:\n\(log)")
+        let show = try runGit(["show", "main:2026-01-02 Meeting.md"], in: remote)
+        XCTAssertTrue(show.contains("Summary body."),
+                      "remote should hold the pushed note content")
+    }
+
+    func test_sync_rebases_nonconflicting_remote_change_and_pushes() async throws {
+        // A second checkout pushes an unrelated file, so the remote `main` is
+        // now ahead of the vault.
+        let other = tempRoot.appendingPathComponent("other", isDirectory: true)
+        try runGit(["clone", remote.path, other.path], in: tempRoot)
+        try configureRepo(other)
+        try write("remote-added\n", to: other.appendingPathComponent("b.md"))
+        try runGit(["add", "."], in: other)
+        try runGit(["commit", "-m", "remote change b"], in: other)
+        try runGit(["push", "origin", "HEAD:main"], in: other)
+
+        // The vault writes its own note and syncs; pull --rebase must fold in
+        // the remote's commit, then push both.
+        let note = vault.appendingPathComponent("a.md")
+        try write("local-added\n", to: note)
+        let syncer = ObsidianGitSyncer()
+        let error = await syncer.sync(vault: vault,
+                                      changedPaths: [note],
+                                      branch: "main",
+                                      commitMessage: "Add transcript: A")
+        XCTAssertNil(error, "expected a clean rebase+push, got: \(error ?? "")")
+
+        let files = try runGit(["ls-tree", "--name-only", "main"], in: remote)
+        XCTAssertTrue(files.contains("a.md"), "the vault's note must be pushed; got:\n\(files)")
+        XCTAssertTrue(files.contains("b.md"), "the remote's commit must be preserved; got:\n\(files)")
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func runGit(_ arguments: [String], in directory: URL) throws -> String {
+        let process = Process()
+        process.executableURL = gitURL
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+        var env = ProcessInfo.processInfo.environment
+        env["HOME"] = home.path
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        process.environment = env
+
+        let out = Pipe(), err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+        process.waitUntilExit()
+        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        if process.terminationStatus != 0 {
+            throw NSError(domain: "git", code: Int(process.terminationStatus), userInfo: [
+                NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stderr)\(stdout)"
+            ])
+        }
+        return stdout
+    }
+
+    private func configureRepo(_ repo: URL) throws {
+        try runGit(["config", "user.email", "test@example.com"], in: repo)
+        try runGit(["config", "user.name", "Mila Test"], in: repo)
+        try runGit(["config", "commit.gpgsign", "false"], in: repo)
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/MilaTests/ObsidianGitSyncerTests.swift
+++ b/MilaTests/ObsidianGitSyncerTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Mila
+
+/// Records every git invocation and returns programmable results, so we can
+/// assert the command sequence without a real repo. An actor because
+/// `ObsidianGitSyncer` calls it from actor-isolated context and reads must be
+/// awaited afterwards.
+private actor FakeGitRunner: GitCommandRunning {
+    private(set) var calls: [[String]] = []
+    private let handler: @Sendable ([String]) -> GitCommandResult
+
+    init(handler: @escaping @Sendable ([String]) -> GitCommandResult) {
+        self.handler = handler
+    }
+
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult {
+        calls.append(arguments)
+        return handler(arguments)
+    }
+}
+
+private func ok(_ stdout: String = "") -> GitCommandResult {
+    GitCommandResult(exitCode: 0, stdout: stdout, stderr: "", timedOut: false)
+}
+
+private func fail(_ stderr: String) -> GitCommandResult {
+    GitCommandResult(exitCode: 1, stdout: "", stderr: stderr, timedOut: false)
+}
+
+final class ObsidianGitSyncerTests: XCTestCase {
+
+    private let vault = URL(fileURLWithPath: "/repo/vault")
+    private let file = URL(fileURLWithPath: "/repo/vault/note.md")
+
+    func test_happy_path_runs_add_commit_rebase_push_in_order() async {
+        let fake = FakeGitRunner { args in
+            args.first == "rev-parse" ? ok("/repo") : ok()
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "Add transcript: T")
+        XCTAssertNil(error)
+        let calls = await fake.calls
+        XCTAssertEqual(calls, [
+            ["rev-parse", "--show-toplevel"],
+            ["add", "--all", "--", file.path],
+            ["commit", "-m", "Add transcript: T"],
+            ["pull", "--rebase", "origin", "main"],
+            ["push", "origin", "HEAD:main"],
+        ])
+    }
+
+    func test_not_a_repo_returns_error_and_stops() async {
+        let fake = FakeGitRunner { _ in fail("not a git repository") }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        let calls = await fake.calls
+        XCTAssertEqual(calls, [["rev-parse", "--show-toplevel"]])
+    }
+
+    func test_nothing_to_commit_still_pulls_and_pushes() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "commit": return fail("nothing to commit, working tree clean")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNil(error, "an unchanged note is not a failure")
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "main"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:main"]))
+    }
+
+    func test_rebase_conflict_aborts_and_does_not_push() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "pull": return fail("CONFLICT (content): Merge conflict")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["rebase", "--abort"]),
+                      "a rebase conflict must be aborted so the vault isn't left mid-rebase")
+        XCTAssertFalse(calls.contains(where: { $0.first == "push" }),
+                       "push must not run after a failed rebase")
+    }
+
+    func test_push_failure_is_surfaced() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "push": return fail("Permission denied (publickey)")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error?.contains("push") == true)
+    }
+
+    func test_branch_is_honored() async {
+        let fake = FakeGitRunner { args in args.first == "rev-parse" ? ok("/repo") : ok() }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        _ = await syncer.sync(vault: vault, changedPaths: [file],
+                              branch: "notes", commitMessage: "m")
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "notes"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:notes"]))
+    }
+}

--- a/MilaTests/ObsidianVaultSettingsTests.swift
+++ b/MilaTests/ObsidianVaultSettingsTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class ObsidianVaultSettingsTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianVaultTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        suiteName = "ObsidianVaultSettingsTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    func test_defaults_are_off_with_transcripts_subfolder_and_main_branch() {
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertFalse(settings.enabled)
+        XCTAssertNil(settings.vaultURL)
+        XCTAssertEqual(settings.subfolder, "Transcripts")
+        XCTAssertFalse(settings.gitSyncEnabled)
+        XCTAssertEqual(settings.gitBranch, "main")
+    }
+
+    func test_setVault_persists_bookmark_and_resolves_on_relaunch() throws {
+        let vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let first = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(first.setVault(vault))
+        XCTAssertEqual(first.vaultURL?.standardizedFileURL, vault.standardizedFileURL)
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertEqual(second.vaultURL?.standardizedFileURL, vault.standardizedFileURL)
+    }
+
+    func test_clearVault_removes_the_bookmark() throws {
+        let vault = tempRoot.appendingPathComponent("Vault2", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(settings.setVault(vault))
+        settings.clearVault()
+        XCTAssertNil(settings.vaultURL)
+        XCTAssertNil(defaults.data(forKey: ObsidianVaultSettings.bookmarkKey))
+    }
+
+    func test_resolution_falls_back_when_folder_deleted() throws {
+        let vault = tempRoot.appendingPathComponent("Gone", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let first = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(first.setVault(vault))
+        try FileManager.default.removeItem(at: vault)
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertNil(second.vaultURL)
+    }
+
+    func test_enabled_subfolder_git_persist_across_instances() {
+        let first = ObsidianVaultSettings(defaults: defaults)
+        first.enabled = true
+        first.subfolder = "Meetings/2026"
+        first.gitSyncEnabled = true
+        first.gitBranch = "notes"
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(second.enabled)
+        XCTAssertEqual(second.subfolder, "Meetings/2026")
+        XCTAssertTrue(second.gitSyncEnabled)
+        XCTAssertEqual(second.gitBranch, "notes")
+    }
+
+    func test_destinationDirectory_appends_subfolder_and_strips_slashes() throws {
+        let vault = tempRoot.appendingPathComponent("VaultD", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(settings.setVault(vault))
+        // Compare against the RESOLVED vault URL (bookmark resolution can
+        // return a /private-prefixed path) and via `.path`, which drops the
+        // trailing slash `appendingPathComponent(isDirectory:)` adds.
+        let base = try XCTUnwrap(settings.vaultURL)
+
+        settings.subfolder = "/Transcripts/"
+        XCTAssertEqual(settings.destinationDirectory?.standardizedFileURL.path,
+                       base.appendingPathComponent("Transcripts").standardizedFileURL.path)
+
+        settings.subfolder = "   "
+        XCTAssertEqual(settings.destinationDirectory?.standardizedFileURL.path,
+                       base.standardizedFileURL.path,
+                       "Blank subfolder should target the vault root")
+    }
+}

--- a/MilaTests/ProgressCoalescerTests.swift
+++ b/MilaTests/ProgressCoalescerTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Mila
+
+/// Unit tests for `ProgressCoalescer` — the piece that stopped whisper's
+/// high-frequency progress callbacks from flooding the main actor with one
+/// `Task` per tick (and applying them out of order). See the UI-freeze fix in
+/// `docs/PLAN-ui-render-flood-freeze.md`.
+final class ProgressCoalescerTests: XCTestCase {
+
+    /// The first `offer` schedules a flush; further offers while that flush is
+    /// still pending do NOT — that single-pending-flush property is what caps
+    /// the flood.
+    func test_only_first_offer_schedules_until_flushed() {
+        let c = ProgressCoalescer()
+        XCTAssertTrue(c.offer(0.1), "first offer should schedule a flush")
+        XCTAssertFalse(c.offer(0.2), "second offer with a flush pending must not schedule")
+        XCTAssertFalse(c.offer(0.3), "third offer with a flush pending must not schedule")
+        _ = c.flush()
+        XCTAssertTrue(c.offer(0.4), "after a flush, the next offer schedules again")
+    }
+
+    /// `flush` returns the max of everything offered since the last flush —
+    /// intermediate values are coalesced, the latest/highest wins.
+    func test_flush_returns_max_offered() {
+        let c = ProgressCoalescer()
+        _ = c.offer(0.1)
+        _ = c.offer(0.5)
+        _ = c.offer(0.4)
+        XCTAssertEqual(c.flush(), 0.5, accuracy: 1e-9,
+                       "flush must return the highest value offered in the window")
+    }
+
+    /// Out-of-order offers never regress the reported value: progress only ever
+    /// moves forward, so the bar can't jump backward or freeze below a value it
+    /// already passed.
+    func test_progress_is_monotonic_across_flushes() {
+        let c = ProgressCoalescer()
+        _ = c.offer(0.2)
+        XCTAssertEqual(c.flush(), 0.2, accuracy: 1e-9)
+
+        // A stale, lower value arriving later must not lower the reported value.
+        _ = c.offer(0.15)
+        XCTAssertEqual(c.flush(), 0.2, accuracy: 1e-9,
+                       "a lower late value must not regress progress")
+
+        _ = c.offer(1.0)
+        XCTAssertEqual(c.flush(), 1.0, accuracy: 1e-9)
+    }
+
+    /// A realistic burst: many rapid offers collapse to a single scheduled
+    /// flush that reports the final value.
+    func test_burst_collapses_to_single_flush_with_final_value() {
+        let c = ProgressCoalescer()
+        var scheduledCount = 0
+        for i in 0...100 {
+            if c.offer(Double(i) / 100.0) { scheduledCount += 1 }
+        }
+        XCTAssertEqual(scheduledCount, 1, "a burst with no interleaved flush schedules exactly once")
+        XCTAssertEqual(c.flush(), 1.0, accuracy: 1e-9, "flush reports the final (max) value")
+    }
+}

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -99,6 +99,48 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertTrue(session.state == .idle)
     }
 
+    // MARK: - Next-recording folder default
+
+    /// The next-recording folder must always default to All Transcriptions
+    /// (nil) on a fresh controller, even if a previous session left a value
+    /// in UserDefaults — the choice is per-session, not sticky across
+    /// launches.
+    func test_nextRecordingFolder_defaults_to_all_transcriptions() {
+        UserDefaults.standard.set("Stale Folder", forKey: "quickActions.nextRecordingFolder")
+        defer { UserDefaults.standard.removeObject(forKey: "quickActions.nextRecordingFolder") }
+        let fresh = QuickActionsController(
+            session: RecordingSession(),
+            store: store,
+            transcription: service,
+            languageSettings: languageSettings,
+            postRecording: PostRecordingCoordinator(
+                store: store,
+                transcription: service,
+                llm: LLMSettings(defaults: UserDefaults(suiteName: "QuickActionsControllerTests.llm2")!)))
+        XCTAssertNil(fresh.nextRecordingFolder,
+                     "next-recording folder must default to All Transcriptions, not a persisted folder")
+    }
+
+    // MARK: - Resolved recording title (meeting name override)
+
+    /// An empty or whitespace-only meeting name falls back to the
+    /// auto-generated date-stamped default title.
+    func test_resolvedRecordingTitle_falls_back_to_default_when_empty() {
+        let def = "Recording · Jul 20, 2026"
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "", defaultTitle: def), def)
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "   \n\t", defaultTitle: def), def)
+    }
+
+    /// A non-empty meeting name wins over the default and is trimmed of
+    /// surrounding whitespace.
+    func test_resolvedRecordingTitle_prefers_trimmed_user_title() {
+        let def = "Recording · Jul 20, 2026"
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "Weekly Sync", defaultTitle: def),
+                       "Weekly Sync")
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "  Weekly Sync  ", defaultTitle: def),
+                       "Weekly Sync")
+    }
+
     // MARK: - File import → enqueue → transcribe
 
     func test_transcribe_file_adds_recording_and_kicks_off_transcription() async throws {

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -62,6 +62,43 @@ final class QuickActionsControllerTests: XCTestCase {
         try await super.tearDown()
     }
 
+    // MARK: - Pause / resume
+
+    /// Pause and resume drive the session state through the controller.
+    /// Uses the fake-start seam so no real mic/engine is needed on CI.
+    func test_pause_and_resume_toggle_session_state() async {
+        let url = store.freshAudioURL(suggestedName: "PauseTest")
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertFalse(controller.isPaused)
+
+        controller.pauseRecording()
+        XCTAssertTrue(controller.isPaused)
+        XCTAssertTrue(session.state == .paused)
+
+        // Double-pause is a no-op — stays paused.
+        controller.pauseRecording()
+        XCTAssertTrue(session.state == .paused)
+
+        // togglePause resumes.
+        controller.togglePause()
+        XCTAssertFalse(controller.isPaused)
+        XCTAssertTrue(session.state == .recording)
+
+        _ = await session.stop()
+    }
+
+    /// Pause/resume are guarded no-ops when nothing is recording, so a
+    /// stray keyboard shortcut / menu action can't corrupt session state.
+    func test_pause_is_noop_when_not_recording() {
+        XCTAssertFalse(controller.isRecording)
+        controller.pauseRecording()
+        XCTAssertFalse(controller.isPaused)
+        XCTAssertTrue(session.state == .idle)
+        controller.resumeRecording()
+        XCTAssertTrue(session.state == .idle)
+    }
+
     // MARK: - File import → enqueue → transcribe
 
     func test_transcribe_file_adds_recording_and_kicks_off_transcription() async throws {

--- a/MilaTests/RecordingSessionPauseTests.swift
+++ b/MilaTests/RecordingSessionPauseTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Mila
+
+/// Tests for the pause/resume additions to `RecordingSession`. The audio
+/// engine itself can't run on CI, so these cover the parts that don't need
+/// it: the pure elapsed-time accounting and the state machine driven via
+/// the fake-start seam (`startFakeForTesting`).
+@MainActor
+final class RecordingSessionPauseTests: XCTestCase {
+
+    // MARK: - Pure elapsed accounting
+
+    func test_elapsed_excludes_paused_time() {
+        let start = Date()
+        let now = start.addingTimeInterval(30)
+        XCTAssertEqual(RecordingSession.elapsed(now: now, startTime: start, totalPaused: 0),
+                       30, accuracy: 0.001)
+        // 10s of that 30s wall-clock was spent paused → 20s of recorded time.
+        XCTAssertEqual(RecordingSession.elapsed(now: now, startTime: start, totalPaused: 10),
+                       20, accuracy: 0.001)
+    }
+
+    func test_elapsed_never_goes_negative() {
+        let start = Date()
+        // Clock skew / rounding must never produce a negative elapsed.
+        XCTAssertEqual(RecordingSession.elapsed(now: start, startTime: start, totalPaused: 5),
+                       0, accuracy: 0.001)
+    }
+
+    // MARK: - State machine
+
+    func test_pause_and_resume_toggle_state() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        XCTAssertTrue(session.state == .recording)
+
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        // Double-pause is a no-op.
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        session.resume()
+        XCTAssertTrue(session.state == .recording)
+
+        // Double-resume is a no-op.
+        session.resume()
+        XCTAssertTrue(session.state == .recording)
+
+        _ = await session.stop()
+        XCTAssertTrue(session.state == .idle)
+    }
+
+    func test_pause_and_resume_are_noops_when_idle() {
+        let session = RecordingSession()
+        XCTAssertTrue(session.state == .idle)
+        session.pause()
+        XCTAssertTrue(session.state == .idle)
+        session.resume()
+        XCTAssertTrue(session.state == .idle)
+    }
+
+    /// Stop must work while paused (the user can hit Stop without resuming
+    /// first) and return the recording's URL, landing back at `.idle`.
+    func test_stop_while_paused_returns_url_and_idles() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-stop-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        let out = await session.stop()
+        XCTAssertEqual(out, url)
+        XCTAssertTrue(session.state == .idle)
+    }
+}

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -64,6 +64,45 @@ final class RecordingStoreTests: XCTestCase {
                       "Tombstones must persist across store instances")
     }
 
+    func test_setSpeakerName_sets_clears_and_persists() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Meeting", source: .meeting,
+                            audioFileName: "meeting.wav",
+                            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")])
+        store.add(rec)
+
+        store.setSpeakerName("  Daniel ", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(store.recordings.first?.speakerNames, ["SPEAKER_00": "Daniel"],
+                       "Name must be trimmed and stored keyed by the raw ID")
+
+        // Survives a relaunch via recordings.json.
+        let reloaded = RecordingStore(rootDirectory: tempRoot)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, ["SPEAKER_00": "Daniel"])
+
+        // nil (and empty/whitespace) clears the assignment.
+        reloaded.setSpeakerName(nil, forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, [:])
+        reloaded.setSpeakerName("Noa", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        reloaded.setSpeakerName("   ", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+        XCTAssertEqual(reloaded.recordings.first?.speakerNames, [:])
+    }
+
+    func test_setSpeakerName_regenerates_srt_sidecar_for_completed_recording() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let rec = Recording(title: "Meeting", source: .meeting,
+                            audioFileName: "meeting.wav",
+                            status: .completed,
+                            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")])
+        store.add(rec)
+
+        store.setSpeakerName("Daniel", forSpeaker: "SPEAKER_00", recordingID: rec.id)
+
+        let srtURL = store.recordingsDirectory.appendingPathComponent("meeting.srt")
+        let srt = try String(contentsOf: srtURL, encoding: .utf8)
+        XCTAssertTrue(srt.contains("Daniel: hi"),
+                      "The on-disk .srt sidecar must be rewritten with the assigned name")
+    }
+
     func test_permanently_deleting_non_import_leaves_no_tombstone() {
         let store = RecordingStore(rootDirectory: tempRoot)
         let rec = Recording(title: "Mic recording", source: .microphone,

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MilaKit
 @testable import Mila
 
 @MainActor
@@ -596,5 +597,30 @@ final class RecordingStoreTests: XCTestCase {
         store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
         XCTAssertEqual(store.softDeleteVoiceMemos(fromFolderID: "FOLDER-UNKNOWN"), 0)
         XCTAssertFalse(store.recordings.first?.isTrashed ?? true)
+    }
+
+    // MARK: - Store-location pointer (mila-mcp discovery contract)
+
+    func test_init_writes_store_location_pointer_at_root() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory, store.recordingsDirectory.path)
+        XCTAssertEqual(pointer.storeFile, store.storeURL.path)
+    }
+
+    func test_relocate_updates_pointer_and_reset_restores_it() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let custom = tempRoot.appendingPathComponent("Elsewhere", isDirectory: true)
+
+        store.relocateRecordings(to: custom)
+        var pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory, custom.path)
+        XCTAssertEqual(pointer.storeFile,
+                       custom.appendingPathComponent("recordings.json").path)
+
+        store.relocateRecordings(to: nil)
+        pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory,
+                       store.defaultRecordingsDirectory.path)
     }
 }

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -446,6 +446,76 @@ final class RecordingStoreTests: XCTestCase {
                        "Whitespace-only summary must be treated as empty")
     }
 
+    // MARK: - Empty Trash (bulk permanent delete)
+
+    /// `emptyTrash()` removes every trashed recording (metadata + on-disk
+    /// audio) in one pass while leaving live recordings untouched, and
+    /// returns the count it removed.
+    func test_empty_trash_removes_only_trashed_recordings_and_their_files() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+
+        // Two trashed recordings with real audio on disk.
+        let trashedURLs: [URL] = try (0..<2).map { i in
+            let url = store.freshAudioURL(suggestedName: "Trashed\(i)")
+            try Data(repeating: 0, count: 512).write(to: url)
+            let rec = Recording(title: "Trashed\(i)", source: .microphone,
+                                audioFileName: url.lastPathComponent)
+            store.add(rec)
+            store.softDelete(rec)
+            return url
+        }
+
+        // One live recording that must survive.
+        let liveURL = store.freshAudioURL(suggestedName: "Live")
+        try Data(repeating: 0, count: 512).write(to: liveURL)
+        let live = Recording(title: "Live", source: .microphone,
+                             audioFileName: liveURL.lastPathComponent)
+        store.add(live)
+
+        let removed = store.emptyTrash()
+
+        XCTAssertEqual(removed, 2)
+        XCTAssertTrue(store.recordings(in: .recentlyDeleted).isEmpty)
+        XCTAssertEqual(store.recordings.map(\.id), [live.id])
+        for url in trashedURLs {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path),
+                           "Trashed audio should be gone")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: liveURL.path),
+                      "Live recording's audio must be untouched")
+
+        // Removal persists across relaunch.
+        let reloaded = RecordingStore(rootDirectory: tempRoot)
+        XCTAssertEqual(reloaded.recordings.map(\.id), [live.id])
+    }
+
+    /// Emptying an already-empty trash is a no-op that reports zero.
+    func test_empty_trash_is_noop_when_trash_empty() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let live = Recording(title: "Live", source: .microphone, audioFileName: "l.wav")
+        store.add(live)
+
+        XCTAssertEqual(store.emptyTrash(), 0)
+        XCTAssertEqual(store.recordings.map(\.id), [live.id])
+    }
+
+    /// Bulk empty must tombstone trashed Voice-Memo imports (same contract as
+    /// the per-row permanent delete) so the next sync doesn't resurrect them.
+    func test_empty_trash_tombstones_trashed_voice_memo_imports() {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let memo = voiceMemoImport("a", fromFolderID: "FOLDER-1")
+        store.add(memo)
+        store.softDelete(memo)
+
+        store.emptyTrash()
+
+        XCTAssertTrue(store.voiceMemoTombstones.contains("unique-a"),
+                      "Emptying the trash must tombstone deleted voice-memo imports")
+        let reloaded = RecordingStore(rootDirectory: tempRoot)
+        XCTAssertTrue(reloaded.voiceMemoTombstones.contains("unique-a"),
+                      "Tombstones from Empty Trash must persist across relaunch")
+    }
+
     // MARK: - Stopping a queued/running transcription
 
     /// Stopping a `.running` recording from the Queue moves it to Recently

--- a/MilaTests/RecordingTests.swift
+++ b/MilaTests/RecordingTests.swift
@@ -44,6 +44,48 @@ final class RecordingTests: XCTestCase {
                        "fullText key must not appear in the JSON-encoded blob")
     }
 
+    func test_speakerNames_round_trip_and_are_omitted_when_empty() throws {
+        let named = Recording(
+            title: "Named",
+            source: .meeting,
+            audioFileName: "named.wav",
+            segments: [.init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00")],
+            speakerNames: ["SPEAKER_00": "Daniel"]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let decoded = try decoder.decode(Recording.self, from: encoder.encode(named))
+        XCTAssertEqual(decoded.speakerNames, ["SPEAKER_00": "Daniel"])
+
+        // Recordings with no renames must not grow a noise key in
+        // recordings.json.
+        let unnamed = Recording(title: "Plain", source: .microphone, audioFileName: "p.wav")
+        let json = String(data: try encoder.encode(unnamed), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"speakerNames\""))
+    }
+
+    func test_legacy_records_without_speakerNames_decode_to_empty_map() throws {
+        let legacy = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Legacy",
+          "createdAt": "2025-01-01T00:00:00Z",
+          "duration": 1.0,
+          "source": "microphone",
+          "audioFileName": "Legacy.wav",
+          "status": "completed",
+          "language": "en"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Recording.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded.speakerNames, [:])
+    }
+
     func test_legacy_records_with_inline_fullText_still_decode() throws {
         // Records persisted under the pre-sidecar schema had `fullText`
         // inside the JSON. We have to keep decoding them so the first

--- a/MilaTests/SpeakerDirectoryTests.swift
+++ b/MilaTests/SpeakerDirectoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class SpeakerDirectoryTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaTests-SpeakerDirectory-\(UUID())", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        super.tearDown()
+    }
+
+    func test_add_trims_and_rejects_empty_input() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(dir.add("  Daniel  "), "Daniel")
+        XCTAssertNil(dir.add("   "))
+        XCTAssertNil(dir.add(""))
+        XCTAssertEqual(dir.names, ["Daniel"])
+    }
+
+    func test_add_dedupes_case_insensitively_returning_canonical_spelling() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(dir.add("Daniel"), "Daniel")
+        // Re-adding with different casing must NOT create a duplicate and
+        // must hand back the existing spelling — the picker relies on this
+        // to land typed names on the canonical entry.
+        XCTAssertEqual(dir.add("daniel"), "Daniel")
+        XCTAssertEqual(dir.names, ["Daniel"])
+    }
+
+    func test_names_stay_sorted() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("noa")
+        dir.add("Avi")
+        dir.add("dana")
+        XCTAssertEqual(dir.names, ["Avi", "dana", "noa"])
+    }
+
+    func test_remove_deletes_case_insensitively() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("Daniel")
+        dir.remove("DANIEL")
+        XCTAssertTrue(dir.names.isEmpty)
+    }
+
+    func test_matches_filters_case_insensitively_and_empty_query_returns_all() {
+        let dir = SpeakerDirectory(directory: tempRoot)
+        dir.add("Daniel")
+        dir.add("Dana")
+        dir.add("Noa")
+        XCTAssertEqual(dir.matches(for: "da"), ["Dana", "Daniel"])
+        XCTAssertEqual(dir.matches(for: "  "), ["Dana", "Daniel", "Noa"])
+        XCTAssertEqual(dir.matches(for: "zzz"), [])
+    }
+
+    func test_names_persist_across_instances() {
+        let first = SpeakerDirectory(directory: tempRoot)
+        first.add("Daniel")
+        first.add("Noa")
+
+        let second = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(second.names, ["Daniel", "Noa"])
+
+        second.remove("Daniel")
+        let third = SpeakerDirectory(directory: tempRoot)
+        XCTAssertEqual(third.names, ["Noa"])
+    }
+}

--- a/MilaTests/SpeakerNameRemapperTests.swift
+++ b/MilaTests/SpeakerNameRemapperTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+final class SpeakerNameRemapperTests: XCTestCase {
+
+    private func seg(_ start: Double, _ end: Double, _ speaker: String?) -> TranscriptSegment {
+        TranscriptSegment(start: start, end: end, text: "t", speaker: speaker)
+    }
+
+    /// Re-key a segment list's speakers the way `rediarizeSegments` does:
+    /// same array, only `.speaker` changes per index.
+    private func rekeyed(_ old: [TranscriptSegment], to newSpeakers: [String?]) -> [TranscriptSegment] {
+        var out = old
+        for i in out.indices { out[i].speaker = newSpeakers[i] }
+        return out
+    }
+
+    func test_identity_rekey_keeps_names() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_swapped_ids_follow_the_utterances() {
+        // The offline pass assigned the IDs in the opposite order — the
+        // name must follow the person (their utterances), not the ID.
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_01", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_01": "Daniel"])
+    }
+
+    func test_merge_dominant_name_wins_by_duration() {
+        // Live over-segmented one person into 00 (8s, named) and 01 (2s,
+        // named differently); offline merges them into a single SPEAKER_00.
+        let old = [seg(0, 8, "SPEAKER_00"), seg(8, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(
+            names: ["SPEAKER_00": "Daniel", "SPEAKER_01": "Noa"],
+            from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_split_propagates_name_to_both_halves() {
+        // Live lumped two utterances under one (named) speaker; offline
+        // splits them. Both halves keep the name — better than silently
+        // dropping it from one, and trivially correctable in the UI.
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_00")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel", "SPEAKER_01": "Daniel"])
+    }
+
+    func test_unnamed_speakers_produce_no_entries() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_01", "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertNil(remapped["SPEAKER_00"],
+                     "The unnamed old SPEAKER_01 (now SPEAKER_00) must stay unnamed")
+    }
+
+    func test_nil_speaker_segments_are_ignored() {
+        let old = [seg(0, 5, nil), seg(5, 10, "SPEAKER_00")]
+        let new = rekeyed(old, to: [nil, "SPEAKER_00"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_empty_inputs() {
+        XCTAssertTrue(SpeakerNameRemapper.remap(names: [:], from: [], to: []).isEmpty)
+        XCTAssertTrue(SpeakerNameRemapper.remap(names: ["SPEAKER_00": "D"], from: [], to: []).isEmpty)
+    }
+
+    func test_zero_duration_segments_still_vote() {
+        // Degenerate timestamps (start == end) must not drop the vote.
+        let old = [seg(3, 3, "SPEAKER_00")]
+        let new = rekeyed(old, to: ["SPEAKER_01"])
+        let remapped = SpeakerNameRemapper.remap(names: ["SPEAKER_00": "Daniel"],
+                                                 from: old, to: new)
+        XCTAssertEqual(remapped, ["SPEAKER_01": "Daniel"])
+    }
+}

--- a/MilaTests/StoredRecordingDriftTests.swift
+++ b/MilaTests/StoredRecordingDriftTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import TranscriptionCore
+import MilaKit
+@testable import Mila
+
+/// Guards the cross-process contract between the app's `Recording`
+/// (what `RecordingStore.persist()` writes into recordings.json) and
+/// MilaKit's read-only `StoredRecording` mirror (what mila-mcp decodes).
+/// If a field is added to `Recording`'s encoder, this test is the tripwire
+/// reminding you to mirror it in `StoredRecording`.
+final class StoredRecordingDriftTests: XCTestCase {
+
+    private func storeEncoder() -> JSONEncoder {
+        // Must match RecordingStore.persist().
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+
+    private func storeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func test_fully_populated_recording_round_trips_into_stored_recording() throws {
+        let id = UUID()
+        let created = Date(timeIntervalSince1970: 1_700_000_000)
+        let deleted = Date(timeIntervalSince1970: 1_700_000_500)
+        let recording = Recording(
+            id: id,
+            title: "Weekly sync",
+            createdAt: created,
+            duration: 123.5,
+            source: .meeting,
+            audioFileName: "Weekly sync.wav",
+            status: .completed,
+            language: "en",
+            modelName: "large-v3",
+            segments: [
+                TranscriptSegment(start: 0, end: 2, text: "hello", speaker: "SPEAKER_00"),
+                TranscriptSegment(start: 2, end: 4, text: "hi there", speaker: "SPEAKER_01"),
+            ],
+            fullText: "hello hi there",
+            deletedAt: deleted,
+            folder: "Work",
+            appName: "zoom.us",
+            summary: "A summary.",
+            actionItems: [ActionItem(id: "a1", text: "Ship it", speaker: "SPEAKER_00",
+                                     timestampSeconds: 3, source: .llmInferred,
+                                     addedAt: created)],
+            voiceMemoUniqueID: "VM-1",
+            voiceMemoFolderUUID: "VMF-1",
+            speakerNames: ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"]
+        )
+
+        let data = try storeEncoder().encode([recording])
+        let stored = try storeDecoder().decode([StoredRecording].self, from: data)
+        XCTAssertEqual(stored.count, 1)
+        let s = try XCTUnwrap(stored.first)
+
+        XCTAssertEqual(s.id, id)
+        XCTAssertEqual(s.title, "Weekly sync")
+        XCTAssertEqual(s.createdAt, created)
+        XCTAssertEqual(s.duration, 123.5, accuracy: 0.001)
+        XCTAssertEqual(s.source, RecordingSource.meeting.rawValue)
+        XCTAssertEqual(s.audioFileName, "Weekly sync.wav")
+        XCTAssertEqual(s.status, TranscriptionStatus.completed.rawValue)
+        XCTAssertEqual(s.language, "en")
+        XCTAssertEqual(s.modelName, "large-v3")
+        XCTAssertEqual(s.segments.count, 2)
+        XCTAssertEqual(s.segments[0].text, "hello")
+        XCTAssertEqual(s.segments[0].speaker, "SPEAKER_00")
+        XCTAssertEqual(s.segments[1].start, 2, accuracy: 0.001)
+        XCTAssertEqual(s.segments[1].end, 4, accuracy: 0.001)
+        XCTAssertEqual(s.deletedAt, deleted)
+        XCTAssertTrue(s.isTrashed)
+        XCTAssertEqual(s.folder, "Work")
+        XCTAssertEqual(s.appName, "zoom.us")
+        XCTAssertEqual(s.summary, "A summary.")
+        XCTAssertEqual(s.actionItems?.count, 1)
+        XCTAssertEqual(s.actionItems?.first?.text, "Ship it")
+        XCTAssertEqual(s.actionItems?.first?.speaker, "SPEAKER_00")
+        XCTAssertEqual(s.actionItems?.first?.timestampSeconds, 3)
+        XCTAssertEqual(s.speakerNames, ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"])
+        // fullText is deliberately NOT encoded by the app (sidecar .txt owns it).
+        XCTAssertNil(s.legacyFullText)
+        XCTAssertEqual(s.transcriptFileName, "Weekly sync.txt")
+        XCTAssertEqual(s.summaryFileName, "Weekly sync.summary.txt")
+        XCTAssertEqual(s.speakerDisplayNames, ["Daniel", "John Doe"])
+    }
+
+    func test_minimal_recording_decodes_with_defaults() throws {
+        let recording = Recording(title: "Bare", source: .microphone,
+                                  audioFileName: "bare.wav")
+        let data = try storeEncoder().encode([recording])
+        let s = try XCTUnwrap(storeDecoder().decode([StoredRecording].self, from: data).first)
+        XCTAssertEqual(s.title, "Bare")
+        XCTAssertEqual(s.status, TranscriptionStatus.pending.rawValue)
+        // speakerNames is omitted from JSON when empty — mirror defaults to [:].
+        XCTAssertEqual(s.speakerNames, [:])
+        XCTAssertNil(s.deletedAt)
+        XCTAssertFalse(s.isTrashed)
+        XCTAssertEqual(s.segments.count, 0)
+        XCTAssertNil(s.actionItems)
+    }
+
+    func test_legacy_inline_fulltext_decodes() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","title":"Old","createdAt":"2023-01-01T00:00:00Z",
+        "duration":1,"source":"microphone","audioFileName":"old.wav","status":"completed",
+        "language":"he","segments":[],"fullText":"inline legacy text"}]
+        """
+        let s = try XCTUnwrap(storeDecoder()
+            .decode([StoredRecording].self, from: Data(json.utf8)).first)
+        XCTAssertEqual(s.legacyFullText, "inline legacy text")
+    }
+}

--- a/MilaTests/TranscriptExporterTests.swift
+++ b/MilaTests/TranscriptExporterTests.swift
@@ -45,6 +45,20 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertFalse(body.contains("3\n"))
     }
 
+    func test_srt_body_uses_assigned_names_with_raw_id_fallback() {
+        var rec = makeRecording(segments: [
+            .init(start: 0.0, end: 1.0, text: "Hi", speaker: "SPEAKER_00"),
+            .init(start: 1.0, end: 2.0, text: "Hello", speaker: "SPEAKER_01")
+        ])
+        rec.speakerNames = ["SPEAKER_00": "Daniel"]
+
+        let body = TranscriptExporter.srtBody(for: rec)
+        XCTAssertTrue(body.contains("Daniel: Hi"),
+                      "Named speaker must export under the assigned name")
+        XCTAssertTrue(body.contains("SPEAKER_01: Hello"),
+                      "Unnamed speaker keeps the raw diarizer ID")
+    }
+
     func test_srt_body_uses_commas_for_decimal_separator() {
         let rec = makeRecording(segments: [
             .init(start: 1.5, end: 2.5, text: "Hi")

--- a/MilaTests/TranscriptFormatterTests.swift
+++ b/MilaTests/TranscriptFormatterTests.swift
@@ -77,4 +77,40 @@ final class TranscriptFormatterTests: XCTestCase {
         )
         XCTAssertEqual(formatted, "Untagged opener\nSPEAKER_00: Tagged line")
     }
+
+    func test_assigned_names_replace_raw_ids_and_unnamed_keep_raw() {
+        let segments = [
+            TranscriptSegment(start: 0, end: 1, text: "Hi", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 2, text: "Hello back", speaker: "SPEAKER_01"),
+        ]
+        let formatted = TranscriptFormatter.plainText(
+            segments: segments,
+            fallback: "ignored",
+            names: ["SPEAKER_00": "Daniel"]
+        )
+        XCTAssertEqual(formatted, "Daniel: Hi\nSPEAKER_01: Hello back")
+    }
+
+    func test_two_raw_ids_with_the_same_assigned_name_collapse_into_one_paragraph() {
+        // The user's fix for an over-split speaker: naming both raw IDs
+        // identically must merge their consecutive turns, same as if the
+        // diarizer had gotten it right.
+        let segments = [
+            TranscriptSegment(start: 0, end: 1, text: "First.", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 2, text: "Second.", speaker: "SPEAKER_01"),
+            TranscriptSegment(start: 2, end: 3, text: "Other person.", speaker: "SPEAKER_02"),
+        ]
+        let formatted = TranscriptFormatter.plainText(
+            segments: segments,
+            fallback: "ignored",
+            names: ["SPEAKER_00": "Daniel", "SPEAKER_01": "Daniel"]
+        )
+        XCTAssertEqual(
+            formatted,
+            """
+            Daniel: First. Second.
+            SPEAKER_02: Other person.
+            """
+        )
+    }
 }

--- a/MilaTests/TranscriptFormatterTests.swift
+++ b/MilaTests/TranscriptFormatterTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TranscriptionCore
+import MilaKit
 @testable import Mila
 
 final class TranscriptFormatterTests: XCTestCase {

--- a/MilaTests/UtteranceDetectorTests.swift
+++ b/MilaTests/UtteranceDetectorTests.swift
@@ -62,6 +62,49 @@ final class UtteranceDetectorTests: XCTestCase {
         XCTAssertLessThan(captured.start, 1.05)
     }
 
+    /// End-to-end regression for the quiet built-in-mic bug: speech at
+    /// RMS 0.006 is below the detector's 0.012 cutoff, so raw it never
+    /// emits — the live transcript stays empty while post-record whisper
+    /// still works. Routed through the AdaptiveGainController first
+    /// (exactly like the mic tap does), the same audio must be boosted
+    /// enough to emit utterances mid-recording.
+    func test_quiet_speech_through_AGC_emits_utterances() {
+        // Raw (no AGC): nothing fires — this is the observed symptom.
+        let rawDet = UtteranceDetector()
+        var rawFired = 0
+        rawDet.onUtterance = { _, _ in rawFired += 1 }
+        rawDet.ingest(silence(seconds: 0.5)[...])
+        for _ in 0..<3 {
+            rawDet.ingest(speech(seconds: 2.0, amp: 0.006)[...])
+            rawDet.ingest(silence(seconds: 0.9)[...])
+        }
+        XCTAssertEqual(rawFired, 0,
+                       "sanity: RMS 0.006 speech is below the raw VAD cutoff")
+
+        // Same audio through the AGC, fed in 30ms chunks like the mic tap.
+        let det = UtteranceDetector()
+        var fired = 0
+        det.onUtterance = { _, _ in fired += 1 }
+        let agc = AdaptiveGainController()
+        func feed(_ samples: [Float]) {
+            let chunkSize = Int(sr * frameMs / 1000)
+            var i = 0
+            while i < samples.count {
+                let end = min(i + chunkSize, samples.count)
+                let boosted = agc.process(Array(samples[i..<end]))
+                det.ingest(boosted[...])
+                i = end
+            }
+        }
+        feed(silence(seconds: 0.5))
+        for _ in 0..<3 {
+            feed(speech(seconds: 2.0, amp: 0.006))
+            feed(silence(seconds: 0.9))
+        }
+        XCTAssertGreaterThanOrEqual(fired, 2,
+                                    "AGC-boosted quiet speech must emit utterances mid-recording (gain=\(agc.currentGain))")
+    }
+
     func test_two_separate_bursts_emit_two_utterances() {
         let det = UtteranceDetector()
         var fired = 0

--- a/MilaTests/UtteranceDetectorTests.swift
+++ b/MilaTests/UtteranceDetectorTests.swift
@@ -165,6 +165,41 @@ final class UtteranceDetectorTests: XCTestCase {
             "flush() must emit any in-progress utterance so end-of-recording tail isn't lost")
     }
 
+    /// `flushForPause()` closes the in-progress utterance (like `flush()`)
+    /// but PRESERVES the recording clock, so utterances emitted after a
+    /// resume keep their absolute timestamps instead of restarting at 0.
+    /// This is the pause/resume fix: `flush()` zeroes the sample counter,
+    /// which would misplace every post-resume line at the start of the
+    /// transcript and misalign it with the speaker diarizer's intervals.
+    func test_flushForPause_preserves_recording_clock_across_resume() {
+        let det = UtteranceDetector()
+        var starts: [Double] = []
+        det.onUtterance = { _, start in starts.append(start) }
+
+        // Pre-pause: one complete utterance, then a second in-progress one,
+        // advancing the clock to ~3.4s of ingested audio.
+        det.ingest(silence(seconds: 0.5)[...])
+        det.ingest(speech(seconds: 1.0)[...])
+        det.ingest(silence(seconds: 0.9)[...])   // emits utterance #1 (start ~0.3s)
+        det.ingest(speech(seconds: 1.0)[...])    // in-progress at the pause
+
+        // Pause boundary: emits the in-progress utterance AND folds the
+        // elapsed audio into the clock offset.
+        det.flushForPause()
+
+        // Resume: fresh speech. Its timestamp must continue from the
+        // pre-pause clock (~3.4s), NOT restart near 0.
+        det.ingest(silence(seconds: 0.3)[...])
+        det.ingest(speech(seconds: 1.0)[...])
+        det.ingest(silence(seconds: 0.9)[...])   // emits the post-resume utterance
+
+        XCTAssertGreaterThanOrEqual(starts.count, 3,
+            "Expected utterance #1, the flushed in-progress one, and the post-resume one — got \(starts)")
+        let lastStart = starts.last ?? 0
+        XCTAssertGreaterThan(lastStart, 3.0,
+            "Post-resume utterance must keep the absolute recording clock (~3.4s+), not restart at 0 — got \(lastStart)")
+    }
+
     func test_reset_clears_state() {
         let det = UtteranceDetector()
         var fired = 0

--- a/MilaTests/WAVHeaderRepairTests.swift
+++ b/MilaTests/WAVHeaderRepairTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import AVFoundation
+@testable import Mila
+
+/// Unit tests for `WAVHeaderRepair` — the crash-recovery fix that rewrites the
+/// `RIFF`/`data` size fields of a WAV whose header was never finalized because
+/// the app was killed mid-recording (AVAudioFile only backfills the sizes on
+/// close()). The audio frames are physically present; only the header lies.
+final class WAVHeaderRepairTests: XCTestCase {
+
+    // MARK: - byte helpers
+
+    private func le32(_ v: UInt32) -> [UInt8] {
+        [UInt8(v & 0xff), UInt8((v >> 8) & 0xff), UInt8((v >> 16) & 0xff), UInt8((v >> 24) & 0xff)]
+    }
+    private func le16(_ v: UInt16) -> [UInt8] {
+        [UInt8(v & 0xff), UInt8((v >> 8) & 0xff)]
+    }
+    private func ascii(_ s: String) -> [UInt8] { Array(s.utf8) }
+
+    /// A `fmt ` chunk (24 bytes) for float32 (or PCM) audio.
+    private func fmtChunk(channels: UInt16, sampleRate: UInt32, bits: UInt16, format: UInt16 = 3) -> [UInt8] {
+        let blockAlign = channels * (bits / 8)
+        let byteRate = sampleRate * UInt32(blockAlign)
+        return ascii("fmt ") + le32(16)
+            + le16(format) + le16(channels) + le32(sampleRate)
+            + le32(byteRate) + le16(blockAlign) + le16(bits)
+    }
+
+    /// Build a WAV with a canonical `fmt`+`data` layout.
+    /// - `declaredData` lets us simulate an unfinalized header (pass 0).
+    /// - Returns the full bytes + the offset of the `data` chunk.
+    private func canonicalWAV(dataByteCount: Int,
+                              declaredRiffSize: UInt32,
+                              declaredDataSize: UInt32,
+                              channels: UInt16 = 1,
+                              sampleRate: UInt32 = 16000,
+                              bits: UInt16 = 32) -> (bytes: [UInt8], dataChunkOffset: Int) {
+        var out = ascii("RIFF") + le32(declaredRiffSize) + ascii("WAVE")
+        out += fmtChunk(channels: channels, sampleRate: sampleRate, bits: bits)
+        let dataChunkOffset = out.count
+        out += ascii("data") + le32(declaredDataSize)
+        out += [UInt8](repeating: 0xAB, count: dataByteCount)
+        return (out, dataChunkOffset)
+    }
+
+    /// Build a WAV that mimics AVAudioFile's real layout: JUNK + fmt + FLLR
+    /// padding before the `data` chunk (exactly the shape observed on disk).
+    private func extendedWAV(dataByteCount: Int,
+                             fllrPadding: Int,
+                             declaredRiffSize: UInt32,
+                             declaredDataSize: UInt32) -> (bytes: [UInt8], dataChunkOffset: Int) {
+        var out = ascii("RIFF") + le32(declaredRiffSize) + ascii("WAVE")
+        out += ascii("JUNK") + le32(28) + [UInt8](repeating: 0, count: 28)
+        out += fmtChunk(channels: 1, sampleRate: 16000, bits: 32)
+        out += ascii("FLLR") + le32(UInt32(fllrPadding)) + [UInt8](repeating: 0, count: fllrPadding)
+        let dataChunkOffset = out.count
+        out += ascii("data") + le32(declaredDataSize)
+        out += [UInt8](repeating: 0xCD, count: dataByteCount)
+        return (out, dataChunkOffset)
+    }
+
+    private func u32(_ bytes: [UInt8], _ offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) | (UInt32(bytes[offset + 1]) << 8)
+            | (UInt32(bytes[offset + 2]) << 16) | (UInt32(bytes[offset + 3]) << 24)
+    }
+
+    private func writeTemp(_ bytes: [UInt8]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wavrepair-\(UUID().uuidString).wav")
+        try Data(bytes).write(to: url)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    // MARK: - plan()
+
+    func test_unfinalized_canonical_yields_plan() {
+        let (bytes, dataOff) = canonicalWAV(dataByteCount: 4000,
+                                            declaredRiffSize: 36,   // header-only (crash)
+                                            declaredDataSize: 0)    // never finalized
+        let plan = WAVHeaderRepair.plan(header: bytes, fileSize: bytes.count)
+        XCTAssertEqual(plan?.riffSizeOffset, 4)
+        XCTAssertEqual(plan?.newRiffSize, UInt32(bytes.count - 8))
+        XCTAssertEqual(plan?.dataSizeOffset, dataOff + 4)
+        XCTAssertEqual(plan?.newDataSize, 4000)
+    }
+
+    func test_extended_header_locates_data_chunk() {
+        // FLLR padding pushes `data` well past the canonical offset 44.
+        let (bytes, dataOff) = extendedWAV(dataByteCount: 8000,
+                                           fllrPadding: 4008,
+                                           declaredRiffSize: 4088,
+                                           declaredDataSize: 0)
+        let plan = WAVHeaderRepair.plan(header: bytes, fileSize: bytes.count)
+        XCTAssertEqual(plan?.dataSizeOffset, dataOff + 4)
+        XCTAssertEqual(plan?.newDataSize, 8000)
+        XCTAssertEqual(plan?.newRiffSize, UInt32(bytes.count - 8))
+    }
+
+    func test_finalized_header_yields_no_plan() {
+        let dataCount = 4000
+        let (bytes, _) = canonicalWAV(dataByteCount: dataCount,
+                                      declaredRiffSize: UInt32(36 + dataCount),
+                                      declaredDataSize: UInt32(dataCount))
+        XCTAssertNil(WAVHeaderRepair.plan(header: bytes, fileSize: bytes.count),
+                     "A correctly-finalized header must not be rewritten.")
+    }
+
+    func test_non_wav_yields_no_plan() {
+        let junk = [UInt8]("not a wave file at all, just some bytes here".utf8)
+        XCTAssertNil(WAVHeaderRepair.plan(header: junk, fileSize: junk.count))
+    }
+
+    func test_too_small_yields_no_plan() {
+        let tiny = ascii("RIFF") + [0, 0, 0, 0] + ascii("WAVE")
+        XCTAssertNil(WAVHeaderRepair.plan(header: tiny, fileSize: tiny.count))
+    }
+
+    func test_frame_flooring_drops_torn_final_frame() {
+        // blockAlign = 4 (float32 mono). A crash left 2 extra bytes = a torn
+        // frame; the repaired size must floor to a whole-frame multiple.
+        let (bytes, _) = canonicalWAV(dataByteCount: 4002,
+                                      declaredRiffSize: 36,
+                                      declaredDataSize: 0)
+        let plan = WAVHeaderRepair.plan(header: bytes, fileSize: bytes.count)
+        XCTAssertEqual(plan?.newDataSize, 4000, "Should floor 4002 down to the nearest 4-byte frame boundary.")
+    }
+
+    // MARK: - repairIfNeeded()
+
+    func test_repairIfNeeded_rewrites_and_is_idempotent() throws {
+        let (bytes, dataOff) = canonicalWAV(dataByteCount: 4000,
+                                            declaredRiffSize: 36,
+                                            declaredDataSize: 0)
+        let url = try writeTemp(bytes)
+
+        XCTAssertTrue(WAVHeaderRepair.repairIfNeeded(at: url), "First call should write a fix.")
+
+        let fixed = [UInt8](try Data(contentsOf: url))
+        XCTAssertEqual(u32(fixed, 4), UInt32(bytes.count - 8), "RIFF size rewritten.")
+        XCTAssertEqual(u32(fixed, dataOff + 4), 4000, "data size rewritten.")
+
+        XCTAssertFalse(WAVHeaderRepair.repairIfNeeded(at: url),
+                       "Second call is a no-op once the header is finalized.")
+    }
+
+    func test_repaired_file_is_readable_by_AVAudioFile() throws {
+        // 250 float32 frames @ 16 kHz mono => 1000 data bytes, header says 0.
+        let frames = 250
+        let (bytes, _) = canonicalWAV(dataByteCount: frames * 4,
+                                      declaredRiffSize: 36,
+                                      declaredDataSize: 0)
+        let url = try writeTemp(bytes)
+
+        // Before repair AVAudioFile sees an empty (or unreadable) file.
+        let before = try? AVAudioFile(forReading: url)
+        XCTAssertTrue(before == nil || before!.length == 0,
+                      "Unfinalized header should read as zero frames.")
+
+        XCTAssertTrue(WAVHeaderRepair.repairIfNeeded(at: url))
+
+        let after = try AVAudioFile(forReading: url)
+        XCTAssertEqual(after.length, AVAudioFramePosition(frames),
+                       "After repair the full audio is readable.")
+    }
+
+    func test_missing_file_is_noop() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).wav")
+        XCTAssertFalse(WAVHeaderRepair.repairIfNeeded(at: url))
+    }
+}

--- a/Packages/MilaKit/Package.swift
+++ b/Packages/MilaKit/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "MilaKit",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "MilaKit", targets: ["MilaKit"]),
+    ],
+    targets: [
+        .target(name: "MilaKit"),
+        .testTarget(
+            name: "MilaKitTests",
+            dependencies: ["MilaKit"]
+        ),
+    ]
+)

--- a/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
+++ b/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// On-disk snapshot of the in-progress recording's live transcript —
+/// `<app-support>/Mila/live/current.json`. Written by the app
+/// (`LiveTranscriptSidecarWriter`) on every live-transcript tick and read
+/// by mila-mcp's `get_live_transcript` tool, so an external Claude session
+/// can follow a meeting while it happens.
+///
+/// Freshness contract: `revision` bumps on every CONTENT change (segments
+/// or speaker names) and is the poller's cheap "anything new?" cursor.
+/// `updatedAt` is a liveness heartbeat, refreshed every few seconds even
+/// when nothing was said — a `recording` snapshot whose heartbeat is stale
+/// means the app crashed or hung mid-meeting. `sessionID` is minted fresh
+/// per recording so a poller can tell "same meeting, nothing new" apart
+/// from "a different meeting whose counters happen to line up".
+public struct LiveTranscriptSnapshot: Codable {
+
+    public enum State: String, Codable {
+        /// A recording is in progress; segments may still grow.
+        case recording
+        /// The recording ended normally; `finalRecordingID` points at the
+        /// saved recording. Kept on disk until the next recording begins
+        /// so a poller can't miss the handoff.
+        case completed
+        /// A leftover `recording` snapshot found at app launch — the app
+        /// died mid-recording. Crash recovery re-transcribes the audio
+        /// separately; the live feed is over.
+        case interrupted
+    }
+
+    public typealias Segment = StoredRecording.Segment
+
+    public var version: Int
+    public var sessionID: UUID
+    public var state: State
+    /// False when the recording runs on hardware below the live-AI bar:
+    /// the meeting is being captured, but no live transcript will appear
+    /// until it completes.
+    public var liveTranscriptAvailable: Bool
+    public var recordingStartedAt: Date
+    public var updatedAt: Date
+    /// Monotonic within a session; bumps only on content changes.
+    public var revision: Int
+    public var title: String?
+    /// Raw `RecordingSource` value, when known.
+    public var source: String?
+    public var segments: [Segment]
+    public var speakerNames: [String: String]
+    /// Set when `state == .completed` — the saved recording's UUID, for
+    /// handoff to `get_transcript`.
+    public var finalRecordingID: UUID?
+
+    public init(version: Int = 1,
+                sessionID: UUID = UUID(),
+                state: State = .recording,
+                liveTranscriptAvailable: Bool = true,
+                recordingStartedAt: Date,
+                updatedAt: Date,
+                revision: Int = 1,
+                title: String? = nil,
+                source: String? = nil,
+                segments: [Segment] = [],
+                speakerNames: [String: String] = [:],
+                finalRecordingID: UUID? = nil) {
+        self.version = version
+        self.sessionID = sessionID
+        self.state = state
+        self.liveTranscriptAvailable = liveTranscriptAvailable
+        self.recordingStartedAt = recordingStartedAt
+        self.updatedAt = updatedAt
+        self.revision = revision
+        self.title = title
+        self.source = source
+        self.segments = segments
+        self.speakerNames = speakerNames
+        self.finalRecordingID = finalRecordingID
+    }
+
+    /// Heartbeat age beyond which a `recording` snapshot is reported stale.
+    public static let staleAfter: TimeInterval = 20
+
+    public static let directoryName = "live"
+    public static let fileName = "current.json"
+
+    public static func fileURL(root: URL = StoreLocationPointer.defaultRoot()) -> URL {
+        root.appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(fileName)
+    }
+
+    public static func read(root: URL = StoreLocationPointer.defaultRoot()) -> LiveTranscriptSnapshot? {
+        guard let data = try? Data(contentsOf: fileURL(root: root)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(LiveTranscriptSnapshot.self, from: data)
+    }
+
+    public func write(root: URL = StoreLocationPointer.defaultRoot()) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(self)
+        let url = Self.fileURL(root: root)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        // .atomic = write-to-temp + rename, so a concurrent reader always
+        // sees a complete JSON document.
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Segments a poller hasn't fully seen. Returns from ONE BEFORE
+    /// `index` — the last segment the client already has is re-sent
+    /// because the live merge can rewrite the trailing segment's text as
+    /// more audio context arrives; the client replaces its copy.
+    public func segments(sinceIndex index: Int) -> [Segment] {
+        let start = max(0, min(index - 1, segments.count))
+        return Array(segments[start...])
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
+++ b/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
@@ -1,0 +1,414 @@
+import Foundation
+
+/// The mila-mcp tool surface, implemented as a pure JSON-in / JSON-out
+/// layer with no MCP-SDK types — the executable's transport wiring stays
+/// a thin shell (and swappable for a hand-rolled JSON-RPC loop if the SDK
+/// ever misbehaves), and everything here is unit-testable in-process.
+public struct MilaMCPToolHandlers {
+
+    public enum ToolError: Error, CustomStringConvertible {
+        case unknownTool(String)
+        case invalidArguments(String)
+        case notFound(String)
+        case storeUnavailable(String)
+
+        public var description: String {
+            switch self {
+            case .unknownTool(let name): return "Unknown tool: \(name)"
+            case .invalidArguments(let msg): return "Invalid arguments: \(msg)"
+            case .notFound(let msg): return msg
+            case .storeUnavailable(let msg):
+                return "Mila's recording store could not be read (\(msg)). "
+                    + "Has the Mila app run at least once on this Mac?"
+            }
+        }
+    }
+
+    public struct ToolSpec {
+        public let name: String
+        public let description: String
+        /// JSON Schema for the tool's arguments, as a JSON object tree
+        /// ([String: Any]), ready to re-encode into any transport's type.
+        public let inputSchema: [String: Any]
+    }
+
+    /// Root under which `store-location.json` and `live/current.json`
+    /// live — the default Mila app-support directory in production, a
+    /// temp fixture in tests.
+    private let root: URL
+    private let now: () -> Date
+
+    public init(root: URL = StoreLocationPointer.defaultRoot(),
+                now: @escaping () -> Date = Date.init) {
+        self.root = root
+        self.now = now
+    }
+
+    // MARK: - Tool definitions
+
+    public static let toolSpecs: [ToolSpec] = [
+        ToolSpec(
+            name: "list_recordings",
+            description: """
+            List Mila recordings (meetings, voice memos, app-audio captures), newest first by \
+            default. Filter by speaker display name to find conversations with a specific \
+            person — e.g. the last meeting with John Doe is list_recordings(speaker: "john \
+            doe", limit: 1). Trashed recordings are excluded.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "query": ["type": "string",
+                              "description": "Substring match over title, app name, and folder."],
+                    "speaker": ["type": "string",
+                                "description": "Case-insensitive substring over the recording's speaker display names (as renamed by the user)."],
+                    "folder": ["type": "string", "description": "Filter to a folder by name."],
+                    "source": ["type": "string",
+                               "enum": ["microphone", "systemAudio", "meeting", "voiceMemo"],
+                               "description": "Filter by capture source."],
+                    "after": ["type": "string",
+                              "description": "ISO 8601 date; only recordings created at/after this instant."],
+                    "before": ["type": "string",
+                               "description": "ISO 8601 date; only recordings created at/before this instant."],
+                    "sort": ["type": "string", "enum": ["created_at", "duration", "title"],
+                             "description": "Sort key (default created_at)."],
+                    "order": ["type": "string", "enum": ["asc", "desc"],
+                              "description": "Sort order (default desc)."],
+                    "limit": ["type": "integer", "description": "Max results (default 20, max 100)."],
+                ],
+            ]
+        ),
+        ToolSpec(
+            name: "get_transcript",
+            description: """
+            Fetch one recording's full transcript with speaker names resolved (e.g. "John \
+            Doe: …"), plus its summary and action items when available. Pass the id from \
+            list_recordings/search_transcripts; omit it for the latest completed recording.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "id": ["type": "string",
+                           "description": "Recording UUID. Omit for the latest completed recording."],
+                    "include_summary": ["type": "boolean",
+                                        "description": "Include summary + action items (default true)."],
+                    "max_chars": ["type": "integer",
+                                  "description": "Truncate the transcript to this many characters."],
+                ],
+            ]
+        ),
+        ToolSpec(
+            name: "search_transcripts",
+            description: """
+            Full-text search over recording titles and transcript text (case- and \
+            diacritic-insensitive). Returns matching recordings with short context snippets; \
+            follow up with get_transcript for the full text.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "query": ["type": "string", "description": "Text to search for."],
+                    "speaker": ["type": "string",
+                                "description": "Only search recordings featuring this speaker display name."],
+                    "sort": ["type": "string", "enum": ["relevance", "created_at"],
+                             "description": "relevance = match count, ties newest-first (default)."],
+                    "order": ["type": "string", "enum": ["asc", "desc"],
+                              "description": "Sort order (default desc)."],
+                    "limit": ["type": "integer", "description": "Max results (default 10)."],
+                ],
+                "required": ["query"],
+            ]
+        ),
+        ToolSpec(
+            name: "get_live_transcript",
+            description: """
+            Read the in-progress Mila recording's live transcript. To follow a meeting, poll \
+            this every 15-20 seconds passing back the returned session_id, revision (as \
+            since_revision) and next_segment_index (as since_segment_index): unchanged \
+            meetings answer with a tiny {changed:false}, and changed ones return only the new \
+            segments (the last previously-seen segment is re-sent because live transcription \
+            may rewrite it — replace your copy). When status becomes "completed", stop \
+            polling and call get_transcript with the returned final_recording_id.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "session_id": ["type": "string",
+                                   "description": "The session_id from the previous poll. A mismatch means a new recording started; the full new transcript is returned."],
+                    "since_revision": ["type": "integer",
+                                       "description": "The revision from the previous poll; equal revision short-circuits to {changed:false}."],
+                    "since_segment_index": ["type": "integer",
+                                            "description": "The next_segment_index from the previous poll; only segments from one before this index are returned."],
+                ],
+            ]
+        ),
+    ]
+
+    // MARK: - Dispatch
+
+    /// Execute a tool call. Returns the result as a JSON string.
+    public func handle(tool: String, arguments: [String: Any]) throws -> String {
+        switch tool {
+        case "list_recordings": return try listRecordings(arguments)
+        case "get_transcript": return try getTranscript(arguments)
+        case "search_transcripts": return try searchTranscripts(arguments)
+        case "get_live_transcript": return try getLiveTranscript(arguments)
+        default: throw ToolError.unknownTool(tool)
+        }
+    }
+
+    // MARK: - Tools
+
+    private func listRecordings(_ args: [String: Any]) throws -> String {
+        let reader = MilaStoreReader(root: root)
+        let filter = MilaStoreReader.Filter(
+            query: args["query"] as? String,
+            speaker: args["speaker"] as? String,
+            folder: args["folder"] as? String,
+            source: args["source"] as? String,
+            after: try date(args, "after"),
+            before: try date(args, "before")
+        )
+        let sort = try enumArg(args, "sort", MilaStoreReader.SortKey.self) ?? .createdAt
+        let order = try enumArg(args, "order", MilaStoreReader.SortOrder.self) ?? .desc
+        let limit = min(args["limit"] as? Int ?? 20, 100)
+        let recordings: [StoredRecording]
+        do {
+            recordings = try reader.listRecordings(filter: filter, sort: sort,
+                                                   order: order, limit: limit)
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+        return try json([
+            "count": recordings.count,
+            "recordings": recordings.map { summaryObject(for: $0) },
+        ])
+    }
+
+    private func getTranscript(_ args: [String: Any]) throws -> String {
+        let reader = MilaStoreReader(root: root)
+        let recording: StoredRecording
+        do {
+            if let idString = args["id"] as? String {
+                guard let id = UUID(uuidString: idString) else {
+                    throw ToolError.invalidArguments("id must be a UUID, got \"\(idString)\"")
+                }
+                guard let found = try reader.recording(id: id) else {
+                    throw ToolError.notFound("No recording with id \(id.uuidString)")
+                }
+                recording = found
+            } else {
+                guard let latest = try reader.latestCompletedRecording() else {
+                    throw ToolError.notFound("No completed recordings exist yet")
+                }
+                recording = latest
+            }
+        } catch let error as ToolError {
+            throw error
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+
+        var transcript = reader.namedTranscript(for: recording)
+        var truncated = false
+        if let maxChars = args["max_chars"] as? Int, maxChars > 0, transcript.count > maxChars {
+            transcript = String(transcript.prefix(maxChars))
+            truncated = true
+        }
+        var result = summaryObject(for: recording)
+        result["language"] = recording.language
+        result["transcript"] = transcript
+        result["transcript_truncated"] = truncated
+        if recording.status != "completed" {
+            result["note"] = "Transcription status is \"\(recording.status)\" — the transcript may be partial."
+        }
+        if (args["include_summary"] as? Bool) ?? true {
+            if let summary = recording.summary, !summary.isEmpty {
+                result["summary"] = summary
+            }
+            if let items = recording.actionItems, !items.isEmpty {
+                result["action_items"] = items.map { item in
+                    var obj: [String: Any] = ["text": item.text]
+                    if let speaker = item.speaker {
+                        obj["speaker"] = recording.speakerNames[speaker] ?? speaker
+                    }
+                    return obj
+                }
+            }
+        }
+        return try json(result)
+    }
+
+    private func searchTranscripts(_ args: [String: Any]) throws -> String {
+        guard let query = args["query"] as? String, !query.isEmpty else {
+            throw ToolError.invalidArguments("query is required")
+        }
+        let reader = MilaStoreReader(root: root)
+        let sort = try enumArg(args, "sort", MilaStoreReader.SearchSortKey.self) ?? .relevance
+        let order = try enumArg(args, "order", MilaStoreReader.SortOrder.self) ?? .desc
+        let limit = min(args["limit"] as? Int ?? 10, 100)
+        let hits: [MilaStoreReader.SearchHit]
+        do {
+            hits = try reader.searchTranscripts(query: query,
+                                                speaker: args["speaker"] as? String,
+                                                sort: sort, order: order, limit: limit)
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+        return try json([
+            "count": hits.count,
+            "results": hits.map { hit -> [String: Any] in
+                var obj = summaryObject(for: hit.recording)
+                obj["match_count"] = hit.matchCount
+                obj["snippets"] = hit.snippets
+                return obj
+            },
+        ])
+    }
+
+    private func getLiveTranscript(_ args: [String: Any]) throws -> String {
+        guard let snapshot = LiveTranscriptSnapshot.read(root: root) else {
+            return try json(["status": "not_recording"])
+        }
+
+        switch snapshot.state {
+        case .interrupted:
+            return try json([
+                "status": "not_recording",
+                "last_session": "interrupted",
+                "note": "The app stopped unexpectedly during the last recording; its audio is re-transcribed in the background — check list_recordings.",
+            ])
+        case .completed, .recording:
+            break
+        }
+
+        var result: [String: Any] = [
+            "session_id": snapshot.sessionID.uuidString,
+            "revision": snapshot.revision,
+            "recording_started_at": iso(snapshot.recordingStartedAt),
+            "updated_at": iso(snapshot.updatedAt),
+        ]
+        if let title = snapshot.title { result["title"] = title }
+        if let source = snapshot.source { result["source"] = source }
+
+        if snapshot.state == .completed {
+            result["status"] = "completed"
+            if let finalID = snapshot.finalRecordingID {
+                result["final_recording_id"] = finalID.uuidString
+                result["note"] = "The recording ended. Call get_transcript with final_recording_id for the authoritative transcript (speaker labels may improve after the post-stop pass)."
+            } else {
+                result["note"] = "The recording ended without a saved transcript handoff; check list_recordings for the newest entry."
+            }
+            return try json(result)
+        }
+
+        // state == .recording
+        guard snapshot.liveTranscriptAvailable else {
+            result["status"] = "recording_live_unavailable"
+            result["elapsed_seconds"] = Int(now().timeIntervalSince(snapshot.recordingStartedAt))
+            result["note"] = "A recording is in progress, but live transcription is disabled on this hardware — no text will appear until it completes. Poll occasionally for status \"completed\" instead of expecting segments."
+            return try json(result)
+        }
+        let heartbeatAge = now().timeIntervalSince(snapshot.updatedAt)
+        let status = heartbeatAge > LiveTranscriptSnapshot.staleAfter ? "stale" : "recording"
+        result["status"] = status
+        result["elapsed_seconds"] = Int(now().timeIntervalSince(snapshot.recordingStartedAt))
+        if status == "stale" {
+            result["note"] = "The live snapshot hasn't been refreshed in \(Int(heartbeatAge))s — the Mila app may have crashed or hung; this transcript may be incomplete and won't grow."
+        }
+
+        let clientSession = (args["session_id"] as? String).flatMap(UUID.init(uuidString:))
+        let sameSession = clientSession == snapshot.sessionID
+        if let clientSession, clientSession != snapshot.sessionID {
+            result["new_session"] = true
+        }
+
+        // Cheap no-change short-circuit — only valid within the same session.
+        if sameSession, let sinceRevision = args["since_revision"] as? Int,
+           sinceRevision == snapshot.revision {
+            return try json([
+                "status": status,
+                "session_id": snapshot.sessionID.uuidString,
+                "revision": snapshot.revision,
+                "changed": false,
+            ])
+        }
+        result["changed"] = true
+        result["speaker_names"] = snapshot.speakerNames
+        result["next_segment_index"] = snapshot.segments.count
+
+        if sameSession, let sinceIndex = args["since_segment_index"] as? Int {
+            result["new_segments"] = snapshot.segments(sinceIndex: sinceIndex)
+                .map(segmentObject(for:))
+        } else {
+            // First poll (or a new session): full transcript + all segments.
+            result["new_segments"] = snapshot.segments.map(segmentObject(for:))
+            result["transcript"] = TranscriptFormatter.plainText(
+                segments: snapshot.segments,
+                fallback: snapshot.segments.map(\.text)
+                    .joined(separator: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                names: snapshot.speakerNames
+            )
+        }
+        return try json(result)
+    }
+
+    // MARK: - Helpers
+
+    private func summaryObject(for recording: StoredRecording) -> [String: Any] {
+        var obj: [String: Any] = [
+            "id": recording.id.uuidString,
+            "title": recording.title,
+            "created_at": iso(recording.createdAt),
+            "duration_seconds": Int(recording.duration.rounded()),
+            "source": recording.source,
+            "status": recording.status,
+            "speakers": recording.speakerDisplayNames,
+            "has_summary": !(recording.summary ?? "").isEmpty,
+        ]
+        if let folder = recording.folder { obj["folder"] = folder }
+        if let appName = recording.appName { obj["app_name"] = appName }
+        return obj
+    }
+
+    private func segmentObject(for segment: LiveTranscriptSnapshot.Segment) -> [String: Any] {
+        var obj: [String: Any] = [
+            "start": segment.start,
+            "end": segment.end,
+            "text": segment.text,
+        ]
+        if let speaker = segment.speaker { obj["speaker"] = speaker }
+        return obj
+    }
+
+    private func json(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object,
+                                              options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func iso(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private func date(_ args: [String: Any], _ key: String) throws -> Date? {
+        guard let raw = args[key] as? String else { return nil }
+        let formatter = ISO8601DateFormatter()
+        if let parsed = formatter.date(from: raw) { return parsed }
+        // Accept plain dates too ("2026-07-15").
+        formatter.formatOptions = [.withFullDate]
+        if let parsed = formatter.date(from: raw) { return parsed }
+        throw ToolError.invalidArguments("\(key) must be an ISO 8601 date, got \"\(raw)\"")
+    }
+
+    private func enumArg<E: RawRepresentable>(_ args: [String: Any], _ key: String,
+                                              _ type: E.Type) throws -> E?
+        where E.RawValue == String {
+        guard let raw = args[key] as? String else { return nil }
+        guard let value = E(rawValue: raw) else {
+            throw ToolError.invalidArguments("\(key) has unsupported value \"\(raw)\"")
+        }
+        return value
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/MilaStoreReader.swift
+++ b/Packages/MilaKit/Sources/MilaKit/MilaStoreReader.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// Read-only access to Mila's recording store for external processes
+/// (mila-mcp). Resolves the store location via `StoreLocationPointer`,
+/// falling back to the default app-support layout when no pointer exists
+/// (the app hasn't run since the pointer feature shipped). Every call
+/// re-reads from disk — the store is small, the app's writes are atomic,
+/// and freshness beats caching for a live assistant.
+public struct MilaStoreReader {
+
+    public let recordingsDirectory: URL
+    public let storeFileURL: URL
+
+    public init(recordingsDirectory: URL, storeFileURL: URL) {
+        self.recordingsDirectory = recordingsDirectory
+        self.storeFileURL = storeFileURL
+    }
+
+    /// Resolve from the pointer file at `root`, or fall back to the
+    /// historical default layout (`<root>/recordings.json` +
+    /// `<root>/Recordings/`).
+    public init(root: URL = StoreLocationPointer.defaultRoot()) {
+        if let pointer = StoreLocationPointer.read(from: root) {
+            self.init(recordingsDirectory: URL(fileURLWithPath: pointer.recordingsDirectory,
+                                               isDirectory: true),
+                      storeFileURL: URL(fileURLWithPath: pointer.storeFile))
+        } else {
+            self.init(recordingsDirectory: root.appendingPathComponent("Recordings",
+                                                                       isDirectory: true),
+                      storeFileURL: root.appendingPathComponent("recordings.json"))
+        }
+    }
+
+    // MARK: - Loading
+
+    public func loadRecordings() throws -> [StoredRecording] {
+        let data = try Data(contentsOf: storeFileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([StoredRecording].self, from: data)
+    }
+
+    /// Plain transcript text: sidecar `.txt` → legacy inline text →
+    /// joined segments (same fallback chain as the app's load path).
+    public func transcriptText(for recording: StoredRecording) -> String {
+        let url = recordingsDirectory.appendingPathComponent(recording.transcriptFileName)
+        if let text = try? String(contentsOf: url, encoding: .utf8), !text.isEmpty {
+            return text
+        }
+        if let legacy = recording.legacyFullText, !legacy.isEmpty { return legacy }
+        return recording.segments.map(\.text).joined()
+    }
+
+    /// Speaker-named transcript — the app's canonical rendering
+    /// (`SPEAKER_00:` prefixes resolved through `speakerNames`, same-speaker
+    /// turns collapsed).
+    public func namedTranscript(for recording: StoredRecording) -> String {
+        TranscriptFormatter.plainText(
+            segments: recording.segments,
+            fallback: transcriptText(for: recording)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            names: recording.speakerNames
+        )
+    }
+
+    // MARK: - Listing
+
+    public struct Filter {
+        /// Substring over title, appName, and folder.
+        public var query: String?
+        /// Substring over resolved speaker display names.
+        public var speaker: String?
+        public var folder: String?
+        /// Raw `RecordingSource` value (`microphone` / `systemAudio` / …).
+        public var source: String?
+        public var after: Date?
+        public var before: Date?
+
+        public init(query: String? = nil, speaker: String? = nil, folder: String? = nil,
+                    source: String? = nil, after: Date? = nil, before: Date? = nil) {
+            self.query = query
+            self.speaker = speaker
+            self.folder = folder
+            self.source = source
+            self.after = after
+            self.before = before
+        }
+    }
+
+    public enum SortKey: String {
+        case createdAt = "created_at"
+        case duration
+        case title
+    }
+
+    public enum SortOrder: String {
+        case asc, desc
+    }
+
+    /// Non-trashed recordings matching `filter`, sorted and capped.
+    public func listRecordings(filter: Filter = Filter(),
+                               sort: SortKey = .createdAt,
+                               order: SortOrder = .desc,
+                               limit: Int = 20) throws -> [StoredRecording] {
+        var results = try loadRecordings().filter { rec in
+            guard !rec.isTrashed else { return false }
+            if let q = filter.query, !q.isEmpty {
+                let haystacks = [rec.title, rec.appName ?? "", rec.folder ?? ""]
+                guard haystacks.contains(where: { $0.localizedStandardContains(q) }) else {
+                    return false
+                }
+            }
+            if let speaker = filter.speaker, !speaker.isEmpty {
+                guard rec.speakerDisplayNames.contains(where: {
+                    $0.localizedStandardContains(speaker)
+                }) else { return false }
+            }
+            if let folder = filter.folder, !folder.isEmpty {
+                guard rec.folder?.localizedStandardContains(folder) == true else { return false }
+            }
+            if let source = filter.source, !source.isEmpty {
+                guard rec.source == source else { return false }
+            }
+            if let after = filter.after, rec.createdAt < after { return false }
+            if let before = filter.before, rec.createdAt > before { return false }
+            return true
+        }
+        results.sort { a, b in
+            let ascending: Bool
+            switch sort {
+            case .createdAt: ascending = a.createdAt < b.createdAt
+            case .duration: ascending = a.duration < b.duration
+            case .title:
+                ascending = a.title.localizedCaseInsensitiveCompare(b.title) == .orderedAscending
+            }
+            return order == .asc ? ascending : !ascending
+        }
+        return Array(results.prefix(max(0, limit)))
+    }
+
+    /// Latest non-trashed completed recording, if any.
+    public func latestCompletedRecording() throws -> StoredRecording? {
+        try listRecordings(limit: Int.max).first { $0.status == "completed" }
+    }
+
+    public func recording(id: UUID) throws -> StoredRecording? {
+        try loadRecordings().first { $0.id == id }
+    }
+
+    // MARK: - Search
+
+    public struct SearchHit {
+        public let recording: StoredRecording
+        /// Total case-insensitive matches across title + transcript.
+        public let matchCount: Int
+        /// Up to a few matching lines with one line of context each side.
+        public let snippets: [String]
+    }
+
+    public enum SearchSortKey: String {
+        case relevance
+        case createdAt = "created_at"
+    }
+
+    /// Case/diacritic-insensitive full-text search over titles and
+    /// transcript text of non-trashed recordings.
+    public func searchTranscripts(query: String,
+                                  speaker: String? = nil,
+                                  sort: SearchSortKey = .relevance,
+                                  order: SortOrder = .desc,
+                                  limit: Int = 10) throws -> [SearchHit] {
+        let recordings = try listRecordings(filter: Filter(speaker: speaker), limit: Int.max)
+        var hits: [SearchHit] = []
+        for rec in recordings {
+            let transcript = namedTranscript(for: rec)
+            let titleMatches = matchCount(of: query, in: rec.title)
+            let lines = transcript.components(separatedBy: .newlines)
+            var textMatches = 0
+            var snippets: [String] = []
+            for (i, line) in lines.enumerated() {
+                let n = matchCount(of: query, in: line)
+                guard n > 0 else { continue }
+                textMatches += n
+                if snippets.count < 3 {
+                    let context = lines[max(0, i - 1)...min(lines.count - 1, i + 1)]
+                    snippets.append(context.joined(separator: "\n"))
+                }
+            }
+            let total = titleMatches + textMatches
+            guard total > 0 else { continue }
+            hits.append(SearchHit(recording: rec, matchCount: total, snippets: snippets))
+        }
+        hits.sort { a, b in
+            let ascending: Bool
+            switch sort {
+            case .relevance:
+                if a.matchCount != b.matchCount {
+                    ascending = a.matchCount < b.matchCount
+                } else {
+                    ascending = a.recording.createdAt < b.recording.createdAt
+                }
+            case .createdAt:
+                ascending = a.recording.createdAt < b.recording.createdAt
+            }
+            return order == .asc ? ascending : !ascending
+        }
+        return Array(hits.prefix(max(0, limit)))
+    }
+
+    private func matchCount(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let found = haystack.range(of: needle,
+                                         options: [.caseInsensitive, .diacriticInsensitive],
+                                         range: searchRange) {
+            count += 1
+            searchRange = found.upperBound..<haystack.endIndex
+        }
+        return count
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/StoreLocationPointer.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoreLocationPointer.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Cross-process contract telling external tools (mila-mcp) where the
+/// recording store currently lives. The app's relocated-recordings feature
+/// stores the user's choice as a security-scoped bookmark in UserDefaults,
+/// which a separate process can't resolve — so RecordingStore mirrors the
+/// resolved paths into this small JSON file at the DEFAULT app-support root
+/// on every launch and relocation.
+public struct StoreLocationPointer: Codable, Equatable {
+    public var version: Int
+    /// Directory holding the audio files + sidecars (`.txt`/`.srt`/…).
+    public var recordingsDirectory: String
+    /// Full path of `recordings.json`.
+    public var storeFile: String
+    public var updatedAt: Date
+
+    public init(version: Int = 1, recordingsDirectory: String, storeFile: String, updatedAt: Date) {
+        self.version = version
+        self.recordingsDirectory = recordingsDirectory
+        self.storeFile = storeFile
+        self.updatedAt = updatedAt
+    }
+
+    public static let fileName = "store-location.json"
+
+    /// The default Mila app-support root (`~/Library/Application Support/Mila`).
+    public static func defaultRoot() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask)[0]
+        return appSupport.appendingPathComponent("Mila", isDirectory: true)
+    }
+
+    public static func read(from root: URL = defaultRoot()) -> StoreLocationPointer? {
+        let url = root.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(StoreLocationPointer.self, from: data)
+    }
+
+    public func write(to root: URL = defaultRoot()) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try data.write(to: root.appendingPathComponent(Self.fileName), options: .atomic)
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Decoding is deliberately lenient (`decodeIfPresent` + defaults) so an
 /// older helper never chokes on a newer app's additions.
 public struct StoredRecording: Codable, Identifiable {
-    public struct Segment: Codable, SpeakerTextSegment {
+    public struct Segment: Codable, Equatable, SpeakerTextSegment {
         public var start: Double
         public var end: Double
         public var text: String

--- a/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Read-only mirror of one entry in the app's `recordings.json`.
+///
+/// The app's `Recording` type stays in the app target (its init is
+/// referenced across dozens of files); this mirror exists so the external
+/// mila-mcp helper can decode the store without linking app code. Every
+/// field the app encodes must decode here — guarded by
+/// `StoredRecordingDriftTests` in MilaTests, which encodes a fully
+/// populated app `Recording` and asserts this type round-trips it.
+/// Decoding is deliberately lenient (`decodeIfPresent` + defaults) so an
+/// older helper never chokes on a newer app's additions.
+public struct StoredRecording: Codable, Identifiable {
+    public struct Segment: Codable, SpeakerTextSegment {
+        public var start: Double
+        public var end: Double
+        public var text: String
+        public var speaker: String?
+
+        public init(start: Double, end: Double, text: String, speaker: String? = nil) {
+            self.start = start
+            self.end = end
+            self.text = text
+            self.speaker = speaker
+        }
+
+        private enum CodingKeys: String, CodingKey { case start, end, text, speaker }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            start = try c.decodeIfPresent(Double.self, forKey: .start) ?? 0
+            end = try c.decodeIfPresent(Double.self, forKey: .end) ?? 0
+            text = try c.decodeIfPresent(String.self, forKey: .text) ?? ""
+            speaker = try c.decodeIfPresent(String.self, forKey: .speaker)
+        }
+    }
+
+    public struct ActionItem: Codable {
+        public var text: String
+        public var speaker: String?
+        public var timestampSeconds: Double?
+
+        public init(text: String, speaker: String? = nil, timestampSeconds: Double? = nil) {
+            self.text = text
+            self.speaker = speaker
+            self.timestampSeconds = timestampSeconds
+        }
+
+        private enum CodingKeys: String, CodingKey { case text, speaker, timestampSeconds }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            text = try c.decodeIfPresent(String.self, forKey: .text) ?? ""
+            speaker = try c.decodeIfPresent(String.self, forKey: .speaker)
+            timestampSeconds = try c.decodeIfPresent(Double.self, forKey: .timestampSeconds)
+        }
+    }
+
+    public var id: UUID
+    public var title: String
+    public var createdAt: Date
+    public var duration: Double
+    /// Raw value of the app's `RecordingSource` (`microphone` /
+    /// `systemAudio` / `meeting` / `voiceMemo`). Kept as a string so a
+    /// future source added by the app doesn't fail the decode.
+    public var source: String
+    public var audioFileName: String
+    /// Raw value of the app's `TranscriptionStatus` (`pending` / `running`
+    /// / `completed` / `failed`).
+    public var status: String
+    public var language: String
+    public var modelName: String?
+    public var segments: [Segment]
+    public var deletedAt: Date?
+    public var folder: String?
+    public var appName: String?
+    public var summary: String?
+    public var actionItems: [ActionItem]?
+    /// Raw diarizer ID (`SPEAKER_00`) → user-assigned display name.
+    public var speakerNames: [String: String]
+    /// Inline transcript on legacy records only; current records keep the
+    /// text in the `.txt` sidecar and omit this key.
+    public var legacyFullText: String?
+
+    public var isTrashed: Bool { deletedAt != nil }
+
+    /// Sidecar names, derived from `audioFileName` the same way the app does.
+    public var transcriptFileName: String {
+        (audioFileName as NSString).deletingPathExtension + ".txt"
+    }
+    public var summaryFileName: String {
+        (audioFileName as NSString).deletingPathExtension + ".summary.txt"
+    }
+
+    /// Display names of this recording's diarized speakers (raw IDs
+    /// resolved through `speakerNames`; unnamed IDs stay raw), in
+    /// first-spoken order.
+    public var speakerDisplayNames: [String] {
+        var seen = Set<String>()
+        var names: [String] = []
+        for seg in segments {
+            guard let raw = seg.speaker else { continue }
+            let resolved = speakerNames[raw] ?? raw
+            if seen.insert(resolved).inserted { names.append(resolved) }
+        }
+        return names
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, createdAt, duration, source, audioFileName,
+             status, language, modelName, segments, deletedAt, folder, appName,
+             summary, actionItems, speakerNames
+        case legacyFullText = "fullText"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? .distantPast
+        duration = try c.decodeIfPresent(Double.self, forKey: .duration) ?? 0
+        source = try c.decodeIfPresent(String.self, forKey: .source) ?? ""
+        audioFileName = try c.decodeIfPresent(String.self, forKey: .audioFileName) ?? ""
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? ""
+        language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
+        modelName = try c.decodeIfPresent(String.self, forKey: .modelName)
+        segments = try c.decodeIfPresent([Segment].self, forKey: .segments) ?? []
+        deletedAt = try c.decodeIfPresent(Date.self, forKey: .deletedAt)
+        folder = try c.decodeIfPresent(String.self, forKey: .folder)
+        appName = try c.decodeIfPresent(String.self, forKey: .appName)
+        summary = try c.decodeIfPresent(String.self, forKey: .summary)
+        actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
+        speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
+        legacyFullText = try c.decodeIfPresent(String.self, forKey: .legacyFullText)
+    }
+
+    public init(id: UUID = UUID(), title: String, createdAt: Date, duration: Double = 0,
+                source: String = "microphone", audioFileName: String, status: String = "completed",
+                language: String = "en", modelName: String? = nil, segments: [Segment] = [],
+                deletedAt: Date? = nil, folder: String? = nil, appName: String? = nil,
+                summary: String? = nil, actionItems: [ActionItem]? = nil,
+                speakerNames: [String: String] = [:], legacyFullText: String? = nil) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.duration = duration
+        self.source = source
+        self.audioFileName = audioFileName
+        self.status = status
+        self.language = language
+        self.modelName = modelName
+        self.segments = segments
+        self.deletedAt = deletedAt
+        self.folder = folder
+        self.appName = appName
+        self.summary = summary
+        self.actionItems = actionItems
+        self.speakerNames = speakerNames
+        self.legacyFullText = legacyFullText
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/TranscriptFormatter.swift
+++ b/Packages/MilaKit/Sources/MilaKit/TranscriptFormatter.swift
@@ -1,7 +1,16 @@
 import Foundation
-import TranscriptionCore
 
-enum TranscriptFormatter {
+/// Minimal shape TranscriptFormatter needs from a transcript segment.
+/// Both the app's `TranscriptSegment` (TranscriptionCore) and MilaKit's own
+/// stored/live segment types conform, so the formatter lives here without
+/// dragging the whisper.cpp-linked TranscriptionCore into the MCP helper.
+public protocol SpeakerTextSegment {
+    var text: String { get }
+    /// Raw diarizer ID (`SPEAKER_00`), nil when diarization didn't run.
+    var speaker: String? { get }
+}
+
+public enum TranscriptFormatter {
 
     /// Plain-text rendering of `segments` suitable for the clipboard or for
     /// piping into an LLM prompt. When any segment carries a speaker label
@@ -17,8 +26,9 @@ enum TranscriptFormatter {
     ///
     /// Matches the SRT exporter's prefix format so the clipboard text and
     /// the on-disk `.srt` use the same speaker labels.
-    static func plainText(segments: [TranscriptSegment], fallback: String,
-                          names: [String: String] = [:]) -> String {
+    public static func plainText<S: SpeakerTextSegment>(
+        segments: [S], fallback: String, names: [String: String] = [:]
+    ) -> String {
         guard segments.contains(where: { $0.speaker != nil }) else { return fallback }
 
         var lines: [String] = []

--- a/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import MilaKit
+
+final class MilaMCPToolHandlersTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPHandlerTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("Recordings", isDirectory: true),
+            withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func handlers(now: Date = Date()) -> MilaMCPToolHandlers {
+        MilaMCPToolHandlers(root: root, now: { now })
+    }
+
+    private func call(_ tool: String, _ args: [String: Any] = [:],
+                      now: Date = Date()) throws -> [String: Any] {
+        let raw = try handlers(now: now).handle(tool: tool, arguments: args)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any])
+    }
+
+    private func seedStore(_ recordings: [StoredRecording]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(recordings)
+            .write(to: root.appendingPathComponent("recordings.json"))
+    }
+
+    private func meeting(_ title: String, daysAgo: Double,
+                         speakerNames: [String: String] = [:],
+                         summary: String? = nil) -> StoredRecording {
+        StoredRecording(title: title,
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_000 - daysAgo * 86_400),
+                        duration: 300, source: "meeting",
+                        audioFileName: "\(title).wav", status: "completed",
+                        segments: [
+                            .init(start: 0, end: 3, text: "shalom everyone", speaker: "SPEAKER_00"),
+                            .init(start: 3, end: 6, text: "let's begin", speaker: "SPEAKER_01"),
+                        ],
+                        summary: summary, speakerNames: speakerNames)
+    }
+
+    private func liveSnapshot(sessionID: UUID = UUID(), state: LiveTranscriptSnapshot.State = .recording,
+                              revision: Int = 3, liveAvailable: Bool = true,
+                              updatedAt: Date = Date(),
+                              segments: [LiveTranscriptSnapshot.Segment]? = nil,
+                              finalRecordingID: UUID? = nil) throws -> LiveTranscriptSnapshot {
+        let snap = LiveTranscriptSnapshot(
+            sessionID: sessionID, state: state, liveTranscriptAvailable: liveAvailable,
+            recordingStartedAt: updatedAt.addingTimeInterval(-120), updatedAt: updatedAt,
+            revision: revision,
+            segments: segments ?? [
+                .init(start: 0, end: 2, text: "first", speaker: "SPEAKER_00"),
+                .init(start: 2, end: 4, text: "second", speaker: "SPEAKER_00"),
+                .init(start: 4, end: 6, text: "third", speaker: "SPEAKER_01"),
+            ],
+            speakerNames: ["SPEAKER_00": "Dana"],
+            finalRecordingID: finalRecordingID)
+        try snap.write(root: root)
+        return snap
+    }
+
+    // MARK: - list / get / search via raw JSON args
+
+    func test_list_recordings_speaker_filter_and_shape() throws {
+        try seedStore([
+            meeting("With John", daysAgo: 1, speakerNames: ["SPEAKER_01": "John Doe"]),
+            meeting("Other", daysAgo: 0),
+        ])
+        let result = try call("list_recordings", ["speaker": "john", "limit": 5])
+        XCTAssertEqual(result["count"] as? Int, 1)
+        let first = try XCTUnwrap((result["recordings"] as? [[String: Any]])?.first)
+        XCTAssertEqual(first["title"] as? String, "With John")
+        XCTAssertEqual(first["speakers"] as? [String], ["SPEAKER_00", "John Doe"])
+        XCTAssertEqual(first["has_summary"] as? Bool, false)
+    }
+
+    func test_list_recordings_rejects_bad_sort_and_date() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("list_recordings", ["sort": "bogus"]))
+        XCTAssertThrowsError(try call("list_recordings", ["after": "not-a-date"]))
+    }
+
+    func test_get_transcript_latest_with_names_and_summary() throws {
+        try seedStore([
+            meeting("Latest", daysAgo: 0,
+                    speakerNames: ["SPEAKER_00": "Dana", "SPEAKER_01": "John Doe"],
+                    summary: "Quick sync."),
+            meeting("Older", daysAgo: 2),
+        ])
+        let result = try call("get_transcript")
+        XCTAssertEqual(result["title"] as? String, "Latest")
+        XCTAssertEqual(result["transcript"] as? String,
+                       "Dana: shalom everyone\nJohn Doe: let's begin")
+        XCTAssertEqual(result["summary"] as? String, "Quick sync.")
+    }
+
+    func test_get_transcript_max_chars_truncates() throws {
+        try seedStore([meeting("Long", daysAgo: 0)])
+        let result = try call("get_transcript", ["max_chars": 10])
+        XCTAssertEqual((result["transcript"] as? String)?.count, 10)
+        XCTAssertEqual(result["transcript_truncated"] as? Bool, true)
+    }
+
+    func test_get_transcript_unknown_id_throws_not_found() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("get_transcript", ["id": UUID().uuidString]))
+        XCTAssertThrowsError(try call("get_transcript", ["id": "not-a-uuid"]))
+    }
+
+    func test_search_requires_query() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("search_transcripts"))
+        let result = try call("search_transcripts", ["query": "begin"])
+        XCTAssertEqual(result["count"] as? Int, 1)
+    }
+
+    func test_unknown_tool_throws() {
+        XCTAssertThrowsError(try call("bogus_tool"))
+    }
+
+    // MARK: - get_live_transcript
+
+    func test_live_no_snapshot_is_not_recording() throws {
+        XCTAssertEqual(try call("get_live_transcript")["status"] as? String, "not_recording")
+    }
+
+    func test_live_first_poll_returns_full_transcript_and_cursor() throws {
+        let snap = try liveSnapshot()
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "recording")
+        XCTAssertEqual(result["session_id"] as? String, snap.sessionID.uuidString)
+        XCTAssertEqual(result["revision"] as? Int, 3)
+        XCTAssertEqual(result["next_segment_index"] as? Int, 3)
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 3)
+        XCTAssertEqual(result["transcript"] as? String,
+                       "Dana: first second\nSPEAKER_01: third")
+    }
+
+    func test_live_same_revision_short_circuits() throws {
+        let snap = try liveSnapshot(revision: 3)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 3,
+        ])
+        XCTAssertEqual(result["changed"] as? Bool, false)
+        XCTAssertNil(result["new_segments"])
+    }
+
+    func test_live_delta_resends_last_seen_segment() throws {
+        let snap = try liveSnapshot(revision: 4)
+        // Client saw 2 segments; snapshot now has 3 → resend segment 2 + new segment 3.
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 2,
+            "since_segment_index": 2,
+        ])
+        XCTAssertEqual(result["changed"] as? Bool, true)
+        let texts = (result["new_segments"] as? [[String: Any]])?.compactMap { $0["text"] as? String }
+        XCTAssertEqual(texts, ["second", "third"])
+        XCTAssertEqual(result["next_segment_index"] as? Int, 3)
+    }
+
+    func test_live_session_mismatch_returns_new_session_full_set() throws {
+        _ = try liveSnapshot(revision: 3)
+        let result = try call("get_live_transcript", [
+            "session_id": UUID().uuidString,   // stale cursor from a previous meeting
+            "since_revision": 3,
+            "since_segment_index": 99,
+        ])
+        XCTAssertEqual(result["new_session"] as? Bool, true)
+        XCTAssertEqual(result["changed"] as? Bool, true)
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 3)
+        XCTAssertNotNil(result["transcript"])
+    }
+
+    func test_live_stale_heartbeat_reports_stale() throws {
+        let now = Date()
+        _ = try liveSnapshot(updatedAt: now.addingTimeInterval(-60))
+        let result = try call("get_live_transcript", now: now)
+        XCTAssertEqual(result["status"] as? String, "stale")
+    }
+
+    func test_live_gated_hardware_reports_unavailable() throws {
+        _ = try liveSnapshot(liveAvailable: false)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "recording_live_unavailable")
+    }
+
+    func test_live_completed_hands_off_final_recording_id() throws {
+        let finalID = UUID()
+        _ = try liveSnapshot(state: .completed, finalRecordingID: finalID)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "completed")
+        XCTAssertEqual(result["final_recording_id"] as? String, finalID.uuidString)
+    }
+
+    func test_live_interrupted_reports_not_recording_with_hint() throws {
+        _ = try liveSnapshot(state: .interrupted)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "not_recording")
+        XCTAssertEqual(result["last_session"] as? String, "interrupted")
+    }
+}

--- a/Packages/MilaKit/Tests/MilaKitTests/MilaStoreReaderTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/MilaStoreReaderTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import MilaKit
+
+final class MilaStoreReaderTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaKitTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: - Fixtures
+
+    private func writeStore(_ recordings: [StoredRecording],
+                            recordingsDir: URL? = nil,
+                            storeFile: URL? = nil) throws -> MilaStoreReader {
+        let recsDir = recordingsDir ?? root.appendingPathComponent("Recordings", isDirectory: true)
+        let store = storeFile ?? root.appendingPathComponent("recordings.json")
+        try FileManager.default.createDirectory(at: recsDir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(recordings).write(to: store)
+        return MilaStoreReader(recordingsDirectory: recsDir, storeFileURL: store)
+    }
+
+    private func rec(_ title: String, daysAgo: Double, duration: Double = 60,
+                     source: String = "meeting", status: String = "completed",
+                     folder: String? = nil, appName: String? = nil,
+                     deleted: Bool = false,
+                     segments: [StoredRecording.Segment] = [],
+                     speakerNames: [String: String] = [:]) -> StoredRecording {
+        StoredRecording(title: title,
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_000 - daysAgo * 86_400),
+                        duration: duration, source: source,
+                        audioFileName: "\(title).wav", status: status,
+                        segments: segments,
+                        deletedAt: deleted ? Date(timeIntervalSince1970: 1_700_000_001) : nil,
+                        folder: folder, appName: appName,
+                        speakerNames: speakerNames)
+    }
+
+    private func johnSegments() -> [StoredRecording.Segment] {
+        [.init(start: 0, end: 2, text: "hello team", speaker: "SPEAKER_00"),
+         .init(start: 2, end: 5, text: "hi, thanks for joining", speaker: "SPEAKER_01")]
+    }
+
+    // MARK: - Pointer resolution
+
+    func test_pointer_resolution_follows_relocated_store() throws {
+        let custom = root.appendingPathComponent("Custom", isDirectory: true)
+        try FileManager.default.createDirectory(at: custom, withIntermediateDirectories: true)
+        try StoreLocationPointer(recordingsDirectory: custom.path,
+                                 storeFile: custom.appendingPathComponent("recordings.json").path,
+                                 updatedAt: Date()).write(to: root)
+
+        let reader = MilaStoreReader(root: root)
+        XCTAssertEqual(reader.recordingsDirectory.path, custom.path)
+        XCTAssertEqual(reader.storeFileURL.lastPathComponent, "recordings.json")
+        XCTAssertEqual(reader.storeFileURL.deletingLastPathComponent().path, custom.path)
+    }
+
+    func test_missing_pointer_falls_back_to_default_layout() {
+        let reader = MilaStoreReader(root: root)
+        XCTAssertEqual(reader.recordingsDirectory.path,
+                       root.appendingPathComponent("Recordings").path)
+        XCTAssertEqual(reader.storeFileURL.path,
+                       root.appendingPathComponent("recordings.json").path)
+    }
+
+    // MARK: - Listing
+
+    func test_list_excludes_trashed_and_sorts_newest_first() throws {
+        let reader = try writeStore([
+            rec("Old", daysAgo: 3),
+            rec("New", daysAgo: 1),
+            rec("Trashed", daysAgo: 0, deleted: true),
+        ])
+        let listed = try reader.listRecordings()
+        XCTAssertEqual(listed.map(\.title), ["New", "Old"])
+    }
+
+    func test_speaker_filter_is_case_insensitive_over_display_names() throws {
+        let reader = try writeStore([
+            rec("With John", daysAgo: 1, segments: johnSegments(),
+                speakerNames: ["SPEAKER_01": "John Doe"]),
+            rec("Without", daysAgo: 0, segments: johnSegments()),
+        ])
+        let hits = try reader.listRecordings(filter: .init(speaker: "john doe"))
+        XCTAssertEqual(hits.map(\.title), ["With John"])
+    }
+
+    func test_source_and_date_filters() throws {
+        let reader = try writeStore([
+            rec("Mic", daysAgo: 1, source: "microphone"),
+            rec("Meeting", daysAgo: 2, source: "meeting"),
+        ])
+        XCTAssertEqual(try reader.listRecordings(filter: .init(source: "microphone")).map(\.title),
+                       ["Mic"])
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000 - 1.5 * 86_400)
+        XCTAssertEqual(try reader.listRecordings(filter: .init(after: cutoff)).map(\.title),
+                       ["Mic"])
+        XCTAssertEqual(try reader.listRecordings(filter: .init(before: cutoff)).map(\.title),
+                       ["Meeting"])
+    }
+
+    func test_sort_by_duration_and_title_with_order() throws {
+        let reader = try writeStore([
+            rec("Bravo", daysAgo: 1, duration: 30),
+            rec("alpha", daysAgo: 2, duration: 90),
+        ])
+        XCTAssertEqual(try reader.listRecordings(sort: .duration, order: .desc).map(\.title),
+                       ["alpha", "Bravo"])
+        XCTAssertEqual(try reader.listRecordings(sort: .title, order: .asc).map(\.title),
+                       ["alpha", "Bravo"])
+    }
+
+    func test_limit_caps_results() throws {
+        let reader = try writeStore((0..<5).map { rec("R\($0)", daysAgo: Double($0)) })
+        XCTAssertEqual(try reader.listRecordings(limit: 2).count, 2)
+    }
+
+    func test_latest_completed_skips_pending() throws {
+        let reader = try writeStore([
+            rec("Pending", daysAgo: 0, status: "pending"),
+            rec("Done", daysAgo: 1),
+        ])
+        XCTAssertEqual(try reader.latestCompletedRecording()?.title, "Done")
+    }
+
+    // MARK: - Transcript rendering
+
+    func test_transcript_prefers_sidecar_txt() throws {
+        let recording = rec("Side", daysAgo: 0, segments: johnSegments())
+        let reader = try writeStore([recording])
+        try "sidecar text".write(
+            to: reader.recordingsDirectory.appendingPathComponent("Side.txt"),
+            atomically: true, encoding: .utf8)
+        XCTAssertEqual(reader.transcriptText(for: recording), "sidecar text")
+    }
+
+    func test_transcript_falls_back_to_segments_join() throws {
+        let recording = rec("NoSidecar", daysAgo: 0, segments: johnSegments())
+        let reader = try writeStore([recording])
+        XCTAssertEqual(reader.transcriptText(for: recording),
+                       "hello teamhi, thanks for joining")
+    }
+
+    func test_named_transcript_resolves_speaker_names() throws {
+        let recording = rec("Named", daysAgo: 0, segments: johnSegments(),
+                            speakerNames: ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"])
+        let reader = try writeStore([recording])
+        XCTAssertEqual(reader.namedTranscript(for: recording),
+                       "Daniel: hello team\nJohn Doe: hi, thanks for joining")
+    }
+
+    // MARK: - Search
+
+    func test_search_matches_transcript_with_snippets_and_relevance() throws {
+        let hitRec = rec("Roadmap", daysAgo: 1, segments: [
+            .init(start: 0, end: 1, text: "the roadmap looks solid", speaker: "SPEAKER_00"),
+            .init(start: 1, end: 2, text: "ship the roadmap next week", speaker: "SPEAKER_01"),
+        ])
+        let missRec = rec("Standup", daysAgo: 0, segments: [
+            .init(start: 0, end: 1, text: "nothing to report", speaker: "SPEAKER_00"),
+        ])
+        let reader = try writeStore([hitRec, missRec])
+        let hits = try reader.searchTranscripts(query: "roadmap")
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits.first?.recording.title, "Roadmap")
+        // Title match + two transcript matches.
+        XCTAssertEqual(hits.first?.matchCount, 3)
+        XCTAssertFalse(hits.first?.snippets.isEmpty ?? true)
+    }
+
+    func test_search_sort_by_relevance_then_recency() throws {
+        let often = rec("Often", daysAgo: 5, segments: [
+            .init(start: 0, end: 1, text: "kafka kafka kafka", speaker: "SPEAKER_00"),
+        ])
+        let once = rec("Once", daysAgo: 0, segments: [
+            .init(start: 0, end: 1, text: "kafka maybe", speaker: "SPEAKER_00"),
+        ])
+        let reader = try writeStore([often, once])
+        XCTAssertEqual(try reader.searchTranscripts(query: "kafka").map(\.recording.title),
+                       ["Often", "Once"])
+        XCTAssertEqual(try reader.searchTranscripts(query: "kafka", sort: .createdAt)
+            .map(\.recording.title), ["Once", "Often"])
+    }
+}

--- a/Packages/MilaKit/Tests/MilaKitTests/TranscriptFormatterTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/TranscriptFormatterTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import MilaKit
+
+private struct Seg: SpeakerTextSegment {
+    var text: String
+    var speaker: String?
+}
+
+final class MilaKitTranscriptFormatterTests: XCTestCase {
+
+    func test_no_speakers_returns_fallback() {
+        let segments = [Seg(text: "hello", speaker: nil), Seg(text: "world", speaker: nil)]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: "hello world"),
+                       "hello world")
+    }
+
+    func test_speaker_turns_collapse_and_prefix() {
+        let segments = [
+            Seg(text: "hi", speaker: "SPEAKER_00"),
+            Seg(text: "there", speaker: "SPEAKER_00"),
+            Seg(text: "hey", speaker: "SPEAKER_01"),
+        ]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: ""),
+                       "SPEAKER_00: hi there\nSPEAKER_01: hey")
+    }
+
+    func test_names_resolve_and_merge_identically_named_ids() {
+        let segments = [
+            Seg(text: "one", speaker: "SPEAKER_00"),
+            Seg(text: "two", speaker: "SPEAKER_01"),
+        ]
+        let names = ["SPEAKER_00": "Dana", "SPEAKER_01": "Dana"]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: "", names: names),
+                       "Dana: one two")
+    }
+
+    func test_empty_segments_skipped_and_unlabeled_segment_kept_bare() {
+        let segments = [
+            Seg(text: "  ", speaker: "SPEAKER_00"),
+            Seg(text: "spoken", speaker: "SPEAKER_00"),
+            Seg(text: "aside", speaker: nil),
+        ]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: ""),
+                       "SPEAKER_00: spoken\naside")
+    }
+}

--- a/docs/PLAN-obsidian-destination.md
+++ b/docs/PLAN-obsidian-destination.md
@@ -1,11 +1,109 @@
-# PLAN — Obsidian destination via the LLM CLI + skills/MCP (macOS)
+# PLAN — Obsidian destination (macOS)
 
-**Status:** Draft for confirmation (do not implement yet)
+**Status:** IMPLEMENTED (direct-write). See §0 for the shipped design; §1–§9
+below are retained as historical record of the earlier delegate approach.
 **Scope:** First slice of the PRD's "destinations" capability
 (`docs/PRD-mila-anywhere.md` §7), narrowed to Obsidian on the existing macOS
-app. **Pivoted 2026-07-16:** Mila does NOT write files itself — it **delegates
-filing to the user's configured LLM CLI** (`claude`/`cursor-agent`/`gemini`)
-using that CLI's **Obsidian skill/MCP tool**.
+app.
+
+---
+
+## 0. Re-pivot (2026-07-19): Mila writes the notes directly
+
+The delegate design in §1–§9 (Mila asks the user's LLM CLI + an Obsidian
+skill/MCP to file the note) was **superseded**. Mila now **writes the Markdown
+note itself** into a user-picked vault folder, and optionally commits + pushes
+the vault's git repo. This is simpler, LLM-independent (a transcript-only user
+still gets notes), and needs no MCP/skill setup by the user.
+
+### What shipped
+
+- **`Mila/Models/ObsidianVaultSettings.swift`** — opt-in `enabled`, a
+  security-scoped bookmark to the vault folder (mirrors
+  `RecordingStorageSettings`), a `subfolder` (default `Transcripts`, blank =
+  vault root), and git fields (`gitSyncEnabled`, `gitBranch` default `main`,
+  plus a non-persisted `lastSyncError` for the UI). `destinationDirectory`
+  resolves `vault/subfolder`.
+- **`Mila/Actions/ObsidianExporter.swift`** — builds the note and writes it.
+  Content is **summary + action items**, falling back to **transcript
+  (`TranscriptFormatter.plainText`) + action items** when no summary exists.
+  One `.md` per recording named `<yyyy-MM-dd> <sanitized title>.md`. A
+  per-recording seen-index (`obsidian.writtenIndex` in `UserDefaults`) maps
+  recording ID → last relative path so a title edit / re-transcription
+  overwrites (and renames) the same note instead of duplicating. A `pending`
+  set is the sequencing gate: only recordings marked pending on a fresh
+  completion are exported, so a launch-time summary backfill never spams the
+  vault. On success it kicks the git syncer when enabled.
+- **`Mila/Actions/ObsidianGitSyncer.swift`** — an `actor` (serializes concurrent
+  completions) running `rev-parse --show-toplevel` → `add` → `commit` →
+  `pull --rebase origin <branch>` → `push origin HEAD:<branch>`. "Nothing to
+  commit" is treated as success; a rebase conflict triggers `rebase --abort`
+  (never leaves the vault mid-rebase, local commit preserved for the next
+  push). Runs git non-interactively (`GIT_TERMINAL_PROMPT=0`, SSH `BatchMode`)
+  with a bounded timeout. A `GitCommandRunning` seam lets tests assert the exact
+  command sequence without a real repo.
+- **`RecordingSummarizer.onSummaryFinished`** — fired once per summarize attempt
+  after the summary state is final (generated / skipped / failed), passing the
+  latest recording; NOT fired for a dedup early-return or a deleted recording.
+  This is the "summary is ready" signal the exporter waits on (resolves the
+  §4.3 ordering race), with a synchronous fire on the skip paths so a
+  transcript-only export never hangs.
+- **Wiring** — `MilaApp` constructs `ObsidianVaultSettings` + `ObsidianExporter`,
+  sets `summarizer.onSummaryFinished` (export if pending, then clear), and marks
+  fresh completions pending in both the batch path
+  (`TranscriptionService.onTranscriptionCompleted`) and the live path
+  (`QuickActionsController`). The re-transcription + summaries-off case exports
+  immediately (no summarizer hook to await).
+- **`Mila/Views/ObsidianSettingsSection.swift`** — an Obsidian section embedded
+  in the **Storage** settings tab (not a standalone tab, to avoid overflowing
+  the fixed-width tab bar): enable toggle, vault folder picker (`NSOpenPanel`),
+  subfolder field, git toggle + branch field, stale-bookmark notice, and
+  last-sync error display. `StorageSettingsTab` wraps its content in a
+  `ScrollView` and appends this section below a divider.
+- **Tests** — `ObsidianVaultSettingsTests`, `ObsidianExporterTests`,
+  `ObsidianGitSyncerTests`, `ObsidianGitSyncerIntegrationTests`,
+  `ObsidianExportSequencingTests`. All green.
+
+### Follow-up (2026-07-19b): backfill + Mila-folder mirroring
+
+- **Backfill existing transcripts** — `ObsidianExporter.exportAll([Recording])`
+  writes every recording that has content and kicks a **single** git sync for
+  the whole batch. Surfaced as a "Sync existing transcripts" button in the
+  Obsidian section (`ObsidianSettingsSection`, gated on a chosen vault). Solves
+  "Obsidian was enabled after recordings already existed".
+- **Mila folder → vault subfolder** — a note now lands in
+  `vault/<subfolder>/<Mila folder>/<file>.md` when the recording is filed under
+  a Mila folder (`Recording.folder`), created if needed and sanitized like a
+  title; unfiled recordings stay in the base dir. The seen-index tracks the
+  full relative path, so moving a recording between folders removes the old note.
+- **Git staging generalized** — `ObsidianGitSyncer.sync` now takes
+  `changedPaths: [URL]` and stages with `git add --all --` (captures the new
+  note, a renamed note's deletion, and a whole backfill batch) without touching
+  unrelated vault files.
+
+### Mila-folder assignment UI (2026-07-19c)
+
+Three surfaces to file a recording into a Mila folder (which the Obsidian
+exporter then mirrors into the vault, per above):
+
+- **Record-start (Home)** — a "Save to" folder dropdown under the record
+  controls, bound to `QuickActionsController.nextRecordingFolder` (sticky,
+  persisted in `UserDefaults`). Applied when the recording is saved in
+  `stopRecording` (`folder:` on the `Recording` + `store.assign` to register
+  the folder). "All Transcriptions" = unfiled.
+- **Finalize (rename sheet)** — a "Folder" menu (None / existing / New Folder…)
+  in `RenameRecordingSheet`, applied on Save/Send via `store.assign`.
+- **Detail view** — a folder chip in `RecordingDetailView`'s header metadata row
+  (None / existing / New Folder… via an alert) that reassigns live.
+
+New recordings still land in "All Transcriptions" by default and can be dragged
+into a folder from the sidebar (pre-existing behavior).
+
+### Not in this pass
+
+- No manual per-recording "Export to Obsidian" button (auto-run + bulk backfill only).
+- Git credential/auth management (the vault must already push non-interactively).
+- Front-matter / audio links / per-note customization beyond the above.
 
 ---
 

--- a/docs/PLAN-obsidian-destination.md
+++ b/docs/PLAN-obsidian-destination.md
@@ -1,0 +1,233 @@
+# PLAN — Obsidian destination via the LLM CLI + skills/MCP (macOS)
+
+**Status:** Draft for confirmation (do not implement yet)
+**Scope:** First slice of the PRD's "destinations" capability
+(`docs/PRD-mila-anywhere.md` §7), narrowed to Obsidian on the existing macOS
+app. **Pivoted 2026-07-16:** Mila does NOT write files itself — it **delegates
+filing to the user's configured LLM CLI** (`claude`/`cursor-agent`/`gemini`)
+using that CLI's **Obsidian skill/MCP tool**.
+
+---
+
+## 1. Goal (restated after the pivot)
+
+When a recording finishes transcribing, Mila **automatically** runs the user's
+LLM CLI with the recording's **summary + action items** and asks it to file
+them into Obsidian, **using a skill/MCP tool the CLI has for Obsidian**. Mila's
+new reusable capability: *"when calling the LLM CLI, request specific
+skills/tools to be used."*
+
+**Success criteria**
+- With an Obsidian skill/MCP configured in the user's CLI, a completed
+  recording's summary + action items land in Obsidian without manual steps.
+- Users who don't configure this see no behavior change (feature is opt-in/off).
+- The "request skills/tools" mechanism is generic (not Obsidian-hardcoded) and
+  works for the CLIs Mila supports.
+- New logic is unit-tested; existing suite stays green.
+
+---
+
+## 2. Confirmed decisions (2026-07-16 review)
+
+| # | Decision |
+|---|----------|
+| Trigger | **Automatic** on transcription complete (+ a manual re-run path for the existing library — see §5 note). |
+| Content | **Summary + Action items only** (no transcript, no front-matter). |
+| Audio | **Nothing** — not attached/linked. |
+| Filing/location | **Delegated to the LLM + its Obsidian skill/MCP** — Mila does not compute paths or write files. |
+| Granularity | **One note per recording** (the skill/prompt decides layout). |
+
+---
+
+## 3. Method research — "request skills/tools when calling the CLI"
+
+Verified current (2026). Two distinct mechanisms:
+
+### 3.1 Claude "Agent Skills" (Claude-only)
+- Skills are `SKILL.md` folders auto-discovered from `~/.claude/skills/` (user)
+  and `.claude/skills/` (project); **model-invoked**.
+- Headless `-p` mode: no interactive toggle, **but** you can **invoke a skill
+  by prefixing the prompt** — `claude -p "/obsidian <prompt>"` — and chain up
+  to six (`/a /b <prompt>`), added in Claude Code **v2.1.199**.
+- Tool gating: `--allowedTools` restricts which tools may run.
+- Easiest to wire from Mila: it's just **prompt text** (`/skillname ` prefix) —
+  no new config plumbing, no flags.
+
+### 3.2 MCP servers (portable across claude / cursor-agent / gemini)
+- The cross-tool standard. Good Obsidian MCP servers exist (e.g.
+  `@yanxue06/obsidian-mcp`, `mcp-obsidian`); most need Obsidian's **Local REST
+  API** community plugin + an API key, or a vault path.
+- Configured once per CLI:
+  - Claude: `claude mcp add obsidian -e OBSIDIAN_API_KEY=… -- npx -y …`
+    (→ `~/.claude/settings.json` / `.mcp.json`).
+  - Cursor: `.cursor/mcp.json` (or `~/.cursor/mcp.json`).
+  - Gemini: `~/.gemini/settings.json` `mcpServers`; per-invocation
+    `--allowed-mcp-server-names obsidian`; headless requires
+    `"mcp": { "autoAllowInHeadless": true }` (default-deny otherwise).
+- Per-invocation enabling flags differ by tool (Gemini has a first-class flag;
+  Claude/Cursor lean on config + allowed-tools).
+
+### 3.3 What already works in Mila today (don't rebuild)
+`LLMSettings.extraArgs` (free-text CLI args, tokenized) + the editable
+`postActionPrompt` already let a user, right now: configure an Obsidian
+MCP/skill in their CLI, write "file this into Obsidian" as the action, and pass
+e.g. `--allowed-mcp-server-names obsidian` via extra args. The gap is: (a) it's
+not **automatic** on completion, (b) skills/tools aren't a **first-class,
+per-tool-aware** field, and (c) `gemini` isn't a supported tool yet.
+
+### 3.4 Recommended method (for confirmation)
+- **Ship `gemini` support first** (`LLMTool.gemini`) — needed regardless, tiny.
+- **Add a first-class "Skills / tools to use" field** on the action config that
+  is applied per-tool:
+  - Claude → prepend `/skill` tokens to the prompt (§3.1) and/or add
+    `--allowedTools`.
+  - Gemini → inject `--allowed-mcp-server-names <names>` (§3.2).
+  - Cursor → rely on its MCP config (document it); no per-invocation flag.
+- **Recommendation:** treat **MCP as the primary, portable path** (works on all
+  three tools, and Obsidian has solid MCP servers), and support **Claude skill
+  prompt-prefix** as the zero-config bonus for Claude users. This is the
+  "best + easy" balance: MCP for robustness/portability, `/skill` prefix for
+  Claude convenience.
+
+**→ Open choice C1 (see §7): confirm MCP-primary vs Claude-skills-primary vs both.**
+
+---
+
+## 4. Design (delegate approach)
+
+Builds entirely on the existing LLM integration
+(`Mila/Actions/LLMSettings.swift`, `LLMRunner.swift`, `LLMTool`,
+`PostRecordingCoordinator`, `RecordingSummarizer`). **No** `ObsidianExporter`,
+**no** vault folder picker, **no** new entitlement.
+
+### 4.1 Gemini support
+- Add `case gemini` to `LLMTool`: `executableName = "gemini"`,
+  `arguments → ["-p", prompt]` (+ `["-m", model]` when set). Session ignored
+  (like `cursor`). Extend PATH fallback to include `~/.gemini` if needed.
+
+### 4.2 First-class "skills/tools" on the action
+- Add to `LLMSettings`: `actionSkills: [String]` (or a single free-text field
+  tokenized like `extraArgs`) + persistence.
+- Extend `LLMTool.arguments(...)` / `LLMRunner.run(...)` to apply skills
+  per-tool:
+  - Claude: prepend `/name ` tokens to the composed prompt.
+  - Gemini: append `--allowed-mcp-server-names <csv>`.
+  - Cursor: no-op at the flag level (documented as config-driven).
+
+### 4.3 Auto-run action on completion
+- New toggle `autoRunActionEnabled` (default OFF).
+- Wire a hook off `TranscriptionService.onTranscriptionCompleted` (same seam
+  `RecordingSummarizer` uses in `MilaApp.init`): when enabled + LLM configured,
+  after the summary/action items exist, run `LLMRunner.run` with
+  `postActionPrompt` + the configured skills, feeding **summary + action
+  items** (not the transcript — per §2). Runs on the background/`.userInitiated`
+  path with the existing `cliTimeout`.
+- **Ordering caveat [risk]:** the summary is itself produced by an async LLM
+  call (`RecordingSummarizer`). Auto-run must fire **after** summary+actions are
+  ready, or it'll send empty content. Needs sequencing against the summarizer.
+
+### 4.4 Settings UI
+- Extend the existing **LLM** settings tab (not a new tab): add the
+  "Auto-run action after transcription" toggle and the "Skills / tools to use"
+  field, with a short helper explaining MCP setup + the Claude `/skill` prefix.
+  Reuse the existing test panel to dry-run the action + skills.
+
+---
+
+## 5. Test plan (test-first)
+
+- `LLMTool.arguments` unit tests for `gemini` (arg vector) and for skill
+  application per tool (Claude `/skill` prefix present; Gemini
+  `--allowed-mcp-server-names` appended; Cursor unchanged). Extend
+  `MilaTests/LLMRunnerTests.swift`.
+- Prompt-composition test: auto-run feeds **summary + action items** and NOT
+  the transcript; empty summary/actions → no-op (don't invoke the CLI).
+- Auto-run sequencing test: action fires only after summary/actions are
+  populated (guard against the §4.3 ordering race).
+- `LLMSettings` persistence test for the new toggle + skills field (injected
+  `UserDefaults(suiteName:)` per project convention).
+- Reuse `scripts/fake-llm-cli.sh` as a stand-in binary for an end-to-end-ish
+  runner test (assert it receives the expected argv incl. skills/flags).
+
+"Done" = new tests green + `make test` green.
+
+---
+
+## 6. Out of scope
+- Mila writing files / a vault folder picker (rejected — the LLM+skill files it).
+- Transcript body, front-matter, audio in the note.
+- Google Drive, NotebookLM, mobile, OAuth.
+- Bundling/installing an Obsidian MCP server with Mila (user's own setup);
+  Mila only *documents* it and *requests* it at invocation.
+
+**Manual path note:** auto-run only covers NEW completions. The existing
+"Send to <LLM>…" sheet (`SendToLLMSheet`) already provides a manual per-recording
+action for the back-catalogue; it will inherit the new skills field, so no
+separate manual Obsidian button is strictly needed.
+
+---
+
+## 7. Resolved decisions (2026-07-16)
+
+- **C1 → BOTH.** Build the portable **MCP** path (Gemini
+  `--allowed-mcp-server-names`; Claude/Cursor via their MCP config + allowed
+  tools) **and** the Claude **`/skill` prompt-prefix** convenience.
+- **C2 → INCLUDE A SETUP GUIDE.** The user does not yet have an Obsidian
+  MCP/skill configured, so this feature ships with a short doc (new deliverable,
+  §8) covering the Obsidian **Local REST API** plugin + adding an Obsidian MCP
+  server to each supported CLI, plus the Claude `/skill` note.
+
+## 8. Deliverable: setup guide
+
+New `docs/OBSIDIAN_DESTINATION.md` (user-facing), covering:
+1. Enable Obsidian's **Local REST API** community plugin; copy the API key.
+2. Add an Obsidian MCP server to your CLI:
+   - Claude: `claude mcp add obsidian -e OBSIDIAN_API_KEY=… -- npx -y <server>`
+   - Gemini: `~/.gemini/settings.json` `mcpServers` + `"mcp": {
+     "autoAllowInHeadless": true }`.
+   - Cursor: `.cursor/mcp.json` / `~/.cursor/mcp.json`.
+3. In Mila → Settings → LLM: pick the tool, set the "Skills / tools to use"
+   field (e.g. `obsidian`), enable "Auto-run action after transcription", and
+   set the action prompt (e.g. "File this summary and action items into my
+   Obsidian vault as a new note").
+4. Claude-only convenience: reference an installed skill by prefixing the
+   prompt (`/obsidian …`).
+
+---
+
+## 9. Status
+
+Implementation order (tests first):
+
+1. **`LLMTool.gemini` — DONE (2026-07-16).** Added the `.gemini` case
+   (`displayName`, `executableName = "gemini"`, `arguments` → `gemini -p
+   <prompt> --skip-trust` with optional `-m <model>`; session ignored).
+   Picker/help text pick it up via `allCases`. Unit tests in `LLMRunnerTests`
+   cover metadata, the arg vector, executable-lookup dirs, and the child
+   environment; a real-CLI smoke test auto-skips when `gemini` isn't on PATH.
+
+   Two production issues found while validating end-to-end against the real
+   `gemini` CLI, both now fixed in `LLMRunner`:
+   - **PATH / version managers.** `gemini` installed via **nvm** lives under
+     `~/.nvm/versions/node/<v>/bin`, previously not searched. `lookupOnPath`
+     was refactored to `searchDirectories(home:pathEnv:fileManager:)`, which now
+     enumerates all nvm node bins (newest first) plus Volta / asdf / npm-global.
+   - **node interpreter not on child PATH.** `gemini`'s shebang is
+     `#!/usr/bin/env node`; a Finder-launched app has a stripped PATH so the
+     child died with `env: node: No such file or directory`. New
+     `childEnvironment(for:base:)` augments the child's PATH with the resolved
+     executable's own dir (its sibling `node`) + the well-known dirs.
+   - **Workspace trust.** We launch in an isolated empty sandbox (TCC safety),
+     which gemini rejects as untrusted in headless mode. `--skip-trust` (the
+     gemini analogue of cursor's `-f`) is now always passed.
+
+   **Remaining, out of our control:** on the dev machine the smoke test now gets
+   all the way to auth and fails with gemini's `IneligibleTierError`
+   (free-tier "Gemini Code Assist for individuals" is deprecated). Users resolve
+   this with `GEMINI_API_KEY` or a supported tier. CI is unaffected — the smoke
+   test skips when `gemini` isn't installed.
+2. skills/tools plumbing in `LLMSettings`/`LLMTool`/`LLMRunner` (MCP flags +
+   Claude `/skill` prefix);
+3. auto-run-action-on-completion with the summary-ready sequencing guard;
+4. LLM settings-tab UI;
+5. `docs/OBSIDIAN_DESTINATION.md`.

--- a/docs/PLAN-ui-render-flood-freeze.md
+++ b/docs/PLAN-ui-render-flood-freeze.md
@@ -1,0 +1,198 @@
+# PLAN: Fix UI freeze when opening menus during recording/transcription
+
+## Feature description
+
+Opening the folder picker `Menu` on a screen that is receiving high-frequency
+`@Published` updates (the live recording screen, the recording detail view
+during active transcription, and the post-stop rename sheet) can beachball the
+whole app. This plan removes that class of freeze — and the related jank —
+without migrating off `ObservableObject` (the `@Observable` migration was
+explicitly deferred). The user-visible outcome: folder/meeting-name controls
+stay responsive while a recording is being captured or transcribed, and the
+progress indicator no longer stalls/jumps.
+
+## Goal / success criteria
+
+- **Primary (manual, reproducible):** With a recording actively transcribing
+  (or a live recording in progress), opening the folder `Menu` on the live
+  recording screen, the recording detail view, and the rename sheet does **not**
+  freeze the UI. A `sample Mila`/`spindump` taken while the menu is open shows
+  the main thread idle in menu tracking — not stacked with SwiftUI/AttributeGraph
+  re-render work.
+- **Progress is smooth + monotonic:** the transcription progress bar/percent
+  advances without jumping backward and does not visibly stall just short of
+  completion.
+- **No regressions:** folder assignment, meeting-name entry, live auto-scroll,
+  and transcript rendering behave exactly as before (same final state, same
+  persisted data).
+- **Unit-testable cores pass:** the progress-coalescing/monotonic guard and any
+  extracted pure helpers have tests (see Tests section).
+
+## Files explored
+
+| File | Why it matters |
+|---|---|
+| `Mila/Views/LiveAIRecordingView.swift` | `metaRow` (L142–181) puts a folder `Menu` + meeting-name `TextField` in `header`/`body`, which observes `transcriber`/`diarizer`/`aiSession` (high-frequency). Also owns the per-tick auto-scroll (L475–501). Contains the `RecordingElapsedLabel` leaf (L627) — the isolation pattern to reuse. |
+| `Mila/Views/RecordingDetailView.swift` | `folderMenu` (L97–125) in `header`/`body`; view observes `transcription`, so `progress` floods it during active transcription of the open recording. |
+| `Mila/Views/RenameRecordingSheet.swift` | Folder `Menu` (L379–420) in a body that renders `transcription.progress` (L100–118, L492–496); sheet appears right after Stop while batch transcription runs. |
+| `Mila/Views/HomeView.swift` | `folderPicker` (L202–230) in a body observing `transcription` + `actions`; lower-risk instance of the same pattern. |
+| `Mila/Transcription/TranscriptionService.swift` | `progress` `@Published` (L28) updated via one unstructured `Task` per whisper tick (L672–678). Source of the flood + out-of-order/stall. |
+| `Mila/Audio/LiveTranscriber.swift` | `@Published fullText` (L42) + `segments` (L63) update at partial-transcript cadence; drive the live view flood and the per-tick auto-scroll. |
+| `Mila/Models/RecordingStore.swift` | `assign` (L427–441) → `persist()` (L782–792) synchronously encodes the entire recordings array + atomic disk write on the main thread on every folder selection. |
+
+## Existing-design review
+
+The fix deliberately reuses patterns already in the codebase:
+
+- **Leaf-isolation of high-frequency observers** — `RecordingElapsedLabel`
+  (`LiveAIRecordingView.swift` L627) observes only `RecordingSession` so the
+  parent body isn't rebuilt at audio cadence. The folder/meeting controls will
+  follow the same shape: small leaf views observing only what they render
+  (`store.folders`, the `actions` bindings), never `transcriber` /
+  `transcription` / `aiSession`.
+- **`LazyVStack` + deferred `scrollTo`** — already used for the transcript; the
+  scroll debounce builds on the existing `scrollToBottom` runloop-hop.
+- **`@MainActor` service classes** — `TranscriptionService` is already
+  `@MainActor`; the coalesced progress update stays on it, just fed by a single
+  throttled path instead of N Tasks.
+- **Serial background work** — the codebase already offloads heavy work off the
+  main actor (`finalizeTail`, `Task.detached`); persistence debouncing/off-main
+  will match that convention.
+
+## Deviation justification (if any)
+
+*None — reuses existing patterns (leaf isolation à la `RecordingElapsedLabel`,
+throttled main-actor updates, existing off-main task conventions). The
+`@Observable` framework migration — which would solve observation granularity
+structurally — is explicitly out of scope for this plan per the user's
+decision, and is noted below as a future option only.*
+
+## Scope (ordered by impact)
+
+1. **Leaf-isolate the folder picker + meeting-name controls** so they no longer
+   sit in a body observing the high-frequency objects. Extract a
+   `RecordingFolderMenu` (and, where present, isolate the meeting-name field)
+   used by `LiveAIRecordingView`, `RecordingDetailView`, `RenameRecordingSheet`,
+   and `HomeView`. Each observes only `store` (for `folders`) and the relevant
+   `actions`/store binding. **This directly kills the reported freeze.**
+2. **Coalesce + guard `TranscriptionService.progress`.** Replace the
+   one-`Task`-per-tick pattern with a single ordered update path that (a) applies
+   values monotonically (never regress), and (b) throttles to a sane cadence
+   (e.g. only when it changes by ≥1% or every ~100ms). Fixes the "stuck/jumpy
+   progress" and reduces flood pressure.
+3. **Debounce the live auto-scroll** so `fullText` growth triggers at most one
+   `withAnimation` scroll per animation window instead of one per partial tick.
+4. **Move `persist()` off the main thread (or debounce it)** so folder
+   assignment on a large library doesn't stall the main thread.
+
+Steps 1–2 are the core of the fix; 3–4 are the related "similar behaviour"
+items surfaced in review. Each step is independently landable.
+
+## Open questions
+
+1. **Scope confirmation:** do you want all four steps in one pass, or land
+   step 1 (freeze fix) first and treat 2–4 as follow-ups? Recommendation: land
+   1 + 2 together (they share the root cause), then 3 + 4.
+2. **Progress throttle policy:** is "publish on ≥1% change or every 100ms,
+   monotonic" acceptable, or do you want a specific cadence?
+3. **Persistence (step 4):** debounce on the main actor (simplest, keeps
+   ordering) vs. serialize encoding onto a background actor/queue (removes the
+   stall entirely, more moving parts). Recommendation: start with a short
+   debounce; only go off-main if profiling still shows a stall.
+4. **Meeting-name field:** confirm you want it isolated too (it re-renders on
+   every tick today, causing typing lag), or is only the `Menu` in scope?
+
+---
+
+## Tests
+
+> Draft — to be confirmed in workflow step 3 before implementation.
+
+### What to test
+
+- **Progress coalescing/monotonic guard (unit):** feeding an out-of-order /
+  regressing sequence (e.g. 0.1, 0.5, 0.4, 1.0, 0.9) yields a non-decreasing
+  published sequence ending at the max; sub-threshold deltas are dropped.
+- **Auto-scroll debounce (unit, if extracted as a pure throttle):** N rapid
+  triggers within one window collapse to a single scroll invocation.
+- **Folder assignment behavior unchanged (unit):** `store.assign` still files
+  the recording under the (case-insensitively deduped) folder and persists;
+  debouncing/off-main persistence still results in the same on-disk JSON
+  (flush-and-read in the test).
+- **Manual (freeze repro):** enumerated steps to open each folder menu during
+  active transcription/recording and confirm no beachball (+ optional spindump).
+
+### How to test
+
+- Framework: XCTest (`MilaTests/`), matching existing suites like
+  `QuickActionsControllerTests` / `TranscriptionService`-adjacent tests.
+- Isolation: any `TranscriptionService`/`RecordingStore` under test uses the
+  existing test-injection conventions (custom `UserDefaults` suite; temp store
+  directory) per `CLAUDE.md`.
+- Manual: `make dmg VERSION=<x.y.z>` local build; repro script in the plan.
+
+### Done definition
+
+- New unit tests pass; `make test` + `make package-test` green.
+- Manual freeze repro no longer reproduces on the three screens.
+- No behavioral change to folder assignment / transcript content.
+
+---
+
+## Implementation notes (filled in as you go)
+
+Implemented 2026-07-20. Decisions made (user said "implementation" without
+answering the open questions, so the plan's recommended defaults were used):
+
+- **Step 1 — leaf isolation (done).** New `Mila/Views/RecordingFolderControls.swift`
+  with three leaves that observe only `RecordingStore` / `QuickActionsController`:
+  - `NextRecordingFolderPicker` — used by `HomeView` + `LiveAIRecordingView`.
+  - `NextRecordingMeetingNameField` — used by `HomeView` + `LiveAIRecordingView`
+    (meeting-name field isolated too, per open question #4 recommendation).
+  - `RecordingFolderMenu(recordingID:currentFolder:)` — used by
+    `RecordingDetailView`; owns its own "New Folder…" alert state.
+  Rationale: a leaf with constant/stable inputs is not re-invoked when its
+  parent body churns, so the open NSMenu host is never reconciled mid-tracking.
+  Removed now-unused `@EnvironmentObject store` from `HomeView` and
+  `LiveAIRecordingView`, and the dead folder-alert `@State` from
+  `RecordingDetailView`.
+- **Step 3 — rename sheet (done).** `RenameRecordingSheet` no longer holds
+  `@EnvironmentObject transcription`. All progress/status rendering moved into a
+  new file-private `RenameTranscriptionStatusRow` leaf (observes `transcription`
+  + `store`). The sheet body — including the folder `Menu` — therefore no longer
+  re-renders on progress ticks.
+- **Step 2 — progress coalescing (done).** Added `ProgressCoalescer`
+  (lock-guarded, `@unchecked Sendable`) in `TranscriptionService.swift`. The
+  whisper progress callback now `offer`s into a per-run coalescer and only
+  schedules a main-actor flush when none is pending; `flush` applies the
+  monotonic max. Chosen over the "≥1%/100ms" throttle from open question #2
+  because single-pending-flush coalescing bounds outstanding work to one Task
+  AND guarantees monotonicity with less machinery. Unit-tested in
+  `MilaTests/ProgressCoalescerTests.swift`.
+- **Step 5 — auto-scroll debounce (done).** `scrollToBottom` in
+  `LiveAIRecordingView` now cancels/replaces a `DispatchWorkItem` (0.1s), so the
+  per-`fullText`-tick scroll collapses to one animation per window.
+- **Step 4 (persistence) — DEFERRED.** Making `persist()` async/debounced risks
+  flaking ~8 tests that read `recordings.json` synchronously after a mutation
+  (diagnostics, storage relocation, `StoredRecordingDrift`). It's also a
+  separate pre-existing perf issue (select-time stall, not the reported
+  menu-open freeze). Left synchronous; should be handled in its own change with
+  dedicated tests.
+
+### Verification
+
+- `make build` — BUILD SUCCEEDED.
+- `xcodebuild ... -only-testing:MilaTests test` — all pass **except** two
+  pre-existing, environment-dependent `LLMRunnerTests`
+  (`test_gemini_cli_returns_a_title_for_a_sample_transcript`,
+  `test_runner_passes_prompt_in_argv_and_closes_stdin`) that shell out to real
+  LLM CLIs / temp scripts. No LLM/subprocess code was touched, so these are
+  unrelated. `ProgressCoalescerTests` + all folder/rename/transcription tests
+  pass. No lint errors on edited files.
+- **Manual freeze repro still outstanding:** open the folder menu on the live
+  recording screen / detail view during active transcription and confirm no
+  beachball (optionally `sample Mila` while the menu is open).
+
+## Blockers hit
+
+_(none)_

--- a/docs/PLAN-ui-render-flood-freeze.md
+++ b/docs/PLAN-ui-render-flood-freeze.md
@@ -193,6 +193,58 @@ answering the open questions, so the plan's recommended defaults were used):
   recording screen / detail view during active transcription and confirm no
   beachball (optionally `sample Mila` while the menu is open).
 
+## Follow-up 2026-07-20 — Step 1 was necessary but INSUFFICIENT
+
+The user reported the freeze STILL reproduced when opening the folder menu on
+the live recording window during recording. Root cause: Step 1 leaf-isolated
+the menu's *content* (`NextRecordingFolderPicker` / `RecordingFolderMenu`), but
+the menu's **ancestors** still re-rendered every tick. `LiveAIRecordingView`
+held `@EnvironmentObject transcriber/diarizer/aiSession` at the top level, so
+its whole body — including `header`/`metaRow` (which host the folder menu) —
+re-executed on every partial-transcript / AI tick. Reconciling the ancestors
+of an OPEN NSMenu-backed control (nested modal tracking runloop) beachballs the
+app. Same latent bug in `RecordingDetailView`, which held
+`@EnvironmentObject transcription` and read `progress` in its body while
+hosting `RecordingFolderMenu`.
+
+Fix: push the high-frequency observation DOWN out of the menu's ancestors.
+
+- **`LiveAIRecordingView` (done).** Extracted `LiveTranscriptPane` (owns
+  `LiveTranscriber` + the scroll debounce/`exportLiveSRT`), `ActionItemsPane`
+  (owns `LiveAISession` + `LiveTranscriber` for speaker names + the AI-pane RTL
+  logic), and `LiveThinkingIndicator` (owns `LiveAISession` for the header
+  "Thinking…" dot). Removed `transcriber`/`diarizer`/`aiSession` (and the
+  now-dead `diarizer` subscription) + the `pendingScroll` `@State` from the
+  parent. The parent now observes only `actions` / `languageSettings` /
+  `liveAISettings` / `llmSettings` — none tick during recording — so the header
+  + folder menu no longer re-render at transcript cadence. `bulletsFromSummary`
+  kept static on `LiveAIRecordingView` so `LiveAIBulletsTests` is unaffected.
+- **`RecordingDetailView` (done).** Extracted `RecordingDetailActionButtons`
+  (owns `TranscriptionService` for the `busy` gate + `enqueue`) and
+  `RecordingTranscriptArea` (owns `TranscriptionService` `progress`/active/
+  queued state + `ModelManager`). Removed `@EnvironmentObject transcription`
+  (and the now-unused `modelManager`) from the parent. `EmptyTranscriptPlaceholder`
+  + `emptyTranscriptPlaceholder` kept on `RecordingDetailView` so
+  `RecordingDetailPlaceholderTests` is unaffected.
+
+Surroundings: `RenameRecordingSheet` was already correctly isolated
+(`RenameTranscriptionStatusRow` leaf). `HomeView` still holds
+`@EnvironmentObject transcription` but only shows its folder menu when NOT
+recording; a background batch job could still flood it — noted as a lower-risk
+optional follow-up, not done here.
+
+### Verification (follow-up)
+
+- `make build` — BUILD SUCCEEDED.
+- `xcodebuild ... -only-testing:MilaTests/LiveAIBulletsTests
+  -only-testing:MilaTests/RecordingDetailPlaceholderTests test` — TEST
+  SUCCEEDED. No lint errors on either edited view.
+- **Manual freeze repro still outstanding:** open the folder menu on the live
+  recording window AND the recording detail view during active transcription;
+  confirm no beachball (optionally `sample Mila` while the menu is open — the
+  main thread should be idle in menu tracking, not in SwiftUI/AttributeGraph
+  re-render).
+
 ## Blockers hit
 
 _(none)_

--- a/docs/PRD-mila-anywhere.md
+++ b/docs/PRD-mila-anywhere.md
@@ -1,0 +1,569 @@
+# PRD — "Mila Anywhere": Flexible Backends, Mobile Capture, and Knowledge-Base Destinations
+
+**Status:** Draft for review
+**Author:** (you)
+**Date:** 2026-07-15
+**Related docs:** `docs/REMOTE_TRANSCRIPTION_SERVER.md`, `docker/speaches-hebrew/README.md`, `CLAUDE.md`
+
+> This is a **draft PRD written to be argued with**. Every section that
+> depends on a decision you haven't made yet is marked with **[OPEN
+> QUESTION]**. Nothing here is committed until we resolve the questions in
+> §10 and agree on phasing (§9). Do not treat this as a build spec yet.
+
+---
+
+## 1. Summary
+
+Mila today is a **macOS-only** local-first transcription app. It records
+(mic / system audio / meetings), transcribes with `whisper.cpp` (ivrit.ai
+Hebrew + OpenAI English), optionally diarizes, and can summarize via a local
+LLM CLI (`claude` / `cursor-agent`). It **already** supports offloading
+transcription to any OpenAI-compatible `/v1/audio/transcriptions` endpoint
+(`TranscriptionBackend.remote`), and ships a Docker image
+(`docker/speaches-hebrew`) that serves ivrit.ai Hebrew behind that protocol.
+
+This PRD proposes four new capabilities:
+
+1. **First-class dual-mode transcription** — make "run fully local" vs "run
+   fully on my own cloud/remote server (ivrit.ai + Whisper)" a deliberate,
+   well-documented product surface rather than a Settings toggle. *(Largely
+   built on macOS already; this is mostly hardening, packaging, and mobile
+   parity.)*
+2. **Simple mobile capture apps (iOS + Android)** — record audio on a phone
+   and send it for transcription, targeting **either** a cloud server **or**
+   the user's own Mac/home server that is **securely exposed to the
+   internet**.
+3. **Post-transcription destinations** — after a transcript exists, route it
+   to **NotebookLM** (upload) or a **local Obsidian vault** (Markdown note).
+4. **Gemini CLI support** — add Google's `gemini` CLI as a third option
+   alongside `claude` and `cursor-agent` for naming/summary/actions.
+
+The through-line: **Mila becomes a small ecosystem** (capture clients + a
+transcription backend you choose + knowledge-base sinks), while keeping the
+existing privacy-first, local-only path fully intact as the default.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+
+- G1. A user can flip Mila (desktop and mobile) between **100% on-device** and
+  **100% on a remote server they control**, with the privacy trade-off made
+  explicit in the UI.
+- G2. A user can record on their **phone** and get a transcript back, sending
+  audio to either a cloud endpoint or their **own Mac exposed securely**.
+- G3. After any transcript is produced, the user can **push it to NotebookLM
+  or an Obsidian vault** with minimal friction.
+- G4. `gemini` joins `claude`/`cursor-agent` as a supported LLM CLI on desktop.
+- G5. The existing macOS local-only experience is **unchanged by default** —
+  no regression, no new mandatory network/account dependency.
+
+### Non-goals (this round)
+
+- NG1. A hosted, Mila-operated multi-tenant SaaS with sign-up/billing. The
+  "cloud" here is **the user's own server**, not a service we run. **[OPEN
+  QUESTION Q1 — confirm.]**
+- NG2. On-device transcription **on mobile** (running whisper.cpp on the
+  phone). The mobile app is "record & send", per your description. **[OPEN
+  QUESTION Q4.]**
+- NG3. Real-time / live transcription on mobile.
+- NG4. Editing/organizing the full recording library on mobile (mobile is a
+  capture + view-result client, not a full port of the desktop UI).
+- NG5. Windows/Linux desktop clients.
+
+---
+
+## 3. Users & top scenarios
+
+- **U1 — The privacy maximalist.** Runs everything on-device on an M-series
+  Mac. Never wants audio to leave hardware they own. (Today's default; must
+  stay intact.)
+- **U2 — The self-hoster.** Runs the ivrit.ai/Whisper server on a home box or
+  a VPS they control, exposes it securely, and points both the Mac and their
+  phone at it. Wants Hebrew accuracy without a beefy laptop.
+- **U3 — The mobile capturer.** Out and about, opens the phone app, records a
+  meeting/voice note, and it lands transcribed — then flows into their
+  Obsidian vault or a NotebookLM notebook for later synthesis.
+- **U4 — The knowledge worker.** Lives in Obsidian and/or NotebookLM; wants
+  every transcript to auto-file into their existing knowledge base.
+
+Primary flow (U3 → U4) — refined per the folder-sync + Drive-hand-off model:
+
+```
+PHONE (iOS/Android)
+  [record] → [save into chosen local folder]
+  [periodic sync tick] → find untranscribed recordings
+     → batch-upload audio to cloud transcription (ASYNC job)
+        ... cloud transcribes as a batch, out of band ...
+     ← transcript result arrives → attach to the recording in the app
+  [option] → save transcript as a NEW Google Drive file
+
+MAC (Mila desktop) — the destination hub
+  [track transcription files in Google Drive]
+     → for each new transcript file
+        → fan out to configured destinations
+           (Obsidian vault | NotebookLM | … whatever is enabled in Mila)
+```
+
+Google Drive is the **sync / hand-off layer** between phone and Mac; the Mac
+app is the **router** that turns tracked Drive transcripts into knowledge-base
+entries.
+
+---
+
+## 4. Current-state review (what already exists — reuse, don't rebuild)
+
+Grounding the plan in the existing design (per project workflow rules):
+
+- **Remote transcription backend already exists.**
+  `Mila/Models/RemoteTranscriptionSettings.swift` +
+  `Mila/Transcription/RemoteWhisperEngine.swift` implement
+  `TranscriptionBackend.local | .remote`, talking to any OpenAI-compatible
+  `/v1/audio/transcriptions` endpoint, with the API key in Keychain and a
+  "Test connection" probe. **Capability G1 is ~80% done on desktop.** The new
+  work is UX framing, docs, and porting the same client contract to mobile.
+- **The server piece exists.** `docker/speaches-hebrew` serves
+  `ivrit-ai/whisper-large-v3-turbo-ct2` behind the OpenAI protocol. This is
+  the reference "cloud/home server". The gap is **secure exposure + auth**,
+  not the transcription server itself.
+- **LLM CLI abstraction is a clean extension point.**
+  `Mila/Actions/LLMSettings.swift` defines `enum LLMTool { none, claude,
+  cursor }` and `arguments(prompt:model:session:)`. Adding `.gemini` is a
+  small, well-bounded change (see §7.4). Verified invocation: `gemini -p
+  "<prompt>"`, optional `-m <model>`, `--output-format text`.
+- **Export today = SRT sidecars** (`Mila/Transcription/TranscriptExporter.swift`)
+  and `.txt` / `.summary.txt` sidecars managed by `RecordingStore`. There is
+  **no** concept of an external "destination" yet — NotebookLM/Obsidian is
+  net-new (see §7.3).
+- **Data model.** `Mila/Models/Recording.swift` carries everything a
+  destination needs: `title`, `fullText`, `segments` (timestamps + speaker),
+  `speakerNames`, `summary`, `actionItems`, `language`, `createdAt`.
+- **No mobile targets exist.** `project.yml` has a single macOS `application`
+  target. iOS/Android is greenfield (see §6, §8).
+- **Precedent for the Drive-tracking hub + idempotent import:** the Voice Memos
+  importer (`Mila/VoiceMemos/`) already ingests iPhone recordings from a synced
+  folder and dedups via a stable per-item ID (`voiceMemoUniqueID`). The same
+  pattern applies to the Mac tracking transcript files in Drive (§7.1).
+
+---
+
+## 5. Capability 1 — Dual-mode (local / remote) transcription
+
+### 5.1 What changes
+
+- Promote the local-vs-remote choice to a clear, first-run-visible decision
+  with three named presets:
+  - **On-device (private)** — today's default. Audio never leaves the device.
+  - **My server** — point at a self-hosted ivrit.ai/Whisper endpoint (home box
+    or VPS). Requires endpoint URL + optional API key/token.
+  - **Third-party API** — e.g. OpenAI Whisper. (Already supported.)
+- Consistent privacy banner whenever audio leaves the device (already present
+  on desktop; must be mirrored on mobile).
+- **Shared transcription-client contract** so desktop and mobile speak to the
+  same server the same way (multipart upload, `verbose_json`, language hint).
+
+### 5.2 Open items
+
+- **[Q2]** Does "run fully on cloud" mean strictly the **transcription
+  server**, or do you also want the LLM/summary + destination routing to run
+  server-side (so a thin phone client offloads *everything*)? This materially
+  changes the mobile architecture (§7.2).
+- **[Q3]** Diarization currently runs **locally** (reads on-disk audio via
+  pyannote). On a remote/mobile path, do we (a) skip diarization, (b) require
+  the server to diarize, or (c) rely on the server returning speaker labels if
+  it supports them? Today's remote path silently loses diarization on mobile
+  because there's no local pyannote.
+
+---
+
+## 6. Capability 2 — Mobile capture apps (iOS + Android)
+
+### 6.1 Product shape (folder + async-batch-sync model)
+
+A deliberately **simple** app on both platforms, built around a **watched
+recordings folder** and a **periodic async sync**, not a synchronous
+record-and-wait loop:
+
+1. **Pick a recordings folder** (once, in setup). Every recording is saved
+   there as a compact audio file (`.m4a`/AAC, mono 16 kHz — matches the
+   desktop remote path). On iOS this is a security-scoped folder via the
+   document picker (Files / iCloud Drive); on Android a Storage Access
+   Framework tree URI.
+2. One big **Record** button. Show elapsed time + level meter. On stop, write
+   the audio file into the folder and mark it `untranscribed` in a small local
+   index.
+3. **Periodic sync tick** (configurable interval): find recordings in the
+   folder that are `untranscribed` and **batch-upload** their audio to the
+   cloud transcription service. This is an **async job submission**, not a
+   blocking request — the app doesn't wait for the transcript inline.
+4. **Result attach:** when a transcript for a submitted job becomes available
+   (next tick / push), the app downloads it and **attaches it to the matching
+   recording**, flipping its state to `transcribed`.
+5. **Save to Drive (option):** for a transcribed recording, the user can save
+   the transcript as a **new Google Drive file** (this is what the Mac app
+   later tracks — see §7).
+6. A minimal local history list of this device's recordings with per-item
+   state (`untranscribed` / `uploading` / `processing` / `transcribed` /
+   `failed`).
+
+**Resolves Q2/Q4:** the phone does **capture + async transcription offload +
+optional push-to-Drive** only. It runs **no** on-device model and does **no**
+destination fan-out itself — routing to Obsidian/NotebookLM happens on the Mac
+(§7). The phone's contract with the "cloud" is: submit audio → later, get text.
+
+### 6.1a The async / batch transcription contract (new backend shape)
+
+This is a **new requirement that the existing synchronous OpenAI-compatible
+`/v1/audio/transcriptions` endpoint does not satisfy.** That endpoint is
+request/response: one upload blocks until one transcript returns. A
+**batch/async** model needs a **job protocol**:
+
+```
+POST  /jobs        (multipart audio [+ language])   → { job_id, status: queued }
+GET   /jobs/{id}                                    → { status, transcript? }
+      (optional) webhook/push on completion
+```
+
+- This lets the cloud process uploads **as a batch**, decouples upload from
+  result, and tolerates the phone going to sleep between submit and fetch.
+- **Notable fit:** ivrit.ai's own serving project
+  (`ivrit-ai/runpod-serverless`) already speaks an **async RunPod job
+  protocol** (submit → poll), not the OpenAI API — so an async model may map
+  onto it more naturally than the synchronous speaches path does.
+- **[Q16]** Do we (a) define our own small job server (a thin wrapper the user
+  self-hosts in front of speaches/whisper), (b) adopt RunPod-style async
+  jobs, or (c) shim async on top of the synchronous endpoint (the client just
+  submits+polls against a queue we run on the Mac/server)? This decides the
+  backend contract for the whole mobile path.
+- **[Q17] Mobile background-execution reality check.** A "sync interval" that
+  fires reliably in the background is **constrained by the mobile OS**: iOS
+  only grants opportunistic `BGProcessingTask`/`BGAppRefreshTask` windows (no
+  guaranteed timer, especially for uploads), and Android `WorkManager`
+  periodic work has a **15-minute minimum** and Doze/battery limits. Practical
+  implication: "upload every N minutes" is really "upload on next granted
+  background window, and immediately when the app is foregrounded." We should
+  spec the interval as a *target*, not a guarantee, and always sync on app
+  open.
+
+### 6.2 The hard part: securely exposing "my local device to the world"
+
+This is the riskiest requirement and needs an explicit decision. Options,
+cheapest/safest first:
+
+- **Option A — Overlay VPN (Tailscale/WireGuard).** Phone and Mac join a
+  private mesh; the phone hits the Mac's stable private IP. No public exposure
+  at all. **Safest**, but requires the VPN app on the phone and isn't
+  "exposed to the world" literally — it's "reachable by *my* devices".
+- **Option B — Reverse tunnel (Cloudflare Tunnel / ngrok / Tailscale
+  Funnel).** A stable public HTTPS URL fronts the Mac's local server; TLS +
+  auth handled at the edge. Closest to "exposed to the world securely" with
+  managed TLS.
+- **Option C — DIY port-forward + reverse proxy (Caddy/nginx) + Let's
+  Encrypt + token auth.** Most control, most footguns (router config, dynamic
+  DNS, cert renewal, brute-force surface).
+
+In all cases the Mac must run a **local HTTP server** exposing the
+OpenAI-compatible transcription endpoint (the speaches container, or a thin
+Mila-hosted proxy) **with mandatory auth** (bearer token) once it's reachable
+off-LAN.
+
+- **[Q5]** Which exposure model do we support/recommend/document first? My
+  recommendation: **document Option A (Tailscale) as the blessed path** and
+  **Option B as the "public URL" path**, and explicitly *not* build custom
+  tunneling into Mila. Ship a setup guide, not a networking stack.
+- **[Q6]** Does Mila's Mac app need to **run/host** the transcription server
+  itself (spawn/manage the speaches container or an embedded whisper HTTP
+  server), or do we just document "run the container + a tunnel"? Hosting it
+  in-app is a big surface (lifecycle, ports, health, security).
+
+### 6.3 Auth & pairing
+
+Any off-device endpoint (cloud or exposed Mac) needs authentication.
+
+- **[Q7]** Auth model: (a) a static **bearer token** the user pastes into the
+  phone (simple, matches current `RemoteTranscriptionSettings.apiKey`), or (b)
+  a **pairing flow** (Mac shows a QR code encoding URL+token, phone scans)?
+  QR pairing is much nicer UX for "point my phone at my Mac" and is the
+  recommended default.
+
+### 6.4 Non-goals restated
+
+No on-device model, no live mode, no full library management on mobile
+(NG2–NG4).
+
+---
+
+## 7. Capability 3 — Destinations via Google Drive tracking (Mac is the hub)
+
+**Refined model.** Destinations are **not** driven from the phone. The phone's
+only outbound step is "save transcript as a new Google Drive file" (§6.1
+step 5). The **Mac Mila app tracks the transcription files in Google Drive**
+and fans each new one out to whatever destinations the user has configured
+(Obsidian vault, NotebookLM, future sinks). This cleanly resolves the earlier
+"how does a phone write to a Mac's Obsidian vault?" problem (old Q8): it
+doesn't — Drive is the hand-off and the Mac does the filing.
+
+### 7.1 Drive tracking on the Mac (the new core piece)
+
+- Mila (Mac) is configured with a **tracked Drive folder** (where phone
+  transcripts land) via Google OAuth (Drive scope).
+- Mila detects new transcript files there — either by **polling** the Drive
+  API on an interval, or via **Drive push notifications** (`changes.watch`).
+  **[Q18]** Poll vs push? (Polling is simpler and robust; push is timelier but
+  needs a public webhook — awkward for a desktop app.)
+- For each new/unseen transcript file, Mila runs the **destination fan-out**
+  (§7.4), then marks it processed (a local seen-index keyed by Drive file ID
+  so re-scan/restart never double-files — same idempotency discipline as the
+  Voice Memos importer's `voiceMemoUniqueID`).
+- **[Q19]** What exactly lands in Drive from the phone — a **plain-text/Markdown
+  transcript file**, or a **native Google Doc**? (A native Doc is what
+  NotebookLM can live-sync; a `.md`/`.txt` is simplest for Obsidian. We may
+  write the Doc for NotebookLM and derive the Markdown for Obsidian, or store
+  one canonical format and convert on the Mac.)
+
+### 7.2 Obsidian vault (local, written by the Mac)
+
+An Obsidian vault is **just a folder of Markdown files** — so the fan-out step
+is a Markdown formatter + a file write, done **on the Mac** where the vault
+lives.
+
+- Write a `.md` note (front-matter: title, date, duration, language, source;
+  body: summary → action items → transcript) into a user-chosen vault folder
+  (security-scoped bookmark, same pattern as the configurable recordings
+  directory). Optional filename template and target subfolder (e.g.
+  `Transcripts/`).
+- Because the Mac is the writer, **mobile-origin transcripts reach Obsidian
+  the same way desktop ones do** — via the Drive-tracking fan-out. No phone→Mac
+  vault write, no Obsidian URI hacks needed. (Old Q8 dissolved.)
+- **[Q9]** Format details: one note per recording (default, matches the
+  per-file Drive model)? Include timestamps? Link vs copy the audio (audio
+  isn't in Drive/vault by default)?
+
+Desktop-native recordings can also fan out directly (no Drive round-trip
+required) — the Drive path is specifically the bridge for **phone-origin**
+transcripts.
+
+### 7.3 NotebookLM (the constrained sink in the fan-out)
+
+Within the Drive-tracking fan-out (§7.1), Obsidian is trivial (write a file);
+**NotebookLM is the hard sink** because consumer NotebookLM has **no official
+public write API**. Note the per-transcript-file phone model (§6.1 step 5,
+Q19) leans toward the **new-file-per-transcript** shape (Q10-c), which is the
+tension below. Verified current (2026) state:
+
+- **Official API exists only for NotebookLM *Enterprise*** (Google Cloud
+  "discoveryengine" surface): `notebooks.create`,
+  `notebooks.sources.uploadFile`, `notebooks.sources.batchCreate`. Requires a
+  **GCP project, enterprise entitlement, and OAuth/service-account auth**.
+  This is a real, supported path *if the user is a Google Cloud/NotebookLM
+  Enterprise customer*.
+- **Consumer NotebookLM:** no official API. Community SDKs
+  (`notebooklm-py`, `notebooklm-kit`) exist but **automate the web UI** — they
+  depend on browser session cookies, break when Google changes internals, and
+  are **against ToS to varying degrees**. Not a stable base to build a product
+  feature on.
+- **Can we lean on Drive auto-sync to auto-ingest transcripts?** Verified
+  current (2026) behavior: NotebookLM's May-2026 "automatic Drive syncing"
+  **does not watch a Drive folder for new files**. It only keeps the *content*
+  of **already-added** sources (native Google **Docs/Sheets/Slides**) in sync
+  with the original file every few minutes, and removes sources deleted in
+  Drive. Adding a *new* file as a source is still a **manual, per-file action**
+  (consumer accounts). PDFs / uploaded files / web links do **not** auto-sync
+  at all. So "drop a file in a folder → it becomes a new NotebookLM source
+  automatically" is **not possible** on consumer accounts today.
+- **The exploitable pattern — one "living" Doc per notebook.** Because an
+  already-added Doc *does* stay live-synced, Mila can maintain a single
+  long-lived Google **Doc** (e.g. `Mila Transcripts — 2026`) and **append**
+  each new transcript to it via the official Drive/Docs API. The user adds
+  that Doc to their notebook **once**; every subsequent transcript then flows
+  in automatically via NotebookLM's background sync. This is the closest thing
+  to "NotebookLM auto-consumes my new transcripts" achievable with official
+  APIs on a consumer account. Trade-off: all transcripts share one growing
+  source (not separately-citable per meeting) and hit a per-source size
+  ceiling eventually.
+
+Given that, **[Q10]** decides the NotebookLM scope:
+
+- **Q10-a — Official Enterprise API only.** Clean, supported, and the *only*
+  path that can programmatically **add new sources** (`notebooks.sources.
+  uploadFile` / `batchCreate`). But it serves only Google Cloud/NotebookLM
+  Enterprise users (narrow audience) and needs GCP project config + OAuth.
+- **Q10-b — "Living Doc" append (recommended).** Append each transcript to a
+  single Drive-native Doc the user has added to their notebook once; NotebookLM
+  auto-syncs it. Fully official APIs, and gives an "automatic" feel without a
+  per-transcript manual step. One shared source; size-capped.
+- **Q10-c — "New Doc per transcript" + manual add.** One Doc per recording via
+  Drive API → clean per-meeting sources, but the user must click "add to
+  notebook" each time (consumer) unless on Enterprise (Q10-a).
+- **Q10-d — Community web-automation SDK.** Full "one-click new source into a
+  consumer notebook" UX, but **fragile + ToS risk + browser-auth pain**. Not
+  recommended for shipping; acceptable only as clearly-labelled
+  experimental/personal-use.
+
+My recommendation: **Q10-b (living Doc)** as the default — it's the only way to
+get hands-off "new transcripts appear in my notebook" on a normal Google
+account using supported APIs — with **Q10-a** as an opt-in for Enterprise users
+who want each transcript as a distinct source. Treat one-click consumer
+*new-source* creation as blocked-on-Google until an official consumer API
+exists.
+
+### 7.4 Destination fan-out abstraction
+
+Introduce a small `TranscriptDestination` protocol (name TBD) so Obsidian,
+NotebookLM, "copy/share", and future sinks share one plumbing path. **Routing
+runs on the Mac** (resolves old Q2 for the destination side): both
+desktop-native transcripts and phone-origin transcripts pulled from the
+tracked Drive folder (§7.1) flow through the same fan-out. Each enabled
+destination is invoked per new transcript; failures are per-destination and
+retryable without re-filing the ones that succeeded.
+
+---
+
+## 8. Capability 4 — Gemini CLI support (smallest, do-first candidate)
+
+- Add `case gemini` to `LLMTool` (`Mila/Actions/LLMSettings.swift`):
+  - `executableName = "gemini"`, `displayName = "Gemini (gemini CLI)"`.
+  - `arguments(prompt:...)` → `["-p", prompt]`, append `["-m", model]` when a
+    model is set. (Verified: `gemini -p` is one-shot non-interactive and
+    prints to stdout; `-m/--model` selects the model.)
+  - Session handling: like `cursor`, Gemini has no `claude`-style
+    `--session-id`/`--resume` in `-p` mode, so `LLMSession` is ignored for
+    Gemini (Live AI session continuity won't apply — matches cursor behavior).
+- `LLMRunner` already discovers binaries on `$PATH` + common dirs and sandboxes
+  the CWD — `gemini` benefits from all of it for free. Add `~/.gemini`-style
+  install dirs to the PATH fallback if needed.
+- Tests: extend `MilaTests/LLMRunnerTests.swift` for the new arg vector; the
+  existing `scripts/fake-llm-cli.sh` harness can stand in for `gemini`.
+- Docs/release notes per `CLAUDE.md` release process.
+
+This is low-risk and independently shippable **now**, decoupled from the
+mobile/cloud/destination work.
+
+---
+
+## 9. Proposed phasing (for discussion)
+
+Ordered by value-to-risk. Each phase is independently shippable.
+
+- **Phase 0 — Gemini CLI.** Days. No architectural risk. (§8)
+- **Phase 1 — Desktop destinations: Obsidian + Google Drive export.** Reuses
+  the security-scoped-folder + exporter patterns. Ships U4 value on the
+  platform that already has the transcripts. (§7.2)
+- **Phase 2 — Mac Drive-tracking + fan-out.** Mila (Mac) watches a tracked
+  Drive folder and fans transcripts out to enabled destinations, idempotently.
+  This is the hub the mobile path plugs into; build it before mobile so the
+  desktop can exercise it. (§7.1, §7.4)
+- **Phase 3 — Async transcription job server + dual-mode hardening.** Stand up
+  the submit→poll job contract (§6.1a, Q16), add mandatory bearer-token auth,
+  and write the "expose your server/Mac securely (Tailscale/Cloudflare)" guide.
+  (§5, §6.1a, §6.2)
+- **Phase 4 — Mobile capture app (one platform first).** Folder capture →
+  periodic async batch upload → attach result → save transcript to Drive.
+  **[Q11]** iOS or Android first (iOS recommended: Swift codebase + iCloud
+  Voice-Memos precedent).
+- **Phase 5 — Second mobile platform + NotebookLM Enterprise API** (if in
+  scope).
+
+---
+
+## 10. Open questions (must-answer before build)
+
+Consolidated. The **bolded** ones are blocking / high-impact.
+
+- **Q1.** Is "cloud" strictly **the user's own self-hosted server** (no
+  Mila-operated SaaS, no accounts we manage)? (§2 NG1)
+- **Q2.** ~~Mobile: server-does-everything vs phone-routes-destinations?~~
+  **RESOLVED (2026-07-16):** phone = capture + async transcription offload +
+  optional push-to-Drive; the **Mac** does destination routing by tracking
+  Drive. (§6.1, §7)
+- **Q3.** Diarization on the remote/mobile path: skip, require server-side, or
+  best-effort from server labels? (§5.2)
+- **Q4.** ~~Confirm no on-device transcription on mobile?~~ **RESOLVED
+  (2026-07-16):** yes, record & send only. (§2 NG2, §6.1)
+- **Q5.** Blessed **secure-exposure** mechanism to document first: Tailscale
+  (VPN), Cloudflare Tunnel (public URL), or DIY proxy? (§6.2)
+- **Q6.** Should the **Mac app host/manage** the transcription server itself,
+  or do we only document running the container + tunnel? (§6.2)
+- **Q7.** Mobile **auth**: pasted bearer token vs **QR pairing**? (§6.3)
+- **Q8.** ~~Mobile→Obsidian delivery mechanism?~~ **RESOLVED (2026-07-16):**
+  Mac-as-hub via Drive tracking — the phone never writes to the vault; the Mac
+  fans transcripts out from the tracked Drive folder. (§7)
+- **Q9.** Obsidian note **format**: per-recording vs daily-note append;
+  timestamps/audio linking; copy vs link audio. (§7.2)
+- **Q10.** **NotebookLM** scope: Enterprise API (a), "living Doc" append (b,
+  recommended), new-Doc-per-transcript + manual add (c), or community
+  web-automation (d)? Note: Drive auto-sync updates *existing* sources only —
+  it does **not** auto-ingest new files from a folder. (§7.2)
+- **Q11.** Which **mobile platform first** (iOS recommended)? (§9)
+- **Q12.** **Cross-platform strategy** for mobile: two native apps
+  (Swift + Kotlin), or one shared codebase (Kotlin Multiplatform / Flutter /
+  React Native)? Affects team, repo layout, and long-term cost. (§ implied by
+  §6, §8)
+- **Q13.** Distribution: TestFlight/App Store + Play Store (accounts,
+  review, privacy nutrition labels), or sideload/self-host builds only?
+- **Q14.** Does the mobile app need **offline queueing** (record now, upload
+  when connectivity/pairing returns)? (Now core to the design — the folder +
+  async-batch model *is* an offline queue; see §6.1.)
+- **Q15.** Where should product docs live going forward — this `docs/` folder,
+  or bootstrap the `.context/` structure (roadmap/tasks/decisions/sessions)
+  referenced in the workspace rules?
+- **Q16.** **Async/batch transcription contract:** own job server, RunPod-style
+  async, or a submit+poll shim over the synchronous endpoint? **Blocking for
+  the whole mobile path.** (§6.1a)
+- **Q17.** Accept that the mobile **"sync interval" is best-effort** (iOS
+  BGTask windows; Android WorkManager 15-min minimum + Doze), always syncing on
+  foreground? (§6.1a)
+- **Q18.** Mac Drive tracking: **poll** the Drive API vs `changes.watch`
+  **push**? (§7.1)
+- **Q19.** What the phone writes to Drive: **plain `.md`/`.txt`** (best for
+  Obsidian) vs **native Google Doc** (needed for NotebookLM live-sync) — one
+  canonical format + convert, or write both? (§7.1)
+- **Q20.** Do phone recordings and their transcripts **also** need to appear in
+  the **Mac Mila library** (unified history), or do they live only on the phone
+  + flow through to destinations? (Affects whether the Mac imports the audio or
+  just the transcript.)
+
+---
+
+## 11. Risks
+
+- **R1 — NotebookLM has no official consumer API.** Even with the Mac
+  fan-out tracking Drive, NotebookLM can't have *new sources* added
+  programmatically on consumer accounts. Mitigation: "living Doc" append
+  (Q10-b) or Enterprise API (Q10-a); treat one-click consumer new-source as
+  blocked-on-Google. Obsidian and other file sinks are unaffected. (§7.3)
+- **R1b — Async job server is net-new infra.** The mobile batch model needs a
+  submit→poll job contract the current synchronous endpoint doesn't provide
+  (Q16); this is a real backend build, not just a client. (§6.1a)
+- **R2 — Exposing a home Mac to the internet is a security liability.**
+  Mandatory auth + TLS + a documented, hardened path (prefer VPN/tunnel over
+  raw port-forward). A misconfigured setup could expose a mic-recording server.
+- **R3 — Scope explosion.** Two new OS platforms + an async job backend +
+  Drive tracking + third-party integrations is far beyond the current single
+  macOS target. Phasing (§9) and answering Q12/Q16 early are the main
+  mitigations.
+- **R4 — Cross-platform maintenance cost.** Two native apps double UI work;
+  a shared framework adds its own complexity. (Q12)
+- **R5 — Privacy expectation regression.** Mila's brand is "audio never leaves
+  your device." Cloud/mobile paths must make the trade-off explicit and keep
+  local-only the default (G5), or risk eroding user trust.
+
+---
+
+## 12. Success criteria (to be firmed up with the Tests section later)
+
+- Existing macOS local-only flow: **zero behavioral change** by default;
+  full test suite green.
+- Gemini CLI: name/summary/action produce output via `gemini -p`; unit tests on
+  the arg vector; test panel works end-to-end.
+- Destinations: a transcript lands as a correctly-formatted `.md` in a chosen
+  Obsidian vault, and as a Doc/file in Google Drive, verified on disk / via API.
+- Mobile: a recording made on the phone returns a transcript from a configured
+  backend (cloud and "my Mac") and can be routed to at least one destination.
+
+---
+
+*Next step: resolve §10 (especially Q2, Q5, Q10, Q12), then I'll write the
+per-phase implementation plan + Tests section per the project's plan-first,
+test-first workflow.*

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,102 @@
+# Using Mila with Claude (MCP)
+
+Mila ships an MCP server — `mila-mcp`, embedded in the app bundle — that
+lets any Claude session (Claude Code, Claude Desktop) read your
+transcriptions: past recordings with resolved speaker names, and the
+live transcript of a meeting **while it's still happening**.
+
+Everything stays local: the server reads Mila's own on-disk store; no
+audio or text leaves your Mac unless you ask Claude to do something
+with it.
+
+## Setup (once)
+
+Claude Code:
+
+```bash
+claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp
+```
+
+Claude Desktop — add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mila": {
+      "command": "/Applications/Mila.app/Contents/MacOS/mila-mcp"
+    }
+  }
+}
+```
+
+Optionally install the bundled skill so Claude knows the workflows
+without being told (see `skills/mila-meetings/`):
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R skills/mila-meetings ~/.claude/skills/
+```
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `list_recordings` | List/filter recordings — by speaker display name, title/app/folder text, source, date range; sortable by date/duration/title. |
+| `get_transcript` | One recording's full speaker-named transcript + summary + action items. Omit `id` for the latest completed recording. |
+| `search_transcripts` | Full-text search over titles + transcripts with context snippets; relevance or date sort. |
+| `get_live_transcript` | The in-progress recording's transcript, with a polling cursor for cheap deltas. |
+
+## Reading past recordings
+
+Just ask, e.g.:
+
+> Read my last transcription with John Doe and summarize it.
+
+Claude calls `list_recordings(speaker: "john doe", limit: 1)` and then
+`get_transcript(id: …)`. Speaker filters match the display names you
+assigned in Mila's rename popover — unnamed speakers stay `SPEAKER_NN`.
+
+## Following a live meeting
+
+1. Start a recording in Mila (any mode with the live transcript pane —
+   mic, system audio, or meeting).
+2. In a Claude session:
+
+> Follow my current Mila meeting via the mila MCP server. Poll
+> get_live_transcript with the cursor every ~15–20 seconds; whenever
+> something new lands, suggest in one or two sentences what I should
+> say next. When the status becomes "completed", fetch the final
+> transcript and give me a summary.
+
+How the polling works under the hood:
+
+- Each recording session has a `session_id`; the snapshot carries a
+  `revision` that bumps only when content changes. Claude echoes
+  `session_id`, `since_revision`, and `since_segment_index` back on each
+  poll.
+- Nothing new → a tiny `{changed: false}` response.
+- New content → only the new segments (the last previously-seen segment
+  is re-sent, since live transcription may rewrite it; Claude replaces
+  its copy).
+- A `session_id` mismatch means a new recording started between polls —
+  Claude gets the new meeting's transcript from the top with
+  `new_session: true`.
+- `status` values: `recording` (keep polling), `stale` (the app stopped
+  updating the snapshot — likely crashed), `recording_live_unavailable`
+  (recording on hardware where live transcription is gated off — wait
+  for completion), `completed` (stop polling; `final_recording_id`
+  hands off to `get_transcript`), `not_recording`.
+
+## How it finds your data
+
+- `~/Library/Application Support/Mila/store-location.json` — written by
+  the app on every launch and whenever you relocate the recordings
+  folder (Settings ▸ Storage), so the server follows the move.
+- `~/Library/Application Support/Mila/live/current.json` — the live
+  transcript sidecar, written during recording (throttled, atomic) and
+  closed with the saved recording's id at Stop.
+
+If the app has never run (no pointer file), the server falls back to
+the default layout. Changes to the `recordings.json` schema must be
+mirrored in MilaKit's `StoredRecording` — `StoredRecordingDriftTests`
+guards this.

--- a/project.yml
+++ b/project.yml
@@ -98,6 +98,11 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     revision: 066e75a8b3e99962685d6a90cdd5293ebffd9261
+  # MCP Swift SDK for the mila-mcp helper (stdio server exposing
+  # transcriptions to Claude). Pinned exactly, like Sparkle.
+  MCP:
+    url: https://github.com/modelcontextprotocol/swift-sdk
+    exactVersion: 0.12.1
     
 targets:
   Mila:
@@ -185,9 +190,45 @@ targets:
         product: MilaKit
       - package: Sparkle
         product: Sparkle
+      # Build-order only: the post-build script below copies the helper
+      # into Contents/MacOS. Not linked (it's an executable, not a lib).
+      - target: mila-mcp
+        link: false
+        embed: false
     settings:
       base:
         OTHER_LDFLAGS: "$(inherited) -framework Accelerate -framework Metal -framework MetalKit"
+    postBuildScripts:
+      # Ship the MCP helper inside the app bundle so users can register it
+      # with `claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp`.
+      # Runs before the app's code-sign step, so the copy is covered by the
+      # bundle seal; the helper binary carries its own signature from its
+      # target build (and make-dmg.sh's --deep re-sign covers DMGs).
+      - name: Embed mila-mcp helper
+        script: |
+          cp -f "$BUILT_PRODUCTS_DIR/mila-mcp" "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/mila-mcp"
+        inputFiles:
+          - $(BUILT_PRODUCTS_DIR)/mila-mcp
+        outputFiles:
+          - $(TARGET_BUILD_DIR)/$(EXECUTABLE_FOLDER_PATH)/mila-mcp
+
+  mila-mcp:
+    type: tool
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: MilaMCP
+    dependencies:
+      - package: MilaKit
+        product: MilaKit
+      - package: MCP
+        product: MCP
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.island.whisper.IslandWhisper.mcp
+        # The SDK's ServiceLifecycle/NIO deps use Swift 6 features; our
+        # own sources stay on the project-wide 5.10 language mode.
+        GENERATE_INFOPLIST_FILE: NO
 
   MilaTests:
     type: bundle.unit-test

--- a/project.yml
+++ b/project.yml
@@ -93,6 +93,8 @@ settings:
 packages:
   TranscriptionCore:
     path: Packages/TranscriptionCore
+  MilaKit:
+    path: Packages/MilaKit
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     revision: 066e75a8b3e99962685d6a90cdd5293ebffd9261
@@ -179,6 +181,8 @@ targets:
     dependencies:
       - package: TranscriptionCore
         product: TranscriptionCore
+      - package: MilaKit
+        product: MilaKit
       - package: Sparkle
         product: Sparkle
     settings:
@@ -195,6 +199,8 @@ targets:
       - target: Mila
       - package: TranscriptionCore
         product: TranscriptionCore
+      - package: MilaKit
+        product: MilaKit
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -9,8 +9,9 @@
 # login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
 # grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper
 # right-click → Open prompt on first launch and lose TCC grants on every
-# reinstall. Re-sign with `codesign -s "Developer ID Application: ..."` before
-# distributing externally.
+# reinstall; pass CODESIGN_IDENTITY=- to force ad-hoc (e.g. to test that
+# Gatekeeper first-launch path). Re-sign with
+# `codesign -s "Developer ID Application: ..."` before distributing externally.
 
 set -euo pipefail
 
@@ -47,9 +48,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENTITLEMENTS="$SCRIPT_DIR/../Mila/Resources/Mila.entitlements"
 
 if [[ -z "${CODESIGN_IDENTITY:-}" ]]; then
-    LOCAL_DEV_SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+    LOCAL_DEV_SHAS=$(security find-certificate -c "Mila Local Dev" -a -Z \
         "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
-        | awk '/SHA-1 hash/ {print $NF}' | head -1 || true)
+        | awk '/SHA-1 hash/ {print $NF}' || true)
+    if [[ $(grep -c . <<<"$LOCAL_DEV_SHAS") -gt 1 ]]; then
+        echo "warning: multiple 'Mila Local Dev' certs in login keychain; using the first —" >&2
+        echo "         if TCC still re-prompts, delete the stale duplicates and re-sign." >&2
+    fi
+    LOCAL_DEV_SHA=$(head -1 <<<"$LOCAL_DEV_SHAS")
     if [[ -n "$LOCAL_DEV_SHA" ]]; then
         echo "signing with Mila Local Dev cert ($LOCAL_DEV_SHA)" >&2
         CODESIGN_IDENTITY="$LOCAL_DEV_SHA"

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -3,8 +3,11 @@
 #
 # Usage: scripts/make-dmg.sh path/to/Mila.app Mila-1.0.0.dmg 1.0.0
 #
-# Output: $DMG_PATH (relative or absolute) ready to upload as a GitHub release
-# asset. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
+# Output: $DMG_PATH (relative or absolute), a LOCAL TEST artifact. Published
+# releases are produced by the private signing pipeline, which notarizes and
+# runs the release-notes gate (scripts/check-release-notes.sh) before building;
+# this script deliberately skips that gate so local test DMGs don't require
+# release notes. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
 # else the persistent "Mila Local Dev" self-signed cert if present in the
 # login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
 # grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -4,9 +4,12 @@
 # Usage: scripts/make-dmg.sh path/to/Mila.app Mila-1.0.0.dmg 1.0.0
 #
 # Output: $DMG_PATH (relative or absolute) ready to upload as a GitHub release
-# asset. The app is ad-hoc signed (no Apple Developer ID required) so on first
-# launch macOS will Gatekeeper-prompt the user; right-click → Open works around
-# it. Re-sign with `codesign -s "Developer ID Application: ..."` before
+# asset. Signing identity: $CODESIGN_IDENTITY if set (CI / private pipeline),
+# else the persistent "Mila Local Dev" self-signed cert if present in the
+# login keychain (created by scripts/install-debug.sh — keeps TCC mic/screen
+# grants across installs), else ad-hoc. Ad-hoc-signed apps get the Gatekeeper
+# right-click → Open prompt on first launch and lose TCC grants on every
+# reinstall. Re-sign with `codesign -s "Developer ID Application: ..."` before
 # distributing externally.
 
 set -euo pipefail
@@ -29,14 +32,42 @@ cp -R "$APP_PATH" "$STAGE/"
 ln -s /Applications "$STAGE/Applications"
 
 # Re-sign the bundle to make sure the embedded `whisper.framework` and the
-# wrapping app stay in sync after the cp -R above. Honors `CODESIGN_IDENTITY`
-# so CI can sign with our self-signed Developer-ID-equivalent cert (its
-# SHA1 fingerprint is the trust anchor for TCC permissions across releases —
-# every build signed with the SAME cert keeps the user's previously-granted
-# Accessibility / mic permissions). Defaults to ad-hoc ("-") for local
-# builds where the cert isn't in keychain.
-CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
-codesign --force --deep --sign "$CODESIGN_IDENTITY" "$STAGE/$(basename "$APP_PATH")"
+# wrapping app stay in sync after the cp -R above. Identity resolution:
+#   1. $CODESIGN_IDENTITY — CI / the private signing pipeline sets this (its
+#      SHA1 fingerprint is the trust anchor for TCC permissions across
+#      releases — every build signed with the SAME cert keeps the user's
+#      previously-granted Accessibility / mic permissions).
+#   2. The persistent "Mila Local Dev" self-signed cert (created by
+#      scripts/install-debug.sh) if it exists in the login keychain, signed
+#      by SHA-1 since self-signed certs never become "trusted identities" —
+#      same stability property for local installs.
+#   3. Ad-hoc ("-") as a last resort; macOS treats every ad-hoc rebuild as a
+#      new app, so TCC re-prompts for mic/recording after each install.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="$SCRIPT_DIR/../Mila/Resources/Mila.entitlements"
+
+if [[ -z "${CODESIGN_IDENTITY:-}" ]]; then
+    LOCAL_DEV_SHA=$(security find-certificate -c "Mila Local Dev" -a -Z \
+        "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null \
+        | awk '/SHA-1 hash/ {print $NF}' | head -1 || true)
+    if [[ -n "$LOCAL_DEV_SHA" ]]; then
+        echo "signing with Mila Local Dev cert ($LOCAL_DEV_SHA)" >&2
+        CODESIGN_IDENTITY="$LOCAL_DEV_SHA"
+    else
+        echo "warning: no CODESIGN_IDENTITY and no 'Mila Local Dev' cert in login keychain;" >&2
+        echo "         ad-hoc signing — TCC will re-prompt for mic/recording after install." >&2
+        echo "         Run scripts/install-debug.sh once to create the persistent cert." >&2
+        CODESIGN_IDENTITY="-"
+    fi
+fi
+
+STAGED_APP="$STAGE/$(basename "$APP_PATH")"
+# Deep-sign nested code first, then re-sign the outer bundle with the app
+# entitlements (mic access, disable-library-validation, …) — a --deep sign
+# with --entitlements would stamp the app's entitlements onto every nested
+# framework, so entitlements go on the outer signature only.
+codesign --force --deep --sign "$CODESIGN_IDENTITY" "$STAGED_APP"
+codesign --force --sign "$CODESIGN_IDENTITY" --entitlements "$ENTITLEMENTS" "$STAGED_APP"
 
 VOLNAME="Mila $VERSION"
 TMP_DMG="$(mktemp -t MilaDMG.XXXXXX).dmg"

--- a/skills/mila-meetings/SKILL.md
+++ b/skills/mila-meetings/SKILL.md
@@ -45,6 +45,14 @@ assistant:
    - `{changed: false}` → nothing new; keep waiting silently.
    - New segments → the first returned segment replaces the last one
      you already had (live transcription rewrites it); the rest append.
+
+   **Output ordering (critical):** in harnesses that hide text written
+   between tool calls, anything you write before your next tool call is
+   LOST to the user. In every loop turn: poll, **arm the next wake-up
+   timer first** (background sleep / scheduled wakeup), and only then
+   write the echo/answer as the turn's FINAL message with no tool calls
+   after it. Never end a loop turn with a placeholder like "(listening)"
+   after the real content — the placeholder is all the user will see.
 3. Only speak up when the new content warrants it. Default output per
    update: one or two sentences of "what to say next" — a concrete
    suggestion the user could actually say, plus (only when useful) a

--- a/skills/mila-meetings/SKILL.md
+++ b/skills/mila-meetings/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: mila-meetings
+description: >
+  Work with Mila transcriptions via the mila MCP server — summarize or
+  search past recordings/meetings ("my last meeting with John"), and
+  follow the current in-progress meeting in real time to suggest what
+  to say next. Use whenever the user mentions Mila, their recordings,
+  meeting transcripts, or asks for live meeting help.
+---
+
+# Mila meetings
+
+Mila is the user's local macOS transcription app. The `mila` MCP server
+exposes its recordings. If its tools (`list_recordings`,
+`get_transcript`, `search_transcripts`, `get_live_transcript`) are not
+available, tell the user to register the server once:
+`claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp`
+
+## Past recordings
+
+- "Last meeting with <name>" → `list_recordings(speaker: "<name>", limit: 1)`,
+  then `get_transcript(id: …)`. Speaker matching is a case-insensitive
+  substring over the display names the user assigned in Mila; if it
+  finds nothing, retry with a shorter fragment (first name), then fall
+  back to `search_transcripts(query: "<name>")` — the name may appear
+  in the text or title rather than the speaker labels.
+- "What did we say about X" → `search_transcripts(query: "X")`, then
+  `get_transcript` on the interesting hits.
+- Recordings may be long. For summarization, `get_transcript` already
+  returns a stored `summary` when one exists — read it before deciding
+  to re-summarize from the raw transcript. Transcripts may be in any
+  language (often Hebrew); answer in the user's language.
+
+## Live meeting assistant
+
+When the user asks to follow the current meeting / act as a live
+assistant:
+
+1. Call `get_live_transcript` with no arguments. If `status` is
+   `not_recording`, tell the user to start a Mila recording and
+   offer to check again shortly.
+2. Poll in a loop every ~15–20 seconds, passing back the previous
+   response's `session_id`, `revision` as `since_revision`, and
+   `next_segment_index` as `since_segment_index`.
+   - `{changed: false}` → nothing new; keep waiting silently.
+   - New segments → the first returned segment replaces the last one
+     you already had (live transcription rewrites it); the rest append.
+3. Only speak up when the new content warrants it. Default output per
+   update: one or two sentences of "what to say next" — a concrete
+   suggestion the user could actually say, plus (only when useful) a
+   one-line reason. Don't re-summarize the whole meeting every tick.
+   Match the meeting's language.
+4. Special statuses:
+   - `recording_live_unavailable`: no live text will appear on this
+     hardware — say so and stop polling frequently; check occasionally
+     for `completed`.
+   - `stale`: warn that Mila seems to have stopped updating (possible
+     crash); the transcript won't grow.
+   - `new_session: true`: a different recording started — confirm with
+     the user before following the new one.
+5. On `status: completed`: stop polling, call
+   `get_transcript(id: final_recording_id)`, and close with a short
+   summary + action items.


### PR DESCRIPTION
## Summary

Contributes the fork's accumulated work back to upstream (35 commits). Major themes:

- **Obsidian export**: export completed recordings to an Obsidian vault; mila-anywhere PRD + destination plan.
- **Gemini CLI**: added Gemini CLI support and hardened LLM executable lookup.
- **MCP server (`mila-mcp`)**: MCP stdio server over Mila's transcriptions, `MilaKit` package extraction, live-transcript sidecar during recording, and a store-location pointer for read-only store access.
- **Speaker renaming**: persistent, searchable speaker name directory threaded into live copy-transcript text.
- **Live-recording UX**: recording-folder + meeting-name controls, always-scroll transcript, pause/resume, per-line deletion, and a copy-transcript button.
- **Reliability fixes**:
  - Fix UI freeze when opening folder menus during recording/transcription.
  - Repair unfinalized WAV headers on crash recovery so force-quit recordings stay transcribable.
  - Fix recording folder lost when renaming after stop.
  - AGC / VAD noise-floor fixes for quiet built-in mics.
- **Packaging**: DMG entitlements + "Mila Local Dev" cert so TCC grants survive installs; wider Settings window.

## Test plan

- [ ] `make project && make build`
- [ ] `make test` and `make package-test` (TranscriptionCore + MilaKit) pass
- [ ] Manual: record, force-quit, relaunch -> recording recovers and transcribes (WAV header repair)
- [ ] Manual: open folder menu during recording/transcription -> no UI freeze
- [ ] Manual: Obsidian export writes to the configured vault

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pause/resume for recordings (with accurate paused elapsed-time) plus live transcript controls: speaker renaming, line deletion, clipboard copy, and speaker-aware exports.
  * Added optional Obsidian Markdown export with organized files, backfill, and optional Git sync.
  * Added Gemini CLI support and a bundled MCP server for transcript search and live meeting polling.
  * Added live transcript crash recovery and automatic repair for incomplete WAV headers.
* **Bug Fixes**
  * Reduced UI freezes by throttling transcription updates and isolating high-frequency views.
  * Improved adaptive gain for quiet speech/background noise.
* **Documentation**
  * Expanded local build/signing guidance and MCP/Obsidian destination setup docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->