### PR TITLE
fix(remote): per-language model routing; remove Auto-detect

### DIFF
--- a/Mila/Models/MilaConfig.swift
+++ b/Mila/Models/MilaConfig.swift
@@ -26,7 +26,8 @@ struct MilaConfig: Codable, Equatable {
     var version: Int
 
     var remoteTranscription: RemoteTranscription?
-    /// ISO-style language code for new recordings: `"he"`, `"en"`, or `"auto"`.
+    /// ISO-style language code for new recordings: `"he"` or `"en"`. Anything
+    /// else — including the retired `"auto"` — is read as Hebrew.
     var recordingLanguage: String?
     var liveAI: LiveAI?
     var diarization: Toggle?

--- a/Mila/Models/MilaConfig.swift
+++ b/Mila/Models/MilaConfig.swift
@@ -43,6 +43,10 @@ struct MilaConfig: Codable, Equatable {
         var endpoint: String?
         /// Model id the server expects, e.g. `ivrit-ai/whisper-large-v3-turbo-ct2`.
         var model: String?
+        /// Optional model id for English and auto-detect recordings, for servers
+        /// whose main model is language-specific (the ivrit.ai finetune is
+        /// Hebrew-only). Absent or empty means `model` handles every language.
+        var englishModel: String?
         /// Bearer token. Stored in the Keychain on apply, never in UserDefaults.
         var apiKey: String?
     }

--- a/Mila/Models/MilaConfigImporter.swift
+++ b/Mila/Models/MilaConfigImporter.swift
@@ -117,6 +117,10 @@ final class MilaConfigImporter: ObservableObject {
             if let model = r.model, model != remote.model {
                 out.append(.init(label: "Model", value: model))
             }
+            if let englishModel = r.englishModel, englishModel != remote.englishModel {
+                out.append(.init(label: "English model",
+                                 value: englishModel.isEmpty ? "Same as Model" : englishModel))
+            }
             if let apiKey = r.apiKey, apiKey != remote.apiKey {
                 out.append(.init(label: "API key", value: Self.mask(apiKey)))
             }
@@ -156,6 +160,7 @@ final class MilaConfigImporter: ObservableObject {
             // stale stored one.
             if let endpoint = r.endpoint { remote.endpoint = endpoint }
             if let model = r.model { remote.model = model }
+            if let englishModel = r.englishModel { remote.englishModel = englishModel }
             if let apiKey = r.apiKey { remote.apiKey = apiKey }
             if let enabled = r.enabled { remote.backend = enabled ? .remote : .local }
         }

--- a/Mila/Models/RecordingLanguageSettings.swift
+++ b/Mila/Models/RecordingLanguageSettings.swift
@@ -53,9 +53,17 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
     /// before the rename) and for the retired `"auto"`.
     static func fromCode(_ code: String) -> RecordingLanguage {
         let normalized = code.lowercased()
-        if normalized == "iw" || normalized.hasPrefix("he") { return .hebrew }
-        if normalized.hasPrefix("en") { return .english }
+        if normalized == "iw" || isVariant(normalized, of: "he") { return .hebrew }
+        if isVariant(normalized, of: "en") { return .english }
         return .hebrew
+    }
+
+    /// Whether `code` is `base` or a regional form of it (`en-US`, `en_GB`).
+    /// A bare `hasPrefix` would also swallow unrelated codes that merely start
+    /// with those letters — `"enochian"` must fall back to Hebrew like any
+    /// other unrecognised value, not pick the English model.
+    private static func isVariant(_ code: String, of base: String) -> Bool {
+        code == base || code.hasPrefix("\(base)-") || code.hasPrefix("\(base)_")
     }
 }
 

--- a/Mila/Models/RecordingLanguageSettings.swift
+++ b/Mila/Models/RecordingLanguageSettings.swift
@@ -7,18 +7,17 @@ import Combine
 /// digging into Settings.
 ///
 /// Persisted to `UserDefaults` so the choice sticks across launches.
+/// The language is always an explicit choice — there is deliberately no
+/// auto-detect option. Detection sounds free but isn't: it can only be as good
+/// as the model behind it, and the model itself is picked *from* this setting
+/// (Hebrew → the ivrit.ai finetune, English → the multilingual one, and the
+/// same split for a remote endpoint's two model ids). "Let the model decide"
+/// therefore meant "guess which specialist to ask before knowing the
+/// language", which produced worse transcripts than simply saying which
+/// language you're about to speak. Legacy `"auto"` values are read as Hebrew.
 enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
     case hebrew = "he"
     case english = "en"
-    /// Let whisper detect the language of each utterance instead of forcing
-    /// one. Whisper's `detect_language` runs per `whisper_full` call, and the
-    /// live path transcribes one VAD-bounded utterance per call — so this
-    /// handles code-switching (a Hebrew meeting with the odd English
-    /// sentence) without rendering the English *as Hebrew*, which is what
-    /// forcing `he` on a Hebrew-specialised model does. Keeps the user's
-    /// selected model (see `ModelManager.model(for:)`), so a Hebrew user's
-    /// Hebrew accuracy isn't traded away for the multilingual generalist.
-    case auto = "auto"
 
     var id: String { rawValue }
 
@@ -26,40 +25,34 @@ enum RecordingLanguage: String, CaseIterable, Identifiable, Codable {
         switch self {
         case .hebrew:  return "Hebrew"
         case .english: return "English"
-        case .auto:    return "Auto-detect"
         }
     }
 
     /// Regional flag emoji used in the toolbar picker. Hebrew shows the
     /// Israeli flag; English shows the British flag (matches the user's
-    /// "Israel and UK" mental model); Auto shows a globe.
+    /// "Israel and UK" mental model).
     var flagEmoji: String {
         switch self {
         case .hebrew:  return "🇮🇱"
         case .english: return "🇬🇧"
-        case .auto:    return "🌐"
         }
     }
 
     /// The opposite-language pair, used by the right-click "Re-transcribe in
-    /// the other language" menu item on a recording. Auto-detected
-    /// recordings offer a re-transcribe forced to Hebrew (the dominant
-    /// language for our users) as the manual override.
+    /// the other language" menu item on a recording.
     var other: RecordingLanguage {
         switch self {
         case .hebrew:  return .english
         case .english: return .hebrew
-        case .auto:    return .hebrew
         }
     }
 
     /// Best-effort decode of an ISO-style language string (`"he"`, `"he-IL"`,
-    /// `"iw"`, `"en"`, `"en-US"`, `"auto"`, …). Falls back to Hebrew for
-    /// legacy recordings that pre-date the per-language UX (those were always
-    /// Hebrew before the rename).
+    /// `"iw"`, `"en"`, `"en-US"`, …). Falls back to Hebrew for legacy
+    /// recordings that pre-date the per-language UX (those were always Hebrew
+    /// before the rename) and for the retired `"auto"`.
     static func fromCode(_ code: String) -> RecordingLanguage {
         let normalized = code.lowercased()
-        if normalized == "auto" { return .auto }
         if normalized == "iw" || normalized.hasPrefix("he") { return .hebrew }
         if normalized.hasPrefix("en") { return .english }
         return .hebrew
@@ -81,11 +74,19 @@ final class RecordingLanguageSettings: ObservableObject {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        if let raw = defaults.string(forKey: Self.key),
-           let stored = RecordingLanguage(rawValue: raw) {
+        let raw = defaults.string(forKey: Self.key)
+        if let raw, let stored = RecordingLanguage(rawValue: raw) {
             self.current = stored
         } else {
+            // Unrecognised — a fresh install, or the retired `"auto"` left in
+            // defaults by an older build. Fall back to Hebrew and rewrite the
+            // key: `current`'s `didSet` doesn't fire from `init`, so without
+            // this the stale value would sit in the plist until the user
+            // touched the picker.
             self.current = .hebrew
+            if raw != nil {
+                defaults.set(RecordingLanguage.hebrew.rawValue, forKey: Self.key)
+            }
         }
     }
 }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -83,6 +83,25 @@ final class RemoteTranscriptionSettings: ObservableObject {
         }
     }
 
+    /// Optional second model id, used for English and auto-detect recordings.
+    ///
+    /// Exists because a server's main model may be *language-specific*: the
+    /// ivrit.ai finetune Mila's own server runs is Hebrew-only, and sending it
+    /// English audio yields English speech rendered with Hebrew words spliced
+    /// in — `language=en` is honoured by the decoder but can't fix weights that
+    /// were never trained multilingual. A single model id had no way to express
+    /// "Hebrew here, English there".
+    ///
+    /// Empty (the default) means "use `model` for every language", which is
+    /// correct for genuinely multilingual endpoints like OpenAI's `whisper-1`
+    /// and preserves the pre-existing behaviour for anyone already configured.
+    @Published var englishModel: String {
+        didSet {
+            guard englishModel != oldValue else { return }
+            defaults.set(englishModel, forKey: Keys.englishModel)
+        }
+    }
+
     /// The bearer token. Stored in the Keychain, never in `UserDefaults`. The
     /// `@Published` mirror lets SwiftUI bind a `SecureField` directly; every
     /// edit writes through to the Keychain.
@@ -124,6 +143,7 @@ final class RemoteTranscriptionSettings: ObservableObject {
             ?? .local
         self.endpoint = defaults.string(forKey: Keys.endpoint) ?? Self.defaultEndpoint
         self.model = defaults.string(forKey: Keys.model) ?? Self.defaultModel
+        self.englishModel = defaults.string(forKey: Keys.englishModel) ?? ""
         // Start empty and defer the Keychain read. Reading the token at launch
         // unconditionally pops the macOS "Mila wants to use confidential
         // information stored in your keychain" prompt for *every* user — even
@@ -188,14 +208,51 @@ final class RemoteTranscriptionSettings: ObservableObject {
         return true
     }
 
+    /// The model id to send for a recording in `languageCode` — the remote
+    /// mirror of `ModelManager.model(for:)`, which does the same routing for the
+    /// on-device backend.
+    ///
+    /// * `he` (and legacy `iw`/unrecognised codes) → `model`, the primary.
+    /// * `en` → `englishModel`.
+    /// * `auto` → `englishModel`.
+    ///
+    /// Auto goes to the English model rather than the primary because `auto`'s
+    /// whole contract is "detect per utterance, don't render English as
+    /// Hebrew". Only a multilingual model can honour that; a Hebrew-only
+    /// primary would defeat the setting the moment someone spoke English. This
+    /// deliberately differs from `ModelManager.model(for:)`, which keeps the
+    /// user's selected model on auto — that's sound locally, where *both*
+    /// shipped models are multilingual-capable, and unsound here, where the
+    /// primary may not be.
+    ///
+    /// With `englishModel` empty every language resolves to the primary, so a
+    /// single-model endpoint behaves exactly as it did before this existed.
+    func model(for languageCode: String) -> String {
+        let primary = Self.resolve(model)
+        let english = englishModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !english.isEmpty else { return primary }
+        switch RecordingLanguage.fromCode(languageCode) {
+        case .hebrew:          return primary
+        case .english, .auto:  return english
+        }
+    }
+
+    /// Trim a user-entered model id, falling back to the default when blank.
+    private static func resolve(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultModel : trimmed
+    }
+
     /// Snapshot for the engine, or `nil` if the endpoint can't be parsed.
-    func currentConfig() -> RemoteTranscriptionConfig? {
+    ///
+    /// Pass the recording's language so the right model id is baked into the
+    /// snapshot; omit it (the connection probe does) to get the primary model.
+    func currentConfig(for languageCode: String? = nil) -> RemoteTranscriptionConfig? {
         guard let url = endpointURL else { return nil }
-        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
         return RemoteTranscriptionConfig(
             endpoint: url,
             apiKey: apiKey.trimmingCharacters(in: .whitespacesAndNewlines),
-            model: trimmedModel.isEmpty ? Self.defaultModel : trimmedModel
+            model: languageCode.map(model(for:)) ?? Self.resolve(model)
         )
     }
 
@@ -311,6 +368,7 @@ final class RemoteTranscriptionSettings: ObservableObject {
         static let backend = "transcription.backend"
         static let endpoint = "remote.endpoint"
         static let model = "remote.model"
+        static let englishModel = "remote.model.en"
         static let apiKey = "remote.apiKey"
     }
 }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -214,16 +214,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
     ///
     /// * `he` (and legacy `iw`/unrecognised codes) → `model`, the primary.
     /// * `en` → `englishModel`.
-    /// * `auto` → `englishModel`.
-    ///
-    /// Auto goes to the English model rather than the primary because `auto`'s
-    /// whole contract is "detect per utterance, don't render English as
-    /// Hebrew". Only a multilingual model can honour that; a Hebrew-only
-    /// primary would defeat the setting the moment someone spoke English. This
-    /// deliberately differs from `ModelManager.model(for:)`, which keeps the
-    /// user's selected model on auto — that's sound locally, where *both*
-    /// shipped models are multilingual-capable, and unsound here, where the
-    /// primary may not be.
+    /// * legacy `auto` → `englishModel`, the only one that can serve a
+    ///   detect-the-language request. Auto-detect was retired as a user
+    ///   choice (see `RecordingLanguage`), but recordings made under it keep
+    ///   the string on disk and can still be re-transcribed.
     ///
     /// With `englishModel` empty every language resolves to the primary, so a
     /// single-model endpoint behaves exactly as it did before this existed.
@@ -231,9 +225,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
         let primary = Self.resolve(model)
         let english = englishModel.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !english.isEmpty else { return primary }
+        if languageCode.lowercased() == "auto" { return english }
         switch RecordingLanguage.fromCode(languageCode) {
-        case .hebrew:          return primary
-        case .english, .auto:  return english
+        case .hebrew:   return primary
+        case .english:  return english
         }
     }
 

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -130,18 +130,11 @@ final class ModelManager: NSObject, ObservableObject {
     /// installed yet (so dictation can still work in offline-but-different
     /// language mode while a download is in flight).
     func model(for languageCode: String) -> WhisperModel? {
-        // "auto" = let whisper detect each utterance's language rather than
-        // forcing one. Keep the user's *selected* model so a Hebrew user
-        // doesn't trade ivrit.ai's Hebrew accuracy for the multilingual
-        // generalist just to catch the occasional English sentence; both
-        // shipped models are multilingual-capable, so detection still routes
-        // English utterances to English text. Fall back to the turbo
-        // (explicitly multilingual) if nothing usable is selected.
-        if languageCode.lowercased() == "auto" {
-            if let selected = selectedModel(), isInstalled(selected) { return selected }
-            if isInstalled(.openaiTurbo) { return .openaiTurbo }
-            return selectedModel() ?? .openaiTurbo
-        }
+        // Legacy `"auto"` (the retired auto-detect option — see
+        // `RecordingLanguage`) resolves through `bestModel` to the turbo, the
+        // explicitly multilingual one, which is the right engine for a
+        // detect-the-language pass. Only reachable by re-transcribing a
+        // recording made before auto-detect was removed.
         let best = WhisperModel.bestModel(for: languageCode)
         if isInstalled(best) { return best }
         return selectedModel().flatMap { isInstalled($0) ? $0 : nil } ?? best

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -326,7 +326,8 @@ final class TranscriptionService: ObservableObject {
         // path. Misconfiguration degrades to an empty result (same contract as
         // a missing local model) rather than throwing into the live loop.
         if remoteSettings.isActive {
-            guard remoteSettings.isConfigured, let config = remoteSettings.currentConfig() else {
+            guard remoteSettings.isConfigured,
+                  let config = remoteSettings.currentConfig(for: language) else {
                 serviceLog.log("transcribeOnceSegments: SKIP — remote backend active but not configured")
                 return []
             }
@@ -517,7 +518,11 @@ final class TranscriptionService: ObservableObject {
         let localModel: WhisperModel?
         let modelDisplayName: String
         if useRemote {
-            guard remoteSettings.isConfigured, let config = remoteSettings.currentConfig() else {
+            // Language-routed: a server whose primary model is Hebrew-only (the
+            // ivrit.ai finetune) needs the English model id for English audio,
+            // or the transcript comes back with Hebrew words spliced in.
+            guard remoteSettings.isConfigured,
+                  let config = remoteSettings.currentConfig(for: working.language) else {
                 lastError = "Remote transcription is selected but not configured. Open Settings → Models to set the endpoint and API key."
                 markFailed(recording)
                 return

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -608,6 +608,16 @@ private struct RemoteBackendSection: View {
                         .autocorrectionDisabled()
                 }
 
+                fieldRow(label: "English model") {
+                    TextField("Same as above", text: $remote.englishModel)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                }
+                Text("Optional. Set this when the model above only handles one language — an ivrit.ai server, for example, returns Hebrew words for English speech. English and auto-detect recordings then use this model instead. Leave blank for multilingual endpoints like OpenAI.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 fieldRow(label: "API key") {
                     SecureField("Stored in your Keychain", text: $remote.apiKey)
                         .textFieldStyle(.roundedBorder)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -613,7 +613,7 @@ private struct RemoteBackendSection: View {
                         .textFieldStyle(.roundedBorder)
                         .autocorrectionDisabled()
                 }
-                Text("Optional. Set this when the model above only handles one language — an ivrit.ai server, for example, returns Hebrew words for English speech. English and auto-detect recordings then use this model instead. Leave blank for multilingual endpoints like OpenAI.")
+                Text("Optional. Set this when the model above only handles one language — an ivrit.ai server, for example, returns Hebrew words for English speech. English recordings then use this model instead. Leave blank for multilingual endpoints like OpenAI.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/MilaTests/RecordingLanguageSettingsTests.swift
+++ b/MilaTests/RecordingLanguageSettingsTests.swift
@@ -62,4 +62,38 @@ final class RecordingLanguageSettingsTests: XCTestCase {
         XCTAssertEqual(RecordingLanguage.fromCode("fr"), .hebrew)
         XCTAssertEqual(RecordingLanguage.fromCode(""), .hebrew)
     }
+
+    /// Auto-detect was removed: the language is always an explicit choice, and
+    /// the toolbar picker is `allCases`-driven, so this guards the picker's
+    /// contents too.
+    func test_only_hebrew_and_english_are_offered() {
+        XCTAssertEqual(RecordingLanguage.allCases, [.hebrew, .english])
+        XCTAssertNil(RecordingLanguage(rawValue: "auto"))
+    }
+
+    /// A recording tagged by an older build still carries `"auto"`; the UI must
+    /// read it as Hebrew rather than crashing or showing a blank language.
+    func test_legacy_auto_code_reads_as_hebrew() {
+        XCTAssertEqual(RecordingLanguage.fromCode("auto"), .hebrew)
+    }
+
+    /// Someone upgrading from a build that had auto-detect has `"auto"` sitting
+    /// in defaults. It must resolve to Hebrew *and* be rewritten, so the stale
+    /// value doesn't linger in the plist.
+    func test_persisted_auto_migrates_to_hebrew() {
+        defaults.set("auto", forKey: "recording.language")
+
+        let settings = RecordingLanguageSettings(defaults: defaults)
+        XCTAssertEqual(settings.current, .hebrew)
+        XCTAssertEqual(defaults.string(forKey: "recording.language"), "he",
+                       "The retired value must be rewritten, not just ignored")
+    }
+
+    /// A fresh install has no stored value — don't write one just to migrate
+    /// nothing (that would make "never chosen" indistinguishable from "chose
+    /// Hebrew" for any future first-run logic).
+    func test_fresh_install_does_not_write_a_language() {
+        _ = RecordingLanguageSettings(defaults: defaults)
+        XCTAssertNil(defaults.string(forKey: "recording.language"))
+    }
 }

--- a/MilaTests/RecordingLanguageSettingsTests.swift
+++ b/MilaTests/RecordingLanguageSettingsTests.swift
@@ -63,6 +63,16 @@ final class RecordingLanguageSettingsTests: XCTestCase {
         XCTAssertEqual(RecordingLanguage.fromCode(""), .hebrew)
     }
 
+    /// Only `en` and its regional forms are English. A bare prefix match would
+    /// route anything starting with those letters to the English model, against
+    /// the documented "unrecognised → Hebrew" contract.
+    func test_language_code_decoding_does_not_prefix_match_unrelated_codes() {
+        XCTAssertEqual(RecordingLanguage.fromCode("en_GB"), .english)
+        XCTAssertEqual(RecordingLanguage.fromCode("enochian"), .hebrew)
+        XCTAssertEqual(RecordingLanguage.fromCode("held"), .hebrew,
+                       "Unrecognised codes land on Hebrew either way, but not via a prefix match")
+    }
+
     /// Auto-detect was removed: the language is always an explicit choice, and
     /// the toolbar picker is `allCases`-driven, so this guards the picker's
     /// contents too.

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -60,6 +60,68 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(config?.model, RemoteTranscriptionSettings.defaultModel)
     }
 
+    // MARK: - Per-language model routing
+
+    func test_modelForLanguage_withoutEnglishModel_alwaysUsesPrimary() {
+        let settings = makeSettings()
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        // Empty englishModel is the default and must preserve the old
+        // single-model behaviour for every language.
+        XCTAssertEqual(settings.model(for: "he"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.model(for: "en"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.model(for: "auto"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+    }
+
+    func test_modelForLanguage_routesEnglishAndAutoToEnglishModel() {
+        let settings = makeSettings()
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        settings.englishModel = "deepdml/faster-whisper-large-v3-turbo-ct2"
+        XCTAssertEqual(settings.model(for: "he"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.model(for: "iw"), "ivrit-ai/whisper-large-v3-turbo-ct2",
+                       "Legacy Hebrew code must route like `he`")
+        XCTAssertEqual(settings.model(for: "en"), "deepdml/faster-whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.model(for: "en-US"), "deepdml/faster-whisper-large-v3-turbo-ct2")
+        // Auto's contract is "don't render English as Hebrew", which only the
+        // multilingual model can honour. See `model(for:)`.
+        XCTAssertEqual(settings.model(for: "auto"), "deepdml/faster-whisper-large-v3-turbo-ct2")
+    }
+
+    func test_modelForLanguage_trimsWhitespace() {
+        let settings = makeSettings()
+        settings.model = "  primary  "
+        settings.englishModel = "  english  "
+        XCTAssertEqual(settings.model(for: "he"), "primary")
+        XCTAssertEqual(settings.model(for: "en"), "english")
+        // Whitespace-only is indistinguishable from unset.
+        settings.englishModel = "   "
+        XCTAssertEqual(settings.model(for: "en"), "primary")
+    }
+
+    func test_currentConfig_bakesInTheLanguageRoutedModel() {
+        let settings = makeSettings()
+        settings.backend = .remote
+        settings.endpoint = "https://example.com/v1"
+        settings.model = "hebrew-model"
+        settings.englishModel = "english-model"
+        XCTAssertEqual(settings.currentConfig(for: "en")?.model, "english-model")
+        XCTAssertEqual(settings.currentConfig(for: "he")?.model, "hebrew-model")
+        // No language (the connection probe) → primary.
+        XCTAssertEqual(settings.currentConfig()?.model, "hebrew-model")
+    }
+
+    func test_englishModel_persistsAcrossInstances() {
+        let suite = UserDefaults(suiteName: "RemoteTranscriptionSettingsTests.\(#function)")!
+        suite.removePersistentDomain(forName: "RemoteTranscriptionSettingsTests.\(#function)")
+        let key = "RemoteTranscriptionSettingsTests.\(#function).apiKey"
+
+        let first = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+        XCTAssertEqual(first.englishModel, "", "Must default to empty (= use primary)")
+        first.englishModel = "deepdml/faster-whisper-large-v3-turbo-ct2"
+
+        let second = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: key)
+        XCTAssertEqual(second.englishModel, "deepdml/faster-whisper-large-v3-turbo-ct2")
+    }
+
     func test_localBackend_doesNotReadKeychain() {
         // Seed a real token under an isolated key, then construct with the
         // default (local) backend. A local-only user must come up with an empty

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -69,7 +69,8 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         // single-model behaviour for every language.
         XCTAssertEqual(settings.model(for: "he"), "ivrit-ai/whisper-large-v3-turbo-ct2")
         XCTAssertEqual(settings.model(for: "en"), "ivrit-ai/whisper-large-v3-turbo-ct2")
-        XCTAssertEqual(settings.model(for: "auto"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.model(for: "auto"), "ivrit-ai/whisper-large-v3-turbo-ct2",
+                       "Legacy auto must not resolve to a model the user never configured")
     }
 
     func test_modelForLanguage_routesEnglishAndAutoToEnglishModel() {
@@ -81,8 +82,9 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
                        "Legacy Hebrew code must route like `he`")
         XCTAssertEqual(settings.model(for: "en"), "deepdml/faster-whisper-large-v3-turbo-ct2")
         XCTAssertEqual(settings.model(for: "en-US"), "deepdml/faster-whisper-large-v3-turbo-ct2")
-        // Auto's contract is "don't render English as Hebrew", which only the
-        // multilingual model can honour. See `model(for:)`.
+        // Auto-detect is retired as a user choice, but recordings made under it
+        // keep "auto" on disk and can be re-transcribed. Only the multilingual
+        // model can serve a detect-the-language request.
         XCTAssertEqual(settings.model(for: "auto"), "deepdml/faster-whisper-large-v3-turbo-ct2")
     }
 

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -121,7 +121,9 @@ Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
   network you don't trust.
 - **Language.** Mila forwards the recording language (`he` / `en`), and uses it
   to pick which model id to send when you've set an **English model** (Settings
-  → Models). There's no auto-detect — the speaker picks the language in the
-  toolbar, because the model is chosen *from* that choice.
+  → Models). Leave that field empty — as this quickstart does — and *every*
+  language uses **Model**, which is what you want for a multilingual server.
+  There's no auto-detect: the speaker picks the language in the toolbar, because
+  the model is chosen *from* that choice.
 - **Diarization** still runs locally (it reads the on-disk audio), so speaker
   labels work regardless of which transcription backend you choose.

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -119,7 +119,9 @@ Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
   host, terminate TLS (e.g. behind a reverse proxy) and require an API key —
   then set that key in Mila. Don't send audio over plaintext HTTP across a
   network you don't trust.
-- **Language.** Mila forwards the recording language (`he` / `en`); on
-  "Auto-detect" it omits the field and lets the server detect it.
+- **Language.** Mila forwards the recording language (`he` / `en`), and uses it
+  to pick which model id to send when you've set an **English model** (Settings
+  → Models). There's no auto-detect — the speaker picks the language in the
+  toolbar, because the model is chosen *from* that choice.
 - **Diarization** still runs locally (it reads the on-disk audio), so speaker
   labels work regardless of which transcription backend you choose.

--- a/docs/self-hosted-server/README.md
+++ b/docs/self-hosted-server/README.md
@@ -129,8 +129,8 @@ Set them in Mila under Settings → Models:
 | Model         | `ivrit-ai/whisper-large-v3-turbo-ct2`      |
 | English model | `deepdml/faster-whisper-large-v3-turbo-ct2` |
 
-Hebrew recordings use **Model**; English and Auto-detect use **English model**.
-Leave *English model* blank if your endpoint is already multilingual (OpenAI's
+Hebrew recordings use **Model**; English recordings use **English model**. Leave
+*English model* blank if your endpoint is already multilingual (OpenAI's
 `whisper-1`, or a plain `Systran/faster-whisper-large-v3` deployment) — then
 every language uses **Model**.
 
@@ -259,9 +259,8 @@ To distribute it:
   flags this in the UI. Self-hosting keeps it on infrastructure you control.
 - **Diarization still runs locally** in Mila (it reads the on-disk audio), so
   speaker labels work regardless of which transcription backend you pick.
-- **Language.** Mila forwards the recording language (`he` / `en`); on
-  Auto-detect it omits the field and lets the server detect it. The language
-  also picks *which model id* is sent: Hebrew → **Model**, English and
-  Auto-detect → **English model** (when set). Auto goes to the multilingual
-  model on purpose — a Hebrew-only model would render detected English as
-  Hebrew, which is exactly what Auto-detect exists to avoid.
+- **Language.** Mila forwards the recording language (`he` / `en`), which also
+  picks *which model id* is sent: Hebrew → **Model**, English → **English
+  model** (when set). There's no auto-detect: the model is chosen *from* the
+  language, so detection would mean picking a specialist before knowing what
+  language it needs to handle. Speakers pick the language in the toolbar.

--- a/docs/self-hosted-server/README.md
+++ b/docs/self-hosted-server/README.md
@@ -108,15 +108,35 @@ What the [Deployment](./k8s/deployment.yaml) does:
   VRAM of float32.
 - Uses `/health` for the startup / readiness / liveness probes (that endpoint is
   auth-free on this image).
-- Runs a **`postStart` hook** that waits for the server, then pre-registers the
+- Runs a **`postStart` hook** that waits for the server, then pre-registers each
   model (`POST /v1/models/{id}`) so the first user request doesn't pay the full
   cold download. It's non-fatal — speaches also lazy-loads on first use.
-- Caches the model in a pod-local **`emptyDir`** (re-downloaded on restart,
-  ~1–2 min; swap for a PVC if you want it to persist).
+- Caches the models in a pod-local **`emptyDir`** (re-downloaded on restart,
+  ~1–2 min each; swap for a PVC if you want it to persist).
 
-**Changing the model:** edit the `model_id` in the deployment's `postStart`
-hook and set the matching id in your `.milaconfig` / Mila settings. For a
-multilingual deployment use `Systran/faster-whisper-large-v3`.
+**Two models, and why.** The `ivrit-ai` finetune is **Hebrew-only**. Send it
+English audio and you get English speech with Hebrew words spliced in — the
+`language=en` field is honoured by the decoder but can't fix weights that were
+never trained multilingual. So the deployment warms a second, multilingual
+model (`deepdml/faster-whisper-large-v3-turbo-ct2`, a CT2 build of Whisper
+large-v3-turbo) and Mila routes to it per recording language. Both stay
+resident under `STT_MODEL_TTL=-1` at ~1.6 GB VRAM each.
+
+Set them in Mila under Settings → Models:
+
+| Field         | Value                                      |
+| ------------- | ------------------------------------------ |
+| Model         | `ivrit-ai/whisper-large-v3-turbo-ct2`      |
+| English model | `deepdml/faster-whisper-large-v3-turbo-ct2` |
+
+Hebrew recordings use **Model**; English and Auto-detect use **English model**.
+Leave *English model* blank if your endpoint is already multilingual (OpenAI's
+`whisper-1`, or a plain `Systran/faster-whisper-large-v3` deployment) — then
+every language uses **Model**.
+
+**Changing a model:** edit the ids in the deployment's `postStart` hook and set
+the matching ids in your `.milaconfig` / Mila settings. If you only ever
+transcribe Hebrew, drop the second id from both places.
 
 Watch it come up (the first boot downloads the model, so give it a few minutes):
 
@@ -174,12 +194,13 @@ in business.
 
 In Mila: **Settings → Models → Remote**.
 
-| Field    | Value                                     |
-| -------- | ----------------------------------------- |
-| Backend  | **Remote**                                |
-| Base URL | `https://mila-asr.your-org.example/v1`    |
-| Model    | `ivrit-ai/whisper-large-v3-turbo-ct2`     |
-| API key  | the key you created in Step 2             |
+| Field         | Value                                       |
+| ------------- | ------------------------------------------- |
+| Backend       | **Remote**                                  |
+| Base URL      | `https://mila-asr.your-org.example/v1`      |
+| Model         | `ivrit-ai/whisper-large-v3-turbo-ct2`       |
+| English model | `deepdml/faster-whisper-large-v3-turbo-ct2` |
+| API key       | the key you created in Step 2               |
 
 Click **Test connection**. Once it's green, record — Mila uploads each recording
 and asks for `verbose_json`, so timestamps (and therefore SRT export + speaker
@@ -205,6 +226,7 @@ See [`example.milaconfig`](./example.milaconfig):
     "enabled": true,
     "endpoint": "https://mila-asr.your-org.example/v1",
     "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+    "englishModel": "deepdml/faster-whisper-large-v3-turbo-ct2",
     "apiKey": "YOUR_API_KEY_HERE"
   },
   "recordingLanguage": "he"
@@ -238,4 +260,8 @@ To distribute it:
 - **Diarization still runs locally** in Mila (it reads the on-disk audio), so
   speaker labels work regardless of which transcription backend you pick.
 - **Language.** Mila forwards the recording language (`he` / `en`); on
-  Auto-detect it omits the field and lets the server detect it.
+  Auto-detect it omits the field and lets the server detect it. The language
+  also picks *which model id* is sent: Hebrew → **Model**, English and
+  Auto-detect → **English model** (when set). Auto goes to the multilingual
+  model on purpose — a Hebrew-only model would render detected English as
+  Hebrew, which is exactly what Auto-detect exists to avoid.

--- a/docs/self-hosted-server/example.milaconfig
+++ b/docs/self-hosted-server/example.milaconfig
@@ -4,6 +4,7 @@
     "enabled": true,
     "endpoint": "https://mila-asr.your-org.example/v1",
     "model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+    "englishModel": "deepdml/faster-whisper-large-v3-turbo-ct2",
     "apiKey": "YOUR_API_KEY_HERE"
   },
   "recordingLanguage": "he"

--- a/docs/self-hosted-server/k8s/deployment.yaml
+++ b/docs/self-hosted-server/k8s/deployment.yaml
@@ -67,6 +67,12 @@ spec:
             # float32. Use int8_float16 if you're tight on VRAM.
             - name: WHISPER__COMPUTE_TYPE
               value: float16
+            # Never unload an idle model. Matters with two models: the cache is
+            # an emptyDir, so an evicted model doesn't just reload from disk on
+            # the next request — it re-downloads. Drop this if you're tight on
+            # VRAM and would rather trade the cold load.
+            - name: STT_MODEL_TTL
+              value: "-1"
             # Point the HuggingFace cache at the mounted volume (see below).
             - name: HF_HOME
               value: /home/ubuntu/.cache/huggingface
@@ -111,14 +117,18 @@ spec:
                   - /bin/sh
                   - -c
                   - |
+                    # Every curl is bounded: postStart holds the container out of
+                    # Running until this script exits, so an unbounded request
+                    # against a wedged server would stall the rollout forever.
                     for i in $(seq 1 60); do
-                      curl -sf http://127.0.0.1:8000/health && break || sleep 5
+                      curl -sf --connect-timeout 5 --max-time 10 \
+                        http://127.0.0.1:8000/health && break || sleep 5
                     done
                     for model in \
                       ivrit-ai/whisper-large-v3-turbo-ct2 \
                       deepdml/faster-whisper-large-v3-turbo-ct2; do
                       for j in $(seq 1 30); do
-                        curl -sf -X POST \
+                        curl -sf --connect-timeout 5 --max-time 600 -X POST \
                           -H "Authorization: Bearer $API_KEY" \
                           "http://127.0.0.1:8000/v1/models/$model" \
                           && break || sleep 10

--- a/docs/self-hosted-server/k8s/deployment.yaml
+++ b/docs/self-hosted-server/k8s/deployment.yaml
@@ -89,13 +89,21 @@ spec:
           volumeMounts:
             - name: model-cache
               mountPath: /home/ubuntu/.cache/huggingface
-          # Warm the model on startup so the first user request doesn't pay the
+          # Warm both models on startup so the first user request doesn't pay the
           # full cold download/load. The hook waits for the server's own /health
-          # to pass, then triggers the download via speaches' registration
+          # to pass, then triggers each download via speaches' registration
           # endpoint: POST /v1/models/{model_id:path} — a FastAPI ":path"
           # converter, so the HuggingFace id is passed literally WITH slashes.
-          # Non-fatal (|| true): speaches also lazy-loads the model on the first
+          # Non-fatal (|| true): speaches also lazy-loads a model on the first
           # request, so a transient network hiccup must not crash-loop the pod.
+          #
+          # Two models, because the ivrit.ai finetune is Hebrew-ONLY: give it
+          # English audio and it returns English speech with Hebrew words
+          # spliced in, no matter what `language` the client sends. The turbo
+          # build covers English (and everything else); Mila picks per recording
+          # language via Settings → Models → "English model". Drop the second id
+          # if you only ever transcribe Hebrew. STT_MODEL_TTL=-1 keeps both
+          # resident — ~1.6 GB VRAM each, comfortable on a 16 GB T4.
           lifecycle:
             postStart:
               exec:
@@ -106,11 +114,15 @@ spec:
                     for i in $(seq 1 60); do
                       curl -sf http://127.0.0.1:8000/health && break || sleep 5
                     done
-                    for j in $(seq 1 30); do
-                      curl -sf -X POST \
-                        -H "Authorization: Bearer $API_KEY" \
-                        "http://127.0.0.1:8000/v1/models/ivrit-ai/whisper-large-v3-turbo-ct2" \
-                        && break || sleep 10
+                    for model in \
+                      ivrit-ai/whisper-large-v3-turbo-ct2 \
+                      deepdml/faster-whisper-large-v3-turbo-ct2; do
+                      for j in $(seq 1 30); do
+                        curl -sf -X POST \
+                          -H "Authorization: Bearer $API_KEY" \
+                          "http://127.0.0.1:8000/v1/models/$model" \
+                          && break || sleep 10
+                      done
                     done || true
           # Hold off readiness/liveness until the server is up. A cold model
           # download can take a couple of minutes: 60 * 5s = up to 5 min before


### PR DESCRIPTION
Closes #121, closes #123

Two commits: the remote-model fix, then the Auto-detect removal that follows from it.

## 1. English recordings went to the Hebrew-only model (#121)

On the Remote backend, English recordings came back with Hebrew words spliced in. The language hint was fine — `language=en` is sent, confirmed from a live session:

```
RemoteWhisperEngine transcribe: POST model=ivrit-ai/whisper-large-v3-turbo-ct2 lang=en
```

It's the model. `remote.model` was a single fixed string, and the ivrit.ai finetune is Hebrew-only — the decoder honours `<|en|>`, but weights that were never trained multilingual still leak Hebrew tokens. The local backend has routed per language since forever (`ModelManager.model(for:)`); remote returned before that gate and called `currentConfig()`, which had no language parameter. The toolbar 🇬🇧 flag set a form field and nothing else.

- `RemoteTranscriptionSettings.englishModel` (`remote.model.en`) + `model(for:)`, the remote mirror of `ModelManager.model(for:)`
- `currentConfig(for:)` bakes the routed id into the snapshot; both call sites that were dropping the language — live and batch — now pass it
- Settings → Models gains an **English model** field, blank by default
- `.milaconfig` carries `englishModel`, so a team config hands over both ids
- Self-hosted docs + the example `k8s/deployment.yaml` warm both models

**Empty means "use the primary for every language"** — OpenAI's `whisper-1`, any multilingual deployment, and every existing configuration behave exactly as before. Inert until someone fills the field in.

## 2. Auto-detect is gone (#123)

Auto existed to handle code-switching, but it couldn't: the model is chosen *from* the language setting, so auto meant picking which specialist to ask before knowing what language it had to handle. The local path kept whichever model was selected — usually the Hebrew finetune — which rendered detected English as Hebrew, the exact failure auto was supposed to prevent. Speakers pick the language; it's one click and it produces a better transcript.

- `RecordingLanguage.auto` dropped. The toolbar picker is `allCases`-driven, so it disappears with the case, and both model-routing switches simplify.
- A persisted `"auto"` migrates to Hebrew *and* the key is rewritten, so the retired value doesn't linger in defaults (`current`'s `didSet` doesn't fire from `init`).
- `fromCode("auto")` → `.hebrew` via the existing unknown-code fallback.
- Recordings made under auto keep `"auto"` on disk and can still be re-transcribed, so the engines keep tolerating the literal string. Those resolve to the multilingual model — local `bestModel` default → turbo, remote → the English model id — which is the right engine for a detect pass.

## Server side

Needs [zeroabstraction/cloud-helm-configurations#11358](https://github.com/zeroabstraction/cloud-helm-configurations/pull/11358), which warms `deepdml/faster-whisper-large-v3-turbo-ct2` alongside ivrit on `mila-asr`. Order doesn't matter — this PR is a no-op until the field is set, and that PR is a no-op until a client asks for the second model.

Why that model: speaches serves faster-whisper/CT2 only, so NeMo models (Parakeet, Canary) that top the Open ASR leaderboard aren't an option without a different serving stack. Turbo over full `large-v3` because the live path posts one VAD utterance at a time — round-trip is ~0.8 s today and non-turbo (32 decoder layers vs 4) would visibly lag the live pane for a marginal English WER difference.

## Testing

- `make build` and `xcodebuild build-for-testing` — both clean, so no stale `.auto` references anywhere including the test and UI-test targets.
- 5 new tests in `RemoteTranscriptionTests`: empty-english-model preserves single-model behaviour across all languages, `he`/`iw`/`en`/`en-US`/legacy-`auto` routing, whitespace trimming (whitespace-only == unset), `currentConfig(for:)` baking in the right id, persistence across instances.
- 4 new tests in `RecordingLanguageSettingsTests`: `allCases == [.hebrew, .english]` (also guards the picker's contents), `fromCode("auto")` → Hebrew, persisted `"auto"` migrates *and* rewrites the key, and a fresh install doesn't write a language at all.
- `ModelManagerTests`' `bestModel(for: "auto") == .openaiTurbo` still holds — that's now the default branch rather than a special case.
- Tests not run locally: the host app was mid-recording and a run would launch a second instance. CI is the first real execution.
- End-to-end verification of the English path is blocked until the CHC PR lands, since the server only serves ivrit today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional **English model** override for remote transcription, with language-aware routing (English/auto → English model when set; otherwise uses the primary model).
  - Exposed the English model setting in configuration import/export and the remote transcription settings UI.
- **Bug Fixes**
  - Remote transcription now selects the correct backend model based on the recording language.
  - Retired/unknown language values now reliably resolve to Hebrew.
- **Documentation**
  - Updated self-hosted server docs and examples for a two-model deployment (Model + English model), including configuration and warm-up behavior.
- **Tests**
  - Added per-language routing and legacy language decoding/migration coverage for remote transcription and language settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->