### PR TITLE
Add .milaconfig double-click setup files

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -252,6 +252,8 @@ struct MilaApp: App {
     /// Persistent, app-wide list of speaker names — the pick-list behind
     /// the transcript's speaker rename popover.
     @StateObject private var speakerDirectory: SpeakerDirectory
+    /// Applies double-clicked `.milaconfig` files (with a confirmation sheet).
+    @StateObject private var configImporter: MilaConfigImporter
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -464,6 +466,15 @@ struct MilaApp: App {
             settings: meetingSettings,
             actions: actions
         )
+        // Applies `.milaconfig` files. Given the settings objects it's allowed
+        // to mutate; the open event is routed in from `MilaAppDelegate`.
+        let configImporter = MilaConfigImporter(
+            remote: remoteSettings,
+            language: langSettings,
+            liveAI: liveAI,
+            diarization: diarSettings,
+            meetingDetection: meetingSettings
+        )
         _store = StateObject(wrappedValue: store)
         _storageSettings = StateObject(wrappedValue: storage)
         _modelManager = StateObject(wrappedValue: mgr)
@@ -498,6 +509,7 @@ struct MilaApp: App {
         _voiceMemosSettings = StateObject(wrappedValue: vmSettings)
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
         _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
+        _configImporter = StateObject(wrappedValue: configImporter)
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,
@@ -550,6 +562,28 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(configImporter)
+                .sheet(item: Binding(
+                    get: { configImporter.pending },
+                    set: { if $0 == nil { configImporter.cancel() } }
+                )) { pending in
+                    MilaConfigConfirmationView(
+                        pending: pending,
+                        onApply: { configImporter.confirm() },
+                        onCancel: { configImporter.cancel() }
+                    )
+                }
+                .alert(
+                    "Couldn't import configuration",
+                    isPresented: Binding(
+                        get: { configImporter.errorMessage != nil },
+                        set: { if !$0 { configImporter.errorMessage = nil } }
+                    )
+                ) {
+                    Button("OK", role: .cancel) { }
+                } message: {
+                    Text(configImporter.errorMessage ?? "")
+                }
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -604,6 +638,7 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(configImporter)
         }
     }
 
@@ -642,6 +677,10 @@ struct MilaApp: App {
         appDelegate.dictation = dictation
         appDelegate.modelManager = modelManager
         appDelegate.actions = actions
+        // Route `.milaconfig` opens through the importer, and drain any that
+        // arrived during a cold launch (before this wiring ran).
+        appDelegate.configImporter = configImporter
+        appDelegate.flushBufferedConfigOpens()
         appDelegate.startScreenLockObserversIfNeeded()
     }
 
@@ -1434,9 +1473,41 @@ final class MilaAppDelegate: NSObject, NSApplicationDelegate {
     weak var dictation: DictationController?
     weak var modelManager: ModelManager?
     weak var actions: QuickActionsController?
+    weak var configImporter: MilaConfigImporter?
 
     private var didShutDown = false
     private var screenLockObserversInstalled = false
+    /// `.milaconfig` URLs delivered by a cold launch (double-click while Mila
+    /// was not running) before `wireDelegate()` connected the importer. Drained
+    /// by `flushBufferedConfigOpens()`.
+    private var bufferedConfigURLs: [URL] = []
+
+    /// macOS calls this when the user double-clicks / drops a file the app
+    /// declares it opens (`CFBundleDocumentTypes` in Info.plist). We only claim
+    /// `.milaconfig`; anything else is ignored.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        let configURLs = urls.filter {
+            $0.pathExtension.lowercased() == MilaConfig.fileExtension
+        }
+        guard !configURLs.isEmpty else { return }
+        Task { @MainActor in
+            if let importer = self.configImporter {
+                configURLs.forEach { importer.handleOpen($0) }
+            } else {
+                // Cold launch: hold until the importer is wired in.
+                self.bufferedConfigURLs.append(contentsOf: configURLs)
+            }
+        }
+    }
+
+    /// Deliver any config opens that arrived before the importer was wired.
+    @MainActor
+    func flushBufferedConfigOpens() {
+        guard let importer = configImporter, !bufferedConfigURLs.isEmpty else { return }
+        let urls = bufferedConfigURLs
+        bufferedConfigURLs.removeAll()
+        urls.forEach { importer.handleOpen($0) }
+    }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         if didShutDown { return .terminateNow }

