### PR TITLE
Cancel the Live AI session when a recording stops

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -550,6 +550,10 @@ final class QuickActionsController: ObservableObject {
             // recording. Cursor (PRRT_kwDOSY2m-s6GOIj-) flagged it.
             liveTranscriber?.stop()
             liveDiarizer?.stop()
+            // Nothing was captured, so there's no snapshot to protect —
+            // shut the Live AI session down with the rest of the pipeline.
+            // See the normal path for why this matters.
+            liveAISession?.cancel()
             // Same reason as the normal-path clear below: the meeting is
             // over either way, so its notes must not carry into the next
             // recording.
@@ -770,6 +774,9 @@ final class QuickActionsController: ObservableObject {
             // pipelines below before returning.
             liveTranscriber?.stop()
             liveDiarizer?.stop()
+            // The row this snapshot belonged to is gone, so there is
+            // nothing left to read `summary` / `actionItems` for.
+            liveAISession?.cancel()
             // Third exit from a finished recording, and it needs the same
             // clear as the other two — otherwise cancelling the rename
             // sheet is enough to carry this meeting's notes into the next
@@ -805,6 +812,30 @@ final class QuickActionsController: ObservableObject {
         // Cleanup: `.idle` handler skipped these because the flag was set.
         liveTranscriber?.stop()
         liveDiarizer?.stop()
+        // Shut the Live AI session down too — deliberately AFTER the
+        // snapshot above, because `cancel()` clears `summary` /
+        // `actionItems` and those are what we just saved.
+        //
+        // Left running, the session outlives the recording in two ways:
+        //
+        //   1. A `pendingKickTask` sleeping out the min-interval floor
+        //      wakes up after the meeting is over and spawns a full
+        //      `claude --resume` subprocess whose result lands on a
+        //      Recording that was already written — observed 2026-07-26:
+        //      stop at 13:33:58, a tick at 13:34:49. `finalizeTail`
+        //      regenerates the summary from the complete transcript
+        //      anyway, so that call was never anything but waste.
+        //   2. The session's stable sandbox
+        //      (`/tmp/island-mila-llm-session-<uuid>`, plus a
+        //      `~/.claude/projects/` dir per recording) is only removed by
+        //      `cancel()` — so it survived until the NEXT recording called
+        //      `start()`, and forever if the app quit first.
+        //
+        // Not done in `wireLiveAIPipeline`'s `.idle` handler: that fires
+        // during `session.stop()` above, i.e. BEFORE the snapshot, and it
+        // deliberately leaves the session alone for exactly that reason.
+        // This is the one place that knows the snapshot is already safe.
+        liveAISession?.cancel()
         // Per-meeting background notes die with the meeting. Cleared HERE
         // (not in `LiveAISession.start()`) because a recording can begin
         // before the user has pasted anything — clearing at start would

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1304,11 +1304,15 @@ struct MilaApp: App {
                     await diarizer.awaitPending()
                     diarizer.stop()
                 }
-                // Note: don't cancel aiSession here — QuickActionsController
-                // still needs to read .summary and .actionItems out of
-                // it when assembling the saved Recording. The NEXT
-                // recording clears these via `liveAISession?.start()` at
-                // record-start (in QuickActionsController).
+                // Note: don't cancel aiSession here — this handler fires
+                // during `session.stop()`, BEFORE QuickActionsController
+                // has read .summary / .actionItems for the saved
+                // Recording, and `cancel()` clears both. `stopRecording`
+                // cancels it itself once that snapshot is safely in the
+                // store (it's the only path that knows when that is); on
+                // the paths that don't go through `stopRecording`
+                // (cancelAll / app quit), the next recording's
+                // `liveAISession?.start()` resets it.
                 sessionRef.onLiveSamples = nil
             }
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1303,16 +1303,29 @@ struct MilaApp: App {
                     // utterance would lose its speaker label.
                     await diarizer.awaitPending()
                     diarizer.stop()
+                    // This branch owns the whole teardown, so kill the Live
+                    // AI session with the rest of it: otherwise a tick
+                    // deferred by the min-interval floor can still wake and
+                    // spawn a `claude` child while the app is tearing down
+                    // AVAudioEngine (CodeRabbit on #113). Safe to clear
+                    // `summary` / `actionItems` here — the only path that
+                    // reaches this branch today is `cancelAll()` at app
+                    // termination, which by design does NOT flush a WAV or
+                    // assemble a Recording (the orphan WAV is recovered on
+                    // next launch instead), so there is no snapshot to
+                    // protect. Sleep and screen-lock both route through
+                    // `stopRecording`, which owns finalize and cancels the
+                    // session itself once its snapshot is stored.
+                    aiSession.cancel()
                 }
-                // Note: don't cancel aiSession here — this handler fires
-                // during `session.stop()`, BEFORE QuickActionsController
-                // has read .summary / .actionItems for the saved
-                // Recording, and `cancel()` clears both. `stopRecording`
-                // cancels it itself once that snapshot is safely in the
-                // store (it's the only path that knows when that is); on
-                // the paths that don't go through `stopRecording`
-                // (cancelAll / app quit), the next recording's
-                // `liveAISession?.start()` resets it.
+                // Note: no aiSession.cancel() out here, outside the branch
+                // above — this handler fires during `session.stop()`,
+                // BEFORE QuickActionsController has read .summary /
+                // .actionItems for the saved Recording, and `cancel()`
+                // clears both. When `stopRecording` owns finalize it
+                // cancels the session itself, after its snapshot is
+                // safely in the store; it's the only path that knows
+                // when that is.
                 sessionRef.onLiveSamples = nil
             }
         }

