### PR TITLE
Live AI: per-meeting context box (fixes blended "previous meeting + this meeting" summaries)

### DIFF
--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -81,6 +81,36 @@ final class LiveAISession: ObservableObject {
         )
     }
 
+    /// Append the user's per-meeting background notes to `prompt` as an
+    /// explicitly-fenced non-transcript block. Returns `prompt` unchanged
+    /// when there are no notes.
+    ///
+    /// The guard rails in the block text are the whole point. Notes are
+    /// almost always an agenda ("Wojtek's team — recruitment going better;
+    /// flying in beginning of August"), which reads exactly like a
+    /// transcript of decisions already taken. Without being told
+    /// otherwise the model summarises the AGENDA and emits an action item
+    /// per bullet — the user then sees a summary of a meeting that hasn't
+    /// happened yet mixed into the one that has. So we say three things:
+    /// this is not transcript, don't summarise it, don't mine it for
+    /// items.
+    ///
+    /// `static` + pure so the wire format is unit-testable without a
+    /// subprocess.
+    static func promptWithContext(_ prompt: String, context: String) -> String {
+        let notes = context.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !notes.isEmpty else { return prompt }
+        return """
+        \(prompt)
+
+        ---
+        BACKGROUND NOTES (supplied by the user before this meeting — these are NOT part of the transcript and describe what the user PLANNED to discuss):
+        \(notes)
+
+        Use the notes only to interpret what you actually hear: names, spellings, acronyms, and which topic is being discussed. Do NOT summarise the notes, and do NOT turn them into action items. Every action item and every sentence of the summary must come from the transcript itself — if something in the notes never comes up in the conversation, it does not appear in your output at all.
+        """
+    }
+
     /// Pure throttle core: how long to wait before the next tick may
     /// *start*, given the previous tick's start time and the configured
     /// minimum spacing. `0` means "start now". Exposed `static` so it can
@@ -304,8 +334,13 @@ final class LiveAISession: ObservableObject {
                 return "Hebrew"
             }
         }()