--- a/Mila/Models/MilaConfig.swift
+++ b/Mila/Models/MilaConfig.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// A `.milaconfig` file — a shareable, partial snapshot of Mila settings.
+///
+/// **Partial-override semantics.** Every field is optional. When a config is
+/// applied (see `MilaConfigImporter`), a field that is *present* overrides the
+/// current setting; a field that is *absent* leaves the current setting
+/// untouched. This lets someone hand out a file that configures, say, just the
+/// remote transcription server without disturbing the recipient's hotkeys,
+/// language, or anything else.
+///
+/// The on-disk format is JSON. `version` gates forward-compatibility: a file
+/// whose `version` is newer than `MilaConfig.currentVersion` is rejected with a
+/// clear message rather than silently half-applied. Absent/older-but-valid
+/// versions are accepted.
+///
+/// Deliberately *not* representable here: machine-specific settings that can't
+/// travel between Macs — the selected audio input device UID and the
+/// recordings-directory security-scoped bookmark — and per-key hotkey bindings.
+/// See `MilaConfigImporter` for the rationale.
+struct MilaConfig: Codable, Equatable {
+    /// Bump when the schema changes in a way older apps couldn't safely apply.
+    static let currentVersion = 1
+
+    /// Schema version of this file. Required.
+    var version: Int
+
+    var remoteTranscription: RemoteTranscription?
+    /// ISO-style language code for new recordings: `"he"`, `"en"`, or `"auto"`.
+    var recordingLanguage: String?
+    var liveAI: LiveAI?
+    var diarization: Toggle?
+    var meetingDetection: Toggle?
+
+    /// OpenAI-compatible remote transcription backend (e.g. a self-hosted
+    /// `speaches` server running an ivrit.ai model).
+    struct RemoteTranscription: Codable, Equatable {
+        /// `true` switches Mila to the remote backend; `false` reverts to
+        /// on-device whisper.cpp.
+        var enabled: Bool?
+        /// Base URL, e.g. `https://mila-asr.internal.island.io/v1`. The engine
+        /// appends `audio/transcriptions`.
+        var endpoint: String?
+        /// Model id the server expects, e.g. `ivrit-ai/whisper-large-v3-turbo-ct2`.
+        var model: String?
+        /// Bearer token. Stored in the Keychain on apply, never in UserDefaults.
+        var apiKey: String?
+    }
+
+    struct LiveAI: Codable, Equatable {
+        var enabled: Bool?
+        var model: String?
+    }
+
+    /// A single on/off feature toggle.
+    struct Toggle: Codable, Equatable {
+        var enabled: Bool?
+    }
+}
+
+extension MilaConfig {
+    /// The file extension (without the dot) and the UTI registered in
+    /// `Info.plist` for double-click-to-open.
+    static let fileExtension = "milaconfig"
+
+    enum LoadError: LocalizedError, Equatable {
+        case unreadable(String)
+        case malformed(String)
+        case unsupportedVersion(found: Int, supported: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadable(let detail):
+                return "Couldn't read the configuration file. \(detail)"
+            case .malformed(let detail):
+                return "That doesn't look like a valid Mila configuration file. \(detail)"
+            case .unsupportedVersion(let found, let supported):
+                return "This configuration needs a newer version of Mila "
+                    + "(file format v\(found); this app supports up to v\(supported)). "
+                    + "Update Mila and try again."
+            }
+        }
+    }
+
+    /// Parse a `.milaconfig` file, throwing a user-facing `LoadError`.
+    static func load(from url: URL) throws -> MilaConfig {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw LoadError.unreadable(error.localizedDescription)
+        }
+        return try decode(data)
+    }
+
+    /// Parse config bytes. Split out from `load(from:)` so tests don't need a
+    /// file on disk.
+    static func decode(_ data: Data) throws -> MilaConfig {
+        let config: MilaConfig
+        do {
+            config = try JSONDecoder().decode(MilaConfig.self, from: data)
+        } catch let DecodingError.keyNotFound(key, _) where key.stringValue == "version" {
+            throw LoadError.malformed("It's missing the required \"version\" field.")
+        } catch {
+            throw LoadError.malformed(error.localizedDescription)
+        }
+        guard config.version >= 1 else {
+            throw LoadError.malformed("\"version\" must be a positive integer.")
+        }
+        guard config.version <= currentVersion else {
+            throw LoadError.unsupportedVersion(found: config.version, supported: currentVersion)
+        }
+        return config
+    }
+}