--- a/MilaTests/LiveAIThrottleTests.swift
+++ b/MilaTests/LiveAIThrottleTests.swift
@@ -205,6 +205,51 @@ final class LiveAIThrottleTests: XCTestCase {
                       "final call should carry the closing transcript delta")
     }
 
+    // MARK: - Regression: a deferred tick must not outlive the recording
+
+    /// `stopRecording` now calls `liveAISession?.cancel()` once the final
+    /// summary/action-item snapshot is in the store. This pins the
+    /// mechanism that makes that call worth anything: a tick which is
+    /// sleeping out the min-interval floor when the recording ends must
+    /// never fire.
+    ///
+    /// Before the cancel was wired in, the sleeping task woke up after the
+    /// meeting was over and spawned a full `claude --resume` subprocess
+    /// against a Recording that had already been written (observed
+    /// 2026-07-26: stop at 13:33:58, tick at 13:34:49).
+    ///
+    /// Unlike the tests above this one uses a SHORT floor deliberately —
+    /// long enough to defer, short enough that an uncancelled task would
+    /// wake inside the test window and be caught.
+    func test_cancel_dropsDeferredTick() async {
+        let clock = TestClock(Date(timeIntervalSinceReferenceDate: 0))
+        let log = CallLog()
+        let session = makeSession(minInterval: 0.5, clock: clock, log: log,
+                                  suite: "ThrottleCancelDeferred")
+
+        session.feed(transcript: "meeting so far")
+        await waitUntilIdle(session)
+        XCTAssertEqual(log.startedAt.count, 1, "first feed should fire")
+
+        // Inside the floor → this one is deferred, not fired: a
+        // pendingKickTask is now sleeping out the remaining ~0.4s.
+        clock.advance(0.1)
+        session.feed(transcript: "meeting so far plus the last sentence")
+        await Task.yield()
+        XCTAssertEqual(log.startedAt.count, 1, "the second feed should be deferred")
+
+        // The recording ends here.
+        session.cancel()
+
+        // Wait past when the deferred tick would have woken. `clock` only
+        // drives the delay computation; the sleep itself is real time, so
+        // this has to be a real wait.
+        try? await Task.sleep(nanoseconds: 900_000_000)
+        XCTAssertEqual(log.startedAt.count, 1,
+                       "a tick deferred at stop time must not fire after cancel()")
+        XCTAssertFalse(session.isThinking)
+    }
+
     // (Removed `test_callFrequency_reduction_over_15min_meeting`: it asserted
     // on a local arithmetic closure, never touching LiveAISession/kickDelay,
     // so it would have passed even with the throttle removed. The pure


### PR DESCRIPTION
Closes #112 — the follow-up flagged in #111.

## The bug

`stopRecording` tears down `liveTranscriber` and `liveDiarizer` but never cancelled `liveAISession`, so the session outlived the recording in two ways:

1. **A tick fires after the meeting is over.** A `pendingKickTask` sleeping out the min-interval floor at Stop wakes up afterwards and spawns a full `claude --resume` subprocess, whose result lands on a `Recording` that was already assembled and written. `finalizeTail` regenerates the summary from the complete transcript regardless, so the call is pure waste. Observed 2026-07-26:

   ```
   13:33:58  RecordingSession  stop: source=meeting micFrames=14615051
   13:34:00  RecordingSummarizer  started 02831BA1 transcript=8984c force=true
   13:34:49  LiveAISession  tick tick-89094: session=resume(EFB5F132-…) established=true
   ```

2. **The session sandbox leaks.** `/var/folders/…/T/island-mila-llm-session-<uuid>` is only removed by `cancel()`, so it survived until the next recording's `start()` — and forever if the app quit first. `~/.claude/projects/` accumulates a directory per recording too.

## The fix

`liveAISession?.cancel()` on all three exits from a finished recording (failed `session.stop()`, store-removal early return, normal path) — in each case **after** the summary/action-item snapshot is in the store, because `cancel()` clears `summary`/`actionItems` and that's the data being saved.

Deliberately not moved into `wireLiveAIPipeline`'s `.idle` handler: that fires *during* `session.stop()`, i.e. before the snapshot, which is exactly why it leaves the session alone today. `stopRecording` is the only path that knows when the snapshot is safe. Its stale comment ("QuickActionsController still needs to read .summary…") now explains the real ordering constraint. Paths that never reach `stopRecording` (cancelAll / app quit) keep today's behaviour — the next recording's `start()` resets the session.

Checked for consumers that read the session after that point: the only ones are the two snapshots in `stopRecording` itself (both earlier) and `LiveAIRecordingView`, which is off screen by then (`activeJob = .none` is set long before). `finalizeTail` is documented and confirmed not to touch the live singletons — it regenerates the summary from the saved transcript.

## Verification

* `make build` and `xcodebuild build-for-testing` both succeed.
* New `test_cancel_dropsDeferredTick` in `LiveAIThrottleTests` pins the mechanism this fix depends on and that nothing covered before: a tick deferred by the throttle must not fire after `cancel()`. It uses a deliberately short floor (0.5s) so an uncancelled task would wake inside the test window and be caught.
* The call-site wiring itself has no unit test — driving `stopRecording` needs live capture — so that part rests on the build plus the consumer audit above. Suite not run locally (mic + focus); left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording shutdown to reliably tear down live AI sessions across successful, failed, and cancelled recording flows.
  * Ensured recording summary and action items are preserved by cleaning up the live AI session at the correct time.
  * Fixed an issue where deferred AI processing could still run after the session was cancelled.
* **Tests**
  * Added a regression test covering cancellation during deferred AI processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->