### PR TITLE
fix(settings): widen the Settings window so the last tab stays clickable

### DIFF
--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -49,7 +49,9 @@ struct SettingsView: View {
                 .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
                 .tag(SettingsTab.updates)
         }
-        .frame(width: 560, height: 560)
+        // Wide enough that the full 10-tab bar fits and the last tab
+        // (Updates) stays clickable — at 560 it can clip off the right edge.
+        .frame(width: 640, height: 560)
         .padding(20)
         .onChange(of: SettingsNavigation.shared.pendingTab, initial: true) { _, newTab in
             if let tab = newTab {


### PR DESCRIPTION
## Summary

The Settings scene is up to ten tabs (Hotkeys, Audio, Models, LLM, Speakers, Meetings, Live AI, Voice Memos, Storage, Updates), and they no longer fit in a 560pt window — the tab bar clips at the right edge and "Updates" ends up hard or impossible to click. Widen the window to 640pt.

One-line change plus the comment explaining the constraint, so the next tab addition has a hint that the width is load-bearing.

## Notes for reviewers

- Split out of #99 per review feedback. Independent of every other slice.
- The 640pt figure comes from what the ten-tab bar needs in practice on the fork this was developed on; worth a quick look on your setup, since tab-bar metrics shift with the system font size.

## Test plan

- [x] `make build` clean.
- [x] Full `MilaTests` suite: 566 tests, 0 failures (unchanged — this is a layout constant).
- [ ] Reviewer sanity check: open Settings, confirm the Updates tab is fully visible and clickable.