### PR TITLE
feat(llm): add Gemini CLI support and harden LLM executable lookup

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -609,9 +609,10 @@ enum LLMRunner {
         process.arguments = arguments
 
         // Inherit `$PATH` etc. so the CLI can find any helpers it shells out
-        // to. Spawning a Process from a sandboxed-style minimal environment
+        // to, but AUGMENT PATH so node-shebang CLIs find their interpreter.
+        // Spawning a Process from a sandboxed-style minimal environment
         // surprises users whose claude/cursor wrappers source nvm/asdf/etc.
-        process.environment = ProcessInfo.processInfo.environment
+        process.environment = childEnvironment(for: executable)
 
         // CRITICAL: spawn in a fresh, empty temp directory. macOS attributes
         // any file access by the child process to *our* bundle ID, so if
@@ -827,34 +828,82 @@ enum LLMRunner {
 
     /// Walk the user's `$PATH` plus a few common shell-managed locations
     /// (`~/.local/bin`, `/opt/homebrew/bin`, …). GUI apps on macOS inherit
-    /// a stripped-down PATH from launchd, so claude/cursor installed by
+    /// a stripped-down PATH from launchd, so claude/cursor/gemini installed by
     /// Homebrew or a node version manager are typically *not* on the
     /// inherited PATH — falling back to the well-known directories prevents
     /// the "works in Terminal, not in Mila" footgun.
     private static func lookupOnPath(_ name: String) -> URL? {
-        var searchDirs: [String] = []
-        if let path = ProcessInfo.processInfo.environment["PATH"] {
-            searchDirs += path.split(separator: ":").map(String.init)
-        }
-        let home = NSHomeDirectory()
-        searchDirs += [
-            "\(home)/.local/bin",
-            "\(home)/bin",
-            "\(home)/.cargo/bin",
-            "\(home)/.bun/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin"
-        ]
         let fm = FileManager.default
-        for dir in searchDirs {
+        for dir in searchDirectories() {
             let candidate = (dir as NSString).appendingPathComponent(name)
             if fm.isExecutableFile(atPath: candidate) {
                 return URL(fileURLWithPath: candidate)
             }
         }
         return nil
+    }
+
+    /// Environment for the spawned CLI. We inherit Mila's environment (so the
+    /// CLI still sees HOME, npm config, API-key vars, etc.) but *augment* PATH
+    /// so a node-shebang CLI can find its interpreter. `gemini`'s shebang is
+    /// `#!/usr/bin/env node`; a Finder-launched app gets a stripped PATH from
+    /// launchd, so without this it dies with `env: node: No such file or
+    /// directory`. We prepend the resolved executable's own directory (its
+    /// sibling `node` lives there for nvm/npm installs) plus the well-known
+    /// version-manager bins, then the inherited PATH — de-duped, order kept.
+    static func childEnvironment(
+        for executable: URL,
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var env = base
+        let inherited = base["PATH"]?.split(separator: ":").map(String.init) ?? []
+        var ordered: [String] = [executable.deletingLastPathComponent().path]
+        ordered += searchDirectories(pathEnv: nil)
+        ordered += inherited
+        var seen = Set<String>()
+        let merged = ordered.filter { !$0.isEmpty && seen.insert($0).inserted }
+        env["PATH"] = merged.joined(separator: ":")
+        return env
+    }
+
+    /// Ordered candidate directories for `lookupOnPath`: the inherited `$PATH`
+    /// first, then well-known shell/version-manager `bin` dirs. Node-based CLIs
+    /// (claude, cursor-agent, gemini) are commonly installed as global npm
+    /// packages under a version manager, so those roots are enumerated too.
+    /// Exposed (internal) so the version-manager enumeration is unit-testable.
+    static func searchDirectories(
+        home: String = NSHomeDirectory(),
+        pathEnv: String? = ProcessInfo.processInfo.environment["PATH"],
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var dirs: [String] = []
+        if let pathEnv {
+            dirs += pathEnv.split(separator: ":").map(String.init)
+        }
+        dirs += [
+            "\(home)/.local/bin",
+            "\(home)/bin",
+            "\(home)/.cargo/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.volta/bin",        // Volta
+            "\(home)/.asdf/shims",       // asdf
+            "\(home)/.npm-global/bin",   // custom npm prefix
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin"
+        ]
+        // nvm installs each Node version under
+        // ~/.nvm/versions/node/<version>/bin. A global npm package (claude,
+        // cursor-agent, gemini) lands in whichever version was active at
+        // install time, so search every installed version, newest first.
+        let nvmRoot = "\(home)/.nvm/versions/node"
+        if let versions = try? fileManager.contentsOfDirectory(atPath: nvmRoot) {
+            dirs += versions
+                .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+                .map { "\(nvmRoot)/\($0)/bin" }
+        }
+        return dirs
     }
 }
 

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -67,13 +67,14 @@ enum OpenAIProvider: String, CaseIterable, Identifiable, Codable {
 
 /// Which local LLM CLI Mila will shell out to for naming
 /// recordings and running post-recording actions. We deliberately keep this
-/// to a closed set of two so the Settings UI can show working defaults +
-/// concrete examples — supporting arbitrary CLIs would force the user to
-/// know shell-quoting rules.
+/// to a closed set of known CLIs so the Settings UI can show working
+/// defaults + concrete examples — supporting arbitrary CLIs would force the
+/// user to know shell-quoting rules.
 enum LLMTool: String, CaseIterable, Identifiable, Codable {
     case none
     case claude
     case cursor
+    case gemini
     case openaiCompatible = "openai_compatible"
 
     var id: String { rawValue }
@@ -83,6 +84,7 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         case .none:            return "Off"
         case .claude:          return "Claude (claude CLI)"
         case .cursor:          return "Cursor (cursor-agent CLI)"
+        case .gemini:          return "Gemini (gemini CLI)"
         case .openaiCompatible: return "OpenAI Compatible"
         }
     }
@@ -95,6 +97,7 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         case .none:            return ""
         case .claude:          return "claude"
         case .cursor:          return "cursor-agent"
+        case .gemini:          return "gemini"
         case .openaiCompatible: return ""
         }
     }
