### PR TITLE
Fix AGC so quiet built-in mics transcribe live

### DIFF
--- a/Mila/Audio/AdaptiveGainController.swift
+++ b/Mila/Audio/AdaptiveGainController.swift
@@ -16,9 +16,35 @@ import Accelerate
 /// feed and the saved WAV (single source of truth).
 ///
 /// ## Behaviour
-/// - **Update gate**: gain only adapts on frames whose RMS exceeds the VAD
-///   noise floor. Pure silence is passed through at the last-known gain so
-///   the noise floor never gets amplified into garbage.
+/// - **Update gate**: gain only adapts on frames whose RMS clearly exceeds
+///   the *observed* room noise floor — the MINIMUM frame RMS over the
+///   last `noiseFloorWindowSeconds` (two half-window buckets, classic
+///   minimum statistics). The minimum is the right statistic: speech
+///   pauses within any window pin the floor at true room tone no matter
+///   how loud or continuous the talking is, so quiet speech keeps
+///   clearing the gate — while sustained hum, which never pauses, becomes
+///   the window minimum within one window and gates itself off. (An
+///   earlier EMA-toward-signal variant regressed the quiet-mic fix: in a
+///   room with elevated tone it settled at the AVERAGE level and parked
+///   the gate on top of quiet speech.) Pure silence is passed through at
+///   the last-known gain so the noise floor never gets amplified into
+///   garbage.
+///
+///   The gate was previously a static 0.012 — the same value as the live
+///   VAD's speech cutoff — which made the controller useless in exactly
+///   the scenario it was built for: speech quieter than 0.012 never
+///   adapted the gain, so it stayed below the VAD cutoff forever and the
+///   live transcript sat empty for the whole recording (observed on a
+///   MacBook Pro built-in mic at ~0.004-0.010 RMS speech).
+///
+/// - **Sustained-noise relaxation**: hum that starts mid-recording (AC
+///   kicking in after a quiet stretch) briefly clears the gate while the
+///   floor catches up, picking up some gain. Any gain acquired that way
+///   must not stick: after `noiseRelaxAfterSeconds` of *continuous*
+///   below-gate (but non-silent) signal, the gain decays back toward 1
+///   with a `noiseRelaxSeconds` time constant. Ordinary speech pauses are
+///   far shorter than the trigger, so hold semantics are preserved for
+///   conversation; only genuinely sustained noise unwinds the gain.
 /// - **Attack** (signal louder than target, gain too high): ~200 ms time
 ///   constant — fast enough to prevent clipping on sudden voice onsets.
 /// - **Release** (signal quieter than target, gain too low): ~2 s time
@@ -47,11 +73,38 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// Minimum gain. 1.0 means "never attenuate" — a loud speaker passes
     /// through unchanged.
     static let defaultMinGain: Float = 1.0
