### PR TITLE
feat(recording): pause and resume an active recording

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -1218,4 +1218,39 @@ final class QuickActionsController: ObservableObject {
         guard let file = try? AVAudioFile(forReading: url) else { return nil }
         return Double(file.length) / file.processingFormat.sampleRate
     }
+
+    /// True while an active recording is paused. Reads straight off the
+    /// session's published state so the UI's Pause/Resume affordances stay
+    /// in sync without a separate mirrored flag.
+    var isPaused: Bool { session.state == .paused }
+
+    /// Pause the active recording. While paused the session drops all
+    /// incoming audio (see `RecordingSession.pause()`), so nothing said
+    /// during the pause is written to the WAV or the live transcript. The
+    /// VAD utterance in progress is flushed so it doesn't span the gap.
+    /// No-op if not recording or already finalizing.
+    func pauseRecording() {
+        guard isRecording, !isFinalizingRecording, !isPaused else { return }
+        session.pause()
+        liveTranscriber?.pauseBoundary()
+    }
+
+    /// Resume a paused recording. Capture picks back up where it left off;
+    /// the paused span is absent from the recording and excluded from the
+    /// elapsed clock. No-op if not currently paused.
+    func resumeRecording() {
+        guard isPaused else { return }
+        session.resume()
+    }
+
+    /// Toggle between paused and recording. Bound to the Pause/Resume UI
+    /// controls and safe to call from a keyboard shortcut / menu.
+    func togglePause() {
+        if isPaused {
+            resumeRecording()
+        } else {
+            pauseRecording()
+        }
+    }
 }