@@ -153,6 +156,21 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
                 args.append(contentsOf: ["--model", m])
             }
             // session intentionally ignored — see doc above.
+            return args
+        case .gemini:
+            // `gemini -p <prompt>` runs one-shot and streams the answer to
+            // stdout. `--skip-trust` is the gemini analogue of cursor's `-f`:
+            // we always launch in an isolated, empty sandbox dir (for TCC
+            // safety) which gemini treats as an untrusted workspace and
+            // otherwise refuses to run in headless mode. `-m` pins a model
+            // (e.g. gemini-2.5-flash); the CLI's configured default is used
+            // when omitted.
+            var args: [String] = ["-p", prompt, "--skip-trust"]
+            if hasModel, let m = trimmedModel {
+                args.append(contentsOf: ["-m", m])
+            }
+            // session intentionally ignored — gemini's -p mode has no
+            // documented conversation-resume flag.
             return args
         }
     }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1060,11 +1060,11 @@ private struct AIProviderSettingsTab: View {
     // MARK: Tool
 
     private var toolRow: some View {
-        // A pop-up menu, not a full-width segmented control: four options of
+        // A pop-up menu, not a full-width segmented control: five options of
         // very uneven length stretched across the pane gave "Off" a segment
         // the size of a button.
         fieldRow("Tool",
-                 help: "Claude and Cursor shell out to a CLI on this Mac, using the login you already set up. OpenAI Compatible calls any /chat/completions endpoint over HTTP, including a local Ollama.") {
+                 help: "Claude, Cursor and Gemini shell out to a CLI on this Mac, using the login you already set up. OpenAI Compatible calls any /chat/completions endpoint over HTTP, including a local Ollama.") {
             Picker("Tool", selection: $settings.tool) {
                 ForEach(LLMTool.allCases) { tool in
                     Text(tool.displayName).tag(tool)
@@ -1083,7 +1083,7 @@ private struct AIProviderSettingsTab: View {
     private var cliFields: some View {
         VStack(alignment: .leading, spacing: 6) {
             fieldRow("Executable",
-                     help: "Set this when `claude` / `cursor-agent` lives somewhere a GUI app won't see by default — ~/.local/bin, an asdf shim, a Homebrew prefix that isn't on the system PATH.") {
+                     help: "Set this when `claude` / `cursor-agent` / `gemini` lives somewhere a GUI app won't see by default — ~/.local/bin, an asdf shim, a Homebrew prefix that isn't on the system PATH.") {
                 TextField("(use $PATH)", text: $settings.executablePath)
                     .textFieldStyle(.roundedBorder)
                     .autocorrectionDisabled()

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -654,15 +654,37 @@ final class LLMRunnerTests: XCTestCase {
             throw XCTSkip("gemini CLI not installed on this machine")
         }
         let transcript = "We agreed to migrate the staging ECR to the new account by Friday and Uri will open the PR."
-        let result = try await LLMRunner.run(
-            tool: .gemini,
-            prompt: LLMSettings.defaultNamePrompt,
-            transcript: transcript,
-            executablePathOverride: geminiPath,
-            timeout: 120
-        )
+        let result: String
+        do {
+            result = try await LLMRunner.run(
+                tool: .gemini,
+                prompt: LLMSettings.defaultNamePrompt,
+                transcript: transcript,
+                executablePathOverride: geminiPath,
+                timeout: 120
+            )
+        } catch let error as LLMRunnerError {
+            // An installed-but-unusable CLI is an environment problem, not a
+            // regression in our argv/plumbing: gemini exits non-zero when the
+            // machine isn't logged in, or when the account's tier is no longer
+            // eligible (Google retired free-tier Code Assist for this client).
+            // Skip rather than fail so the suite stays green off a login.
+            guard case .nonZeroExit(_, let stderr) = error,
+                  Self.looksLikeGeminiAuthFailure(stderr) else { throw error }
+            throw XCTSkip("gemini CLI is installed but not usable on this machine (auth/tier): \(stderr.prefix(200))")
+        }
         XCTAssertFalse(result.isEmpty, "gemini returned empty output")
         XCTAssertLessThan(result.count, 200,
                           "gemini reply looks like prose, not a title: \(result)")
+    }
+
+    /// Whether a `gemini` non-zero exit is an auth/eligibility problem (skip)
+    /// rather than a real failure of the invocation we're testing (fail).
+    private static func looksLikeGeminiAuthFailure(_ stderr: String) -> Bool {
+        let s = stderr.lowercased()
+        return s.contains("error authenticating")
+            || s.contains("ineligibletiererror")
+            || s.contains("please login")
+            || s.contains("not authenticated")
     }
 }

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -267,14 +267,10 @@ final class LLMRunnerTests: XCTestCase {
     // this fix in the first place.
 
     private func resolve(_ name: String) -> String? {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        let dirs = path.split(separator: ":").map(String.init) + [
-            "\(NSHomeDirectory())/.local/bin",
-            "\(NSHomeDirectory())/.bun/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin"
-        ]
-        for d in dirs {
+        // Reuse the production lookup dirs (incl. nvm/Volta/asdf/npm-global) so
+        // these smoke tests find CLIs installed by a node version manager
+        // rather than spuriously skipping.
+        for d in LLMRunner.searchDirectories() {
             let p = (d as NSString).appendingPathComponent(name)
             if FileManager.default.isExecutableFile(atPath: p) { return p }
         }
@@ -548,5 +544,125 @@ final class LLMRunnerTests: XCTestCase {
                                           temperature: 0.5)
         XCTAssertEqual(out, "cursor-ran",
                        "cursor was diverted away from the CLI spawn path: \(out)")
+    }
+
+    // MARK: - Gemini CLI (LLMTool.gemini)
+
+    func test_gemini_metadata_matches_cli() {
+        XCTAssertEqual(LLMTool.gemini.executableName, "gemini")
+        XCTAssertEqual(LLMTool.gemini.displayName, "Gemini (gemini CLI)")
+        // Must be selectable in the Settings picker (ForEach over allCases).
+        XCTAssertTrue(LLMTool.allCases.contains(.gemini))
+    }
+
+    func test_gemini_arguments_are_prompt_and_skip_trust_by_default() {
+        // `--skip-trust` is always passed: we launch in an isolated sandbox
+        // dir which gemini would otherwise reject as an untrusted workspace.
+        XCTAssertEqual(LLMTool.gemini.arguments(prompt: "Summarize"),
+                       ["-p", "Summarize", "--skip-trust"])
+    }
+
+    func test_gemini_arguments_append_model_with_short_flag() {
+        // Gemini uses `-m`, unlike claude/cursor's `--model`.
+        XCTAssertEqual(
+            LLMTool.gemini.arguments(prompt: "Summarize", model: "gemini-2.5-flash"),
+            ["-p", "Summarize", "--skip-trust", "-m", "gemini-2.5-flash"])
+    }
+
+    func test_gemini_arguments_blank_model_is_omitted() {
+        XCTAssertEqual(LLMTool.gemini.arguments(prompt: "Summarize", model: "   "),
+                       ["-p", "Summarize", "--skip-trust"])
+    }
+
+    func test_gemini_arguments_ignore_session() {
+        // Gemini's -p mode has no conversation-resume flag; a session value
+        // must not leak flags into argv.
+        let args = LLMTool.gemini.arguments(prompt: "Summarize",
+                                            session: .new(UUID()))
+        XCTAssertEqual(args, ["-p", "Summarize", "--skip-trust"])
+    }
+
+    // MARK: - Executable lookup directories
+
+    func test_searchDirectories_includes_version_manager_bins() {
+        let dirs = LLMRunner.searchDirectories(home: "/Users/tester", pathEnv: nil)
+        XCTAssertTrue(dirs.contains("/Users/tester/.volta/bin"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/Users/tester/.asdf/shims"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/Users/tester/.npm-global/bin"), "\(dirs)")
+        XCTAssertTrue(dirs.contains("/opt/homebrew/bin"), "\(dirs)")
+    }
+
+    func test_searchDirectories_prepends_PATH_entries_in_order() {
+        let dirs = LLMRunner.searchDirectories(home: "/Users/tester",
+                                               pathEnv: "/a:/b")
+        XCTAssertEqual(Array(dirs.prefix(2)), ["/a", "/b"])
+    }
+
+    func test_searchDirectories_enumerates_nvm_versions_newest_first() throws {
+        // Build a fake home with two nvm node versions; the newer one must
+        // sort ahead so a global CLI installed under it wins.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-nvm-\(UUID().uuidString)")
+        let nodeRoot = home.appendingPathComponent(".nvm/versions/node")
+        for v in ["v20.1.0", "v22.15.0"] {
+            try FileManager.default.createDirectory(
+                at: nodeRoot.appendingPathComponent("\(v)/bin"),
+                withIntermediateDirectories: true)
+        }
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let dirs = LLMRunner.searchDirectories(home: home.path, pathEnv: nil)
+        let nvmDirs = dirs.filter { $0.contains("/.nvm/versions/node/") }
+        XCTAssertEqual(nvmDirs, [
+            "\(home.path)/.nvm/versions/node/v22.15.0/bin",
+            "\(home.path)/.nvm/versions/node/v20.1.0/bin",
+        ], "nvm version bins must be present, newest first: \(dirs)")
+    }
+
+    func test_childEnvironment_prepends_executable_dir_to_PATH() {
+        // node-shebang CLIs (gemini) need their sibling `node` on PATH; the
+        // resolved binary's own dir must come first so that install wins.
+        let exe = URL(fileURLWithPath: "/Users/tester/.nvm/versions/node/v22.15.0/bin/gemini")
+        let env = LLMRunner.childEnvironment(for: exe, base: ["PATH": "/usr/bin"])
+        let path = env["PATH"] ?? ""
+        let entries = path.split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.first, "/Users/tester/.nvm/versions/node/v22.15.0/bin",
+                       "executable dir must be first: \(path)")
+        XCTAssertTrue(entries.contains("/usr/bin"), "inherited PATH must survive: \(path)")
+        XCTAssertTrue(entries.contains("/opt/homebrew/bin"), "well-known dirs must be added: \(path)")
+    }
+
+    func test_childEnvironment_dedupes_and_preserves_other_vars() {
+        let exe = URL(fileURLWithPath: "/opt/homebrew/bin/claude")
+        let env = LLMRunner.childEnvironment(
+            for: exe, base: ["PATH": "/opt/homebrew/bin", "HOME": "/Users/tester"])
+        let entries = (env["PATH"] ?? "").split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.filter { $0 == "/opt/homebrew/bin" }.count, 1,
+                       "duplicate dirs must be collapsed: \(entries)")
+        XCTAssertEqual(env["HOME"], "/Users/tester", "other env vars must be inherited")
+    }
+
+    func test_searchDirectories_without_nvm_is_stable() {
+        // A home with no ~/.nvm must not crash or inject nvm dirs.
+        let dirs = LLMRunner.searchDirectories(
+            home: "/nonexistent-home-\(UUID().uuidString)", pathEnv: nil)
+        XCTAssertFalse(dirs.contains { $0.contains("/.nvm/versions/node/") })
+    }
+
+    func test_gemini_cli_returns_a_title_for_a_sample_transcript() async throws {
+        guard let geminiPath = resolve("gemini") else {
+            throw XCTSkip("gemini CLI not installed on this machine")
+        }
+        let transcript = "We agreed to migrate the staging ECR to the new account by Friday and Uri will open the PR."
+        let result = try await LLMRunner.run(
+            tool: .gemini,
+            prompt: LLMSettings.defaultNamePrompt,
+            transcript: transcript,
+            executablePathOverride: geminiPath,
+            timeout: 120
+        )
+        XCTAssertFalse(result.isEmpty, "gemini returned empty output")
+        XCTAssertLessThan(result.count, 200,
+                          "gemini reply looks like prose, not a title: \(result)")
     }
 }


### PR DESCRIPTION
## Summary

Two related pieces.

**`LLMTool.gemini`.** Mila can now shell out to the `gemini` CLI for naming recordings and post-recording actions, alongside claude and cursor-agent. The tool picker (`ForEach` over `allCases`) and the executable-path hint pick it up automatically. Argv is `gemini -p <prompt> --skip-trust`, plus `-m <model>` when a model is pinned:

- `--skip-trust` is the gemini analogue of cursor's `-f`. We always launch in an isolated, empty sandbox dir for TCC safety, and gemini treats that as an untrusted workspace and refuses to run headless without it.
- `-m`, not `--model` — gemini differs from claude/cursor here.
- `session` is ignored: gemini's `-p` mode has no documented conversation-resume flag.

**Hardened executable lookup for node-based CLIs.** A GUI app inherits launchd's stripped `PATH`, so a CLI installed by a node version manager isn't found, and even once found a node-shebang CLI (`#!/usr/bin/env node`) dies with `env: node: No such file or directory`. Two changes:

- The PATH walk becomes a testable `LLMRunner.searchDirectories(...)` that also enumerates nvm node bins (newest version first), Volta, asdf, and a custom npm prefix.
- New `LLMRunner.childEnvironment(for:)` augments the spawned CLI's `PATH` with the resolved binary's own directory (where its sibling `node` lives for nvm/npm installs) plus the well-known dirs, then the inherited `PATH`, de-duped and order-preserving. Everything else in the environment is still inherited.

This half is not gemini-specific — it makes claude and cursor-agent more robust to find on the same machines.

## Notes for reviewers

- Split out of #99 per review feedback, and rebased onto the post-#95 LLM layer: `.gemini` is added alongside `.openaiCompatible`, and the HTTP path is untouched (`.gemini` takes the normal CLI spawn path).
- One small deviation from the existing smoke-test convention, worth a look: the claude/cursor smoke tests skip when the CLI isn't installed but fail when it's installed and unauthenticated. Google has since retired free-tier Gemini Code Assist for this client, so `gemini -p` now exits non-zero with `IneligibleTierError` for anyone on that tier — which would fail the suite for reasons that have nothing to do with our plumbing. The gemini smoke test therefore also skips on a non-zero exit whose stderr looks like an auth/eligibility failure, and still fails on anything else. Happy to align the claude/cursor tests the same way in a follow-up if you like that shape.

## Test plan

- [x] 12 new tests in `MilaTests/LLMRunnerTests.swift`: gemini metadata and `allCases` membership; the arg vector by default, with `-m`, with a blank model, and with a session present; `searchDirectories` version-manager dirs, PATH-first ordering, nvm newest-first enumeration against a fake home, and no-nvm stability; `childEnvironment` exe-dir-first, dedupe, and preserved non-PATH vars.
- [x] `make build` clean.
- [x] Full `MilaTests` suite: 578 tests, 0 failures (566 before this PR). The gemini real-CLI smoke test skipped on my machine for the tier reason above; the rest of the new tests are pure unit tests and ran.

Made with [Cursor](https://cursor.com)


Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini as a supported AI provider.
  * Improved executable detection for tools installed through Volta, asdf, nvm, npm prefixes, and custom PATH locations.
  * Enhanced process launching to preserve existing environment settings while extending executable search paths.

* **Documentation**
  * Updated AI provider settings guidance to include Gemini and its executable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->