-    /// Threshold below which we treat the frame as silence and *hold* the
-    /// last gain instead of adapting. Matches the live VAD's static cutoff
-    /// (`UtteranceDetector.rmsThreshold`) so we adapt on the same frames
-    /// the VAD treats as speech.
-    static let defaultSilenceFloor: Float = 0.012
+    /// Absolute minimum RMS below which a frame can never adapt the gain,
+    /// regardless of how quiet the observed noise floor is. Keeps a dead-
+    /// silent room (floor ≈ 0) from letting sub-audible rumble adapt.
+    /// Deliberately far below the VAD cutoff (0.012): frames between the
+    /// two are exactly the quiet speech this controller exists to boost.
+    static let defaultSilenceFloor: Float = 0.002
+    /// The adaptation gate is `max(silenceFloor, noiseFloor × this)`. 4×
+    /// sits between room tone (the floor itself, fluctuating up to ~2-3×
+    /// its own minimum) and quiet speech (≥ 5-10× the floor) — hum near
+    /// the floor holds the gain, speech adapts it. Observed field values
+    /// that must stay separated: room-tone minimum ~0.0005-0.0015 on a
+    /// MacBook Pro built-in mic vs quiet-speech frames ~0.004-0.010.
+    static let defaultNoiseFloorMultiplier: Float = 4.0
+    /// Length of the minimum-statistics window. Hum that starts after a
+    /// silent stretch owns the floor once the window has fully rotated
+    /// past the silence — ≤ 12 s — bounding how long its onset can keep
+    /// adapting the gain. Conversation always pauses within any 12 s
+    /// span, so speech never becomes its own floor.
+    static let defaultNoiseFloorWindowSeconds: Double = 12.0
+    /// How long the signal must sit continuously below the adaptation
+    /// gate (but above dead silence) before the gain starts relaxing
+    /// back toward 1. Longer than any conversational pause or single
+    /// utterance, shorter than "the AC has clearly been on for a while".
+    static let defaultNoiseRelaxAfterSeconds: Double = 15.0
+    /// Time constant of that relaxation once it engages. ~20 s unwinds
+    /// a hum-acquired gain within half a minute without audible pumping.
+    static let defaultNoiseRelaxSeconds: Double = 20.0
+    /// RMS below which a frame counts as dead silence: the gain holds
+    /// and the sustained-noise run is reset (silence is not noise). Well
+    /// below any real room tone; digital zero-fill and muted inputs land
+    /// here.
+    static let defaultDeadSilenceFloor: Float = 1e-4
     /// Attack time-constant in seconds. ~200 ms — fast enough to bring the
     /// gain back down when speech turns out louder than expected.
     static let defaultAttackSeconds: Double = 0.2