+

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -1229,9 +1229,14 @@ final class QuickActionsController: ObservableObject {
     /// during the pause is written to the WAV or the live transcript. The
     /// VAD utterance in progress is flushed so it doesn't span the gap.
     /// No-op if not recording or already finalizing.
-    func pauseRecording() {
+    ///
+    /// Async because `session.pause()` writes out the system-audio tail that
+    /// was parked at the pause instant. Ordering matters: that tail is
+    /// pre-pause audio and reaches the transcriber through `onLiveSamples`,
+    /// so the detector's pause boundary has to come after it.
+    func pauseRecording() async {
         guard isRecording, !isFinalizingRecording, !isPaused else { return }
-        session.pause()
+        await session.pause()
         liveTranscriber?.pauseBoundary()
     }
 
@@ -1245,12 +1250,11 @@ final class QuickActionsController: ObservableObject {
 
     /// Toggle between paused and recording. Bound to the Pause/Resume UI
     /// controls and safe to call from a keyboard shortcut / menu.
-    func togglePause() {
+    func togglePause() async {
         if isPaused {
             resumeRecording()
         } else {
-            pauseRecording()
+            await pauseRecording()
         }
     }
 }
-

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -961,7 +961,7 @@ struct MilaApp: App {
                     }
                     await Self.pumpFixtureWAVOnce(path: wavPath, to: sessionRef, agcEnabled: true)
                 }
-            case .stopping:
+            case .paused, .stopping:
                 break
             case .idle:
                 pumpTask?.cancel()
@@ -1200,9 +1200,18 @@ struct MilaApp: App {
         // The state observer below runs forever now; the `.recording`
         // branch is where we gate on `aiSettings.isLiveAIAvailable`.
 
+        var priorLiveState: RecordingSession.State = .idle
         for await state in sessionRef.$state.values {
+            let previousLiveState = priorLiveState
+            priorLiveState = state
             switch state {
             case .recording:
+                // Resume from pause: the live pipeline is already wired and
+                // the accumulated transcript is intact. Re-running the setup
+                // below would call `transcriber.start()`, which resets
+                // `segments` / `fullText` and wipes everything the user has
+                // seen so far. A pause→resume must be a no-op here.
+                if previousLiveState == .paused { break }
                 guard aiSettings.isLiveAIAvailable else {
                     // Hardware below the Live AI bar AND no override
                     // flipped. Recording still runs via RecordingSession;
@@ -1351,6 +1360,13 @@ struct MilaApp: App {
                         }
                     }
                 }
+            case .paused:
+                // A pause suspends capture but keeps the whole live
+                // pipeline intact — RecordingSession simply drops incoming
+                // audio while paused, so the transcriber / diarizer / feed
+                // loop just see a gap and pick back up on resume. No
+                // teardown (that only happens on `.idle`).
+                break
             case .stopping:
                 // Don't tear down yet — RecordingSession.stop() still
                 // flushes the buffered system-audio tail during

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -988,8 +988,11 @@ struct MilaApp: App {
         let chunkSamples = Int(sampleRate * 0.02)  // 20ms
         let startedAt = Date()
         var pumped = 0
+        var pausedFor: TimeInterval = 0
         var offset = 0
         while offset < samples.count {
+            if Task.isCancelled { return }
+            pausedFor += await Self.waitWhilePaused(session)
             if Task.isCancelled { return }
             let end = min(offset + chunkSamples, samples.count)
             var chunk = Array(samples[offset..<end])
@@ -1000,12 +1003,32 @@ struct MilaApp: App {
             offset = end
             pumped += chunk.count
             let elapsedTarget = Double(pumped) / sampleRate
-            let elapsedReal = Date().timeIntervalSince(startedAt)
+            let elapsedReal = Date().timeIntervalSince(startedAt) - pausedFor
             if elapsedTarget > elapsedReal {
                 let napNs = UInt64((elapsedTarget - elapsedReal) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: napNs)
             }
         }
+    }
+
+    /// Hold an injection pump while the session is paused, and report how
+    /// long the hold lasted.
+    ///
+    /// The pumps feed `session.onLiveSamples` directly, which sits
+    /// DOWNSTREAM of `RecordingSession`'s paused capture gate — so without
+    /// this they'd keep pushing fixture audio into the live transcriber
+    /// across a pause, and any UI test of pause/resume would be asserting
+    /// against behaviour production doesn't have. Returning the paused
+    /// duration lets the caller shift its real-time pacing baseline; without
+    /// that it would think it had fallen behind and dump the whole paused
+    /// span in one un-paced burst on resume.
+    private static func waitWhilePaused(_ session: RecordingSession) async -> TimeInterval {
+        guard session.state == .paused else { return 0 }
+        let began = Date()
+        while session.state == .paused, !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return Date().timeIntervalSince(began)
     }
 
     /// Read a 16kHz mono WAV from disk and feed it to
@@ -1039,6 +1062,7 @@ struct MilaApp: App {
         let chunkSamples = Int(sampleRate * 0.02)  // 20ms
         let startedAt = Date()
         var pumped = 0
+        var pausedFor: TimeInterval = 0
         // Loop the fixture indefinitely — the test runs for ~2 min but
         // our generated fixture is only ~70s. Without looping, segments
         // plateau halfway through the test and the "no 30s stall"
@@ -1047,6 +1071,9 @@ struct MilaApp: App {
         while !Task.isCancelled {
             var offset = 0
             while offset < samples.count {
+                if Task.isCancelled { return }
+                // Mirror the production capture gate — see `waitWhilePaused`.
+                pausedFor += await Self.waitWhilePaused(session)
                 if Task.isCancelled { return }
                 let end = min(offset + chunkSamples, samples.count)
                 // Copy out the chunk so we can mutate it in place
@@ -1059,9 +1086,10 @@ struct MilaApp: App {
                 offset = end
                 pumped += chunk.count
                 // Pace ourselves: stay one chunk's worth ahead of wall
-                // clock so VAD / whisper run at real-time speed.
+                // clock so VAD / whisper run at real-time speed. The paused
+                // span doesn't count as wall clock we've fallen behind.
                 let elapsedTarget = Double(pumped) / sampleRate
-                let elapsedReal = Date().timeIntervalSince(startedAt)
+                let elapsedReal = Date().timeIntervalSince(startedAt) - pausedFor
                 if elapsedTarget > elapsedReal {
                     let napNs = UInt64((elapsedTarget - elapsedReal) * 1_000_000_000)
                     try? await Task.sleep(nanoseconds: napNs)
@@ -1200,18 +1228,28 @@ struct MilaApp: App {
         // The state observer below runs forever now; the `.recording`
         // branch is where we gate on `aiSettings.isLiveAIAvailable`.
 
-        var priorLiveState: RecordingSession.State = .idle
+        // Epoch of the capture this observer has already wired. `nil` until
+        // the first recording.
+        var wiredCaptureEpoch: Int?
         for await state in sessionRef.$state.values {
-            let previousLiveState = priorLiveState
-            priorLiveState = state
             switch state {
             case .recording:
-                // Resume from pause: the live pipeline is already wired and
-                // the accumulated transcript is intact. Re-running the setup
-                // below would call `transcriber.start()`, which resets
-                // `segments` / `fullText` and wipes everything the user has
-                // seen so far. A pause→resume must be a no-op here.
-                if previousLiveState == .paused { break }
+                // `.recording` is published twice per recording that gets
+                // paused: once at start, once on resume. Only the first is a
+                // new recording — re-running the setup below on a resume
+                // would call `transcriber.start()`, which resets `segments` /
+                // `fullText` and wipes the entire transcript the user has
+                // been reading.
+                //
+                // Keyed on the session's capture epoch rather than on the
+                // previously-observed state, because the `.paused` in between
+                // is not guaranteed to be delivered: `@Published` drops values
+                // published while its `.values` consumer has no outstanding
+                // demand, so a fast pause→resume can arrive here as a bare
+                // second `.recording`. The epoch only moves on a real
+                // `start()`, so it cannot be fooled that way.
+                if wiredCaptureEpoch == sessionRef.captureEpoch { break }
+                wiredCaptureEpoch = sessionRef.captureEpoch
                 guard aiSettings.isLiveAIAvailable else {
                     // Hardware below the Live AI bar AND no override
                     // flipped. Recording still runs via RecordingSession;

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -212,6 +212,19 @@ final class LiveTranscriber: ObservableObject {
         }
     }
 
+    /// Called when the recording is paused. In VAD mode, close the current
+    /// utterance at the pause point — otherwise resume would append post-pause
+    /// audio onto the same utterance, gluing the two sides of the gap into a
+    /// single segment with a bogus duration. Uses `flushForPause()` (not
+    /// `flush()`) so the detector's recording clock is preserved: post-resume
+    /// utterances keep their absolute timestamps instead of restarting at 0.
+    /// The fixed-window path keeps a plain rolling buffer with no in-flight
+    /// utterance to close, so this is a no-op there (paused audio simply
+    /// never arrives via `ingest`).
+    func pauseBoundary() {
+        detector?.flushForPause()
+    }
+
     func transcribeNow() async {
         if let detector {
             // End-of-recording flush: force-emit any in-progress

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -10,7 +10,7 @@ private let recLog = Logger(subsystem: "io.island.whisper.IslandWhisper", catego
 /// Orchestrates microphone + system audio capture into a single mono 16kHz WAV file.
 @MainActor
 final class RecordingSession: ObservableObject {
-    enum State { case idle, recording, stopping }
+    enum State { case idle, recording, paused, stopping }
     @Published private(set) var state: State = .idle
     @Published private(set) var elapsed: TimeInterval = 0
     @Published private(set) var micLevel: Float = 0
@@ -39,6 +39,17 @@ final class RecordingSession: ObservableObject {
     private(set) var fileURL: URL?
     private var audioFile: AVAudioFile?
     private var startTime: Date?
+    /// Wall-clock instant the current pause began. `nil` unless
+    /// `state == .paused`. Used to accumulate `totalPaused` on resume so
+    /// `elapsed` never counts paused time.
+    private var pausedAt: Date?
+    /// Total wall-clock time spent paused so far this session. Subtracted
+    /// from the raw `now - startTime` so `elapsed` reflects only the audio
+    /// that actually made it into the WAV (paused spans are dropped by the
+    /// capture-gate in `consumeMic` / `consumeSystem`), keeping `elapsed`
+    /// aligned with both the on-disk duration and the live segment
+    /// timestamps.
+    private var totalPaused: TimeInterval = 0
     private var timerTask: Task<Void, Never>?
     private var micTask: Task<Void, Never>?
     private var systemTask: Task<Void, Never>?
@@ -147,15 +158,66 @@ final class RecordingSession: ObservableObject {
         }
 
         startTime = Date()
+        pausedAt = nil
+        totalPaused = 0
         state = .recording
+        startElapsedTimer()
+    }
+
+    /// Drives the `elapsed` clock while a session is active. Kept running
+    /// across pauses (`state == .paused`) but only advances the published
+    /// value while `.recording`, so a pause freezes the timer instead of
+    /// letting it jump forward by the paused span on resume.
+    private func startElapsedTimer() {
+        timerTask?.cancel()
         timerTask = Task { @MainActor [weak self] in
-            while let self, self.state == .recording {
-                if let start = self.startTime {
-                    self.elapsed = Date().timeIntervalSince(start)
+            while let self, self.state == .recording || self.state == .paused {
+                if self.state == .recording, let start = self.startTime {
+                    self.elapsed = Self.elapsed(now: Date(), startTime: start,
+                                                totalPaused: self.totalPaused)
                 }
                 try? await Task.sleep(nanoseconds: 200_000_000)
             }
         }
+    }
+
+    /// Pure elapsed-time computation: raw wall clock since `startTime`
+    /// minus the time already spent paused. Factored out so the
+    /// pause-accounting math is unit-testable without an audio engine.
+    static func elapsed(now: Date, startTime: Date, totalPaused: TimeInterval) -> TimeInterval {
+        max(0, now.timeIntervalSince(startTime) - totalPaused)
+    }
+
+    /// Suspend capture without tearing down the engine. While paused,
+    /// `consumeMic` / `consumeSystem` drop every incoming buffer, so nothing
+    /// is written to the WAV or forwarded to the live transcriber — the
+    /// paused span is genuinely absent from the recording. The mic /
+    /// system-audio engines keep running (we just discard their output)
+    /// rather than stopping, which avoids the fragile fresh-engine-per-
+    /// session bring-up on resume.
+    func pause() {
+        guard state == .recording else { return }
+        pausedAt = Date()
+        // Drop any system-audio the jitter buffer parked before the pause so
+        // it isn't mixed in on resume — otherwise a pre-pause tail would be
+        // glued onto post-pause audio with the paused gap collapsed out.
+        pendingSystem.removeAll(keepingCapacity: false)
+        state = .paused
+        recLog.log("pause: source=\(self.source.rawValue, privacy: .public) elapsed=\(self.elapsed, privacy: .public)")
+    }
+
+    /// Resume a paused session. Accumulates the just-finished pause into
+    /// `totalPaused` so `elapsed` skips it, and clears any system-audio that
+    /// arrived while paused before capture resumes.
+    func resume() {
+        guard state == .paused else { return }
+        if let pausedAt {
+            totalPaused += Date().timeIntervalSince(pausedAt)
+        }
+        pausedAt = nil
+        pendingSystem.removeAll(keepingCapacity: false)
+        state = .recording
+        recLog.log("resume: source=\(self.source.rawValue, privacy: .public) totalPaused=\(self.totalPaused, privacy: .public)")
     }
 
     /// UI-test seam: flip state to .recording without spinning up
@@ -176,19 +238,14 @@ final class RecordingSession: ObservableObject {
         // Skip AVAudioFile setup — the test injects samples directly
         // into onLiveSamples; nothing should be writing to disk.
         startTime = Date()
+        pausedAt = nil
+        totalPaused = 0
         state = .recording
-        timerTask = Task { @MainActor [weak self] in
-            while let self, self.state == .recording {
-                if let start = self.startTime {
-                    self.elapsed = Date().timeIntervalSince(start)
-                }
-                try? await Task.sleep(nanoseconds: 200_000_000)
-            }
-        }
+        startElapsedTimer()
     }
 
     func stop() async -> URL? {
-        guard state == .recording else { return fileURL }
+        guard state == .recording || state == .paused else { return fileURL }
         state = .stopping
         // Snapshot the mic frame count BEFORE teardown so the caller can tell
         // a genuinely-empty mic session apart from a normal one. A fake
@@ -211,6 +268,8 @@ final class RecordingSession: ObservableObject {
         audioFile = nil
         fileURL = nil
         startTime = nil
+        pausedAt = nil
+        totalPaused = 0
         elapsed = 0
         isFakeForTesting = false
         state = .idle
@@ -231,6 +290,8 @@ final class RecordingSession: ObservableObject {
         audioFile = nil
         fileURL = nil
         startTime = nil
+        pausedAt = nil
+        totalPaused = 0
         elapsed = 0
         isFakeForTesting = false
         pendingSystem.removeAll(keepingCapacity: false)
@@ -240,6 +301,10 @@ final class RecordingSession: ObservableObject {
     // MARK: - Mixing
 
     private func consumeMic(_ buffer: AVAudioPCMBuffer) async {
+        // Paused: discard the buffer entirely so nothing reaches the WAV or
+        // the live transcriber. The engine keeps running; we just drop its
+        // output until `resume()`.
+        guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
         await MainActor.run { self.micLevel = AudioMeter.level(from: buffer) }
         if source == .microphone {
@@ -263,6 +328,10 @@ final class RecordingSession: ObservableObject {
     }
 
     private func consumeSystem(_ buffer: AVAudioPCMBuffer) async {
+        // Paused: drop system audio too (both the inline `.systemAudio`
+        // write and the `.meeting` jitter-buffer append) so the paused span
+        // is absent from the recording.
+        guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
         await MainActor.run { self.systemLevel = AudioMeter.level(from: buffer) }
         if source == .systemAudio {

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -50,6 +50,22 @@ final class RecordingSession: ObservableObject {
     /// aligned with both the on-disk duration and the live segment
     /// timestamps.
     private var totalPaused: TimeInterval = 0
+    /// Monotonic id for the current capture, bumped by `start()` /
+    /// `startFakeForTesting()` and by nothing else — in particular NOT by
+    /// `pause()` / `resume()`.
+    ///
+    /// Exists so a `$state` observer can tell "a brand-new recording began"
+    /// from "the same recording came back from a pause" WITHOUT having to
+    /// see every intermediate state. That distinction can't be made by
+    /// remembering the previously-observed state: `@Published` drops values
+    /// published while its `.values` async consumer has no outstanding
+    /// demand, so a quick pause→resume (a double-tap on the Pause button, or
+    /// a hotkey pressed twice) can surface to the observer as a bare second
+    /// `.recording` with the `.paused` in between never delivered. Treating
+    /// that as a new recording re-runs live-pipeline setup and
+    /// `transcriber.start()` wipes `segments` / `fullText` — the whole
+    /// transcript the user has been reading.
+    private(set) var captureEpoch: Int = 0
     private var timerTask: Task<Void, Never>?
     private var micTask: Task<Void, Never>?
     private var systemTask: Task<Void, Never>?
@@ -160,6 +176,7 @@ final class RecordingSession: ObservableObject {
         startTime = Date()
         pausedAt = nil
         totalPaused = 0
+        captureEpoch += 1
         state = .recording
         startElapsedTimer()
     }
@@ -191,30 +208,65 @@ final class RecordingSession: ObservableObject {
     /// Suspend capture without tearing down the engine. While paused,
     /// `consumeMic` / `consumeSystem` drop every incoming buffer, so nothing
     /// is written to the WAV or forwarded to the live transcriber — the
-    /// paused span is genuinely absent from the recording. The mic /
-    /// system-audio engines keep running (we just discard their output)
-    /// rather than stopping, which avoids the fragile fresh-engine-per-
-    /// session bring-up on resume.
-    func pause() {
+    /// paused span is genuinely absent from the recording.
+    ///
+    /// The mic / system-audio engines keep RUNNING (we just discard their
+    /// output) rather than stopping. Two reasons:
+    ///
+    ///  1. It avoids a fresh-engine-per-resume bring-up, which is the
+    ///     fragile part of capture (see `MicrophoneRecorder`'s notes on
+    ///     CoreAudio stalling for seconds on a wireless mic profile switch).
+    ///  2. It keeps `MicrophoneRecorder`'s stall watchdog honest. That
+    ///     watchdog rebuilds the engine when `MicFrameStats.frames` stops
+    ///     growing — but that counter is incremented **inside the audio tap**,
+    ///     upstream of the paused gate below, so it keeps advancing for the
+    ///     whole pause and the watchdog never sees a flatline. Stopping the
+    ///     engine here, or gating the tap instead of gating downstream, would
+    ///     make a pause look exactly like a dead input device and hand the
+    ///     watchdog a rebuild it must not perform.
+    ///
+    /// The watchdog is deliberately left ARMED across a pause: if the input
+    /// device really does die while paused, we want it repaired before the
+    /// user resumes, not four seconds after.
+    func pause() async {
         guard state == .recording else { return }
         pausedAt = Date()
-        // Drop any system-audio the jitter buffer parked before the pause so
-        // it isn't mixed in on resume — otherwise a pre-pause tail would be
-        // glued onto post-pause audio with the paused gap collapsed out.
-        pendingSystem.removeAll(keepingCapacity: false)
+        // Flip the gate FIRST so nothing else lands in `pendingSystem` while
+        // the flush below awaits.
         state = .paused
+        // Meeting mode parks system audio here for the mic clock to consume.
+        // Whatever is parked at the pause instant is audio the other side
+        // already produced BEFORE the pause, so write it out (system-only, at
+        // full scale — exactly what `stop()` does with the same tail) instead
+        // of discarding it. Discarding is normally a sub-100ms loss, but the
+        // buffer holds up to 30s when the mic clock is stalled (display
+        // sleep/wake), and losing half a minute of the other side of a meeting
+        // to a Pause tap is not a trade the user agreed to.
+        await flushPendingSystemTail()
+        // The meters are driven from `consumeMic` / `consumeSystem`, which
+        // stop running now — without this they'd sit frozen at their last
+        // pre-pause reading and read as "still listening".
+        micLevel = 0
+        systemLevel = 0
         recLog.log("pause: source=\(self.source.rawValue, privacy: .public) elapsed=\(self.elapsed, privacy: .public)")
     }
 
     /// Resume a paused session. Accumulates the just-finished pause into
-    /// `totalPaused` so `elapsed` skips it, and clears any system-audio that
-    /// arrived while paused before capture resumes.
+    /// `totalPaused` so `elapsed` skips it, and clears any system audio that
+    /// slipped in while paused before capture resumes.
     func resume() {
         guard state == .paused else { return }
         if let pausedAt {
             totalPaused += Date().timeIntervalSince(pausedAt)
         }
         pausedAt = nil
+        // `consumeSystem` checks the state gate and then awaits before
+        // appending, so a buffer that passed the gate just as `pause()` ran
+        // can still land in the buffer afterwards. Anything sitting here now
+        // is therefore either that straggler or a leftover the pause flush
+        // raced — either way it predates the gap, and mixing it into the
+        // post-resume audio would glue the two sides of the pause together
+        // with the gap collapsed out. Drop it.
         pendingSystem.removeAll(keepingCapacity: false)
         state = .recording
         recLog.log("resume: source=\(self.source.rawValue, privacy: .public) totalPaused=\(self.totalPaused, privacy: .public)")
@@ -240,6 +292,7 @@ final class RecordingSession: ObservableObject {
         startTime = Date()
         pausedAt = nil
         totalPaused = 0
+        captureEpoch += 1
         state = .recording
         startElapsedTimer()
     }
@@ -306,7 +359,12 @@ final class RecordingSession: ObservableObject {
         // output until `resume()`.
         guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
-        await MainActor.run { self.micLevel = AudioMeter.level(from: buffer) }
+        // Assign directly instead of hopping through `MainActor.run`: the
+        // whole class is already `@MainActor`, so the hop bought nothing and
+        // cost a suspension point — one a `pause()` could land inside, which
+        // would leave the meter lit at a live-looking level for the rest of
+        // the pause with nothing still running to clear it.
+        micLevel = AudioMeter.level(from: buffer)
         if source == .microphone {
             // Mic-only: the live feed and the saved file are both just the
             // mic, so drive the live transcriber here and write directly.
@@ -333,7 +391,8 @@ final class RecordingSession: ObservableObject {
         // is absent from the recording.
         guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
-        await MainActor.run { self.systemLevel = AudioMeter.level(from: buffer) }
+        // Direct assignment for the same reason as `consumeMic` — see there.
+        systemLevel = AudioMeter.level(from: buffer)
         if source == .systemAudio {
             // No mic to clock against — system audio IS the recording.
             // write() drives the live feed for `.systemAudio`.

--- a/Mila/Audio/UtteranceDetector.swift
+++ b/Mila/Audio/UtteranceDetector.swift
@@ -112,6 +112,13 @@ final class UtteranceDetector {
     private var partial: [Float] = []
     private var samplesIngested: Int = 0
     private var currentStartSample: Int = 0
+    /// Absolute recording-time seconds already elapsed BEFORE the current
+    /// `samplesIngested` counter (which restarts at 0 after a pause
+    /// boundary). Added to every emitted `startSec` so timestamps stay on
+    /// one continuous recording clock across pause/resume. Paused audio is
+    /// never ingested (RecordingSession drops it), so this stays aligned
+    /// with the gapless WAV — no gap is introduced for the paused span.
+    private var clockOffset: Double = 0
     /// Rolling estimate of the room's background RMS, tracked only
     /// during `.silence`. The effective absolute cutoff is
     /// `max(rmsThreshold, noiseFloor * noiseFloorMultiplier)` — so a
@@ -195,6 +202,23 @@ final class UtteranceDetector {
         clearAllState()
     }
 
+    /// Pause boundary: force-emit any in-progress utterance (so post-resume
+    /// audio isn't glued onto it across the paused gap) but PRESERVE the
+    /// recording clock. Unlike `flush()`, which zeroes the sample counter for
+    /// end-of-recording, this folds the audio ingested so far into
+    /// `clockOffset` before the state wipe, so utterances emitted after the
+    /// resume keep their absolute recording-time timestamps. Paused audio is
+    /// never ingested (RecordingSession drops it while paused), so the clock
+    /// stays aligned with the gapless WAV — no gap is introduced.
+    func flushForPause() {
+        let elapsed = clockOffset + Double(samplesIngested) / sampleRate
+        if state == .speech, speechFramesInCurrent >= minUtteranceFrames {
+            emit()
+        }
+        clearAllState()
+        clockOffset = elapsed
+    }
+
     /// Shared state-wipe used by both `reset()` and `flush()`. Wipes
     /// the state machine, in-progress utterance, pre-roll ring buffer,
     /// pending-speech onset buffer, partial-frame accumulator, sample
@@ -211,6 +235,7 @@ final class UtteranceDetector {
         partial.removeAll(keepingCapacity: true)
         samplesIngested = 0
         currentStartSample = 0
+        clockOffset = 0
         noiseFloor = 0.001
         signalEnvelope = 0
         pendingSpeechFrames = 0
@@ -389,7 +414,7 @@ final class UtteranceDetector {
     }
 
     private func emit() {
-        let startSec = max(0, Double(currentStartSample) / sampleRate)
+        let startSec = max(0, clockOffset + Double(currentStartSample) / sampleRate)
         let dur = Double(current.count) / sampleRate
         vadLog.log("VAD emit utterance: startSec=\(startSec, privacy: .public) dur=\(dur, privacy: .public)s noiseFloor=\(self.noiseFloor, privacy: .public) envelope=\(self.signalEnvelope, privacy: .public) speechFrames=\(self.speechFramesInCurrent, privacy: .public)")
         onUtterance?(current, startSec)

--- a/Mila/Audio/UtteranceDetector.swift
+++ b/Mila/Audio/UtteranceDetector.swift
@@ -210,8 +210,14 @@ final class UtteranceDetector {
     /// resume keep their absolute recording-time timestamps. Paused audio is
     /// never ingested (RecordingSession drops it while paused), so the clock
     /// stays aligned with the gapless WAV — no gap is introduced.
+    ///
+    /// `partial` counts towards the offset even though `clearAllState()` is
+    /// about to throw it away: those samples are in the WAV, they just
+    /// hadn't filled a whole VAD frame yet. Leaving them out would run the
+    /// post-resume clock up to one frame (30ms) early against the file, and
+    /// the error would compound across pauses.
     func flushForPause() {
-        let elapsed = clockOffset + Double(samplesIngested) / sampleRate
+        let elapsed = clockOffset + Double(samplesIngested + partial.count) / sampleRate
         if state == .speech, speechFramesInCurrent >= minUtteranceFrames {
             emit()
         }

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -487,13 +487,17 @@ private struct RecordingChip: View {
     @EnvironmentObject private var session: RecordingSession
 
     var body: some View {
-        HStack(spacing: 10) {
+        // One read of the paused state for the whole chip — the dot, the
+        // clock and the capsule border must agree, or a paused recording
+        // still reads as live from the border alone.
+        let paused = session.state == .paused
+        return HStack(spacing: 10) {
             Circle()
-                .fill(session.state == .paused ? Color.orange : Color.red)
+                .fill(paused ? Color.orange : Color.red)
                 .frame(width: 8, height: 8)
             Text(formatDuration(session.elapsed))
                 .font(.callout.monospacedDigit())
-                .foregroundStyle(session.state == .paused ? .orange : .primary)
+                .foregroundStyle(paused ? .orange : .primary)
             // `RecordingPauseButton` applies its own `.buttonStyle(.plain)`
             // internally (closest-to-the-Button wins), so don't restate a
             // style here — it would read as doing something and do nothing.
@@ -511,7 +515,7 @@ private struct RecordingChip: View {
         .padding(.vertical, 6)
         .background(.regularMaterial, in: Capsule())
         .overlay(
-            Capsule().strokeBorder(Color.red.opacity(0.4), lineWidth: 1)
+            Capsule().strokeBorder((paused ? Color.orange : Color.red).opacity(0.4), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.1), radius: 6, y: 2)
     }

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -489,10 +489,13 @@ private struct RecordingChip: View {
     var body: some View {
         HStack(spacing: 10) {
             Circle()
-                .fill(Color.red)
+                .fill(session.state == .paused ? Color.orange : Color.red)
                 .frame(width: 8, height: 8)
             Text(formatDuration(session.elapsed))
                 .font(.callout.monospacedDigit())
+                .foregroundStyle(session.state == .paused ? .orange : .primary)
+            RecordingPauseButton(compact: true)
+                .buttonStyle(.borderless)
             Button {
                 Task { await actions.stopRecording() }
             } label: {

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -494,8 +494,10 @@ private struct RecordingChip: View {
             Text(formatDuration(session.elapsed))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(session.state == .paused ? .orange : .primary)
+            // `RecordingPauseButton` applies its own `.buttonStyle(.plain)`
+            // internally (closest-to-the-Button wins), so don't restate a
+            // style here — it would read as doing something and do nothing.
             RecordingPauseButton(compact: true)
-                .buttonStyle(.borderless)
             Button {
                 Task { await actions.stopRecording() }
             } label: {

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -49,8 +49,7 @@ struct HomeView: View {
                     // Pause/Resume sits under the hero Record/Stop button so
                     // it's reachable even in Live AI background mode, where
                     // the app stays on Home instead of the split-pane view.
-                    RecordingPauseButton()
-                        .controlSize(.large)
+                    RecordingPauseButton(prominent: true)
                 }
                 dictationHint
             }

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -45,6 +45,13 @@ struct HomeView: View {
                 header
                 heroAction
                 sourceToggles
+                if actions.isRecording {
+                    // Pause/Resume sits under the hero Record/Stop button so
+                    // it's reachable even in Live AI background mode, where
+                    // the app stays on Home instead of the split-pane view.
+                    RecordingPauseButton()
+                        .controlSize(.large)
+                }
                 dictationHint
             }
             .padding(.horizontal, 24)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -667,7 +667,7 @@ struct RecordingPauseButton: View {
     var body: some View {
         let paused = session.state == .paused
         Button {
-            actions.togglePause()
+            Task { await actions.togglePause() }
         } label: {
             if compact {
                 Image(systemName: paused ? "play.fill" : "pause.fill")

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -663,6 +663,16 @@ struct RecordingPauseButton: View {
     /// Icon-only rendering for the compact floating chip; labeled pill
     /// everywhere else.
     var compact: Bool = false
+    /// Hero sizing, for the Home screen where this sits directly under the
+    /// large Record/Stop button and would otherwise look like an afterthought.
+    ///
+    /// A size knob rather than `.controlSize(.large)` at the call site: this
+    /// button uses `.buttonStyle(.plain)` with its own hardcoded padding, and
+    /// `controlSize` only reaches the *built-in* styles — against a plain
+    /// style it silently does nothing. Same trap as restating `.buttonStyle`
+    /// here, and worth an explicit parameter rather than a modifier that
+    /// reads as doing something and doesn't.
+    var prominent: Bool = false
 
     var body: some View {
         let paused = session.state == .paused
@@ -676,12 +686,12 @@ struct RecordingPauseButton: View {
                 HStack(spacing: 6) {
                     Image(systemName: paused ? "play.fill" : "pause.fill")
                     Text(paused ? "Resume" : "Pause")
-                        .font(.callout.weight(.semibold))
+                        .font((prominent ? Font.body : Font.callout).weight(.semibold))
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
+                .padding(.horizontal, prominent ? 16 : 10)
+                .padding(.vertical, prominent ? 10 : 6)
                 .background(Color.primary.opacity(0.08),
-                            in: RoundedRectangle(cornerRadius: 8))
+                            in: RoundedRectangle(cornerRadius: prominent ? 10 : 8))
             }
         }
         .buttonStyle(.plain)

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -112,6 +112,8 @@ struct LiveAIRecordingView: View {
             // the Home Record button to confirm it isn't stuck "Finalizing").
             .accessibilityIdentifier("liveAI.stop")
 
+            RecordingPauseButton()
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(aiActive ? "Recording — Live AI" : "Recording")
                     .font(.callout.weight(.semibold))
@@ -638,9 +640,55 @@ private struct RecordingElapsedLabel: View {
 
     var body: some View {
         let t = Int(session.elapsed.rounded())
-        Text(String(format: "%02d:%02d", t / 60, t % 60))
+        let clock = String(format: "%02d:%02d", t / 60, t % 60)
+        // Show "Paused" alongside the (frozen) clock so the user gets clear
+        // feedback that capture is suspended. This leaf already observes the
+        // session, so folding the paused state in here keeps the larger
+        // view body from re-rendering.
+        Text(session.state == .paused ? "Paused · \(clock)" : clock)
             .font(.caption.monospacedDigit())
-            .foregroundStyle(.secondary)
+            .foregroundStyle(session.state == .paused ? .orange : .secondary)
+    }
+}
+
+/// Pause / Resume control for the active recording. Isolated as a leaf that
+/// observes `RecordingSession` so its paused-state flip doesn't re-render
+/// larger views (which the session's high-frequency level updates would
+/// otherwise churn). Pausing drops all audio until resume, so nothing said
+/// during the pause is recorded. Used by the Live AI header, Home, and the
+/// floating recording chip.
+struct RecordingPauseButton: View {
+    @EnvironmentObject private var actions: QuickActionsController
+    @EnvironmentObject private var session: RecordingSession
+    /// Icon-only rendering for the compact floating chip; labeled pill
+    /// everywhere else.
+    var compact: Bool = false
+
+    var body: some View {
+        let paused = session.state == .paused
+        Button {
+            actions.togglePause()
+        } label: {
+            if compact {
+                Image(systemName: paused ? "play.fill" : "pause.fill")
+                    .foregroundStyle(paused ? Color.accentColor : .primary)
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: paused ? "play.fill" : "pause.fill")
+                    Text(paused ? "Resume" : "Pause")
+                        .font(.callout.weight(.semibold))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.primary.opacity(0.08),
+                            in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(actions.isFinalizingRecording)
+        .help(paused ? "Resume recording" : "Pause recording (audio during the pause isn't recorded)")
+        .accessibilityLabel(paused ? "Resume recording" : "Pause recording")
+        .accessibilityIdentifier(paused ? "recording.resume" : "recording.pause")
     }
 }
 

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -141,6 +141,30 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    /// Pausing mid-utterance must cut the current VAD utterance cleanly:
+    /// `pauseBoundary()` flushes the detector so the in-progress speech is
+    /// emitted at the pause point instead of being glued onto whatever is
+    /// said after resume. Without a boundary, the detector holds the speech
+    /// until it next sees ≥400ms of silence.
+    func test_pauseBoundary_emits_in_progress_VAD_utterance() async {
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "midway")])
+        transcriber.useVAD = true
+        transcriber.start(language: "en")
+        // 1.2s of speech energy with NO trailing silence — the detector
+        // holds it as an in-progress utterance that wouldn't emit on its own.
+        let speech = Array(repeating: Float(0.05), count: 16_000 * 12 / 10)
+        transcriber.ingest(ArraySlice(speech))
+        XCTAssertTrue(transcriber.segments.isEmpty,
+                      "utterance shouldn't emit before a silence/pause boundary")
+
+        transcriber.pauseBoundary()
+        // Await the transcribe the flush scheduled.
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["midway"],
+                       "pauseBoundary should flush the in-progress utterance to whisper")
+        _ = transcriber.stop()
+    }
+
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "first"),

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -72,16 +72,16 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertTrue(controller.isRecording)
         XCTAssertFalse(controller.isPaused)
 
-        controller.pauseRecording()
+        await controller.pauseRecording()
         XCTAssertTrue(controller.isPaused)
         XCTAssertTrue(session.state == .paused)
 
         // Double-pause is a no-op — stays paused.
-        controller.pauseRecording()
+        await controller.pauseRecording()
         XCTAssertTrue(session.state == .paused)
 
         // togglePause resumes.
-        controller.togglePause()
+        await controller.togglePause()
         XCTAssertFalse(controller.isPaused)
         XCTAssertTrue(session.state == .recording)
 
@@ -90,13 +90,47 @@ final class QuickActionsControllerTests: XCTestCase {
 
     /// Pause/resume are guarded no-ops when nothing is recording, so a
     /// stray keyboard shortcut / menu action can't corrupt session state.
-    func test_pause_is_noop_when_not_recording() {
+    func test_pause_is_noop_when_not_recording() async {
         XCTAssertFalse(controller.isRecording)
-        controller.pauseRecording()
+        await controller.pauseRecording()
         XCTAssertFalse(controller.isPaused)
         XCTAssertTrue(session.state == .idle)
         controller.resumeRecording()
         XCTAssertTrue(session.state == .idle)
+    }
+
+    /// Pause is refused while the previous recording is finalizing. The
+    /// finalize window tears the live pipeline down; letting a Pause land in
+    /// it would move the session out from under `stopRecording`.
+    func test_pause_is_refused_while_finalizing() async {
+        let url = store.freshAudioURL(suggestedName: "PauseFinalizing")
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        controller.isFinalizingRecording = true
+        await controller.pauseRecording()
+        XCTAssertFalse(controller.isPaused,
+                       "pause must not fire while stopRecording owns the lifecycle")
+        XCTAssertTrue(session.state == .recording)
+        controller.isFinalizingRecording = false
+        _ = await session.stop()
+    }
+
+    // MARK: - Pause and the short-capture heuristic
+
+    /// `stopRecording` warns when the audio on disk is far shorter than the
+    /// wall clock — capture died mid-session. A paused span shortens the WAV
+    /// on purpose, so the warning must not fire for it. This holds only
+    /// because `session.elapsed` subtracts paused time: the wall clock handed
+    /// to the heuristic is recorded time, not door-to-door time.
+    func test_paused_span_does_not_trip_the_short_capture_warning() {
+        // 20 minutes of recording with 10 of them paused: the WAV is 10
+        // minutes and `elapsed` is 10 minutes. They agree.
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: 600, captured: 600))
+        // The regression this guards: if `elapsed` ever counted paused time
+        // again, the same recording would look like it lost half its audio.
+        XCTAssertTrue(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: 1200, captured: 600),
+            "a 600s file against a 1200s clock IS a real short capture — the point is that a pause must not produce this shape")
     }
 
     // MARK: - File import → enqueue → transcribe

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -62,6 +62,43 @@ final class QuickActionsControllerTests: XCTestCase {
         try await super.tearDown()
     }
 
+    // MARK: - Pause / resume
+
+    /// Pause and resume drive the session state through the controller.
+    /// Uses the fake-start seam so no real mic/engine is needed on CI.
+    func test_pause_and_resume_toggle_session_state() async {
+        let url = store.freshAudioURL(suggestedName: "PauseTest")
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        XCTAssertTrue(controller.isRecording)
+        XCTAssertFalse(controller.isPaused)
+
+        controller.pauseRecording()
+        XCTAssertTrue(controller.isPaused)
+        XCTAssertTrue(session.state == .paused)
+
+        // Double-pause is a no-op — stays paused.
+        controller.pauseRecording()
+        XCTAssertTrue(session.state == .paused)
+
+        // togglePause resumes.
+        controller.togglePause()
+        XCTAssertFalse(controller.isPaused)
+        XCTAssertTrue(session.state == .recording)
+
+        _ = await session.stop()
+    }
+
+    /// Pause/resume are guarded no-ops when nothing is recording, so a
+    /// stray keyboard shortcut / menu action can't corrupt session state.
+    func test_pause_is_noop_when_not_recording() {
+        XCTAssertFalse(controller.isRecording)
+        controller.pauseRecording()
+        XCTAssertFalse(controller.isPaused)
+        XCTAssertTrue(session.state == .idle)
+        controller.resumeRecording()
+        XCTAssertTrue(session.state == .idle)
+    }
+
     // MARK: - File import → enqueue → transcribe
 
     func test_transcribe_file_adds_recording_and_kicks_off_transcription() async throws {

--- a/MilaTests/RecordingSessionPauseTests.swift
+++ b/MilaTests/RecordingSessionPauseTests.swift
@@ -27,6 +27,18 @@ final class RecordingSessionPauseTests: XCTestCase {
                        0, accuracy: 0.001)
     }
 
+    /// Several pauses in one recording must all be subtracted, not just the
+    /// last one — `totalPaused` accumulates. Recomputing `elapsed`
+    /// absolutely (rather than incrementing it per tick) is also what keeps
+    /// the ≤200ms timer granularity from compounding across pauses.
+    func test_elapsed_subtracts_every_pause_in_the_session() {
+        let start = Date()
+        let now = start.addingTimeInterval(600)     // 10 min door-to-door
+        // Three pauses: 60 + 30 + 90 = 180s.
+        XCTAssertEqual(RecordingSession.elapsed(now: now, startTime: start, totalPaused: 180),
+                       420, accuracy: 0.001)
+    }
+
     // MARK: - State machine
 
     func test_pause_and_resume_toggle_state() async {
@@ -36,11 +48,11 @@ final class RecordingSessionPauseTests: XCTestCase {
         await session.startFakeForTesting(outputURL: url)
         XCTAssertTrue(session.state == .recording)
 
-        session.pause()
+        await session.pause()
         XCTAssertTrue(session.state == .paused)
 
         // Double-pause is a no-op.
-        session.pause()
+        await session.pause()
         XCTAssertTrue(session.state == .paused)
 
         session.resume()
@@ -54,10 +66,10 @@ final class RecordingSessionPauseTests: XCTestCase {
         XCTAssertTrue(session.state == .idle)
     }
 
-    func test_pause_and_resume_are_noops_when_idle() {
+    func test_pause_and_resume_are_noops_when_idle() async {
         let session = RecordingSession()
         XCTAssertTrue(session.state == .idle)
-        session.pause()
+        await session.pause()
         XCTAssertTrue(session.state == .idle)
         session.resume()
         XCTAssertTrue(session.state == .idle)
@@ -70,11 +82,161 @@ final class RecordingSessionPauseTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("pause-stop-\(UUID().uuidString).wav")
         await session.startFakeForTesting(outputURL: url)
-        session.pause()
+        await session.pause()
         XCTAssertTrue(session.state == .paused)
 
         let out = await session.stop()
         XCTAssertEqual(out, url)
         XCTAssertTrue(session.state == .idle)
+    }
+
+    /// `cancelAll()` is the crash-adjacent path — app quit, sleep, lock
+    /// screen. It must accept a paused session (its guard is `!= .idle`) and
+    /// leave nothing behind that a following recording could inherit.
+    func test_cancelAll_while_paused_returns_to_idle() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-cancel-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        await session.pause()
+
+        await session.cancelAll()
+        XCTAssertTrue(session.state == .idle)
+        XCTAssertEqual(session.elapsed, 0, accuracy: 0.001)
+        XCTAssertNil(session.fileURL)
+
+        // And the next recording starts clean rather than inheriting the
+        // abandoned pause.
+        let next = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-cancel-next-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: next)
+        XCTAssertTrue(session.state == .recording)
+        _ = await session.stop()
+    }
+
+    /// The elapsed clock must freeze for the duration of a pause and pick up
+    /// where it left off — never jump forward by the paused span on resume.
+    /// This is the accounting that keeps `elapsed` equal to the length of the
+    /// WAV, which `stopRecording`'s short-capture warning compares against.
+    func test_elapsed_clock_freezes_across_a_real_pause() async throws {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-clock-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        // Let the 200ms timer tick a couple of times.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        await session.pause()
+        let frozen = session.elapsed
+        XCTAssertGreaterThan(frozen, 0, "the timer should have ticked before the pause")
+
+        // Sit paused for meaningfully longer than the timer interval.
+        try await Task.sleep(nanoseconds: 800_000_000)
+        XCTAssertEqual(session.elapsed, frozen, accuracy: 0.001,
+                       "elapsed must not advance while paused")
+
+        session.resume()
+        let resumedAt = Date()
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let postResumeWall = Date().timeIntervalSince(resumedAt)
+        let afterResume = session.elapsed
+        XCTAssertGreaterThan(afterResume, frozen,
+                             "the clock must restart on resume")
+        // Budgeted off the MEASURED post-resume wall time rather than the
+        // requested sleep, so a loaded CI runner overshooting its sleeps
+        // can't fail this. If the 800ms pause leaked back in, `elapsed`
+        // would exceed this by roughly the length of the pause.
+        XCTAssertLessThanOrEqual(afterResume, frozen + postResumeWall + 0.3,
+                                 "the paused span leaked back into elapsed (got \(afterResume), frozen \(frozen), post-resume wall \(postResumeWall))")
+
+        _ = await session.stop()
+    }
+
+    // MARK: - Capture-recovery watchdog interaction
+
+    /// A pause must not look like a dead microphone.
+    ///
+    /// `MicrophoneRecorder`'s stall watchdog rebuilds the engine when the
+    /// capture frame count stops growing — and a self-triggering rebuild loop
+    /// is exactly the production bug in issue #147. The reason a pause is
+    /// safe is structural: the frame counter is incremented inside the audio
+    /// tap, and `pause()` gates the buffer DOWNSTREAM of that in
+    /// `consumeMic`. Pausing therefore leaves the counter advancing and the
+    /// watchdog sees a healthy device.
+    ///
+    /// This pins the policy half of that with the real detector: as long as
+    /// frames keep arriving, no stall is ever declared — however long the
+    /// pause runs.
+    func test_a_pause_that_keeps_the_tap_running_never_declares_a_stall() {
+        var detector = CaptureStallDetector(timeout: 4.0)
+        let start = Date()
+        var frames = 0
+        // Five minutes of "paused" at a realistic ~93ms tap cadence. The
+        // buffers are all being discarded by RecordingSession; the tap that
+        // feeds the counter is untouched.
+        for tick in 0..<3200 {
+            frames += 1024
+            let now = start.addingTimeInterval(Double(tick) * 0.093)
+            XCTAssertFalse(detector.observe(frames: frames, now: now),
+                           "a running tap must never read as a stall, paused or not")
+        }
+    }
+
+    /// The counterweight: if the device genuinely dies while the session is
+    /// paused, the frame count DOES flatline and the watchdog still fires.
+    /// Pause deliberately leaves the watchdog armed so the repair happens
+    /// before the user resumes rather than four seconds after.
+    func test_a_dead_device_still_stalls_while_paused() {
+        var detector = CaptureStallDetector(timeout: 4.0)
+        let start = Date()
+        XCTAssertFalse(detector.observe(frames: 1024, now: start))
+        XCTAssertFalse(detector.observe(frames: 1024, now: start.addingTimeInterval(1)))
+        XCTAssertTrue(detector.observe(frames: 1024, now: start.addingTimeInterval(4.1)),
+                      "a flatlined counter must still trip the watchdog during a pause")
+    }
+
+    // MARK: - Live-pipeline resume detection
+
+    /// `MilaApp`'s live-pipeline observer decides "new recording" vs "resumed
+    /// from a pause" off `captureEpoch`, because the `.paused` state in
+    /// between is not guaranteed to be delivered to a `@Published` async
+    /// consumer. Get this wrong and a resume re-runs `transcriber.start()`,
+    /// which wipes the transcript the user has been reading.
+    func test_captureEpoch_moves_only_on_a_new_recording() async {
+        let session = RecordingSession()
+        let first = FileManager.default.temporaryDirectory
+            .appendingPathComponent("epoch-1-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: first)
+        let epochAtStart = session.captureEpoch
+
+        await session.pause()
+        XCTAssertEqual(session.captureEpoch, epochAtStart,
+                       "pausing is not a new recording")
+        session.resume()
+        XCTAssertEqual(session.captureEpoch, epochAtStart,
+                       "resuming is not a new recording — this is the guard that saves the live transcript")
+
+        _ = await session.stop()
+        let second = FileManager.default.temporaryDirectory
+            .appendingPathComponent("epoch-2-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: second)
+        XCTAssertGreaterThan(session.captureEpoch, epochAtStart,
+                             "a genuinely new recording must be distinguishable")
+        _ = await session.stop()
+    }
+
+    // MARK: - Level meters
+
+    /// The level meters are driven from `consumeMic` / `consumeSystem`, which
+    /// stop running while paused. Without an explicit zero they'd sit frozen
+    /// at their last pre-pause reading and read as "still listening".
+    func test_pause_zeroes_the_level_meters() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-levels-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        await session.pause()
+        XCTAssertEqual(session.micLevel, 0)
+        XCTAssertEqual(session.systemLevel, 0)
+        _ = await session.stop()
     }
 }

--- a/MilaTests/RecordingSessionPauseTests.swift
+++ b/MilaTests/RecordingSessionPauseTests.swift
@@ -194,6 +194,49 @@ final class RecordingSessionPauseTests: XCTestCase {
                       "a flatlined counter must still trip the watchdog during a pause")
     }
 
+    /// The two tests above pin the *policy* — given a counter that keeps
+    /// growing, no stall is declared. They pass whether or not a pause
+    /// actually leaves the counter growing, because they drive
+    /// `CaptureStallDetector` directly.
+    ///
+    /// This pins the *structural* half they depend on: `pause()` must leave
+    /// `MicrophoneRecorder` running. The frame counter lives inside the audio
+    /// tap, so a pause that stopped the engine (or moved the gate up into the
+    /// tap) would flatline it, the watchdog would read the pause as a yanked
+    /// device, and #147's rebuild loop would be back — with both policy tests
+    /// above still green. This is the assertion that would fail instead.
+    func test_pause_leaves_the_capture_engine_running() async throws {
+        let session = RecordingSession()
+        // Bring the recorder up through its test seam, so there's a genuinely
+        // "running" recorder without a microphone. The watchdog is armed on
+        // this path too and the seam installs no tap, so the frame count never
+        // grows — a long stall timeout keeps it from firing mid-test and
+        // muddying `restartCount`.
+        session.mic.captureStallTimeout = 600
+        session.mic.bringUpOverride = { }
+        try await session.mic.start()
+        XCTAssertTrue(session.mic.isRunning)
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-engine-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+
+        await session.pause()
+        XCTAssertTrue(session.mic.isRunning,
+                      "pause() must not stop the capture engine — a stopped engine stops the frame counter, which is exactly what the stall watchdog treats as a dead device (#147)")
+        XCTAssertEqual(session.mic.restartCount, 0,
+                       "pausing must not provoke a capture rebuild")
+
+        session.resume()
+        XCTAssertTrue(session.mic.isRunning,
+                      "resume() must not depend on a fresh bring-up")
+        XCTAssertEqual(session.mic.restartCount, 0)
+
+        // Teardown stays `stop()`'s job, not `pause()`'s.
+        _ = await session.stop()
+        XCTAssertFalse(session.mic.isRunning, "stop() still tears the engine down")
+    }
+
     // MARK: - Live-pipeline resume detection
 
     /// `MilaApp`'s live-pipeline observer decides "new recording" vs "resumed

--- a/MilaTests/RecordingSessionPauseTests.swift
+++ b/MilaTests/RecordingSessionPauseTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Mila
+
+/// Tests for the pause/resume additions to `RecordingSession`. The audio
+/// engine itself can't run on CI, so these cover the parts that don't need
+/// it: the pure elapsed-time accounting and the state machine driven via
+/// the fake-start seam (`startFakeForTesting`).
+@MainActor
+final class RecordingSessionPauseTests: XCTestCase {
+
+    // MARK: - Pure elapsed accounting
+
+    func test_elapsed_excludes_paused_time() {
+        let start = Date()
+        let now = start.addingTimeInterval(30)
+        XCTAssertEqual(RecordingSession.elapsed(now: now, startTime: start, totalPaused: 0),
+                       30, accuracy: 0.001)
+        // 10s of that 30s wall-clock was spent paused → 20s of recorded time.
+        XCTAssertEqual(RecordingSession.elapsed(now: now, startTime: start, totalPaused: 10),
+                       20, accuracy: 0.001)
+    }
+
+    func test_elapsed_never_goes_negative() {
+        let start = Date()
+        // Clock skew / rounding must never produce a negative elapsed.
+        XCTAssertEqual(RecordingSession.elapsed(now: start, startTime: start, totalPaused: 5),
+                       0, accuracy: 0.001)
+    }
+
+    // MARK: - State machine
+
+    func test_pause_and_resume_toggle_state() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        XCTAssertTrue(session.state == .recording)
+
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        // Double-pause is a no-op.
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        session.resume()
+        XCTAssertTrue(session.state == .recording)
+
+        // Double-resume is a no-op.
+        session.resume()
+        XCTAssertTrue(session.state == .recording)
+
+        _ = await session.stop()
+        XCTAssertTrue(session.state == .idle)
+    }
+
+    func test_pause_and_resume_are_noops_when_idle() {
+        let session = RecordingSession()
+        XCTAssertTrue(session.state == .idle)
+        session.pause()
+        XCTAssertTrue(session.state == .idle)
+        session.resume()
+        XCTAssertTrue(session.state == .idle)
+    }
+
+    /// Stop must work while paused (the user can hit Stop without resuming
+    /// first) and return the recording's URL, landing back at `.idle`.
+    func test_stop_while_paused_returns_url_and_idles() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pause-stop-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        session.pause()
+        XCTAssertTrue(session.state == .paused)
+
+        let out = await session.stop()
+        XCTAssertEqual(out, url)
+        XCTAssertTrue(session.state == .idle)
+    }
+}

--- a/MilaTests/UtteranceDetectorTests.swift
+++ b/MilaTests/UtteranceDetectorTests.swift
@@ -200,6 +200,47 @@ final class UtteranceDetectorTests: XCTestCase {
             "Post-resume utterance must keep the absolute recording clock (~3.4s+), not restart at 0 — got \(lastStart)")
     }
 
+    /// A pause almost never lands on a 30ms VAD frame boundary: whatever the
+    /// user was doing when they hit the button, `ingest` will be holding a
+    /// sub-frame remainder in `partial`. Those samples ARE in the WAV, so the
+    /// clock offset has to count them — otherwise every post-resume timestamp
+    /// runs up to one frame early against the file, and the error compounds
+    /// across pauses.
+    ///
+    /// Drives thirty pauses at a deliberately awkward, non-frame-aligned
+    /// cadence and checks the clock against the exact amount of audio
+    /// ingested.
+    func test_flushForPause_clock_is_exact_when_the_pause_is_not_frame_aligned() {
+        let det = UtteranceDetector()
+        var starts: [Double] = []
+        det.onUtterance = { _, start in starts.append(start) }
+
+        // 7,679 samples = 15 whole 480-sample frames + a 479-sample
+        // remainder: the worst case, just short of a full frame stranded in
+        // `partial` at every boundary.
+        let oddChunk = 7_679
+        let pauses = 30
+        var totalIngested = 0
+        for _ in 0..<pauses {
+            det.ingest(ArraySlice(Array(repeating: Float(0), count: oddChunk)))
+            totalIngested += oddChunk
+            det.flushForPause()
+        }
+
+        // Now speak. The utterance's absolute start must line up with the
+        // audio ingested so far. Counting only whole frames would leave the
+        // clock 30 × 479 samples ≈ 0.9s in the past.
+        det.ingest(ArraySlice(speech(seconds: 1.0)))
+        det.ingest(ArraySlice(silence(seconds: 0.9)))
+
+        let ingestedSeconds = Double(totalIngested) / sr
+        guard let start = starts.last else {
+            return XCTFail("expected a post-pause utterance, got \(starts)")
+        }
+        XCTAssertEqual(start, ingestedSeconds, accuracy: 0.1,
+            "clock is \(ingestedSeconds - start)s out after \(pauses) non-frame-aligned pauses — the `partial` remainder isn't being counted into the offset")
+    }
+
     func test_reset_clears_state() {
         let det = UtteranceDetector()
         var fired = 0

--- a/MilaTests/UtteranceDetectorTests.swift
+++ b/MilaTests/UtteranceDetectorTests.swift
@@ -165,6 +165,41 @@ final class UtteranceDetectorTests: XCTestCase {
             "flush() must emit any in-progress utterance so end-of-recording tail isn't lost")
     }
 
+    /// `flushForPause()` closes the in-progress utterance (like `flush()`)
+    /// but PRESERVES the recording clock, so utterances emitted after a
+    /// resume keep their absolute timestamps instead of restarting at 0.
+    /// This is the pause/resume fix: `flush()` zeroes the sample counter,
+    /// which would misplace every post-resume line at the start of the
+    /// transcript and misalign it with the speaker diarizer's intervals.
+    func test_flushForPause_preserves_recording_clock_across_resume() {
+        let det = UtteranceDetector()
+        var starts: [Double] = []
+        det.onUtterance = { _, start in starts.append(start) }
+
+        // Pre-pause: one complete utterance, then a second in-progress one,
+        // advancing the clock to ~3.4s of ingested audio.
+        det.ingest(silence(seconds: 0.5)[...])
+        det.ingest(speech(seconds: 1.0)[...])
+        det.ingest(silence(seconds: 0.9)[...])   // emits utterance #1 (start ~0.3s)
+        det.ingest(speech(seconds: 1.0)[...])    // in-progress at the pause
+
+        // Pause boundary: emits the in-progress utterance AND folds the
+        // elapsed audio into the clock offset.
+        det.flushForPause()
+
+        // Resume: fresh speech. Its timestamp must continue from the
+        // pre-pause clock (~3.4s), NOT restart near 0.
+        det.ingest(silence(seconds: 0.3)[...])
+        det.ingest(speech(seconds: 1.0)[...])
+        det.ingest(silence(seconds: 0.9)[...])   // emits the post-resume utterance
+
+        XCTAssertGreaterThanOrEqual(starts.count, 3,
+            "Expected utterance #1, the flushed in-progress one, and the post-resume one — got \(starts)")
+        let lastStart = starts.last ?? 0
+        XCTAssertGreaterThan(lastStart, 3.0,
+            "Post-resume utterance must keep the absolute recording clock (~3.4s+), not restart at 0 — got \(lastStart)")
+    }
+
     func test_reset_clears_state() {
         let det = UtteranceDetector()
         var fired = 0


### PR DESCRIPTION
Closes #155

Part of the #99 split (roadmap in that PR). First of the live-recording UX slices.

## What

Adds a **Pause / Resume** control to an active recording. While paused, `RecordingSession` drops every incoming mic and system-audio buffer, so the paused span is genuinely absent from the WAV and the live transcript — it isn't recorded-then-hidden.

## Why

Long meetings have stretches you don't want captured at all (a side conversation, a break, someone reading a password out loud). Today the only options are stop-and-restart, which fragments the recording into separate files, or let it run and edit afterwards.

## How

- **`RecordingSession`** gains a `.paused` state plus `pause()` / `resume()`. The elapsed clock keeps ticking but only advances while `.recording`, and the accumulated paused span is subtracted so `elapsed` stays aligned with the on-disk duration. The arithmetic is factored into a static `elapsed(now:startTime:totalPaused:)` so it's unit-testable without an audio engine.
- The audio engines **keep running** across a pause (we discard their output) rather than being torn down — this avoids a fragile fresh-engine-per-session bring-up on resume. Buffered system audio is cleared on both pause and resume so a pre-pause tail isn't glued onto post-pause audio with the gap collapsed out.
- **`UtteranceDetector.flushForPause()`** force-emits the in-progress utterance so it doesn't span the gap, but preserves the recording clock via a `clockOffset`, so post-resume utterances keep absolute timestamps instead of restarting at 0.
- **`MilaApp`**'s session-state observer treats `paused -> recording` as a no-op. Re-running live-pipeline setup would call `transcriber.start()`, which resets `segments` / `fullText` and would wipe everything the user has been reading.
- **`RecordingPauseButton`** is a leaf view observing `RecordingSession` directly, so the paused-state flip doesn't re-render larger views that the session's high-frequency level updates would otherwise churn. It appears in the Live AI header, on Home (so it's reachable in Live AI background mode, where the app stays on Home), and in the floating recording chip.

## Tests

- `RecordingSessionPauseTests` — state machine transitions and the elapsed-time accounting.
- `UtteranceDetectorTests` — clock preservation across a pause boundary.
- `QuickActionsControllerTests` — the pause / resume / toggle guards.
- `LiveTranscriberTests` — the in-progress utterance is flushed at the boundary.

52 tests pass locally in the four affected suites, and `make build` succeeds.

## Note on verification

I could not run the **UI test** target locally — the XCUITest runner fails to launch on my machine with "Timed out while enabling automation mode", which reproduces on a clean checkout of `main` too, so it looks environmental rather than caused by this change. Unit tests and the build are verified. A reviewer sanity-check of the actual pause/resume interaction would be welcome.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pause and resume controls across the home screen, recording chip, and Live AI view.
  * Paused recordings display distinct status styling and freeze elapsed-time tracking.
  * Recordings can be stopped while paused.

* **Bug Fixes**
  * Audio capture and transcription now pause cleanly and resume without losing timeline accuracy.
  * Prevented paused audio from being included in recordings or transcriptions.
  * Preserved utterance timestamps across pause and resume.

* **Tests**
  * Added coverage for pause/resume behavior, elapsed time, transcription boundaries, and timestamp continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