--- a/Mila/Models/MilaConfigImporter.swift
+++ b/Mila/Models/MilaConfigImporter.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Combine
+import os
+
+/// Loads a `.milaconfig`, previews the changes it would make, and — once the
+/// user confirms — applies the present fields onto the app's live settings
+/// objects. Absent fields are left untouched (see `MilaConfig`).
+///
+/// Only settings that make sense to carry between machines are handled here:
+/// the remote transcription server, the recording language, and the feature
+/// toggles. Deliberately excluded — because they don't transfer meaningfully:
+///   - the selected audio input device UID (machine-specific hardware),
+///   - the recordings-directory security-scoped bookmark (path + per-machine
+///     sandbox grant), and
+///   - per-key hotkey bindings.
+///
+/// Constructed once in `MilaApp.init()` and injected via `.environmentObject`;
+/// the file-open handler in `MilaAppDelegate` calls `handleOpen(_:)`.
+@MainActor
+final class MilaConfigImporter: ObservableObject {
+
+    /// One human-readable "this will change" line for the confirmation sheet.
+    struct PlannedChange: Identifiable, Equatable {
+        let id = UUID()
+        /// e.g. "Transcription server".
+        let label: String
+        /// The value the setting will be set to (secrets are masked).
+        let value: String
+    }
+
+    /// A parsed config staged for the user to confirm. `Identifiable` so it can
+    /// drive a `.sheet(item:)`.
+    struct PendingImport: Identifiable {
+        let id = UUID()
+        let config: MilaConfig
+        let changes: [PlannedChange]
+        /// The file name it came from, shown in the sheet.
+        let sourceName: String
+    }
+
+    /// Non-nil while a confirmation sheet should be shown.
+    @Published var pending: PendingImport?
+    /// Non-nil to surface a load/parse error to the user.
+    @Published var errorMessage: String?
+
+    private let remote: RemoteTranscriptionSettings
+    private let language: RecordingLanguageSettings
+    private let liveAI: LiveAISettings
+    private let diarization: DiarizationSettings
+    private let meetingDetection: MeetingDetectionSettings
+    private let log = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaConfig")
+
+    init(remote: RemoteTranscriptionSettings,
+         language: RecordingLanguageSettings,
+         liveAI: LiveAISettings,
+         diarization: DiarizationSettings,
+         meetingDetection: MeetingDetectionSettings) {
+        self.remote = remote
+        self.language = language
+        self.liveAI = liveAI
+        self.diarization = diarization
+        self.meetingDetection = meetingDetection
+    }
+
+    // MARK: - Open / confirm / cancel
+
+    /// Entry point from the file-open handler. Loads and stages the config for
+    /// confirmation; parse failures surface via `errorMessage`.
+    func handleOpen(_ url: URL) {
+        // The file may live outside the app's sandbox-granted locations (e.g. a
+        // download the user double-clicked). Take a security scope if one is
+        // offered — harmless when it isn't.
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+        do {
+            let config = try MilaConfig.load(from: url)
+            pending = PendingImport(config: config,
+                                    changes: plannedChanges(for: config),
+                                    sourceName: url.lastPathComponent)
+            log.log("staged \(url.lastPathComponent, privacy: .public) for import (\(self.pending?.changes.count ?? 0) change(s))")
+        } catch {
+            errorMessage = (error as? MilaConfig.LoadError)?.errorDescription
+                ?? error.localizedDescription
+            log.error("failed to load config: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Apply the staged config and clear the pending state.
+    func confirm() {
+        guard let pending else { return }
+        apply(pending.config)
+        self.pending = nil
+    }
+
+    /// Dismiss the staged config without applying it.
+    func cancel() { pending = nil }
+
+    // MARK: - Diff (for the confirmation sheet)
+
+    /// The human-readable changes a config would make against the *current*
+    /// settings, skipping fields that already match — so the sheet lists only
+    /// genuine changes. A present-but-equal field is a no-op.
+    func plannedChanges(for config: MilaConfig) -> [PlannedChange] {
+        var out: [PlannedChange] = []
+
+        if let r = config.remoteTranscription {
+            if let enabled = r.enabled {
+                let target: TranscriptionBackend = enabled ? .remote : .local
+                if target != remote.backend {
+                    out.append(.init(label: "Transcription", value: target.displayName))
+                }
+            }
+            if let endpoint = r.endpoint, endpoint != remote.endpoint {
+                out.append(.init(label: "Server URL", value: endpoint))
+            }
+            if let model = r.model, model != remote.model {
+                out.append(.init(label: "Model", value: model))
+            }
+            if let apiKey = r.apiKey, apiKey != remote.apiKey {
+                out.append(.init(label: "API key", value: Self.mask(apiKey)))
+            }
+        }
+        if let langCode = config.recordingLanguage {
+            let target = RecordingLanguage.fromCode(langCode)
+            if target != language.current {
+                out.append(.init(label: "Recording language", value: target.displayName))
+            }
+        }
+        if let live = config.liveAI {
+            if let enabled = live.enabled, enabled != liveAI.enabled {
+                out.append(.init(label: "Live AI", value: enabled ? "On" : "Off"))
+            }
+            if let model = live.model, model != liveAI.model {
+                out.append(.init(label: "Live AI model", value: model))
+            }
+        }
+        if let d = config.diarization, let enabled = d.enabled, enabled != diarization.isEnabled {
+            out.append(.init(label: "Speaker diarization", value: enabled ? "On" : "Off"))
+        }
+        if let m = config.meetingDetection, let enabled = m.enabled, enabled != meetingDetection.enabled {
+            out.append(.init(label: "Meeting detection", value: enabled ? "On" : "Off"))
+        }
+        return out
+    }
+
+    // MARK: - Apply
+
+    /// Override every present field; leave absent fields untouched.
+    func apply(_ config: MilaConfig) {
+        if let r = config.remoteTranscription {
+            // Set endpoint/model/key BEFORE flipping the backend. Switching to
+            // `.remote` triggers `RemoteTranscriptionSettings`' lazy Keychain
+            // read; setting the key first means that read sees a non-empty
+            // in-memory value and won't overwrite the key we're applying with a
+            // stale stored one.
+            if let endpoint = r.endpoint { remote.endpoint = endpoint }
+            if let model = r.model { remote.model = model }
+            if let apiKey = r.apiKey { remote.apiKey = apiKey }
+            if let enabled = r.enabled { remote.backend = enabled ? .remote : .local }
+        }
+        if let langCode = config.recordingLanguage {
+            language.current = RecordingLanguage.fromCode(langCode)
+        }
+        if let live = config.liveAI {
+            if let enabled = live.enabled { liveAI.enabled = enabled }
+            if let model = live.model { liveAI.model = model }
+        }
+        if let d = config.diarization, let enabled = d.enabled {
+            diarization.isEnabled = enabled
+        }
+        if let m = config.meetingDetection, let enabled = m.enabled {
+            meetingDetection.enabled = enabled
+        }
+        log.log("applied configuration")
+    }
+
+    /// Mask a secret for display: keep the last 4 chars, dot out the rest.
+    static func mask(_ secret: String) -> String {
+        let visible = 4
+        guard secret.count > visible else { return String(repeating: "•", count: 8) }
+        return String(repeating: "•", count: 8) + secret.suffix(visible)
+    }
+}

--- a/Mila/Resources/Info.plist
+++ b/Mila/Resources/Info.plist
@@ -6,6 +6,21 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Mila</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Mila Configuration</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>io.island.mila.config</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -59,6 +74,23 @@
 			<string>io.island.whisper.recording</string>
 			<key>UTTypeTagSpecification</key>
 			<dict/>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Mila Configuration</string>
+			<key>UTTypeIdentifier</key>
+			<string>io.island.mila.config</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>milaconfig</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/Mila/Views/MilaConfigConfirmationView.swift
+++ b/Mila/Views/MilaConfigConfirmationView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Confirmation sheet shown when the user opens a `.milaconfig` file. Lists the
+/// exact settings the file will change (secrets masked) so a double-clicked
+/// file can never silently reconfigure the app. Settings not named in the file
+/// are left as they are.
+struct MilaConfigConfirmationView: View {
+    let pending: MilaConfigImporter.PendingImport
+    let onApply: () -> Void
+    let onCancel: () -> Void
+
+    private var hasChanges: Bool { !pending.changes.isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Image(systemName: "gearshape.2.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Apply Mila configuration?")
+                        .font(.headline)
+                    Text(pending.sourceName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if hasChanges {
+                Text("The following settings will be updated:")
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(pending.changes) { change in
+                        HStack(alignment: .firstTextBaseline, spacing: 16) {
+                            Text(change.label)
+                                .foregroundStyle(.secondary)
+                            Spacer(minLength: 0)
+                            Text(change.value)
+                                .fontWeight(.medium)
+                                .multilineTextAlignment(.trailing)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.4))
+                )
+                Text("Settings not listed in the file are left unchanged.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("This configuration matches your current settings — nothing will change.")
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel, action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(hasChanges ? "Apply" : "OK", action: onApply)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 440)
+    }
+}

--- a/MilaTests/MilaConfigTests.swift
+++ b/MilaTests/MilaConfigTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import Mila
+
+// MARK: - Parsing / versioning
+
+final class MilaConfigDecodeTests: XCTestCase {
+
+    func test_decode_parsesAllFields() throws {
+        let json = """
+        {
+          "version": 1,
+          "remoteTranscription": {
+            "enabled": true,
+            "endpoint": "https://mila-asr.internal.island.io/v1",
+            "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+            "apiKey": "secret-123"
+          },
+          "recordingLanguage": "he",
+          "liveAI": { "enabled": false, "model": "claude" },
+          "diarization": { "enabled": true },
+          "meetingDetection": { "enabled": false }
+        }
+        """.data(using: .utf8)!
+
+        let config = try MilaConfig.decode(json)
+        XCTAssertEqual(config.version, 1)
+        XCTAssertEqual(config.remoteTranscription?.enabled, true)
+        XCTAssertEqual(config.remoteTranscription?.endpoint, "https://mila-asr.internal.island.io/v1")
+        XCTAssertEqual(config.remoteTranscription?.model, "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(config.remoteTranscription?.apiKey, "secret-123")
+        XCTAssertEqual(config.recordingLanguage, "he")
+        XCTAssertEqual(config.liveAI?.enabled, false)
+        XCTAssertEqual(config.liveAI?.model, "claude")
+        XCTAssertEqual(config.diarization?.enabled, true)
+        XCTAssertEqual(config.meetingDetection?.enabled, false)
+    }
+
+    func test_decode_absentFieldsAreNil() throws {
+        // Only the server URL is present; everything else must decode to nil so
+        // the applier leaves those settings untouched.
+        let json = """
+        { "version": 1, "remoteTranscription": { "endpoint": "https://x/v1" } }
+        """.data(using: .utf8)!
+
+        let config = try MilaConfig.decode(json)
+        XCTAssertEqual(config.remoteTranscription?.endpoint, "https://x/v1")
+        XCTAssertNil(config.remoteTranscription?.enabled)
+        XCTAssertNil(config.remoteTranscription?.model)
+        XCTAssertNil(config.remoteTranscription?.apiKey)
+        XCTAssertNil(config.recordingLanguage)
+        XCTAssertNil(config.liveAI)
+        XCTAssertNil(config.diarization)
+        XCTAssertNil(config.meetingDetection)
+    }
+
+    func test_decode_missingVersion_throwsMalformed() {
+        let json = """
+        { "recordingLanguage": "he" }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try MilaConfig.decode(json)) { error in
+            guard case MilaConfig.LoadError.malformed = error else {
+                return XCTFail("Expected .malformed, got \(error)")
+            }
+        }
+    }
+
+    func test_decode_futureVersion_throwsUnsupported() {
+        let json = """
+        { "version": 999 }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try MilaConfig.decode(json)) { error in
+            guard case MilaConfig.LoadError.unsupportedVersion(let found, let supported) = error else {
+                return XCTFail("Expected .unsupportedVersion, got \(error)")
+            }
+            XCTAssertEqual(found, 999)
+            XCTAssertEqual(supported, MilaConfig.currentVersion)
+        }
+    }
+
+    func test_decode_garbage_throwsMalformed() {
+        let json = "not json at all".data(using: .utf8)!
+        XCTAssertThrowsError(try MilaConfig.decode(json)) { error in
+            guard case MilaConfig.LoadError.malformed = error else {
+                return XCTFail("Expected .malformed, got \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Apply / diff
+
+@MainActor
+final class MilaConfigImporterTests: XCTestCase {
+
+    private struct Harness {
+        let importer: MilaConfigImporter
+        let remote: RemoteTranscriptionSettings
+        let language: RecordingLanguageSettings
+        let liveAI: LiveAISettings
+        let diarization: DiarizationSettings
+        let meetingDetection: MeetingDetectionSettings
+        let keychainKey: String
+    }
+
+    private func makeHarness(_ label: String = #function) -> Harness {
+        let suiteName = "MilaConfigTests.\(label)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        let keychainKey = "MilaConfigTests.\(label).apiKey"
+        KeychainHelper.delete(key: keychainKey)
+
+        let remote = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: keychainKey)
+        let language = RecordingLanguageSettings(defaults: suite)
+        let liveAI = LiveAISettings(defaults: suite)
+        let diarization = DiarizationSettings(defaults: suite)
+        let meetingDetection = MeetingDetectionSettings(defaults: suite)
+        let importer = MilaConfigImporter(remote: remote,
+                                          language: language,
+                                          liveAI: liveAI,
+                                          diarization: diarization,
+                                          meetingDetection: meetingDetection)
+        return Harness(importer: importer, remote: remote, language: language,
+                       liveAI: liveAI, diarization: diarization,
+                       meetingDetection: meetingDetection, keychainKey: keychainKey)
+    }
+
+    func test_apply_fullRemote_setsBackendEndpointModelKey() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        XCTAssertEqual(h.remote.backend, .local)
+
+        h.importer.apply(MilaConfig(
+            version: 1,
+            remoteTranscription: .init(enabled: true,
+                                       endpoint: "https://mila-asr.internal.island.io/v1",
+                                       model: "ivrit-ai/whisper-large-v3-turbo-ct2",
+                                       apiKey: "secret-123")
+        ))
+
+        XCTAssertEqual(h.remote.backend, .remote)
+        XCTAssertEqual(h.remote.endpoint, "https://mila-asr.internal.island.io/v1")
+        XCTAssertEqual(h.remote.model, "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(h.remote.apiKey, "secret-123",
+                       "Key set from config must survive the backend switch's lazy Keychain load")
+        XCTAssertTrue(h.remote.isConfigured)
+    }
+
+    func test_apply_absentFieldsLeaveCurrentUntouched() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        // Seed a current state.
+        h.remote.model = "current-model"
+        h.language.current = .english
+
+        // A config that only changes the endpoint.
+        h.importer.apply(MilaConfig(
+            version: 1,
+            remoteTranscription: .init(endpoint: "https://only-endpoint/v1")
+        ))
+
+        XCTAssertEqual(h.remote.endpoint, "https://only-endpoint/v1")
+        XCTAssertEqual(h.remote.model, "current-model", "Absent model must not be overridden")
+        XCTAssertEqual(h.remote.backend, .local, "Absent enabled must not switch the backend")
+        XCTAssertEqual(h.language.current, .english, "Absent language must not be overridden")
+    }
+
+    func test_apply_enabledFalse_revertsToLocal() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        h.remote.backend = .remote
+        XCTAssertEqual(h.remote.backend, .remote)
+
+        h.importer.apply(MilaConfig(version: 1, remoteTranscription: .init(enabled: false)))
+        XCTAssertEqual(h.remote.backend, .local)
+    }
+
+    func test_apply_setsLanguageAndToggles() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        h.importer.apply(MilaConfig(
+            version: 1,
+            recordingLanguage: "en",
+            liveAI: .init(enabled: true, model: "claude"),
+            diarization: .init(enabled: true),
+            meetingDetection: .init(enabled: false)
+        ))
+        XCTAssertEqual(h.language.current, .english)
+        XCTAssertTrue(h.liveAI.enabled)
+        XCTAssertEqual(h.liveAI.model, "claude")
+        XCTAssertTrue(h.diarization.isEnabled)
+        XCTAssertFalse(h.meetingDetection.enabled)
+    }
+
+    func test_plannedChanges_listsOnlyDiffs_andMasksKey() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        // model matches the current default → should NOT appear as a change.
+        let config = MilaConfig(
+            version: 1,
+            remoteTranscription: .init(enabled: true,
+                                       endpoint: "https://mila-asr.internal.island.io/v1",
+                                       model: RemoteTranscriptionSettings.defaultModel,
+                                       apiKey: "supersecretvalue")
+        )
+        let changes = h.importer.plannedChanges(for: config)
+        let labels = changes.map(\.label)
+        XCTAssertTrue(labels.contains("Transcription"))
+        XCTAssertTrue(labels.contains("Server URL"))
+        XCTAssertTrue(labels.contains("API key"))
+        XCTAssertFalse(labels.contains("Model"), "A value equal to current must not be listed")
+
+        let keyChange = changes.first { $0.label == "API key" }
+        XCTAssertNotNil(keyChange)
+        XCTAssertFalse(keyChange!.value.contains("supersecret"), "Key must be masked")
+        XCTAssertTrue(keyChange!.value.hasSuffix("alue"), "Last 4 chars are shown")
+    }
+
+    func test_plannedChanges_emptyWhenConfigMatchesCurrent() {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+        // Current: backend .local, language .hebrew (defaults).
+        let config = MilaConfig(
+            version: 1,
+            remoteTranscription: .init(enabled: false),
+            recordingLanguage: "he"
+        )
+        XCTAssertTrue(h.importer.plannedChanges(for: config).isEmpty)
+    }
+
+    func test_handleOpen_stagesPending_thenConfirmApplies() throws {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+
+        let json = """
+        {
+          "version": 1,
+          "remoteTranscription": {
+            "enabled": true,
+            "endpoint": "https://mila-asr.internal.island.io/v1",
+            "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+            "apiKey": "secret-123"
+          }
+        }
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-test-\(UUID().uuidString).milaconfig")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        h.importer.handleOpen(url)
+        XCTAssertNil(h.importer.errorMessage)
+        XCTAssertNotNil(h.importer.pending)
+        XCTAssertFalse(h.importer.pending?.changes.isEmpty ?? true)
+
+        h.importer.confirm()
+        XCTAssertNil(h.importer.pending, "Confirm clears the pending state")
+        XCTAssertEqual(h.remote.backend, .remote)
+        XCTAssertEqual(h.remote.endpoint, "https://mila-asr.internal.island.io/v1")
+    }
+
+    func test_handleOpen_malformedFile_setsError() throws {
+        let h = makeHarness()
+        defer { KeychainHelper.delete(key: h.keychainKey) }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-bad-\(UUID().uuidString).milaconfig")
+        try "{ not valid ".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        h.importer.handleOpen(url)
+        XCTAssertNil(h.importer.pending)
+        XCTAssertNotNil(h.importer.errorMessage)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -158,6 +158,23 @@ targets:
             UTTypeConformsTo:
               - public.data
             UTTypeTagSpecification: {}
+          # `.milaconfig` — a shareable JSON settings file. Declaring the type
+          # (extension -> UTI) plus the CFBundleDocumentTypes entry below is what
+          # lets a double-clicked `.milaconfig` launch/foreground Mila and route
+          # through MilaAppDelegate.application(_:open:) -> MilaConfigImporter.
+          - UTTypeIdentifier: io.island.mila.config
+            UTTypeDescription: Mila Configuration
+            UTTypeConformsTo:
+              - public.json
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - milaconfig
+        CFBundleDocumentTypes:
+          - CFBundleTypeName: Mila Configuration
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Owner
+            LSItemContentTypes:
+              - io.island.mila.config
         # Sparkle auto-update feed. The appcast is a static file published to
         # GitHub Pages; release binaries are attached to GitHub Releases. Forks
         # that want their own update channel should point this at their own


### PR DESCRIPTION
## What

Adds support for a **`.milaconfig`** file: a shareable, double-clickable settings file that configures Mila for the user. Part of the beta.

The immediate motivation is the shared **mila-asr** Hebrew transcription server (speaches + ivrit model, now live on `internal-tools-us-east-1`): instead of walking each colleague through Settings ▸ Models to enter the server URL, model id, and API key by hand, we hand out one `.milaconfig` file — double-click, confirm, done.

## Semantics

- The file is **JSON, versioned** (`"version": 1`). A missing version is rejected as malformed; a newer version tells the user to update Mila.
- **Every field is optional.** On apply, a field that is *present* overrides the current setting; a field that is *absent* leaves the current setting untouched. So a file can configure just the transcription server without disturbing hotkeys, language, etc.
- Double-clicking a `.milaconfig` opens Mila and shows a **confirmation sheet** listing exactly what will change (API key masked) before anything is applied — a handed-out file can never silently reconfigure the app.

## Example

```json
{
  "version": 1,
  "remoteTranscription": {
    "enabled": true,
    "endpoint": "https://mila-asr.internal.island.io/v1",
    "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
    "apiKey": "…"
  },
  "recordingLanguage": "he"
}
```

## Changes

- **`MilaConfig`** — the versioned Codable schema + `load`/`decode` with user-facing errors.
- **`MilaConfigImporter`** — loads a file, diffs it against the live settings, and on confirm applies present fields. The API key is written to the Keychain; the apply order sets endpoint/model/key *before* flipping the backend so the backend-switch's lazy Keychain read can't clobber a key from the file.
- **`MilaConfigConfirmationView`** — the confirmation sheet.
- **`project.yml`** — registers the `io.island.mila.config` UTI (`.milaconfig` → JSON) + `CFBundleDocumentTypes`; the open event is routed via `MilaAppDelegate.application(_:open:)` with cold-launch buffering. (`Info.plist` is regenerated from this.)
- **`MilaConfigTests`** — 12 tests: parsing/versioning, partial-override apply, key masking, open→confirm flow, malformed handling.

## Scope

Covers remote transcription (enabled/URL/model/key), recording language, and the Live-AI / diarization / meeting-detection toggles. Deliberately excludes machine-specific settings — the selected audio input device, the recordings-directory security-scoped bookmark, and per-key hotkey bindings — none of which transfer meaningfully between Macs.

## Testing

- `make build` and `build-for-testing` both succeed (app + test target compile clean).
- Unit tests will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening `.milaconfig` files directly in Mila.
  - Preview configuration changes before applying them, with options to apply or cancel.
  - Apply selected settings while leaving unspecified settings unchanged.
  - Display clear errors for malformed, unreadable, or unsupported configuration files.
  - Sensitive API keys are masked in change previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->