### PR TITLE
feat(live): delete individual lines from the live transcript

### DIFF
--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -112,6 +112,13 @@ final class LiveTranscriber: ObservableObject {
     /// amount so `windowAbsoluteStart` in `runOnce` keeps producing
     /// correct absolute timestamps for the segment merge.
     private var samplesDropped: Int = 0
+    /// Absolute time ranges of segments the user deleted from the live
+    /// pane. Incoming whisper output overlapping any of these is dropped so
+    /// a just-deleted line can't reappear on a later tick — the fixed-window
+    /// path re-transcribes a rolling buffer and would otherwise re-emit the
+    /// deleted content. The VAD path emits each utterance once, so this is
+    /// mostly a safety net there. Cleared on `start()`.
+    private var deletedRanges: [(start: Double, end: Double)] = []
     private var inFlight: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
     private var language: String = "he"
@@ -140,6 +147,7 @@ final class LiveTranscriber: ObservableObject {
         self.language = language
         self.buffer.removeAll(keepingCapacity: true)
         self.samplesDropped = 0
+        self.deletedRanges = []
         self.fullText = ""
         self.segments = []
         self.speakerNames = [:]
@@ -224,6 +232,32 @@ final class LiveTranscriber: ObservableObject {
     /// never arrives via `ingest`).
     func pauseBoundary() {
         detector?.flushForPause()
+    }
+
+    /// Delete a line from the live transcript. Records the segment's time
+    /// range so a later whisper tick (fixed-window mode re-transcribes a
+    /// rolling buffer) can't re-emit it, removes it from `segments`, and
+    /// recomputes `fullText`. Because `segments` is `@Published`, the app's
+    /// feed loop picks the change up automatically (MCP sidecar + LLM
+    /// re-feed), and the Stop-time snapshot excludes the deleted line.
+    func removeSegment(id: UUID) {
+        guard let idx = segments.firstIndex(where: { $0.id == id }) else { return }
+        let seg = segments[idx]
+        deletedRanges.append((start: seg.startSeconds, end: seg.endSeconds))
+        segments.remove(at: idx)
+        fullText = segments.map(\.text).joined(separator: " ")
+        liveLog.log("LiveTranscriber.removeSegment start=\(seg.startSeconds, privacy: .public) end=\(seg.endSeconds, privacy: .public) remaining=\(self.segments.count, privacy: .public)")
+    }
+
+    /// Whether an incoming segment's absolute time range overlaps a range
+    /// the user deleted. Any positive overlap counts — the intent of a
+    /// delete is "drop what was said in that span," so re-emitted content
+    /// there should stay gone.
+    private func isSuppressed(start: Double, end: Double) -> Bool {
+        for r in deletedRanges where start < r.end && end > r.start {
+            return true
+        }
+        return false
     }
 
     func transcribeNow() async {
@@ -406,10 +440,14 @@ final class LiveTranscriber: ObservableObject {
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { continue }
             guard s.start < originalDuration else { continue }
+            let absStart = startSec + s.start
+            let absEnd = startSec + s.end
+            // Skip anything the user deleted from this time span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { continue }
             segments.append(LiveSegment(
                 id: UUID(),
-                startSeconds: startSec + s.start,
-                endSeconds: startSec + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true
@@ -464,10 +502,14 @@ final class LiveTranscriber: ObservableObject {
         let absoluteSegs: [LiveSegment] = whisperSegs.compactMap { s in
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
+            let absStart = windowAbsoluteStart + s.start
+            let absEnd = windowAbsoluteStart + s.end
+            // Don't resurrect a line the user deleted from this span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { return nil }
             return LiveSegment(
                 id: UUID(),
-                startSeconds: windowAbsoluteStart + s.start,
-                endSeconds: windowAbsoluteStart + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -441,7 +441,10 @@ final class LiveTranscriber: ObservableObject {
             guard !text.isEmpty else { continue }
             guard s.start < originalDuration else { continue }
             let absStart = startSec + s.start
-            let absEnd = startSec + s.end
+            // Whisper can extend a last segment into the silence we padded
+            // onto short utterances. Clamp to the real audio so a delete
+            // cannot mark later utterances as suppressed.
+            let absEnd = min(startSec + s.end, startSec + originalDuration)
             // Skip anything the user deleted from this time span.
             guard !isSuppressed(start: absStart, end: absEnd) else { continue }
             segments.append(LiveSegment(

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -436,6 +436,9 @@ struct LiveAIRecordingView: View {
                                                        } else {
                                                            transcriber.speakerNames.removeValue(forKey: raw)
                                                        }
+                                                   },
+                                                   onDelete: { id in
+                                                       transcriber.removeSegment(id: id)
                                                    })
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
@@ -714,6 +717,11 @@ private struct TranscriptLineView: View {
     /// Persists a rename picked from the label's popover mid-recording:
     /// (raw speaker ID, chosen name or nil-to-reset).
     var onAssignName: (String, String?) -> Void = { _, _ in }
+    /// Deletes this line from the live transcript. Wired to
+    /// `LiveTranscriber.removeSegment(id:)`.
+    var onDelete: (UUID) -> Void = { _ in }
+
+    @State private var hovering = false
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -750,8 +758,41 @@ private struct TranscriptLineView: View {
                 // outer wrapper-level identifier was a no-op (SwiftUI
                 // didn't materialize an a11y node there).
                 .accessibilityIdentifier("liveTranscript.segment")
+            // Hover-revealed delete button. Kept out of the layout-direction
+            // flip (its own LTR) so the trash icon sits on the trailing edge
+            // regardless of the line's script. Always present but near-
+            // invisible until hover so rows don't jump when the button
+            // appears.
+            deleteButton
+                .opacity(hovering ? 1 : 0)
+                .environment(\.layoutDirection, .leftToRight)
         }
         .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        // Right-click / control-click also offers delete, for when the
+        // hover button is easy to miss.
+        .contextMenu {
+            Button(role: .destructive) {
+                onDelete(segment.id)
+            } label: {
+                Label("Delete line", systemImage: "trash")
+            }
+        }
+    }
+
+    private var deleteButton: some View {
+        Button {
+            onDelete(segment.id)
+        } label: {
+            Image(systemName: "trash")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.borderless)
+        .help("Delete this line from the transcript")
+        .accessibilityLabel("Delete line")
+        .accessibilityIdentifier("liveTranscript.deleteLine")
     }
 }
 

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -732,42 +732,47 @@ private struct TranscriptLineView: View {
         // calls — a single English aside inside a Hebrew conversation
         // should still display LTR within its own line).
         let lineRTL = segment.text.isPredominantlyHebrew || language == "he"
+        // Outer HStack stays LTR so the trash control is always the
+        // physical trailing child. Inner stack owns lineRTL for speaker
+        // + text; putting the button inside that stack would mirror it
+        // onto the leading edge. The button stays in layout (opacity
+        // only) so rows don't jump, but is removed from hit-testing and
+        // VoiceOver until hover.
         HStack(alignment: .top, spacing: 8) {
-            if let sp = segment.speaker {
-                SpeakerLabelButton(
-                    rawID: sp,
-                    names: speakerNames,
-                    language: language,
-                    color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
-                    font: .caption.weight(.semibold),
-                    onAssign: { name in onAssignName(sp, name) }
-                )
-                .frame(minWidth: 96, alignment: .leading)
-            } else {
-                Color.clear.frame(width: 96, height: 1)
+            HStack(alignment: .top, spacing: 8) {
+                if let sp = segment.speaker {
+                    SpeakerLabelButton(
+                        rawID: sp,
+                        names: speakerNames,
+                        language: language,
+                        color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
+                        font: .caption.weight(.semibold),
+                        onAssign: { name in onAssignName(sp, name) }
+                    )
+                    .frame(minWidth: 96, alignment: .leading)
+                } else {
+                    Color.clear.frame(width: 96, height: 1)
+                }
+                Text(segment.text)
+                    .font(.callout)
+                    .foregroundStyle(segment.stable ? .primary : .secondary)
+                    .italic(!segment.stable)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                    // Put the identifier on the leaf Text so XCUITest's
+                    // `.staticTexts.matching(identifier:)` finds it. The
+                    // outer wrapper-level identifier was a no-op (SwiftUI
+                    // didn't materialize an a11y node there).
+                    .accessibilityIdentifier("liveTranscript.segment")
             }
-            Text(segment.text)
-                .font(.callout)
-                .foregroundStyle(segment.stable ? .primary : .secondary)
-                .italic(!segment.stable)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .multilineTextAlignment(.leading)
-                // Put the identifier on the leaf Text so XCUITest's
-                // `.staticTexts.matching(identifier:)` finds it. The
-                // outer wrapper-level identifier was a no-op (SwiftUI
-                // didn't materialize an a11y node there).
-                .accessibilityIdentifier("liveTranscript.segment")
-            // Hover-revealed delete button. Kept out of the layout-direction
-            // flip (its own LTR) so the trash icon sits on the trailing edge
-            // regardless of the line's script. Always present but near-
-            // invisible until hover so rows don't jump when the button
-            // appears.
+            .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
             deleteButton
                 .opacity(hovering ? 1 : 0)
-                .environment(\.layoutDirection, .leftToRight)
+                .allowsHitTesting(hovering)
+                .accessibilityHidden(!hovering)
         }
-        .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
+        .environment(\.layoutDirection, .leftToRight)
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
         // Right-click / control-click also offers delete, for when the

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -165,6 +165,73 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    // MARK: - Delete a live line
+
+    func test_removeSegment_removes_line_and_recomputes_fullText() async {
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "keep"),
+            TranscriptSegment(start: 2, end: 3, text: "remove me")
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep", "remove me"])
+
+        let victim = try! XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
+        transcriber.removeSegment(id: victim.id)
+
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep"])
+        XCTAssertEqual(transcriber.fullText, "keep")
+        _ = transcriber.stop()
+    }
+
+    /// A deleted line must not reappear when the fixed-window path
+    /// re-transcribes its rolling buffer on the next tick — the deleted
+    /// time range is suppressed.
+    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async {
+        // Both ticks emit the same two segments; after deleting "beta" it
+        // must stay gone even though tick 2 re-emits it.
+        await stub.setCannedQueue([
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ],
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ]
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha", "beta"])
+
+        let beta = try! XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
+        transcriber.removeSegment(id: beta.id)
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"])
+
+        // Next tick re-emits alpha (already present, skipped) + beta
+        // (suppressed by the deleted range).
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"],
+                       "deleted line reappeared after a re-transcription tick")
+        _ = transcriber.stop()
+    }
+
+    func test_removeSegment_unknown_id_is_a_noop() async {
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "only")])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        transcriber.removeSegment(id: UUID())
+        XCTAssertEqual(transcriber.segments.map(\.text), ["only"])
+        _ = transcriber.stop()
+    }
+
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "first"),

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -167,7 +167,7 @@ final class LiveTranscriberTests: XCTestCase {
 
     // MARK: - Delete a live line
 
-    func test_removeSegment_removes_line_and_recomputes_fullText() async {
+    func test_removeSegment_removes_line_and_recomputes_fullText() async throws {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "keep"),
             TranscriptSegment(start: 2, end: 3, text: "remove me")
@@ -178,7 +178,7 @@ final class LiveTranscriberTests: XCTestCase {
         await transcriber.transcribeNow()
         XCTAssertEqual(transcriber.segments.map(\.text), ["keep", "remove me"])
 
-        let victim = try! XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
+        let victim = try XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
         transcriber.removeSegment(id: victim.id)
 
         XCTAssertEqual(transcriber.segments.map(\.text), ["keep"])
@@ -189,7 +189,7 @@ final class LiveTranscriberTests: XCTestCase {
     /// A deleted line must not reappear when the fixed-window path
     /// re-transcribes its rolling buffer on the next tick — the deleted
     /// time range is suppressed.
-    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async {
+    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async throws {
         // Both ticks emit the same two segments; after deleting "beta" it
         // must stay gone even though tick 2 re-emits it.
         await stub.setCannedQueue([
@@ -208,7 +208,7 @@ final class LiveTranscriberTests: XCTestCase {
         await transcriber.transcribeNow()
         XCTAssertEqual(transcriber.segments.map(\.text), ["alpha", "beta"])
 
-        let beta = try! XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
+        let beta = try XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
         transcriber.removeSegment(id: beta.id)
         XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"])
 
@@ -230,6 +230,52 @@ final class LiveTranscriberTests: XCTestCase {
         transcriber.removeSegment(id: UUID())
         XCTAssertEqual(transcriber.segments.map(\.text), ["only"])
         _ = transcriber.stop()
+    }
+
+    /// Whisper often extends a VAD segment into the trailing silence pad.
+    /// Deleting that line must not suppress the next real utterance — the
+    /// stored range is clamped to the unpadded audio.
+    ///
+    /// Do not call `transcribeNow()` between utterances: that `flush()`es
+    /// the detector and zeroes its clock, which would make the next
+    /// utterance start at 0 and overlap the deleted range for a different
+    /// reason than the padding bug.
+    func test_vad_padded_segment_delete_does_not_suppress_next_utterance() async throws {
+        await stub.setCannedQueue([
+            [TranscriptSegment(start: 0, end: 4.5, text: "first")],
+            [TranscriptSegment(start: 0, end: 1, text: "second")]
+        ])
+        transcriber.useVAD = true
+        transcriber.start(language: "en")
+
+        let speech = Array(repeating: Float(0.05), count: 16_000 * 12 / 10)
+        let silence = Array(repeating: Float(0.0), count: 16_000)
+        transcriber.ingest(ArraySlice(speech + silence))
+        try await waitUntilSegments(count: 1)
+
+        let first = try XCTUnwrap(transcriber.segments.first { $0.text == "first" })
+        XCTAssertLessThan(first.endSeconds, 2.5,
+                          "padded whisper end (4.5s) must be clamped to the ~1.7s utterance")
+        transcriber.removeSegment(id: first.id)
+        XCTAssertTrue(transcriber.segments.isEmpty)
+
+        transcriber.ingest(ArraySlice(speech + silence))
+        try await waitUntilSegments(count: 1)
+        XCTAssertEqual(transcriber.segments.map(\.text), ["second"],
+                       "deleting a pad-extended VAD line suppressed the next utterance")
+        _ = transcriber.stop()
+    }
+
+    /// Poll until `transcriber.segments.count` reaches `count`. The VAD
+    /// path transcribes on a chained Task, so tests cannot `await
+    /// transcribeNow()` without flushing the detector.
+    private func waitUntilSegments(count: Int) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while transcriber.segments.count < count, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(transcriber.segments.count, count,
+                       "timed out waiting for \(count) live segment(s)")
     }
 
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {


### PR DESCRIPTION
Part of the #99 split (roadmap in that PR). Independent of the other live-recording slices; touches `LiveTranscriber` and one view.

## What

Each line in the live transcript pane gets a delete affordance — a trash button revealed on hover, plus a right-click "Delete line" context menu item.

## Why

Whisper occasionally emits a garbage line mid-meeting (a cough transcribed as words, a hallucinated phrase during silence, a snippet of someone else's conversation). Right now the only fix is to wait until the recording ends and edit the saved transcript. Removing it live keeps the pane readable, and — because the live transcript is what gets fed onward — keeps the junk out of the saved transcript and anything downstream of it.

## How

`LiveTranscriber.removeSegment(id:)` records the segment's absolute time range in `deletedRanges`, removes it from `segments`, and recomputes `fullText`. Incoming whisper output that overlaps a deleted range is then skipped.

That suppression is the non-obvious part and the reason this isn't just an array removal: the **fixed-window path re-transcribes a rolling buffer on every tick**, so without it the deleted line simply reappears a second later. The VAD path emits each utterance once, so there it's a safety net rather than load-bearing.

Because `segments` is `@Published`, the deletion propagates for free — the app's feed loop picks it up, and the Stop-time snapshot excludes the deleted line, so it never reaches the saved transcript.

One layout detail worth flagging: the delete button forces its own `.leftToRight` environment so the trash icon stays on the trailing edge for both RTL and LTR lines, and it's always in the layout (just transparent until hover) so rows don't jump as the pointer moves across them.

## Tests

Three cases in `LiveTranscriberTests`:

- removal drops the line and recomputes `fullText`
- an unknown id is a no-op
- **a deleted line stays gone across a subsequent re-transcription tick** — the regression this feature is really about

18 tests pass in the suite, and `make build` succeeds.

## Note on verification

I could not run the **UI test** target locally — the XCUITest runner fails to launch on my machine with "Timed out while enabling automation mode", which reproduces on a clean checkout of `main`, so it looks environmental rather than caused by this change. A reviewer sanity-check of the hover interaction would be welcome.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete individual lines from live transcripts using a hover-revealed button or context menu.
  - Deleted transcript lines are removed from the full transcript and remain suppressed if matching audio is processed again.
  - Deleted-line tracking resets when a new recording starts.

- **Bug Fixes**
  - Prevented deleted transcript lines from reappearing during subsequent transcription updates.
  - Corrected transcript timing so deleting one segment does not suppress adjacent speech.
  - Safely handles deletion requests for unavailable transcript lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci: re-trigger linked-issue check -->
