### PR TITLE
docs(self-hosted): pin Bottlerocket GPU AMI alias to a tested version

### DIFF
--- a/docs/self-hosted-server/k8s/gpu-nodepool.example.yaml
+++ b/docs/self-hosted-server/k8s/gpu-nodepool.example.yaml
@@ -63,10 +63,12 @@ spec:
   # Bottlerocket's NVIDIA variant ships the GPU driver, container toolkit, and
   # the NVIDIA k8s device plugin — so no separate device-plugin DaemonSet is
   # needed. Karpenter resolves the nvidia variant automatically for a GPU
-  # instance type. Pin a version you've tested rather than tracking @latest.
+  # instance type. NOTE: the family alias must be `bottlerocket@<ver>`, NOT
+  # `bottlerocket-nvidia@…` (not a valid Karpenter alias). Pin a version you've
+  # tested — bump to a current Bottlerocket release as needed.
   amiFamily: Bottlerocket
   amiSelectorTerms:
-    - alias: bottlerocket@latest
+    - alias: bottlerocket@v1.62.0
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:


### PR DESCRIPTION
Aligns the self-hosted-server GPU NodeClass example with the real, deployed config. The example's comment advised pinning a tested Bottlerocket version but the manifest used `bottlerocket@latest`; DevOps (@oron.riff) validated `bottlerocket@v1.62.0`, and the invalid `bottlerocket-nvidia@…` alias is a common Karpenter footgun. Pin `bottlerocket@v1.62.0` and document the alias rule. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GPU node pool example to use a specific, tested Bottlerocket version.
  * Clarified the correct AMI alias format and recommended avoiding the moving `@latest` alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->