@@ -67,6 +120,11 @@ final class AdaptiveGainController: @unchecked Sendable {
     let maxGain: Float
     let minGain: Float
     let silenceFloor: Float
+    let noiseFloorMultiplier: Float
+    let noiseFloorWindowSeconds: Double
+    let noiseRelaxAfterSeconds: Double
+    let noiseRelaxSeconds: Double
+    let deadSilenceFloor: Float
     let attackSeconds: Double
     let releaseSeconds: Double
     let softClipThreshold: Float
@@ -76,6 +134,23 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// safe to read from another thread for display because Swift `Float`
     /// loads/stores are atomic and we tolerate one-frame staleness.
     private(set) var currentGain: Float = 1.0
+    /// Minimum-statistics estimate of the room's background RMS: the
+    /// minimum frame RMS over the last `noiseFloorWindowSeconds`, via two
+    /// half-window buckets. Negative sentinel = "no frame seen yet";
+    /// seeded from the first frame so a recording that starts inside
+    /// steady hum treats that hum as floor from sample one. Read-only
+    /// outside for tests/diagnostics.
+    private(set) var observedNoiseFloor: Float = -1
+    /// Current and previous half-window minimum buckets backing
+    /// `observedNoiseFloor`, plus how much of the current half-window
+    /// has elapsed. `.infinity` = bucket empty.
+    private var windowMin: Float = .infinity
+    private var prevWindowMin: Float = .infinity
+    private var windowElapsed: Double = 0
+    /// Seconds of *continuous* below-gate, above-dead-silence signal seen
+    /// so far. Crossing `noiseRelaxAfterSeconds` engages the gain
+    /// relaxation; any speech frame or dead-silence frame resets it.
+    private var sustainedNoiseSeconds: Double = 0
     /// `false` disables all adaptation and bypasses the soft clipper —
     /// output equals input bit-for-bit. Settings toggle.
     var enabled: Bool
@@ -86,6 +161,11 @@ final class AdaptiveGainController: @unchecked Sendable {
         maxGain: Float = defaultMaxGain,
         minGain: Float = defaultMinGain,
         silenceFloor: Float = defaultSilenceFloor,
+        noiseFloorMultiplier: Float = defaultNoiseFloorMultiplier,
+        noiseFloorWindowSeconds: Double = defaultNoiseFloorWindowSeconds,
+        noiseRelaxAfterSeconds: Double = defaultNoiseRelaxAfterSeconds,
+        noiseRelaxSeconds: Double = defaultNoiseRelaxSeconds,
+        deadSilenceFloor: Float = defaultDeadSilenceFloor,
         attackSeconds: Double = defaultAttackSeconds,
         releaseSeconds: Double = defaultReleaseSeconds,
         softClipThreshold: Float = defaultSoftClipThreshold,
@@ -96,6 +176,11 @@ final class AdaptiveGainController: @unchecked Sendable {
         self.maxGain = maxGain
         self.minGain = minGain
         self.silenceFloor = silenceFloor
+        self.noiseFloorMultiplier = noiseFloorMultiplier
+        self.noiseFloorWindowSeconds = noiseFloorWindowSeconds
+        self.noiseRelaxAfterSeconds = noiseRelaxAfterSeconds
+        self.noiseRelaxSeconds = noiseRelaxSeconds
+        self.deadSilenceFloor = deadSilenceFloor
         self.attackSeconds = attackSeconds
         self.releaseSeconds = releaseSeconds
         self.softClipThreshold = softClipThreshold
@@ -106,16 +191,23 @@ final class AdaptiveGainController: @unchecked Sendable {
     /// gain doesn't begin where the previous session left off.
     func reset() {
         currentGain = 1.0
+        observedNoiseFloor = -1
+        windowMin = .infinity
+        prevWindowMin = .infinity
+        windowElapsed = 0
+        sustainedNoiseSeconds = 0
     }
 
     /// Apply gain in-place to a mono Float32 channel buffer. Computes the
-    /// frame's RMS, updates the smoothed gain (if signal is above the
-    /// silence floor), and writes the gained + soft-clipped samples back
-    /// into `samples`.
+    /// frame's RMS, updates the windowed-minimum noise floor and the
+    /// adaptation gate derived from it, updates the smoothed gain (adapting
+    /// toward target when the gate is cleared, relaxing back toward 1
+    /// after sustained below-gate noise, holding through everything else),
+    /// and writes the gained + soft-clipped samples back into `samples`.
     ///
-    /// `frameDurationSeconds` is the elapsed wall-clock time the frame
-    /// represents; used to convert the attack/release time-constants into
-    /// per-frame smoothing coefficients. For a 30 ms frame this is `0.030`.
+    /// The frame's wall-clock duration — `count / sampleRate` — converts
+    /// the floor-window/attack/release/relax time-constants into per-frame
+    /// smoothing coefficients. For a 30 ms frame this is `0.030`.
     func process(_ samples: UnsafeMutablePointer<Float>, count: Int) {
         guard count > 0 else { return }
         if !enabled {
@@ -130,11 +222,40 @@ final class AdaptiveGainController: @unchecked Sendable {
         //    keeps this safe to call on the audio render thread).
         var rms: Float = 0
         vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
+        let frameDuration = Double(count) / sampleRate
 
-        // 2) Adapt the gain only when there's signal — never amplify pure
-        //    room hum. If the frame is below the silence floor, hold the
-        //    last gain and skip straight to applying it.
-        if rms >= silenceFloor {
+        // 2) Track the room's noise floor as the MINIMUM frame RMS over
+        //    the last window (two half-window buckets). Speech pauses
+        //    within any window pin the floor at true room tone — the
+        //    floor must NOT follow the average signal (an earlier EMA
+        //    variant did, and in a room with elevated tone it parked
+        //    the gate on top of quiet speech). A signal that never
+        //    pauses — hum, fan, AC — owns the window minimum once the
+        //    window rotates past whatever preceded it, so a
+        //    mid-recording hum onset gates itself off within
+        //    `noiseFloorWindowSeconds`.
+        let clampedRMS = max(rms, 1e-6)
+        windowMin = min(windowMin, clampedRMS)
+        windowElapsed += frameDuration
+        if windowElapsed >= noiseFloorWindowSeconds / 2 {
+            prevWindowMin = windowMin
+            windowMin = clampedRMS
+            windowElapsed = 0
+        }
+        observedNoiseFloor = min(windowMin, prevWindowMin)
+
+        // 3) Adapt the gain only when the frame is clearly above the
+        //    observed floor — never amplify room hum toward the VAD's
+        //    trigger range. Below the gate: hold the last gain through
+        //    ordinary speech pauses, but if the signal sits below the
+        //    gate CONTINUOUSLY for noiseRelaxAfterSeconds while staying
+        //    above dead silence (i.e. it's sustained noise, not a
+        //    pause), relax the gain back toward 1 — this unwinds any
+        //    gain picked up in the brief window where a mid-recording
+        //    hum onset cleared the gate before the floor caught up.
+        let adaptGate = max(silenceFloor, observedNoiseFloor * noiseFloorMultiplier)
+        if rms >= adaptGate {
+            sustainedNoiseSeconds = 0
             let desired = clamp(targetRMS / max(rms, 1e-6),
                                 lower: minGain,
                                 upper: maxGain)
@@ -142,7 +263,6 @@ final class AdaptiveGainController: @unchecked Sendable {
             // (desired > currentGain, signal too quiet). Convert the
             // time-constant into a 0…1 blend factor using the frame's
             // wall-clock duration: alpha = 1 - exp(-dt / tau).
-            let frameDuration = Double(count) / sampleRate
             let tau = (desired < currentGain) ? attackSeconds : releaseSeconds
             let alpha = Float(1.0 - exp(-frameDuration / max(tau, 1e-6)))
             currentGain += (desired - currentGain) * alpha
@@ -150,16 +270,26 @@ final class AdaptiveGainController: @unchecked Sendable {
             // errors from drifting outside [minGain, maxGain] over a long
             // recording.
             currentGain = clamp(currentGain, lower: minGain, upper: maxGain)
+        } else if rms >= deadSilenceFloor {
+            sustainedNoiseSeconds += frameDuration
+            if sustainedNoiseSeconds >= noiseRelaxAfterSeconds, currentGain > minGain {
+                let alpha = Float(1.0 - exp(-frameDuration / max(noiseRelaxSeconds, 1e-6)))
+                currentGain += (minGain - currentGain) * alpha
+            }
+        } else {
+            // Dead silence: hold the gain and reset the noise run —
+            // silence is not sustained noise.
+            sustainedNoiseSeconds = 0
         }
 
-        // 3) Apply the gain. With min=1, gain==1 is a no-op so skip the
+        // 4) Apply the gain. With min=1, gain==1 is a no-op so skip the
         //    multiply (most loud-speaker frames hit this path).
         let g = currentGain
         if g != 1.0 {
             vDSP_vsmul(samples, 1, [g], samples, 1, vDSP_Length(count))
         }
 
-        // 4) Soft-clip any sample whose magnitude exceeds the threshold.
+        // 5) Soft-clip any sample whose magnitude exceeds the threshold.
         //    The bulk of speech frames won't trigger this; we pay the loop
         //    only on the few transients that need protection.
         let threshold = softClipThreshold

--- a/MilaTests/AdaptiveGainControllerTests.swift
+++ b/MilaTests/AdaptiveGainControllerTests.swift
@@ -45,6 +45,29 @@ final class AdaptiveGainControllerTests: XCTestCase {
         return last
     }
 
+    /// Drive `controller` with speech-shaped input: `bursts` repetitions
+    /// of (`voicedSeconds` of `chunk`, then `gapSeconds` of silence).
+    /// The gaps matter — the noise-floor tracker snaps down during them,
+    /// which is what lets the bursts clear the adaptation gate. Returns
+    /// the gained samples of the final *voiced* chunk.
+    private func driveBursts(_ controller: AdaptiveGainController,
+                             chunk: [Float],
+                             bursts: Int,
+                             voicedSeconds: Double = 1.0,
+                             gapSeconds: Double = 0.5,
+                             gapChunk: [Float]? = nil,
+                             sampleRate: Double = 16_000) -> [Float] {
+        let gap = gapChunk ?? [Float](repeating: 0, count: chunk.count)
+        var lastVoiced: [Float] = []
+        for _ in 0..<bursts {
+            lastVoiced = drive(controller, chunk: chunk,
+                               seconds: voicedSeconds, sampleRate: sampleRate)
+            _ = drive(controller, chunk: gap,
+                      seconds: gapSeconds, sampleRate: sampleRate)
+        }
+        return lastVoiced
+    }
+
     /// Convert a linear RMS to dBFS. Returns `-inf` for zero input.
     private func dBFS(_ rmsValue: Float) -> Float {
         guard rmsValue > 0 else { return -.infinity }
@@ -53,26 +76,101 @@ final class AdaptiveGainControllerTests: XCTestCase {
 
     // MARK: - Tests
 
-    /// Constant low-level input (~-34 dBFS RMS, just above the silence
-    /// floor at 0.012) should be raised toward the -26 dBFS target.
-    /// Allow ±2 dB tolerance and ~4 release time-constants to settle.
-    func test_lowLevelSine_settlesNearTarget() {
+    /// Low-level speech-shaped input (~-34 dBFS RMS bursts with silence
+    /// gaps) should be raised toward the -26 dBFS target. Allow ±2 dB
+    /// tolerance and enough voiced time (~5 release time-constants,
+    /// excluding the seeded first burst) to settle.
+    func test_lowLevelBursts_settleNearTarget() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02 (well above the 0.012 silence floor so adaptation
-        // engages). amplitude = 0.02 * sqrt(2) for a sine of that RMS.
+        // RMS ≈ 0.02. amplitude = 0.02 * sqrt(2) for a sine of that RMS.
         let amplitude: Float = 0.02 * sqrt(2)
         // Use 30 ms chunks (matches the live VAD frame size) so the
         // attack/release dt mapping in `process` is realistic.
         let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
-        // Drive for 8 seconds (4× the release time-constant) so the
-        // smoother is well within ε of steady state.
-        let final = drive(controller, chunk: chunk, seconds: 8.0)
+        let final = driveBursts(controller, chunk: chunk, bursts: 12)
 
         let outRMS = rms(final)
         let outDb = dBFS(outRMS)
         let targetDb = dBFS(AdaptiveGainController.defaultTargetRMS)
         XCTAssertEqual(outDb, targetDb, accuracy: 2.0,
                        "settled RMS \(outDb) dBFS should be within ±2 dB of target \(targetDb) dBFS (gain=\(controller.currentGain))")
+    }
+
+    /// THE regression test for the quiet built-in-mic bug: speech at RMS
+    /// ~0.006 — well below the live VAD's 0.012 cutoff AND below the old
+    /// static adaptation gate (0.012) — must now be amplified above the
+    /// VAD cutoff. With the old gate this speech never adapted the gain,
+    /// the VAD never fired, and the live transcript stayed empty for the
+    /// whole recording (observed on a MacBook Pro built-in mic while a
+    /// headset mic worked).
+    func test_quietSpeechBursts_belowLegacyGate_getAmplifiedAboveVADCutoff() {
+        let controller = AdaptiveGainController()
+        let amplitude: Float = 0.006 * sqrt(2)   // sine RMS ≈ 0.006
+        let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
+        let final = driveBursts(controller, chunk: chunk, bursts: 8)
+
+        XCTAssertGreaterThan(controller.currentGain, 2.0,
+                             "quiet speech must adapt the gain upward")
+        XCTAssertGreaterThan(rms(final), 0.012,
+                             "boosted speech must clear the live VAD cutoff (0.012)")
+    }
+
+    /// Sustained hum — a signal that never pauses — must NOT be
+    /// amplified, even when it sits above the absolute silence floor.
+    /// The minimum-statistics tracker seeds the noise floor from the
+    /// first frame, so the hum is its own floor and never clears the
+    /// adaptation gate. Amplifying it would push room noise into the
+    /// VAD's trigger range and latch the live transcript into endless
+    /// noise "utterances".
+    func test_sustainedHum_holdsGainAtOne() {
+        let controller = AdaptiveGainController()
+        let amplitude: Float = 0.008 * sqrt(2)   // sine RMS ≈ 0.008
+        let chunk = sine(amplitude: amplitude, durationSeconds: 0.030)
+        _ = drive(controller, chunk: chunk, seconds: 20.0)
+
+        XCTAssertEqual(controller.currentGain, 1.0, accuracy: 1e-3,
+                       "sustained hum must never adapt the gain (observed floor \(controller.observedNoiseFloor))")
+    }
+
+    /// Field regression for the windowed-minimum floor: quiet speech over
+    /// REAL room tone (~0.001 RMS between utterances — not digital
+    /// zeros). An earlier EMA-based floor rose toward the average signal,
+    /// settled above room tone, and parked the adaptation gate on top of
+    /// the speech itself — live transcription silently died in any room
+    /// with elevated tone. The windowed minimum must keep the floor at
+    /// the tone's minimum so speech keeps clearing the gate.
+    func test_quietSpeech_overRealRoomTone_getsAmplified() {
+        let controller = AdaptiveGainController()
+        let speech = sine(amplitude: 0.006 * sqrt(2), durationSeconds: 0.030)
+        let roomTone = sine(amplitude: 0.001 * sqrt(2), durationSeconds: 0.030)
+        let final = driveBursts(controller, chunk: speech, bursts: 8,
+                                gapChunk: roomTone)
+
+        XCTAssertGreaterThan(controller.currentGain, 2.0,
+                             "quiet speech over real room tone must adapt the gain (floor \(controller.observedNoiseFloor))")
+        XCTAssertGreaterThan(rms(final), 0.012,
+                             "boosted speech must clear the live VAD cutoff (0.012)")
+    }
+
+    /// Hum that starts only AFTER a silent stretch (AC kicking in
+    /// mid-recording) briefly clears the gate while the noise floor —
+    /// seeded near zero by the silence — catches up, picking up gain.
+    /// The floor must find the hum within seconds, and the
+    /// sustained-noise relaxation must then unwind the acquired gain so
+    /// the boosted hum ends up back below the VAD's 0.012 trigger
+    /// instead of latching the live transcript into noise "utterances".
+    func test_humAfterSilence_gainRelaxesBackDown() {
+        let controller = AdaptiveGainController()
+        let silence = [Float](repeating: 0, count: 480)   // 30 ms @ 16 kHz
+        _ = drive(controller, chunk: silence, seconds: 5.0)
+
+        let hum = sine(amplitude: 0.008 * sqrt(2), durationSeconds: 0.030)
+        let final = drive(controller, chunk: hum, seconds: 90.0)
+
+        XCTAssertLessThan(controller.currentGain, 1.5,
+                          "gain acquired during the hum onset must relax back down")
+        XCTAssertLessThan(rms(final), 0.012,
+                          "steady hum must not stay boosted into the VAD's trigger range")
     }
 
     /// A full-scale signal should be passed through at gain == 1 —
@@ -120,15 +218,15 @@ final class AdaptiveGainControllerTests: XCTestCase {
     }
 
     /// Silence after a quiet signal should also hold (not continue ramping).
-    /// Pre-condition with a low-level signal (gain converges high), then
-    /// silence — gain must stay at the high value, NOT keep rising.
+    /// Pre-condition with low-level speech bursts (gain converges high),
+    /// then silence — gain must stay at the high value, NOT keep rising.
     func test_silence_doesNotKeepRising() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02 — above the silence floor (0.012) so adaptation
-        // engages and pushes the gain up toward target / RMS = 2.5×.
+        // Burst RMS ≈ 0.02 — adaptation pushes the gain up toward
+        // target / RMS = 2.5×.
         let lowSignal = sine(amplitude: 0.02 * sqrt(2),
                               durationSeconds: 0.030)
-        _ = drive(controller, chunk: lowSignal, seconds: 8.0)
+        _ = driveBursts(controller, chunk: lowSignal, bursts: 12)
         let gainAfterSpeech = controller.currentGain
         // Sanity: gain should be elevated (we were boosting low signal).
         XCTAssertGreaterThan(gainAfterSpeech, 2.0)
@@ -145,13 +243,14 @@ final class AdaptiveGainControllerTests: XCTestCase {
     /// the silence floor, then slam in a near-full-scale buffer; output
     /// must stay inside [-1, +1] thanks to the soft-clipper.
     func test_softClipper_keepsOutputInRange() {
-        // Use a custom controller with a very low silence floor so we can
-        // push the gain near the max with a small-amplitude signal. The
-        // production controller's silence floor (0.012) prevents
-        // amplifying ambient noise — that gate is verified by the
-        // silence tests; here we only care that the soft-clipper handles
-        // large-magnitude post-gain samples correctly.
-        let controller = AdaptiveGainController(silenceFloor: 0.0001)
+        // Use a custom controller with a very low silence floor and the
+        // noise-floor gate disabled (multiplier 0) so a constant
+        // small-amplitude signal can push the gain to the max. The
+        // production gates prevent amplifying ambient noise — verified by
+        // the silence/hum tests; here we only care that the soft-clipper
+        // handles large-magnitude post-gain samples correctly.
+        let controller = AdaptiveGainController(silenceFloor: 0.0001,
+                                                noiseFloorMultiplier: 0)
         let tinyChunk = sine(amplitude: 0.001, durationSeconds: 0.030)
         // Drive for ~10× the release time-constant (2.0s) so the smoother
         // gets to within 0.005% of the max gain. 10s only gets ~99.3% of
@@ -209,15 +308,17 @@ final class AdaptiveGainControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(controller.currentGain, 1.0)
     }
 
-    /// Reset wipes the gain back to 1 (fresh recording starts).
-    func test_reset_clearsGain() {
+    /// Reset wipes the gain back to 1 and forgets the observed noise
+    /// floor (fresh recording starts).
+    func test_reset_clearsGainAndNoiseFloor() {
         let controller = AdaptiveGainController()
-        // RMS ≈ 0.02, just above the silence floor so adaptation engages.
         let lowSignal = sine(amplitude: 0.02 * sqrt(2),
                               durationSeconds: 0.030)
-        _ = drive(controller, chunk: lowSignal, seconds: 8.0)
+        _ = driveBursts(controller, chunk: lowSignal, bursts: 12)
         XCTAssertGreaterThan(controller.currentGain, 1.5)
         controller.reset()
         XCTAssertEqual(controller.currentGain, 1.0)
+        XCTAssertLessThan(controller.observedNoiseFloor, 0,
+                          "reset must forget the previous session's noise floor")
     }
 }

--- a/MilaTests/UtteranceDetectorTests.swift
+++ b/MilaTests/UtteranceDetectorTests.swift
@@ -62,6 +62,49 @@ final class UtteranceDetectorTests: XCTestCase {
         XCTAssertLessThan(captured.start, 1.05)
     }
 
+    /// End-to-end regression for the quiet built-in-mic bug: speech at
+    /// RMS 0.006 is below the detector's 0.012 cutoff, so raw it never
+    /// emits — the live transcript stays empty while post-record whisper
+    /// still works. Routed through the AdaptiveGainController first
+    /// (exactly like the mic tap does), the same audio must be boosted
+    /// enough to emit utterances mid-recording.
+    func test_quiet_speech_through_AGC_emits_utterances() {
+        // Raw (no AGC): nothing fires — this is the observed symptom.
+        let rawDet = UtteranceDetector()
+        var rawFired = 0
+        rawDet.onUtterance = { _, _ in rawFired += 1 }
+        rawDet.ingest(silence(seconds: 0.5)[...])
+        for _ in 0..<3 {
+            rawDet.ingest(speech(seconds: 2.0, amp: 0.006)[...])
+            rawDet.ingest(silence(seconds: 0.9)[...])
+        }
+        XCTAssertEqual(rawFired, 0,
+                       "sanity: RMS 0.006 speech is below the raw VAD cutoff")
+
+        // Same audio through the AGC, fed in 30ms chunks like the mic tap.
+        let det = UtteranceDetector()
+        var fired = 0
+        det.onUtterance = { _, _ in fired += 1 }
+        let agc = AdaptiveGainController()
+        func feed(_ samples: [Float]) {
+            let chunkSize = Int(sr * frameMs / 1000)
+            var i = 0
+            while i < samples.count {
+                let end = min(i + chunkSize, samples.count)
+                let boosted = agc.process(Array(samples[i..<end]))
+                det.ingest(boosted[...])
+                i = end
+            }
+        }
+        feed(silence(seconds: 0.5))
+        for _ in 0..<3 {
+            feed(speech(seconds: 2.0, amp: 0.006))
+            feed(silence(seconds: 0.9))
+        }
+        XCTAssertGreaterThanOrEqual(fired, 2,
+                                    "AGC-boosted quiet speech must emit utterances mid-recording (gain=\(agc.currentGain))")
+    }
+
     func test_two_separate_bursts_emit_two_utterances() {
         let det = UtteranceDetector()
         var fired = 0


### PR DESCRIPTION
## Problem

Live transcription never worked on quiet built-in mics (e.g. the MacBook Pro built-in mic, ~0.004–0.010 RMS speech). The live pane sat on "Listening…" for the whole recording; the transcript only appeared after Stop via the post-record whisper pass. A hotter headset mic masked it.

Fixes #100.

## Root cause

`AdaptiveGainController` exists to lift low-level mic capture above the live VAD's `0.012` RMS enter-speech cutoff — but its **adaptation gate was that same `0.012`**, so speech quieter than the cutoff could never adapt the gain. The controller's whole motivating scenario never worked.

## Fix

The adaptation gate now tracks the room's observed noise floor via **minimum statistics** (two half-window buckets — the minimum frame RMS over ~12s, seeded from the first frame) and adapts on frames above `max(0.002, floor × 4)`. Quiet-but-bursty speech clears the gate; sustained hum becomes its own window minimum and gates itself off, so room noise is never amplified into the VAD's trigger range. A mid-recording hum onset that briefly clears the gate has its acquired gain unwound by a sustained-below-gate relaxation back toward unity.

## Provenance

Extracted from #85 (@DanielSolomon), preserved as a `Co-Authored-By` on the commit. #85 also adds a copy-transcript button, which is **deferred**: its `QuickActionsController` refactor (introducing `transcriptSegments`) overlaps the `stopRecording` region changed by #87 and needs a rebase. The AGC fix is self-contained (`AdaptiveGainController` + regression tests), so it lands on its own here.

## Tests

- Quiet-speech regression: utterances now emit through the AGC in front of `UtteranceDetector` (mirrors the mic tap).
- Sustained-hum guard: gain holds at 1.0.
- `AdaptiveGainControllerTests` (12) + `UtteranceDetectorTests` (12) pass locally; `make build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved automatic gain control for quiet speech, helping low-volume utterances reach detection thresholds more reliably.
  * Added noise-aware processing to distinguish speech from background room tone and sustained hum.
  * Preserved natural pauses without continuously increasing amplification.
  * Gradually reduces amplification during extended low-level noise to prevent unwanted background audio from remaining boosted.
  * Improved handling of silence and reset behavior for more consistent recording sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->