### PR TITLE
docs: self-hosted Mila transcription server guide + example .milaconfig

### DIFF
--- a/docs/self-hosted-server/README.md
+++ b/docs/self-hosted-server/README.md
@@ -1,0 +1,241 @@
+# Self-hosting a shared Mila transcription server on Kubernetes
+
+This guide walks a team through standing up **one shared GPU transcription
+server** that everyone's Mila can point at, instead of every Mac transcribing
+on-device. The server is [**speaches**](https://github.com/speaches-ai/speaches)
+— an OpenAI-compatible speech-to-text server built on
+[faster-whisper](https://github.com/SYSTRAN/faster-whisper) — running a Whisper
+model on an NVIDIA GPU. Mila talks to it through its **Remote** backend, which
+speaks OpenAI's [`POST /v1/audio/transcriptions`](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+API.
+
+Why do this:
+
+- **One GPU, many users.** A single T4 comfortably serves a team's short
+  recordings; nobody needs a fast Mac or waits on local transcription.
+- **Any Whisper model.** Load a Hebrew fine-tune like
+  [`ivrit-ai/whisper-large-v3-turbo-ct2`](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ct2),
+  or a multilingual model such as
+  [`Systran/faster-whisper-large-v3`](https://huggingface.co/Systran/faster-whisper-large-v3)
+  — anything published in [CTranslate2](https://github.com/OpenNMT/CTranslate2)
+  form.
+- **You control the data.** Audio goes to a server you run, not a third party.
+
+> **Just want to try it on one machine first?** See
+> [`../REMOTE_TRANSCRIPTION_SERVER.md`](../REMOTE_TRANSCRIPTION_SERVER.md) for a
+> single-host `docker run` quickstart and the OpenAI-hosted-Whisper option. This
+> guide is the production, shared-on-Kubernetes version of the same thing.
+
+> **Every value here is a placeholder.** There are no real keys, hostnames, or
+> accounts in this folder. Fill in your own as you go.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[Mila app<br/>Remote backend] -->|HTTPS + Bearer key| B[Ingress / Gateway<br/>TLS termination]
+    B -->|:8000| C[Service<br/>mila-asr ClusterIP]
+    C --> D[speaches pod<br/>on a GPU node]
+    D -.loads.-> E[(Whisper model<br/>e.g. ivrit-ai turbo)]
+```
+
+The client sends audio over HTTPS with an API key; your ingress terminates TLS
+and forwards to the in-cluster `Service`, which routes to the speaches pod
+pinned to a GPU node.
+
+---
+
+## Prerequisites
+
+- A **Kubernetes cluster** with at least one **NVIDIA GPU node** (an AWS
+  `g4dn.xlarge` / T4 is plenty and cheap; anything with a modern NVIDIA GPU
+  works).
+- The **[NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin)**
+  installed so that `nvidia.com/gpu` is a schedulable resource. (Managed GPU
+  node pools on GKE/AKS/EKS and AWS Bottlerocket GPU AMIs bundle this. Run
+  `kubectl describe node <gpu-node> | grep nvidia.com/gpu` to confirm it shows
+  up under Capacity.)
+- **`kubectl`** configured against the cluster.
+- An **ingress path** you already know how to use (an Ingress controller, the
+  Gateway API, or a cloud LoadBalancer) to expose the service over HTTPS.
+
+The manifests referenced below live in [`k8s/`](./k8s).
+
+---
+
+## Step 1 — Create the namespace
+
+```bash
+kubectl apply -f k8s/namespace.yaml
+```
+
+## Step 2 — Create the API-key Secret
+
+speaches gates its endpoint behind an API key (Mila sends it as a Bearer
+token). Create a Secret with a key of your choosing — **do not commit it**:
+
+```bash
+kubectl -n mila-asr create secret generic mila-asr-secrets \
+  --from-literal=API_KEY="$(openssl rand -hex 32)"
+```
+
+Grab the value you generated (you'll paste it into Mila later):
+
+```bash
+kubectl -n mila-asr get secret mila-asr-secrets \
+  -o jsonpath='{.data.API_KEY}' | base64 --decode; echo
+```
+
+> [`k8s/secret.example.yaml`](./k8s/secret.example.yaml) is a template if you'd
+> rather define the Secret declaratively — just keep the filled-in copy out of
+> version control.
+
+## Step 3 — Deploy speaches
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```
+
+What the [Deployment](./k8s/deployment.yaml) does:
+
+- Runs the upstream `ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda` image and
+  **requests 1 GPU** (`nvidia.com/gpu: "1"`) with a toleration so it lands on a
+  tainted GPU node.
+- Sets `WHISPER__COMPUTE_TYPE=float16` for good accuracy at roughly half the
+  VRAM of float32.
+- Uses `/health` for the startup / readiness / liveness probes (that endpoint is
+  auth-free on this image).
+- Runs a **`postStart` hook** that waits for the server, then pre-registers the
+  model (`POST /v1/models/{id}`) so the first user request doesn't pay the full
+  cold download. It's non-fatal — speaches also lazy-loads on first use.
+- Caches the model in a pod-local **`emptyDir`** (re-downloaded on restart,
+  ~1–2 min; swap for a PVC if you want it to persist).
+
+**Changing the model:** edit the `model_id` in the deployment's `postStart`
+hook and set the matching id in your `.milaconfig` / Mila settings. For a
+multilingual deployment use `Systran/faster-whisper-large-v3`.
+
+Watch it come up (the first boot downloads the model, so give it a few minutes):
+
+```bash
+kubectl -n mila-asr rollout status deploy/mila-asr
+kubectl -n mila-asr logs -f deploy/mila-asr
+```
+
+> **No GPU node yet?** If you run AWS + Karpenter, `k8s/gpu-nodepool.example.yaml`
+> shows how we provision a dedicated on-demand T4 node just for this workload.
+> It's **optional and AWS-specific** — skip it entirely if your cluster already
+> has GPU nodes.
+
+## Step 4 — Expose it
+
+The service listens on `:8000` inside the cluster. Put it behind HTTPS however
+your cluster normally does. [`k8s/ingress.example.yaml`](./k8s/ingress.example.yaml)
+contains a **Gateway API `HTTPRoute`** (what we run) plus a commented standard
+`Ingress` alternative — **adapt it to your setup**, don't apply it blindly:
+
+- Set your real **hostname** (replace `mila-asr.your-org.example`).
+- Point it at **your** Gateway / IngressClass.
+- **Terminate TLS** at the ingress or load balancer. Keep the API-key check on;
+  never send audio over plaintext HTTP across an untrusted network.
+
+```bash
+# after editing it for your environment:
+kubectl apply -f k8s/ingress.example.yaml
+```
+
+## Step 5 — Verify with `curl`
+
+Health check (should return `200`, no auth needed — speaches serves `/health`
+at the root, and the example route forwards `/`):
+
+```bash
+curl -i https://mila-asr.your-org.example/health
+```
+
+End-to-end transcription (needs the Bearer key and an audio file):
+
+```bash
+curl https://mila-asr.your-org.example/v1/audio/transcriptions \
+  -H "Authorization: Bearer YOUR_API_KEY_HERE" \
+  -F file=@sample.m4a \
+  -F model=ivrit-ai/whisper-large-v3-turbo-ct2 \
+  -F language=he \
+  -F response_format=verbose_json
+```
+
+A JSON response with a `text` field (and per-segment timestamps) means you're
+in business.
+
+## Step 6 — Point Mila at it
+
+In Mila: **Settings → Models → Remote**.
+
+| Field    | Value                                     |
+| -------- | ----------------------------------------- |
+| Backend  | **Remote**                                |
+| Base URL | `https://mila-asr.your-org.example/v1`    |
+| Model    | `ivrit-ai/whisper-large-v3-turbo-ct2`     |
+| API key  | the key you created in Step 2             |
+
+Click **Test connection**. Once it's green, record — Mila uploads each recording
+and asks for `verbose_json`, so timestamps (and therefore SRT export + speaker
+diarization) keep working exactly as with the local engine.
+
+---
+
+## Handing the config to your team with `.milaconfig`
+
+Typing the base URL, model, and key into every teammate's Mila is tedious.
+Mila reads **`.milaconfig`** files: double-clicking one applies the settings it
+contains. It's a **partial override** — fields that are *present* update the
+matching setting; fields that are *absent* are left untouched. So a file that
+only carries the remote-server block won't disturb anyone's hotkeys, language,
+or anything else.
+
+See [`example.milaconfig`](./example.milaconfig):
+
+```json
+{
+  "version": 1,
+  "remoteTranscription": {
+    "enabled": true,
+    "endpoint": "https://mila-asr.your-org.example/v1",
+    "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+    "apiKey": "YOUR_API_KEY_HERE"
+  },
+  "recordingLanguage": "he"
+}
+```
+
+To distribute it:
+
+1. Copy `example.milaconfig`, fill in your real `endpoint` and `apiKey` (and
+   drop `recordingLanguage` if you don't want to force a default language).
+2. Hand the file to your users (shared drive, chat, etc.).
+3. They double-click it; Mila confirms and applies the settings. The API key is
+   stored in the macOS Keychain, never in plain UserDefaults.
+
+> The `.milaconfig` file contains your API key in plaintext — share it over a
+> trusted channel, the same way you'd share any credential.
+
+---
+
+## Notes & operational tips
+
+- **Always-on, single replica.** A single GPU hosts exactly one pod, so the
+  Deployment uses the `Recreate` strategy (no rolling surge). To save money
+  off-hours you can scale it to 0 and let your autoscaler drop the GPU node;
+  the model re-downloads on the next start (the `postStart` hook covers it).
+- **`/health` is auth-free** on the `0.9.0-rc.3` image — that's why the probes
+  work without the key. If you bump the image tag, re-check that `/health`
+  stays unauthenticated, or the probes will fail.
+- **Privacy.** With the Remote backend active, audio leaves the device. Mila
+  flags this in the UI. Self-hosting keeps it on infrastructure you control.
+- **Diarization still runs locally** in Mila (it reads the on-disk audio), so
+  speaker labels work regardless of which transcription backend you pick.
+- **Language.** Mila forwards the recording language (`he` / `en`); on
+  Auto-detect it omits the field and lets the server detect it.

--- a/docs/self-hosted-server/example.milaconfig
+++ b/docs/self-hosted-server/example.milaconfig
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "remoteTranscription": {
+    "enabled": true,
+    "endpoint": "https://mila-asr.your-org.example/v1",
+    "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+    "apiKey": "YOUR_API_KEY_HERE"
+  },
+  "recordingLanguage": "he"
+}

--- a/docs/self-hosted-server/k8s/deployment.yaml
+++ b/docs/self-hosted-server/k8s/deployment.yaml
@@ -29,6 +29,14 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+        # The optional gpu-nodepool.example.yaml also taints its nodes
+        # `dedicated=gpu:NoSchedule`, so tolerate that too or the pod stays
+        # Pending on that pool. Tolerating a taint that isn't present is a
+        # no-op, so this is safe even on plain (nvidia-only-tainted) GPU nodes.
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoSchedule
       # Optional: if you keep a dedicated GPU node pool (see
       # gpu-nodepool.example.yaml), label its nodes and pin this workload to
       # them, e.g.:
@@ -42,6 +50,15 @@ spec:
           # tested; check https://github.com/speaches-ai/speaches for releases.
           image: ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda
           imagePullPolicy: IfNotPresent
+          # Baseline hardening. runAsNonRoot / readOnlyRootFilesystem are left
+          # off because the upstream image writes to its cache and may run as
+          # root; add them if your image supports it (with writable mounts).
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: http
               containerPort: 8000

--- a/docs/self-hosted-server/k8s/deployment.yaml
+++ b/docs/self-hosted-server/k8s/deployment.yaml
@@ -1,0 +1,126 @@
+# speaches — an OpenAI-compatible Whisper server — running a CTranslate2 model
+# on a single NVIDIA GPU. Always-on (1 replica); a single GPU can host exactly
+# one pod, so there's no rolling surge.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mila-asr
+  namespace: mila-asr
+  labels:
+    app: mila-asr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mila-asr
+  strategy:
+    type: Recreate # single GPU: a 2nd pod can't schedule, so no rolling surge
+  template:
+    metadata:
+      labels:
+        app: mila-asr
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+      # Many GPU node setups taint their GPU nodes so ordinary pods stay off
+      # them. This toleration lets the pod land on such a node. If your GPU
+      # nodes are NOT tainted this is simply a no-op, so it's safe to leave in.
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      # Optional: if you keep a dedicated GPU node pool (see
+      # gpu-nodepool.example.yaml), label its nodes and pin this workload to
+      # them, e.g.:
+      #   nodeSelector:
+      #     dedicated: gpu
+      containers:
+        - name: speaches
+          # Upstream public image. The 0.9.0-rc.3 tag serves /health WITHOUT
+          # auth, which the probes below rely on (some tags gate /health behind
+          # the API key, so unauthenticated probes would fail). Pin a tag you've
+          # tested; check https://github.com/speaches-ai/speaches for releases.
+          image: ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            # float16 on the GPU: good accuracy, roughly half the VRAM of
+            # float32. Use int8_float16 if you're tight on VRAM.
+            - name: WHISPER__COMPUTE_TYPE
+              value: float16
+            # Point the HuggingFace cache at the mounted volume (see below).
+            - name: HF_HOME
+              value: /home/ubuntu/.cache/huggingface
+            # API key that gates the endpoint. Mila sends it as a Bearer token.
+            # Sourced from the mila-asr-secrets Secret (see secret.example.yaml).
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mila-asr-secrets
+                  key: API_KEY
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "4"
+              memory: 14Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /home/ubuntu/.cache/huggingface
+          # Warm the model on startup so the first user request doesn't pay the
+          # full cold download/load. The hook waits for the server's own /health
+          # to pass, then triggers the download via speaches' registration
+          # endpoint: POST /v1/models/{model_id:path} — a FastAPI ":path"
+          # converter, so the HuggingFace id is passed literally WITH slashes.
+          # Non-fatal (|| true): speaches also lazy-loads the model on the first
+          # request, so a transient network hiccup must not crash-loop the pod.
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    for i in $(seq 1 60); do
+                      curl -sf http://127.0.0.1:8000/health && break || sleep 5
+                    done
+                    for j in $(seq 1 30); do
+                      curl -sf -X POST \
+                        -H "Authorization: Bearer $API_KEY" \
+                        "http://127.0.0.1:8000/v1/models/ivrit-ai/whisper-large-v3-turbo-ct2" \
+                        && break || sleep 10
+                    done || true
+          # Hold off readiness/liveness until the server is up. A cold model
+          # download can take a couple of minutes: 60 * 5s = up to 5 min before
+          # the pod is considered failed to start.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+      volumes:
+        - name: model-cache
+          # Pod-local scratch for the HuggingFace model cache. Deliberately an
+          # emptyDir (not a PVC): a ReadWriteOnce cloud volume is often
+          # zone-locked, so a node that comes up in a different zone would leave
+          # the pod stuck attaching it. The model re-downloads on pod restart
+          # (~1-2 min), absorbed by the postStart warm-up hook above. Swap for a
+          # PVC if you want the cache to persist across restarts.
+          emptyDir:
+            sizeLimit: 20Gi

--- a/docs/self-hosted-server/k8s/gpu-nodepool.example.yaml
+++ b/docs/self-hosted-server/k8s/gpu-nodepool.example.yaml
@@ -1,0 +1,99 @@
+# OPTIONAL — AWS + Karpenter ONLY.
+#
+# This is how WE provision an on-demand NVIDIA T4 (g4dn.xlarge) node just for
+# this workload, using Karpenter on EKS. You do NOT need any of this if your
+# cluster already has a GPU node pool (GKE/AKS managed node pools, a manually
+# provisioned GPU node, etc.). All you truly need is a node that advertises
+# `nvidia.com/gpu`, which means the NVIDIA device plugin must be installed
+# (Bottlerocket's NVIDIA AMI variant, below, bundles it).
+#
+# Replace every REPLACE_WITH_... placeholder with your own AWS values.
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: gpu
+spec:
+  disruption:
+    consolidateAfter: 300s # drop the node 5 min after the pod is gone
+    consolidationPolicy: WhenEmptyOrUnderutilized
+  # Cap GPUs so a mis-scheduled pod can't fan out an expensive fleet.
+  limits:
+    nvidia.com/gpu: "2"
+  template:
+    metadata:
+      labels:
+        dedicated: gpu
+        nvidia.com/gpu: "present"
+    spec:
+      expireAfter: Never
+      nodeClassRef:
+        name: gpu
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["g4dn.xlarge"] # 1x NVIDIA T4, 4 vCPU, 16 GiB — cheapest single-GPU box
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+      # Taint the GPU node so only this workload lands on it. The Deployment's
+      # `nvidia.com/gpu` toleration matches the first taint; add a matching
+      # toleration for `dedicated=gpu` (and/or a nodeSelector) if you want to
+      # strictly pin the pod here.
+      taints:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          value: present
+        - effect: NoSchedule
+          key: dedicated
+          value: gpu
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: gpu
+spec:
+  # Bottlerocket's NVIDIA variant ships the GPU driver, container toolkit, and
+  # the NVIDIA k8s device plugin — so no separate device-plugin DaemonSet is
+  # needed. Karpenter resolves the nvidia variant automatically for a GPU
+  # instance type. Pin a version you've tested rather than tracking @latest.
+  amiFamily: Bottlerocket
+  amiSelectorTerms:
+    - alias: bottlerocket@latest
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        deleteOnTermination: true
+        volumeSize: 10Gi
+        volumeType: gp3
+        encrypted: true
+    - deviceName: /dev/xvdb # room for the CUDA image (~8 GB) + ephemeral storage
+      ebs:
+        deleteOnTermination: true
+        volumeSize: 100Gi
+        volumeType: gp3
+        encrypted: true
+  metadataOptions:
+    httpEndpoint: enabled
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  # The IAM role Karpenter attaches to nodes it launches (your cluster's
+  # Karpenter node role).
+  role: REPLACE_WITH_YOUR_KARPENTER_NODE_ROLE
+  # Tag-based discovery of your subnets and security groups. The standard
+  # Karpenter convention tags them with `karpenter.sh/discovery: <cluster>`.
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: REPLACE_WITH_YOUR_CLUSTER_NAME
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: REPLACE_WITH_YOUR_CLUSTER_NAME
+  tags:
+    managed-by: karpenter

--- a/docs/self-hosted-server/k8s/ingress.example.yaml
+++ b/docs/self-hosted-server/k8s/ingress.example.yaml
@@ -1,0 +1,76 @@
+# EXAMPLE exposure — ADAPT THIS TO YOUR OWN INGRESS. There is no single right
+# way to expose a Service; pick whatever your cluster already uses (an Ingress
+# controller, the Gateway API, a cloud LoadBalancer Service, etc.). Do NOT
+# blindly `kubectl apply` this file — it references objects (a Gateway, a TLS
+# secret, an IngressClass) that are specific to your cluster.
+#
+# TLS: terminate HTTPS at your ingress or load balancer and keep the API-key
+# check on (speaches validates the Bearer token). Never send audio over
+# plaintext HTTP across a network you don't fully trust.
+#
+# Replace every `mila-asr.your-org.example` with your real hostname.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Option 1 (featured) — Kubernetes Gateway API HTTPRoute. This mirrors the setup
+# we run. It requires the Gateway API CRDs plus a GatewayClass/Gateway already
+# installed in your cluster. Point `parentRefs` at YOUR Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mila-asr
+  namespace: mila-asr
+  labels:
+    app: mila-asr
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: my-gateway # <- your Gateway
+      namespace: my-gateway-namespace # <- the namespace your Gateway lives in
+  hostnames:
+    - mila-asr.your-org.example
+  rules:
+    - timeouts:
+        # Generous enough for a short per-utterance clip. Match this to your
+        # load balancer's idle timeout — a longer route timeout isn't honored
+        # if the LB drops the connection first.
+        request: 300s
+        backendRequest: 300s
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: mila-asr
+          port: 8000
+---
+# Option 2 (alternative) — a standard Kubernetes Ingress (e.g. ingress-nginx).
+# If you use this instead, delete the HTTPRoute above and uncomment this block.
+# Replace the hostname, ingressClassName, and TLS secret with your own.
+#
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: mila-asr
+#   namespace: mila-asr
+#   labels:
+#     app: mila-asr
+# spec:
+#   ingressClassName: nginx            # adapt to your ingress controller
+#   tls:
+#     - hosts:
+#         - mila-asr.your-org.example
+#       secretName: mila-asr-tls       # a TLS cert Secret you provide
+#   rules:
+#     - host: mila-asr.your-org.example
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: mila-asr
+#                 port:
+#                   number: 8000

--- a/docs/self-hosted-server/k8s/namespace.yaml
+++ b/docs/self-hosted-server/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mila-asr
+  labels:
+    app: mila-asr

--- a/docs/self-hosted-server/k8s/secret.example.yaml
+++ b/docs/self-hosted-server/k8s/secret.example.yaml
@@ -1,0 +1,23 @@
+# API-key Secret consumed by the Deployment as the API_KEY environment
+# variable. speaches uses it to gate the OpenAI-compatible endpoint, and Mila
+# sends it as a Bearer token.
+#
+# DO NOT commit a real key. Choose ONE of:
+#
+#   1. Create the Secret imperatively (recommended — nothing lands in git):
+#
+#        kubectl -n mila-asr create secret generic mila-asr-secrets \
+#          --from-literal=API_KEY='REPLACE_WITH_YOUR_API_KEY'
+#
+#   2. Or edit the placeholder below and `kubectl apply -f` this file. If you
+#      do, keep the edited copy OUT of version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mila-asr-secrets
+  namespace: mila-asr
+type: Opaque
+stringData:
+  # Any sufficiently long random string works; generate one, e.g.
+  #   openssl rand -hex 32
+  API_KEY: "REPLACE_WITH_YOUR_API_KEY"

--- a/docs/self-hosted-server/k8s/secret.example.yaml
+++ b/docs/self-hosted-server/k8s/secret.example.yaml
@@ -17,7 +17,11 @@ metadata:
   name: mila-asr-secrets
   namespace: mila-asr
 type: Opaque
-stringData:
-  # Any sufficiently long random string works; generate one, e.g.
-  #   openssl rand -hex 32
-  API_KEY: "REPLACE_WITH_YOUR_API_KEY"
+# Intentionally ships with NO data so applying this file unchanged FAILS CLOSED:
+# the Deployment's secretKeyRef(API_KEY) won't resolve and the pod won't start
+# until you provide a real key — never a publicly-known placeholder token. Use
+# option 1 above, or uncomment and set the line below.
+# stringData:
+#   # Any sufficiently long random string works; generate one, e.g.
+#   #   openssl rand -hex 32
+#   API_KEY: "REPLACE_WITH_YOUR_API_KEY"

--- a/docs/self-hosted-server/k8s/service.yaml
+++ b/docs/self-hosted-server/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mila-asr
+  namespace: mila-asr
+  labels:
+    app: mila-asr
+spec:
+  type: ClusterIP
+  selector:
+    app: mila-asr
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## What

Adds `docs/self-hosted-server/` — a guide for **other organizations** to self-host a shared Mila transcription server: [speaches](https://github.com/speaches-ai/speaches) (an OpenAI-compatible speech-to-text server) running a Whisper/ivrit CTranslate2 model on a GPU in Kubernetes. This lets a team point Mila's **Remote** backend at one shared GPU instead of transcribing on-device.

Complements the existing single-host `docker run` quickstart in [`docs/REMOTE_TRANSCRIPTION_SERVER.md`](../blob/main/docs/REMOTE_TRANSCRIPTION_SERVER.md) with the production, Kubernetes/GPU version — and cross-links it.

### Contents

- **`README.md`** — prerequisites, step-by-step deploy (namespace → Secret → Deployment/Service → expose → `curl` verify → point Mila at it), a `.milaconfig` distribution section, an architecture mermaid diagram, and operational notes.
- **`k8s/`** — sanitized, generic manifests a reader can adapt and `kubectl apply`:
  - `namespace.yaml`, `secret.example.yaml` (template + `kubectl create secret` command, no real key)
  - `deployment.yaml` (upstream `ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda`, 1-GPU request + toleration, `/health` probes, `postStart` model-registration hook, `emptyDir` model cache, `API_KEY` from the Secret, `WHISPER__COMPUTE_TYPE=float16`)
  - `service.yaml` (ClusterIP :8000)
  - `ingress.example.yaml` (Gateway-API `HTTPRoute` + commented standard `Ingress`, placeholder hostname, marked "adapt to your ingress")
  - `gpu-nodepool.example.yaml` (optional, AWS/Karpenter g4dn/T4 node pool with placeholder AWS values)
- **`example.milaconfig`** — a valid example config (partial-override), no real secret.

## Notes

- **Docs-only** — no app code changes.
- **All values are placeholders.** No secrets, no API keys, and no Island-internal infrastructure: real hostnames → `mila-asr.your-org.example`, Vault/ExternalSecret wiring → a plain `kubectl create secret`, and AWS account IDs / ECR / IRSA / ArgoCD / cluster names / SG+subnet IDs all removed or replaced with `REPLACE_WITH_...` placeholders. The only real reference kept is the upstream public image tag.
- Verified: `grep` found no leaked internal hostname/account/vault path, every YAML parses, and `example.milaconfig` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete guide for self-hosting a shared remote transcription server on Kubernetes.
  * Included ready-to-adapt Kubernetes manifests for the namespace, service, GPU deployment, secrets, and exposure (Gateway API/Ingress), plus an example Karpenter GPU node pool configuration.
  * Added example Mila configuration to connect Mila Remote to the self-hosted endpoint.

* **Documentation**
  * Documented end-to-end setup, connectivity checks, model registration/caching behavior, and operational notes (health endpoint assumptions, privacy/audio egress considerations, and language handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->