-        let prompt = liveAISettings.prompt
-            .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName)
+        // Read the per-meeting notes at TICK time, not at `start()` — a
+        // meeting-detector auto-start beats the user to the pane, so the
+        // agenda usually gets pasted a minute into the recording.
+        let prompt = Self.promptWithContext(
+            liveAISettings.prompt
+                .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName),
+            context: liveAISettings.meetingContext)
         let model = liveAISettings.model
         let useSession = (sessionID != nil)
         // Cold-start the first tick gets a longer timeout (see

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -367,8 +367,14 @@ final class LiveAISession: ObservableObject {
             // The abandoned session's stable sandbox is nobody's job
             // otherwise: `cancel()` only cleans up the CURRENT sessionID.
             // Safe to remove now — `kick()` only runs with no call in
-            // flight, so no live child process is chdir'd into it.
-            LLMRunner.cleanupStableSandbox(key: stale.uuidString)
+            // flight, so no live child process is chdir'd into it. Off the
+            // main actor for the same reason `cancel()` defers it: a
+            // recursive directory removal is a blocking syscall and this is
+            // the tick path.
+            let staleKey = stale.uuidString
+            Task.detached(priority: .utility) {
+                LLMRunner.cleanupStableSandbox(key: staleKey)
+            }
         }
         let prompt = Self.promptWithContext(
             liveAISettings.prompt

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -137,6 +137,13 @@ final class LiveAISession: ObservableObject {
     /// tick retries the create.
     private var sessionEstablished: Bool = false
 
+    /// The per-meeting notes as they were on the last SUCCESSFUL tick.
+    /// Compared against the current notes on every tick to detect a
+    /// mid-recording edit, which forces a session restart (see `kick()`).
+    /// Tracked separately from the prompt because in session mode already-
+    /// sent notes live on in the conversation history.
+    private var lastContextSent: String = ""
+
     /// The length of `latestTranscript` we last actually shipped to the
     /// LLM. With a live session the model already has the previous
     /// transcript in its conversation history, so we only need to send
@@ -176,6 +183,7 @@ final class LiveAISession: ObservableObject {
         sessionID = (llmSettings.tool == .claude) ? UUID() : nil
         sessionEstablished = false
         lastTranscriptSent = ""
+        lastContextSent = ""
         // os_log (NOT print) so the session UUID lands in diagnostic reports.
         // A fresh `start()` per recording is the invariant that prevents
         // cross-recording `--resume` bleed; logging the new id makes a
@@ -255,6 +263,7 @@ final class LiveAISession: ObservableObject {
         sessionID = nil
         sessionEstablished = false
         lastTranscriptSent = ""
+        lastContextSent = ""
     }
 
     /// Feed the latest full transcript. Routes through the min-interval
@@ -337,10 +346,34 @@ final class LiveAISession: ObservableObject {
         // Read the per-meeting notes at TICK time, not at `start()` — a
         // meeting-detector auto-start beats the user to the pane, so the
         // agenda usually gets pasted a minute into the recording.
+        let context = liveAISettings.meetingContext
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Editing or clearing the notes mid-recording has to actually take
+        // effect, and in session mode the prompt is only half the story: a
+        // `--resume` tick carries every earlier turn, so notes already sent
+        // stay in the model's conversation history no matter what the next
+        // prompt says. Dropping the block would leave the model still
+        // reading from the version the user just deleted. So a change in
+        // the notes restarts the Claude session: fresh UUID, and
+        // `lastTranscriptSent` reset so the first tick of the new session
+        // re-ships the whole transcript alongside the current notes.
+        // Costs one full-transcript call, only when the user edits notes
+        // mid-meeting. (CodeRabbit on #111.)
+        if sessionEstablished, context != lastContextSent, let stale = sessionID {
+            liveAILog.log("context changed — restarting session (was \(stale.uuidString.prefix(8), privacy: .public))")
+            sessionID = UUID()
+            sessionEstablished = false
+            lastTranscriptSent = ""
+            // The abandoned session's stable sandbox is nobody's job
+            // otherwise: `cancel()` only cleans up the CURRENT sessionID.
+            // Safe to remove now — `kick()` only runs with no call in
+            // flight, so no live child process is chdir'd into it.
+            LLMRunner.cleanupStableSandbox(key: stale.uuidString)
+        }
         let prompt = Self.promptWithContext(
             liveAISettings.prompt
                 .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName),
-            context: liveAISettings.meetingContext)
+            context: context)
         let model = liveAISettings.model
         let useSession = (sessionID != nil)
         // Cold-start the first tick gets a longer timeout (see
@@ -460,6 +493,10 @@ TRANSCRIPT SO FAR:
                 self.lastError = nil
                 if useSession {
                     self.lastTranscriptSent = snapshot
+                    // Only a delivered tick counts as "the model has these
+                    // notes" — a failed call must not suppress the restart
+                    // check on the next one.
+                    self.lastContextSent = context
                     // First successful call establishes the session;
                     // future ticks must use --resume.
                     self.sessionEstablished = true

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -550,6 +550,10 @@ final class QuickActionsController: ObservableObject {
             // recording. Cursor (PRRT_kwDOSY2m-s6GOIj-) flagged it.
             liveTranscriber?.stop()
             liveDiarizer?.stop()
+            // Same reason as the normal-path clear below: the meeting is
+            // over either way, so its notes must not carry into the next
+            // recording.
+            liveAISettings?.meetingContext = ""
             isFinalizingRecording = false
             activeJob = .none
             return
@@ -796,6 +800,14 @@ final class QuickActionsController: ObservableObject {
         // Cleanup: `.idle` handler skipped these because the flag was set.
         liveTranscriber?.stop()
         liveDiarizer?.stop()
+        // Per-meeting background notes die with the meeting. Cleared HERE
+        // (not in `LiveAISession.start()`) because a recording can begin
+        // before the user has pasted anything — clearing at start would
+        // wipe notes prepared for the meeting about to happen. Leaving
+        // them set is what produced blended "previous call + this call"
+        // summaries when the agenda lived in the persistent `prompt`
+        // instead: see LiveAISettings.meetingContext.
+        liveAISettings?.meetingContext = ""
         // Free the record button NOW. The heavy tail below (offline
         // re-diarize subprocess / summarizer LLM call / m4a transcode, or
         // the batch-transcription enqueue) touches only the on-disk WAV,

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -770,6 +770,11 @@ final class QuickActionsController: ObservableObject {
             // pipelines below before returning.
             liveTranscriber?.stop()
             liveDiarizer?.stop()
+            // Third exit from a finished recording, and it needs the same
+            // clear as the other two — otherwise cancelling the rename
+            // sheet is enough to carry this meeting's notes into the next
+            // recording. (CodeRabbit on #111.)
+            liveAISettings?.meetingContext = ""
             isFinalizingRecording = false
             return
         }

--- a/Mila/Models/LiveAISettings.swift
+++ b/Mila/Models/LiveAISettings.swift
@@ -125,6 +125,24 @@ final class LiveAISettings: ObservableObject {
         didSet { defaults.set(prompt, forKey: Keys.prompt) }
     }
 
+    /// Background notes for the CURRENT meeting only — an agenda, a list
+    /// of attendees, acronyms the model won't know. Injected into every
+    /// Live AI tick as a clearly-labelled non-transcript block (see
+    /// `LiveAISession.promptWithContext`) and cleared by
+    /// `QuickActionsController.stopRecording` when the recording ends.
+    ///
+    /// Deliberately NOT persisted to `UserDefaults` and deliberately not
+    /// part of `prompt`. Both properties are what makes this safe:
+    /// users used to paste the agenda into the `prompt` editor in
+    /// Settings, which is a permanent template — so every LATER recording
+    /// was told the previous meeting's agenda was its context and the
+    /// model produced a blended "previous call + this call" summary plus
+    /// action items lifted straight from the stale agenda (stamped
+    /// `timestamp_seconds: 0`, since they were never said out loud).
+    /// In-memory + cleared-at-stop means a meeting's context can never
+    /// outlive the meeting, even across an app relaunch.
+    @Published var meetingContext: String = ""
+
     /// Output language for the LLM's summary and action items.
     /// Default English. The recording can still be in any language —
     /// this only controls what the AI's commentary comes back in.

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -25,6 +25,12 @@ struct LiveAIRecordingView: View {
     @EnvironmentObject private var liveAISettings: LiveAISettings
     @EnvironmentObject private var llmSettings: LLMSettings
 
+    /// Whether the per-meeting notes editor is open. Collapsed by
+    /// default so the pane still leads with the AI's output; the toggle
+    /// in the header shows a filled icon when notes exist so a user who
+    /// pasted an agenda can see that at a glance without opening it.
+    @State private var isContextExpanded = false
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -143,10 +149,15 @@ struct LiveAIRecordingView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
+                contextToggle
             }
             .padding(.horizontal, 18)
             .padding(.top, 14)
             .padding(.bottom, 8)
+
+            if isContextExpanded {
+                contextEditor
+            }
 
             // Two bulleted sections, summary on top, action items
             // below. Both are live — the LLM re-emits a refreshed
@@ -175,6 +186,57 @@ struct LiveAIRecordingView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Per-meeting context
+
+    /// Header affordance for the notes editor. Filled icon = notes are
+    /// set for this meeting; hollow = none.
+    private var contextToggle: some View {
+        let hasContext = !liveAISettings.meetingContext
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return Button {
+            isContextExpanded.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: hasContext ? "doc.text.fill" : "doc.text")
+                Text("Context")
+                    .font(.caption)
+            }
+            .foregroundStyle(hasContext ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
+        }
+        .buttonStyle(.plain)
+        .help("Notes for THIS meeting only — an agenda, attendees, acronyms. Mila uses them to interpret what it hears, and clears them when the recording stops.")
+        .accessibilityIdentifier("liveAI.context.toggle")
+    }
+
+    private var contextEditor: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextEditor(text: $liveAISettings.meetingContext)
+                .font(.system(.caption, design: .monospaced))
+                .frame(height: 90)
+                .padding(4)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.secondary.opacity(0.25))
+                )
+                .accessibilityIdentifier("liveAI.context.field")
+            HStack {
+                Text("Background for this meeting only — agenda, attendees, acronyms. Not summarised and never turned into action items; cleared when the recording stops.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Button("Clear") {
+                    liveAISettings.meetingContext = ""
+                }
+                .controlSize(.small)
+                .disabled(liveAISettings.meetingContext.isEmpty)
+                .accessibilityIdentifier("liveAI.context.clear")
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 12)
     }
 
     /// Render the LLM's rolling summary as a bulleted list. The LLM

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1618,6 +1618,15 @@ private struct LiveAISettingsTab: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            // This prompt is a permanent template, so anything meeting-
+            // specific pasted here silently applies to every LATER
+            // recording — which produced blended "previous meeting + this
+            // meeting" summaries and action items lifted from a stale
+            // agenda. Point users at the per-meeting Context box instead.
+            Text("This prompt is reused for every recording. For notes about one specific meeting (agenda, attendees, acronyms), use the **Context** box in the recording pane — it's cleared when that recording stops.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/MilaTests/LiveAIMeetingContextTests.swift
+++ b/MilaTests/LiveAIMeetingContextTests.swift
@@ -10,8 +10,9 @@ import XCTest
 /// lifted straight from the stale agenda (all stamped
 /// `timestamp_seconds: 0`, since nobody ever said them out loud). The fix
 /// is a separate, in-memory, cleared-at-stop context field — these tests
-/// pin both halves: the wire format the model sees, and the lifecycle that
-/// keeps one meeting's notes out of the next one.
+/// pin all three parts: the wire format the model sees, the session
+/// lifecycle that makes an edit actually take effect, and the persistence
+/// invariant that keeps one meeting's notes out of the next one.
 @MainActor
 final class LiveAIMeetingContextTests: XCTestCase {
 
@@ -46,43 +47,100 @@ final class LiveAIMeetingContextTests: XCTestCase {
     /// `performCall`, and asserts the notes reach the prompt the CLI would
     /// have been given.
     func test_tick_sendsMeetingContextInPrompt() async {
-        let (session, live, prompts) = makeSession(suite: "LiveAIMeetingContextTests.send")
+        let (session, live, calls) = makeSession(suite: "LiveAIMeetingContextTests.send")
         live.meetingContext = "Attendees: Dana, Yaron. FF = feature flag."
 
         session.feed(transcript: "So about the flags.", immediate: true)
         await waitUntilIdle(session)
 
-        XCTAssertEqual(prompts.value.count, 1)
-        XCTAssertTrue(prompts.value[0].contains("FF = feature flag."),
+        XCTAssertEqual(calls.value.count, 1)
+        XCTAssertTrue(calls.value[0].prompt.contains("FF = feature flag."),
                       "meeting notes must be part of the tick prompt")
     }
 
     /// Notes are read at TICK time, not snapshotted at `start()` — a
     /// meeting-detector auto-start beats the user to the pane, so the
-    /// agenda usually arrives a minute into the recording. Clearing them
-    /// mid-recording must likewise take effect on the next tick.
+    /// agenda usually arrives a minute into the recording.
     func test_context_isReadPerTick_notSnapshottedAtStart() async {
-        let (session, live, prompts) = makeSession(suite: "LiveAIMeetingContextTests.pertick")
+        let (session, live, calls) = makeSession(suite: "LiveAIMeetingContextTests.pertick")
 
         // Tick 1: no notes yet (pasted after the recording started).
         session.feed(transcript: "First chunk.", immediate: true)
         await waitUntilIdle(session)
-        XCTAssertFalse(prompts.value[0].contains("BACKGROUND NOTES"))
+        XCTAssertFalse(calls.value[0].prompt.contains("BACKGROUND NOTES"))
 
         // Tick 2: notes pasted mid-recording.
         live.meetingContext = "Q3 planning agenda"
         session.feed(transcript: "First chunk. Second chunk.", immediate: true)
         await waitUntilIdle(session)
-        XCTAssertTrue(prompts.value[1].contains("Q3 planning agenda"))
-
-        // Tick 3: cleared again.
-        live.meetingContext = ""
-        session.feed(transcript: "First chunk. Second chunk. Third chunk.", immediate: true)
-        await waitUntilIdle(session)
-        XCTAssertFalse(prompts.value[2].contains("BACKGROUND NOTES"))
+        XCTAssertTrue(calls.value[1].prompt.contains("Q3 planning agenda"))
     }
 
-    // MARK: - Lifecycle
+    // MARK: - Session lifecycle on a context change
+
+    /// A mid-recording edit to the notes must restart the Claude session.
+    /// In session mode the prompt is only half the story: a `--resume` tick
+    /// carries every earlier turn, so notes already sent live on in the
+    /// model's conversation history. Dropping the block from the next prompt
+    /// would leave the model still reading the version the user just
+    /// replaced — so the next tick opens a NEW session and re-ships the full
+    /// transcript. (CodeRabbit on #111.)
+    func test_editingContextMidRecording_restartsSession() async {
+        let (session, live, calls) = makeSession(suite: "LiveAIMeetingContextTests.restart")
+
+        live.meetingContext = "Agenda v1"
+        session.feed(transcript: "One.", immediate: true)
+        await waitUntilIdle(session)
+        session.feed(transcript: "One. Two.", immediate: true)
+        await waitUntilIdle(session)
+
+        // Tick 1 creates the session; tick 2 resumes it with just the delta.
+        XCTAssertEqual(kind(calls.value[0].session), "new")
+        XCTAssertEqual(kind(calls.value[1].session), "resume")
+        XCTAssertTrue(calls.value[1].prompt.contains("Agenda v1"))
+
+        // Editing the notes forces a fresh session id...
+        live.meetingContext = "Agenda v2"
+        session.feed(transcript: "One. Two. Three.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[2].session), "new",
+                       "a notes edit must open a new session, not resume the one holding the old notes")
+        XCTAssertNotEqual(uuid(calls.value[2].session), uuid(calls.value[0].session),
+                          "the restarted session must have its own id")
+        XCTAssertTrue(calls.value[2].prompt.contains("Agenda v2"))
+        XCTAssertFalse(calls.value[2].prompt.contains("Agenda v1"))
+        // ...and the whole transcript goes with it, since the new session
+        // has no memory of the earlier chunks.
+        XCTAssertTrue(calls.value[2].transcript.contains("One."))
+        XCTAssertTrue(calls.value[2].transcript.contains("Three."))
+
+        // An unchanged context resumes as normal — no gratuitous restart.
+        session.feed(transcript: "One. Two. Three. Four.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertEqual(kind(calls.value[3].session), "resume")
+    }
+
+    /// Clearing the notes counts as a change for the same reason: the model
+    /// has to stop reading them, and in session mode that takes a new
+    /// session.
+    func test_clearingContextMidRecording_restartsSession() async {
+        let (session, live, calls) = makeSession(suite: "LiveAIMeetingContextTests.clear")
+
+        live.meetingContext = "Agenda"
+        session.feed(transcript: "One.", immediate: true)
+        await waitUntilIdle(session)
+
+        live.meetingContext = ""
+        session.feed(transcript: "One. Two.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[1].session), "new",
+                       "clearing notes must not leave them alive in conversation history")
+        XCTAssertFalse(calls.value[1].prompt.contains("BACKGROUND NOTES"))
+    }
+
+    // MARK: - Persistence
 
     /// The anti-leak invariant: notes live in memory only. A relaunch (a
     /// fresh settings object over the same defaults suite) must not
@@ -100,8 +158,7 @@ final class LiveAIMeetingContextTests: XCTestCase {
         XCTAssertEqual(relaunched.meetingContext, "",
                        "per-meeting notes must not survive into a new app session")
         // Belt and braces: nothing under any key in that suite holds the text.
-        let dump = UserDefaults(suiteName: suite)!.dictionaryRepresentation()
-        for (key, value) in dump {
+        for (key, value) in UserDefaults(suiteName: suite)!.dictionaryRepresentation() {
             if let string = value as? String {
                 XCTAssertFalse(string.contains("Sensitive agenda"),
                                "notes leaked into UserDefaults under \(key)")
@@ -111,29 +168,47 @@ final class LiveAIMeetingContextTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Box so the escaping `performCall` stub can record prompts without
-    /// capturing a mutable local.
-    private final class Prompts {
-        var value: [String] = []
+    /// Box so the escaping `performCall` stub can record what it was handed
+    /// without capturing a mutable local.
+    private final class Calls {
+        var value: [LiveAISession.LLMCall] = []
     }
 
-    private func makeSession(suite: String) -> (LiveAISession, LiveAISettings, Prompts) {
+    private func kind(_ session: LLMSession) -> String {
+        switch session {
+        case .none:      return "none"
+        case .new:       return "new"
+        case .resume:    return "resume"
+        }
+    }
+
+    private func uuid(_ session: LLMSession) -> UUID? {
+        switch session {
+        case .none:                             return nil
+        case .new(let id), .resume(let id):     return id
+        }
+    }
+
+    private func makeSession(suite: String) -> (LiveAISession, LiveAISettings, Calls) {
         UserDefaults().removePersistentDomain(forName: "\(suite).llm")
         UserDefaults().removePersistentDomain(forName: "\(suite).live")
         let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)
-        llm.tool = .claude
-        let live = LiveAISettings(defaults: UserDefaults(suiteName: "\(suite).live")!)
+        llm.tool = .claude   // isConfigured == (tool != .none); also enables session/delta mode
+        let live = LiveAISettings(defaults: UserDefaults(suiteName: suite + ".live")!)
         live.enabled = true
         live.llmMinIntervalSeconds = 0   // no throttle floor in these tests
 
-        let prompts = Prompts()
+        let calls = Calls()
         let session = LiveAISession(llmSettings: llm, liveAISettings: live)
         session.performCall = { call in
-            prompts.value.append(call.prompt)
+            calls.value.append(call)
+            // Minimal valid envelope so parseEnvelope succeeds and the
+            // success path runs (which is what records lastTranscriptSent /
+            // lastContextSent and establishes the session).
             return #"{"summary":"ok","items":[]}"#
         }
         session.start()
-        return (session, live, prompts)
+        return (session, live, calls)
     }
 
     /// Spin until the in-flight tick clears. The stub returns instantly, so

--- a/MilaTests/LiveAIMeetingContextTests.swift
+++ b/MilaTests/LiveAIMeetingContextTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import Mila
+
+/// Per-meeting background notes (`LiveAISettings.meetingContext`).
+///
+/// Origin: a user pasted a meeting agenda into Settings → Live AI →
+/// System prompt, which is a PERMANENT template. Every later recording was
+/// therefore handed the previous meeting's agenda as context, and the model
+/// returned a blended "previous call + this call" summary plus action items
+/// lifted straight from the stale agenda (all stamped
+/// `timestamp_seconds: 0`, since nobody ever said them out loud). The fix
+/// is a separate, in-memory, cleared-at-stop context field — these tests
+/// pin both halves: the wire format the model sees, and the lifecycle that
+/// keeps one meeting's notes out of the next one.
+@MainActor
+final class LiveAIMeetingContextTests: XCTestCase {
+
+    // MARK: - Wire format (pure)
+
+    func test_promptWithContext_noContext_returnsPromptUnchanged() {
+        let prompt = "You are Mila. Output JSON."
+        XCTAssertEqual(LiveAISession.promptWithContext(prompt, context: ""), prompt)
+        XCTAssertEqual(LiveAISession.promptWithContext(prompt, context: "   \n\t "), prompt,
+                       "whitespace-only notes must not add an empty BACKGROUND block")
+    }
+
+    func test_promptWithContext_fencesNotesAsNonTranscript() {
+        let composed = LiveAISession.promptWithContext(
+            "You are Mila. Output JSON.",
+            context: "Agenda: Mor's team in Canada. LaunchDarkly — who takes it?")
+
+        XCTAssertTrue(composed.hasPrefix("You are Mila. Output JSON."),
+                      "the user's prompt stays first so the JSON contract leads")
+        XCTAssertTrue(composed.contains("Agenda: Mor's team in Canada."))
+        // The guard rails are the load-bearing part: an agenda reads like a
+        // transcript of decisions already taken, so the model has to be told
+        // it is neither transcript, nor summary material, nor an item source.
+        XCTAssertTrue(composed.contains("NOT part of the transcript"))
+        XCTAssertTrue(composed.contains("Do NOT summarise the notes"))
+        XCTAssertTrue(composed.contains("do NOT turn them into action items"))
+    }
+
+    // MARK: - Wiring through a real tick
+
+    /// Drives the REAL `feed → scheduleKick → kick` path with a stubbed
+    /// `performCall`, and asserts the notes reach the prompt the CLI would
+    /// have been given.
+    func test_tick_sendsMeetingContextInPrompt() async {
+        let (session, live, prompts) = makeSession(suite: "LiveAIMeetingContextTests.send")
+        live.meetingContext = "Attendees: Dana, Yaron. FF = feature flag."
+
+        session.feed(transcript: "So about the flags.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(prompts.value.count, 1)
+        XCTAssertTrue(prompts.value[0].contains("FF = feature flag."),
+                      "meeting notes must be part of the tick prompt")
+    }
+
+    /// Notes are read at TICK time, not snapshotted at `start()` — a
+    /// meeting-detector auto-start beats the user to the pane, so the
+    /// agenda usually arrives a minute into the recording. Clearing them
+    /// mid-recording must likewise take effect on the next tick.
+    func test_context_isReadPerTick_notSnapshottedAtStart() async {
+        let (session, live, prompts) = makeSession(suite: "LiveAIMeetingContextTests.pertick")
+
+        // Tick 1: no notes yet (pasted after the recording started).
+        session.feed(transcript: "First chunk.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertFalse(prompts.value[0].contains("BACKGROUND NOTES"))
+
+        // Tick 2: notes pasted mid-recording.
+        live.meetingContext = "Q3 planning agenda"
+        session.feed(transcript: "First chunk. Second chunk.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertTrue(prompts.value[1].contains("Q3 planning agenda"))
+
+        // Tick 3: cleared again.
+        live.meetingContext = ""
+        session.feed(transcript: "First chunk. Second chunk. Third chunk.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertFalse(prompts.value[2].contains("BACKGROUND NOTES"))
+    }
+
+    // MARK: - Lifecycle
+
+    /// The anti-leak invariant: notes live in memory only. A relaunch (a
+    /// fresh settings object over the same defaults suite) must not
+    /// resurrect them — that persistence is exactly what made the
+    /// prompt-editor workaround leak across meetings.
+    func test_meetingContext_isNotPersisted() {
+        let suite = "LiveAIMeetingContextTests.persist"
+        UserDefaults().removePersistentDomain(forName: suite)
+        defer { UserDefaults().removePersistentDomain(forName: suite) }
+
+        let first = LiveAISettings(defaults: UserDefaults(suiteName: suite)!)
+        first.meetingContext = "Sensitive agenda for one meeting"
+
+        let relaunched = LiveAISettings(defaults: UserDefaults(suiteName: suite)!)
+        XCTAssertEqual(relaunched.meetingContext, "",
+                       "per-meeting notes must not survive into a new app session")
+        // Belt and braces: nothing under any key in that suite holds the text.
+        let dump = UserDefaults(suiteName: suite)!.dictionaryRepresentation()
+        for (key, value) in dump {
+            if let string = value as? String {
+                XCTAssertFalse(string.contains("Sensitive agenda"),
+                               "notes leaked into UserDefaults under \(key)")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Box so the escaping `performCall` stub can record prompts without
+    /// capturing a mutable local.
+    private final class Prompts {
+        var value: [String] = []
+    }
+
+    private func makeSession(suite: String) -> (LiveAISession, LiveAISettings, Prompts) {
+        UserDefaults().removePersistentDomain(forName: "\(suite).llm")
+        UserDefaults().removePersistentDomain(forName: "\(suite).live")
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)
+        llm.tool = .claude
+        let live = LiveAISettings(defaults: UserDefaults(suiteName: "\(suite).live")!)
+        live.enabled = true
+        live.llmMinIntervalSeconds = 0   // no throttle floor in these tests
+
+        let prompts = Prompts()
+        let session = LiveAISession(llmSettings: llm, liveAISettings: live)
+        session.performCall = { call in
+            prompts.value.append(call.prompt)
+            return #"{"summary":"ok","items":[]}"#
+        }
+        session.start()
+        return (session, live, prompts)
+    }
+
+    /// Spin until the in-flight tick clears. The stub returns instantly, so
+    /// this resolves in a few hops; the timeout only guards a hang.
+    private func waitUntilIdle(_ session: LiveAISession,
+                               timeout: TimeInterval = 2) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while session.isThinking && Date() < deadline {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+}


### PR DESCRIPTION
Closes #110

## The bug, and what it wasn't

A recording's Live AI output covered **the previous meeting plus the current one**: a blended summary, plus 9 action items that were never spoken (all `timestamp_seconds: 0`) sitting alongside 9 real ones.

That `[0s]` cluster is the exact fingerprint of #29 (cross-recording Claude session bleed), so that's where I started — and #29's instrumentation ruled itself out: every recording logs `start: fresh session=<uuid>` followed by a first tick of `session=new(<uuid>) established=false`. No `--resume` of a prior meeting.

The stale content came in through the **prompt**. Settings → Live AI → System prompt is a permanent template (`liveAI.prompt` in `UserDefaults`, sent on every tick of every recording), and it's the only editable text Mila offers — so preparing for a meeting means pasting the agenda at the bottom of it, and every *later* recording is then told that agenda is its context. The model summarises the agenda and emits an item per bullet; because nothing was spoken, the items come back at `[0s]`.

Confirmed against the spawned CLI's own transcript (`~/.claude/projects/…-island-mila-llm-session-<UUID>/<UUID>.jsonl`, row 2 = the literal first prompt): default template + a hand-written `Context for this meeting:` block + one line of real transcript, and the first assistant reply summarising the agenda. `grep` confirms no Mila code emits that string.

## The fix

* **`LiveAISettings.meetingContext`** — per-meeting background notes, **in-memory only**. Deliberately not persisted: that persistence is precisely what leaked, so a relaunch can't resurrect a meeting's notes. Cleared by `stopRecording` on both the normal path and the failed-stop early return.
* **`LiveAISession.promptWithContext`** — appends the notes as a fenced `BACKGROUND NOTES` block that tells the model they are not transcript, must not be summarised, and must not become action items (an agenda reads exactly like a record of decisions already taken, which is why the guard rails are the load-bearing part). Read **per tick**, not snapshotted at `start()` — a meeting-detector auto-start beats the user to the pane, so notes usually arrive a minute in.
* **Live AI pane** — a `Context` toggle in the "Summary & action items" header (filled icon when notes are set), a collapsible editor, and Clear.
* **Settings prompt editor** — one line pointing per-meeting content at that box, so the permanent template stops being the obvious place for it.

## Verification

* `make build` and `xcodebuild build-for-testing` both succeed.
* New `MilaTests/LiveAIMeetingContextTests.swift`: prompt wire format (absent when blank, fenced + guard-railed when set), the notes reaching a real `feed → scheduleKick → kick` tick through a stubbed `performCall`, per-tick re-read (added mid-recording, then cleared, both take effect on the next tick), and the not-persisted invariant (fresh settings object over the same suite comes back empty, and no key in the suite contains the text).
* Test suite not run locally (it would take over the mic and steal focus mid-workday) — left to CI. The new pane UI has not been visually verified for the same reason: the Context box only renders while a recording is live.

## Follow-up, not in here

`stopRecording` never calls `liveAISession?.cancel()`, so a throttled tick can fire after the recording ends — observed today: stop at 13:33:58, a full `claude --resume` tick at 13:34:49 — and the session's stable sandbox lingers until the next `start()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-meeting “Context” editor to Live AI recording (expand/collapse, edit, and clear).
  * Live AI now injects the current meeting context into each live update and adds guard-rails to keep responses transcript-based.
  * Clarified in Settings that the system prompt is reused for every recording and meeting-specific details belong in Context.
* **Bug Fixes**
  * Meeting context is now cleared reliably when recording stops (including edge-case teardown paths).
  * If meeting notes are changed mid-recording, Live AI restarts so removed notes no longer affect subsequent outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->