### PR TITLE
feat(recording): choose a folder and meeting name for a recording

### DIFF
--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -69,6 +69,51 @@ final class ObsidianExporter: ObservableObject {
         return write.written
     }
 
+    /// Undo the export for `recording`: drop it from the pending gate so a
+    /// summary still in flight can't file it later, and delete the note if one
+    /// was already written. Returns the removed file, or nil when there was
+    /// nothing in the vault for this recording.
+    ///
+    /// Called when the user throws a recording away. Export is driven off the
+    /// summarizer's completion hook, which can fire either side of a discard,
+    /// so clearing the gate alone would still leave a note behind whenever the
+    /// summary happened to land first — and "I discarded it and it's in my
+    /// vault anyway" reads as the app ignoring the discard.
+    @discardableResult
+    func discardNote(for recording: Recording) -> URL? {
+        clearPending(recording.id)
+        guard let vault = settings.vaultURL else { return nil }
+        var index = writtenIndex()
+        let key = Self.indexKey(vault: vault, id: recording.id)
+        migrateLegacyIndexEntry(&index, key: key, vault: vault, id: recording.id)
+        guard let relative = index[key] else {
+            // The migration above may have dropped a legacy entry.
+            setWrittenIndex(index)
+            return nil
+        }
+        index[key] = nil
+        setWrittenIndex(index)
+
+        let note = vault.appendingPathComponent(relative)
+        // Same rule the write path follows: never resolve a stored path back
+        // out of the vault. A path that no longer sits inside it is one we
+        // must not delete, whatever the index says.
+        guard ObsidianPathSanitizer.isContained(note, in: vault, fileManager: fileManager),
+              fileManager.fileExists(atPath: note.path) else { return nil }
+        do {
+            try fileManager.removeItem(at: note)
+        } catch {
+            print("ObsidianExporter: failed to remove \(note.path): \(error)")
+            return nil
+        }
+        if settings.gitSyncEnabled {
+            let title = Self.singleLine(recording.title)
+            let message = "Remove discarded transcript: \(title.isEmpty ? "Untitled recording" : title)"
+            kickGitSync(vault: vault, changedPaths: [note], commitMessage: message)
+        }
+        return note
+    }
+
     /// Backfill: write every provided recording into the vault, then kick a
     /// single git sync covering all of them. Used by "Sync existing
     /// transcripts". Returns the count of notes actually written.

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -120,7 +120,15 @@ final class PostRecordingCoordinator: ObservableObject {
     /// the sheet is already showing a different recording the new one is
     /// dropped (we don't queue — concurrent voice memos are rare and a
     /// stack of sheets is worse UX than just naming the first one).
-    func present(_ recording: Recording) {
+    ///
+    /// `titleWasUserProvided` reports that the recording was saved under a
+    /// meeting name the user typed before / during recording. The background
+    /// auto-title job can only protect a user's title by comparing against the
+    /// default it expects to replace, and here that default IS the user's
+    /// title — so the guard cannot see the difference and the CLI suggestion
+    /// would overwrite the typed name. Skip the job entirely in that case; the
+    /// Suggest button in the sheet still offers it on demand.
+    func present(_ recording: Recording, titleWasUserProvided: Bool = false) {
         // UI-TEST: the record-while-finalizing E2E drives two back-to-back
         // recordings through the real `stopRecording`; a modal rename sheet
         // after each Stop would sit over Home and block the next Record tap
@@ -130,6 +138,7 @@ final class PostRecordingCoordinator: ObservableObject {
         if CommandLine.arguments.contains("--ui-test-finalize-regression") { return }
         guard pending == nil else { return }
         pending = recording
+        guard !titleWasUserProvided else { return }
         armAutoSuggestTitle(for: recording)
     }
 

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -31,6 +31,12 @@ final class PostRecordingCoordinator: ObservableObject {
     private let transcription: TranscriptionService
     private let llm: LLMSettings
 
+    /// Late-bound by `MilaApp`, like the exporter wiring on
+    /// `QuickActionsController`. Discard has to reach the vault: export runs
+    /// off the summarizer's completion hook, which can land either side of the
+    /// user throwing the recording away.
+    var obsidianExporter: ObsidianExporter?
+
     /// Injectable LLM-run seam so tests can assert what `PostRecordingCoordinator`
     /// sends to `LLMRunner` (e.g. that the OpenAI path threads `openAIModelName`
     /// — issue celarent7/mila#3) without spawning a CLI or hitting the network.
@@ -482,7 +488,8 @@ final class PostRecordingCoordinator: ObservableObject {
     ///  2. trip the transcription service's abort flag so whisper.cpp
     ///     unwinds within ~100ms instead of finishing
     ///  3. permanently delete the recording + its audio file
-    ///  4. dismiss the sheet
+    ///  4. un-export it from the Obsidian vault
+    ///  5. dismiss the sheet
     func cancelAndDiscard() {
         guard let recording = pending else { pending = nil; return }
         autoSuggestingIDs.remove(recording.id)
@@ -493,9 +500,14 @@ final class PostRecordingCoordinator: ObservableObject {
             task.cancel()
         }
         transcription.cancel(recordingID: recording.id)
-        if let stored = store.recordings.first(where: { $0.id == recording.id }) {
+        let stored = store.recordings.first(where: { $0.id == recording.id })
+        if let stored {
             store.permanentlyDelete(stored)
         }
+        // After the delete, and against the STORED row when there is one: its
+        // title is what named the note on disk, and the `pending` snapshot's
+        // may predate a rename made in the sheet.
+        obsidianExporter?.discardNote(for: stored ?? recording)
         pending = nil
     }
 

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -648,6 +648,11 @@ final class QuickActionsController: ObservableObject {
         // below once the recording is built so it doesn't carry over.
         let finalTitle = Self.resolvedRecordingTitle(userProvided: nextRecordingTitle,
                                                      defaultTitle: title)
+        // Same one-shot rule as the title: capture, apply, then clear so
+        // the next recording in this launch does not inherit the folder.
+        let chosenFolder = nextRecordingFolder
+        nextRecordingTitle = ""
+        nextRecordingFolder = nil
 
         // A mic-only recording that captured zero frames produces an empty
         // WAV → empty transcript → silent ".failed". Tell the user why
@@ -709,7 +714,7 @@ final class QuickActionsController: ObservableObject {
             language: languageSettings.current.rawValue,
             segments: initialTranscriptSegments,
             fullText: initialTranscriptSegments.map(\.text).joined(separator: " "),
-            folder: nextRecordingFolder,
+            folder: chosenFolder,
             appName: appName,
             appBundleID: appBundleID,
             summary: initialSummary.isEmpty ? nil : initialSummary,
@@ -734,14 +739,11 @@ final class QuickActionsController: ObservableObject {
         // drain, after `store.update`. Every exit from the drain below must
         // finish it: with the id when the row was updated, with `nil` when
         // the row is gone and there is nothing to hand off.
-        // Clear the one-shot meeting name so the next recording starts with
-        // a fresh, auto-generated title unless the user names it again.
-        nextRecordingTitle = ""
-        // Register the chosen folder in the store's folder list (and dedup
-        // case-insensitively) so the recording isn't orphaned out of both
-        // "All Transcriptions" and the folder.
-        if nextRecordingFolder != nil {
-            store.assign(recording, toFolder: nextRecordingFolder)
+        // `add` already persisted the folder field. `assign` is only needed
+        // when the name is not already in `store.folders` (brand-new folder
+        // or a case-insensitive match that needs normalizing).
+        if let chosenFolder, !store.folders.contains(chosenFolder) {
+            store.assign(recording, toFolder: chosenFolder)
         }
         activeJob = .none
         if sleepReason != nil {

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -652,6 +652,11 @@ final class QuickActionsController: ObservableObject {
         // below once the recording is built so it doesn't carry over.
         let finalTitle = Self.resolvedRecordingTitle(userProvided: nextRecordingTitle,
                                                      defaultTitle: title)
+        // Read before the clear below: the rename sheet needs to know the
+        // title came from the user, so its background auto-title job doesn't
+        // hand the name straight to the LLM and overwrite it.
+        let titleWasUserProvided = !nextRecordingTitle
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         // Same one-shot rule as the title: capture, apply, then clear so
         // the next recording in this launch does not inherit the folder.
         let chosenFolder = nextRecordingFolder
@@ -759,7 +764,7 @@ final class QuickActionsController: ObservableObject {
             )
         }
         if sleepReason == nil {
-            postRecording.present(recording)
+            postRecording.present(recording, titleWasUserProvided: titleWasUserProvided)
         }
 
         // ---- INLINE LIVE-PIPELINE DRAIN: finalize whatever was still

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -600,6 +600,10 @@ final class QuickActionsController: ObservableObject {
             // over either way, so its notes must not carry into the next
             // recording.
             liveAISettings?.meetingContext = ""
+            // Same one-shot rule as the successful path: a failed stop
+            // must not leave title/folder selected for the next recording.
+            nextRecordingTitle = ""
+            nextRecordingFolder = nil
             liveSidecarWriter?.finish(recordingID: nil)
             isFinalizingRecording = false
             activeJob = .none

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -64,6 +64,21 @@ final class QuickActionsController: ObservableObject {
     /// new app and the user has to re-grant access.
     @Published var microphonePermissionMissing = false
 
+    /// Mila folder the *next* recording is filed into (nil = All Transcriptions).
+    /// Always defaults to All Transcriptions on launch — the choice is
+    /// per-session only and deliberately NOT persisted across launches, so a
+    /// folder picked for one session never silently becomes the default for
+    /// the next one. Set from the Home record controls; applied when the
+    /// recording is saved in `stopRecording`.
+    @Published var nextRecordingFolder: String?
+
+    /// User-entered meeting name for the *next* recording (empty = use the
+    /// auto-generated date-stamped title). Set from the Home controls and
+    /// the live recording screen; applied when the recording is saved in
+    /// `stopRecording`, then cleared so a name typed for one meeting never
+    /// silently carries into the next one.
+    @Published var nextRecordingTitle: String = ""
+
     /// Populated when a recording was force-stopped because the Mac went
     /// to sleep (lid close on battery, low-battery sleep, etc.). Surfaced
     /// to ContentView as an alert on the next wake so the user knows why
@@ -628,6 +643,12 @@ final class QuickActionsController: ObservableObject {
             }
         }()
 
+        // A user-entered meeting name (from Home or the live recording
+        // screen) overrides the auto-generated date-stamped title. Cleared
+        // below once the recording is built so it doesn't carry over.
+        let finalTitle = Self.resolvedRecordingTitle(userProvided: nextRecordingTitle,
+                                                     defaultTitle: title)
+
         // A mic-only recording that captured zero frames produces an empty
         // WAV → empty transcript → silent ".failed". Tell the user why
         // (the recording itself is still saved, so the rename sheet appears
@@ -680,7 +701,7 @@ final class QuickActionsController: ObservableObject {
         // so the initial-status gate is segment-presence, not mode.
         let initialStatus: TranscriptionStatus = initialSegments.isEmpty ? .pending : .running
         let recording = Recording(
-            title: title,
+            title: finalTitle,
             duration: duration,
             source: source,
             audioFileName: outputURL.lastPathComponent,
@@ -688,6 +709,7 @@ final class QuickActionsController: ObservableObject {
             language: languageSettings.current.rawValue,
             segments: initialTranscriptSegments,
             fullText: initialTranscriptSegments.map(\.text).joined(separator: " "),
+            folder: nextRecordingFolder,
             appName: appName,
             appBundleID: appBundleID,
             summary: initialSummary.isEmpty ? nil : initialSummary,
@@ -712,6 +734,15 @@ final class QuickActionsController: ObservableObject {
         // drain, after `store.update`. Every exit from the drain below must
         // finish it: with the id when the row was updated, with `nil` when
         // the row is gone and there is nothing to hand off.
+        // Clear the one-shot meeting name so the next recording starts with
+        // a fresh, auto-generated title unless the user names it again.
+        nextRecordingTitle = ""
+        // Register the chosen folder in the store's folder list (and dedup
+        // case-insensitively) so the recording isn't orphaned out of both
+        // "All Transcriptions" and the folder.
+        if nextRecordingFolder != nil {
+            store.assign(recording, toFolder: nextRecordingFolder)
+        }
         activeJob = .none
         if sleepReason != nil {
             sleepInterruption = SleepInterruption(
@@ -1307,6 +1338,15 @@ final class QuickActionsController: ObservableObject {
     var elapsed: TimeInterval { session.elapsed }
     var micLevel: Float { session.micLevel }
     var systemLevel: Float { session.systemLevel }
+
+    /// Resolve the title a recording should be saved with: the user-entered
+    /// meeting name (trimmed) when they typed one, otherwise the
+    /// auto-generated date-stamped default. Pure + `static` so it's
+    /// unit-testable without a real recording session.
+    static func resolvedRecordingTitle(userProvided: String, defaultTitle: String) -> String {
+        let trimmed = userProvided.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultTitle : trimmed
+    }
 
     private func defaultTitle(prefix: String) -> String {
         let f = DateFormatter()

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -734,6 +734,9 @@ struct MilaApp: App {
         actions.storageSettings = storage
         actions.obsidianSettings = obsidianSettings
         actions.obsidianExporter = obsidian
+        // Discard un-exports: the note can already be in the vault by the time
+        // the user throws the recording away.
+        coordinator.obsidianExporter = obsidian
         actions.liveSidecarWriter = sidecarWriter
         let meetingSettings = MeetingDetectionSettings()
         let detector = MeetingDetector()

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -885,6 +885,14 @@ final class RecordingStore: ObservableObject {
     /// in the list and so the launch-time recovery sweep can enqueue them
     /// for transcription. Returns the list of newly-added recordings so
     /// the caller can decide whether to re-persist.
+    /// Size of a WAV that captured nothing. `AVAudioFile` reserves a 4 KB
+    /// header block on open, so a recording that never received a frame is
+    /// exactly this big — not the 44 bytes a raw WAV header would suggest.
+    /// The old 512-byte guard therefore never fired, and every empty capture
+    /// came back after the next launch as a "Recovered recording" row that
+    /// transcribed to nothing and settled at `.failed`.
+    static let emptyWAVByteCount = 4096
+
     @discardableResult
     private func recoverOrphanRecordings() -> [Recording] {
         let referenced = Set(recordings.map { $0.audioFileName })
@@ -897,10 +905,13 @@ final class RecordingStore: ObservableObject {
         for url in entries where url.pathExtension.lowercased() == "wav" {
             let name = url.lastPathComponent
             if referenced.contains(name) { continue }
-            // Skip empty files — AVAudioFile creates the WAV header on
-            // open but a 44-byte placeholder isn't worth recovering.
+            // Skip captures that hold no audio. The threshold is a byte count
+            // rather than a decoded frame count on purpose: a genuinely crashed
+            // recording has an UNFINALIZED header claiming zero frames while
+            // its samples are on disk, so asking AVAudioFile how long it is
+            // would discard exactly the recordings this sweep exists to save.
             let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-            if size < 512 { continue }
+            if size <= Self.emptyWAVByteCount { continue }
             let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date()
             let recovered = Recording(
                 title: recoveryTitle(at: mtime),

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -51,6 +51,7 @@ struct HomeView: View {
                     // the app stays on Home instead of the split-pane view.
                     RecordingPauseButton(prominent: true)
                 }
+                recordingDestination
                 dictationHint
             }
             .padding(.horizontal, 24)
@@ -162,6 +163,50 @@ struct HomeView: View {
         .controlSize(.small)
         .disabled(isRecording)
         .frame(maxWidth: 280, alignment: .leading)
+    }
+
+    /// Destination controls for the next recording: the folder on top and the
+    /// meeting name directly under it, both left-aligned to a shared width so
+    /// their leading edges line up.
+    private var recordingDestination: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            folderPicker
+            meetingNameField
+        }
+        .frame(maxWidth: 280, alignment: .leading)
+    }
+
+    /// Optional meeting name for the next recording. Empty falls back to the
+    /// auto-generated date-stamped title. Editable during a recording too,
+    /// since it's applied when the recording is saved.
+    private var meetingNameField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "text.cursor")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            NextRecordingMeetingNameField(placeholder: "Meeting name (optional)",
+                                          accessibilityID: "home.record.meetingName")
+                .textFieldStyle(.roundedBorder)
+        }
+        .controlSize(.small)
+        .frame(maxWidth: 280)
+    }
+
+    /// Optional destination folder for the next recording. Per-session only —
+    /// it resets to All Transcriptions on launch so a folder picked once never
+    /// silently becomes the default. Editable during a recording too, since the
+    /// folder is applied when the recording is saved.
+    private var folderPicker: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text("Save to")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            NextRecordingFolderPicker(accessibilityID: "home.record.folder.menu")
+        }
+        .controlSize(.small)
     }
 
     /// Discrete reminder of the two global dictation hotkeys. Reads live

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -89,6 +89,16 @@ struct LiveAIRecordingView: View {
     // MARK: - Header
 
     private var header: some View {
+        VStack(spacing: 10) {
+            controlsRow
+            metaRow
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+    }
+
+    private var controlsRow: some View {
         HStack(spacing: 12) {
             Button {
                 Task { await actions.stopRecording() }
@@ -134,9 +144,34 @@ struct LiveAIRecordingView: View {
                 ThinkingIndicator(isThinking: aiSession.isThinking)
             }
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 12)
-        .background(.regularMaterial)
+    }
+
+    /// Meeting name + destination folder for the recording being captured.
+    /// Both are editable mid-recording — the name and folder are applied
+    /// when the recording is saved (`QuickActionsController.stopRecording`),
+    /// so changing them here at any point up to Stop takes effect.
+    private var metaRow: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 6) {
+                Image(systemName: "text.cursor")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                NextRecordingMeetingNameField(placeholder: "Meeting name",
+                                              accessibilityID: "liveAI.meetingName")
+                    .textFieldStyle(.plain)
+                    .font(.callout)
+            }
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 6) {
+                Image(systemName: "folder")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                NextRecordingFolderPicker(accessibilityID: "liveAI.folder.menu")
+                    .font(.callout)
+            }
+        }
     }
 
     // MARK: - Action items pane

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -67,6 +67,9 @@ struct RecordingDetailView: View {
                     Text(recording.createdAt, format: .dateTime)
                     Text("·")
                     Text(formatDuration(recording.duration))
+                    Text("·")
+                    RecordingFolderMenu(recordingID: recording.id,
+                                        currentFolder: recording.folder)
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)

--- a/Mila/Views/RecordingFolderControls.swift
+++ b/Mila/Views/RecordingFolderControls.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Isolated leaf views for the recording folder / meeting-name controls.
+///
+/// These deliberately observe ONLY `RecordingStore` (for the folder list) and
+/// `QuickActionsController` (for the bindings) — never the high-frequency
+/// `LiveTranscriber` / `TranscriptionService` / `LiveAISession`. That isolation
+/// is the whole point: on the live recording screen, the detail view during an
+/// active transcription, and the post-stop rename sheet, those objects
+/// `@Publish` many times per second. When an interactive `Menu` (backed by a
+/// native NSMenu that runs a nested modal event-tracking runloop while open)
+/// lives in a body that re-renders at that cadence, the menu host gets
+/// reconciled mid-tracking and the whole app beachballs.
+///
+/// By pulling the controls into leaves whose inputs are constant/stable, the
+/// parent body can churn as much as it likes without ever re-invoking these
+/// bodies — so the open menu stays untouched. Same rationale as
+/// `RecordingElapsedLabel` isolating `RecordingSession`.
+
+/// Folder picker for the NEXT recording (Home + live recording screen). Binds
+/// to `QuickActionsController.nextRecordingFolder`, applied when the recording
+/// is saved.
+struct NextRecordingFolderPicker: View {
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var actions: QuickActionsController
+    let accessibilityID: String
+
+    var body: some View {
+        Menu {
+            Button(actions.nextRecordingFolder == nil ? "✓ All Transcriptions" : "All Transcriptions") {
+                actions.nextRecordingFolder = nil
+            }
+            if !store.folders.isEmpty {
+                Divider()
+                ForEach(store.folders, id: \.self) { folder in
+                    Button(actions.nextRecordingFolder == folder ? "✓ \(folder)" : folder) {
+                        actions.nextRecordingFolder = folder
+                    }
+                }
+            }
+        } label: {
+            Text(actions.nextRecordingFolder ?? "All Transcriptions")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+/// Optional meeting-name field for the NEXT recording (Home + live recording
+/// screen). Isolated so typing stays responsive even while the surrounding
+/// screen re-renders at transcript cadence. Callers apply `.textFieldStyle` /
+/// `.font` via modifiers (both propagate into the inner `TextField` through the
+/// environment).
+struct NextRecordingMeetingNameField: View {
+    @EnvironmentObject private var actions: QuickActionsController
+    let placeholder: String
+    let accessibilityID: String
+
+    var body: some View {
+        TextField(placeholder, text: $actions.nextRecordingTitle)
+            .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+/// Inline folder picker for an EXISTING recording (recording detail view).
+/// Files the recording via `store.assign` and offers a "New Folder…" flow. Takes
+/// the recording id + its current folder as stable inputs (both only change when
+/// the folder actually changes), so an active transcription's progress flood
+/// never re-invokes this body.
+struct RecordingFolderMenu: View {
+    @EnvironmentObject private var store: RecordingStore
+    let recordingID: UUID
+    let currentFolder: String?
+
+    @State private var showingNewFolderAlert = false
+    @State private var newFolderName = ""
+
+    var body: some View {
+        Menu {
+            Button(currentFolder == nil ? "✓ None" : "None") {
+                assign(nil)
+            }
+            if !store.folders.isEmpty {
+                Divider()
+                ForEach(store.folders, id: \.self) { folder in
+                    Button(currentFolder == folder ? "✓ \(folder)" : folder) {
+                        assign(folder)
+                    }
+                }
+            }
+            Divider()
+            Button("New Folder…") {
+                newFolderName = ""
+                showingNewFolderAlert = true
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "folder")
+                Text(currentFolder ?? "No folder")
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Choose the folder this recording is filed under")
+        .accessibilityIdentifier("detail.folder.menu")
+        .alert("New Folder", isPresented: $showingNewFolderAlert) {
+            TextField("Folder name", text: $newFolderName)
+            Button("Create") {
+                let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !name.isEmpty { assign(name) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("File this recording into a new folder.")
+        }
+    }
+
+    private func assign(_ folder: String?) {
+        guard let rec = store.recordings.first(where: { $0.id == recordingID }) else { return }
+        store.assign(rec, toFolder: folder)
+    }
+}

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -13,10 +13,21 @@ struct RenameRecordingSheet: View {
     @EnvironmentObject private var coordinator: PostRecordingCoordinator
     @EnvironmentObject private var store: RecordingStore
     @EnvironmentObject private var llm: LLMSettings
-    @EnvironmentObject private var transcription: TranscriptionService
     @EnvironmentObject private var summarizer: RecordingSummarizer
 
     @State private var title: String
+    /// Mila folder the recording should be filed under (nil = unfiled).
+    /// Seeded from the recording and applied on Save via `store.assign`.
+    @State private var selectedFolder: String?
+    /// Mirrors `userEditedTitle` for the folder: while false, the picker
+    /// tracks the stored recording's folder (so a folder chosen on the
+    /// recording screen shows up here even when SwiftUI reuses this sheet's
+    /// `@State` across presentations and the init seed goes stale). Once the
+    /// user picks a folder in this sheet we stop mirroring so their choice
+    /// isn't clobbered.
+    @State private var userEditedFolder = false
+    @State private var showingNewFolderField = false
+    @State private var newFolderName = ""
     @State private var isFetchingName = false
     @State private var llmError: String?
     /// Set once the user types in the title field (or accepts a manual
@@ -40,6 +51,7 @@ struct RenameRecordingSheet: View {
     init(initialRecording: Recording) {
         self.initialRecording = initialRecording
         _title = State(initialValue: initialRecording.title)
+        _selectedFolder = State(initialValue: initialRecording.folder)
     }
 
     /// Live recording (transcript fills in here as Whisper finishes).
@@ -82,28 +94,6 @@ struct RenameRecordingSheet: View {
             || summarizer.isSummarizing(liveRecording.id)
     }
 
-    /// "Transcribing…", "Identifying speakers…", "Done", "Failed",
-    /// "Waiting in queue" — drives the progress indicator inside the sheet.
-    private var transcriptionLabel: String {
-        let live = liveRecording
-        if transcription.activeRecordingID == live.id {
-            let pct = Int(transcription.progress * 100)
-            return "Transcribing… \(pct)%"
-        }
-        // The offline re-diarize pass: the transcript text is already final
-        // (status is .completed), so "Transcribing" would be wrong — the
-        // pyannote subprocess is only re-clustering speaker labels.
-        if transcription.diarizingRecordingID == live.id {
-            return "Identifying speakers…"
-        }
-        switch live.status {
-        case .pending:   return "Waiting to transcribe…"
-        case .running:   return "Transcribing…"
-        case .completed: return "Transcript ready"
-        case .failed:    return "Transcription failed"
-        }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Fixed top: identity + status. Never scrolls, so the title field
@@ -137,7 +127,9 @@ struct RenameRecordingSheet: View {
                     }
                 }
 
-                transcriptionStatus
+                folderPicker
+
+                RenameTranscriptionStatusRow(recordingID: initialRecording.id)
             }
             .padding(20)
 
@@ -222,6 +214,14 @@ struct RenameRecordingSheet: View {
         // back over the stored suggestion.
         .onAppear {
             if !userEditedTitle { title = liveRecording.title }
+            if !userEditedFolder { selectedFolder = liveRecording.folder }
+        }
+        // Keep the folder in sync with the stored recording until the user
+        // picks one here — mirrors the title mirroring above. This is what
+        // carries a folder chosen on the recording screen into the sheet even
+        // if the init-seeded `@State` was stale.
+        .onChange(of: liveRecording.folder) { _, newFolder in
+            if !userEditedFolder { selectedFolder = newFolder }
         }
         // Mirror a background auto-suggestion into the field as it lands —
         // but only until the user expresses their own preference. The
@@ -351,6 +351,65 @@ struct RenameRecordingSheet: View {
         }
     }
 
+    /// Pick the Mila folder this recording is filed under. Existing folders +
+    /// "None", plus an inline "New Folder…" field. Applied on Save.
+    private var folderPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Folder").font(.callout.weight(.semibold))
+            HStack(spacing: 8) {
+                Menu {
+                    Button(selectedFolder == nil ? "✓ None" : "None") {
+                        chooseFolder(nil)
+                    }
+                    if !store.folders.isEmpty {
+                        Divider()
+                        ForEach(store.folders, id: \.self) { folder in
+                            Button(selectedFolder == folder ? "✓ \(folder)" : folder) {
+                                chooseFolder(folder)
+                            }
+                        }
+                    }
+                    Divider()
+                    Button("New Folder…") {
+                        newFolderName = ""
+                        showingNewFolderField = true
+                    }
+                } label: {
+                    Label(selectedFolder ?? "No folder", systemImage: "folder")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .accessibilityIdentifier("rename.folder.menu")
+                Spacer()
+            }
+            if showingNewFolderField {
+                HStack(spacing: 8) {
+                    TextField("New folder name", text: $newFolderName)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { commitNewFolder() }
+                        .accessibilityIdentifier("rename.newFolder.field")
+                    Button("Add") { commitNewFolder() }
+                        .disabled(newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Button("Cancel") { showingNewFolderField = false }
+                }
+            }
+        }
+    }
+
+    private func commitNewFolder() {
+        let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        chooseFolder(name)
+        showingNewFolderField = false
+    }
+
+    /// Record an explicit in-sheet folder choice and stop mirroring the
+    /// stored recording's folder so the user's pick is never clobbered.
+    private func chooseFolder(_ folder: String?) {
+        selectedFolder = folder
+        userEditedFolder = true
+    }
+
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Name this recording").font(.title3.weight(.semibold))
@@ -400,46 +459,20 @@ struct RenameRecordingSheet: View {
             .isEmpty
     }
 
-    @ViewBuilder
-    private var transcriptionStatus: some View {
-        HStack(spacing: 10) {
-            statusIcon
-            Text(transcriptionLabel)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            if transcription.activeRecordingID == liveRecording.id {
-                ProgressView(value: transcription.progress)
-                    .progressViewStyle(.linear)
-                    .frame(maxWidth: 140)
-            }
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-    }
-
-    @ViewBuilder
-    private var statusIcon: some View {
-        // While the offline re-diarize is in flight the transcript is done
-        // but speaker labels aren't — show a spinner, not the green check,
-        // to match the "Identifying speakers…" label.
-        if transcription.diarizingRecordingID == liveRecording.id {
-            ProgressView().controlSize(.small)
-        } else {
-            switch liveRecording.status {
-            case .completed:
-                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-            case .failed:
-                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
-            default:
-                ProgressView().controlSize(.small)
-            }
-        }
-    }
-
     private func save() {
+        applyFolder()
         coordinator.dismiss(savingTitle: title)
+    }
+
+    /// File the recording under the chosen folder (auto-creates it) before the
+    /// sheet tears down. No-op when the folder is unchanged. Runs before
+    /// `dismiss` on every exit path so anything triggered by the save sees the
+    /// recording already filed.
+    private func applyFolder() {
+        guard let rec = store.recordings.first(where: { $0.id == initialRecording.id }) else { return }
+        if rec.folder != selectedFolder {
+            store.assign(rec, toFolder: selectedFolder)
+        }
     }
 
     /// Save the title, dismiss the sheet, then run the action in the
@@ -466,6 +499,7 @@ struct RenameRecordingSheet: View {
         let summarySnapshot = summary
         let executableOverride = llm.executablePath.isEmpty ? nil : llm.executablePath
         let tool = llm.tool
+        applyFolder()
         coordinator.dismiss(savingTitle: title)
         coordinator.sendToLLM(recordingID: recordingID,
                               tool: tool,
@@ -520,6 +554,82 @@ struct RenameRecordingSheet: View {
             // when withTaskCancellationHandler's onCancel beat us to it.
             if Task.isCancelled { return }
             llmError = error.localizedDescription
+        }
+    }
+}
+
+/// Isolated transcription-status row for the rename sheet.
+///
+/// This is the ONLY part of the sheet that observes `TranscriptionService`, so
+/// the high-frequency `progress` updates during batch transcription re-render
+/// just this small leaf — not the whole sheet. Previously the sheet held
+/// `@EnvironmentObject transcription`, so every progress tick rebuilt the
+/// entire body including the folder `Menu`; opening that menu mid-transcription
+/// then collided with the NSMenu's modal tracking loop and beachballed the app.
+private struct RenameTranscriptionStatusRow: View {
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var transcription: TranscriptionService
+    let recordingID: UUID
+
+    private var status: TranscriptionStatus {
+        store.recordings.first(where: { $0.id == recordingID })?.status ?? .pending
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if transcription.activeRecordingID == recordingID {
+                ProgressView(value: transcription.progress)
+                    .progressViewStyle(.linear)
+                    .frame(maxWidth: 140)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// "Transcribing… NN%", "Identifying speakers…", "Transcript ready",
+    /// "Transcription failed", "Waiting to transcribe…".
+    private var label: String {
+        if transcription.activeRecordingID == recordingID {
+            let pct = Int(transcription.progress * 100)
+            return "Transcribing… \(pct)%"
+        }
+        // The offline re-diarize pass: the transcript text is already final
+        // (status is .completed), so "Transcribing" would be wrong — the
+        // pyannote subprocess is only re-clustering speaker labels.
+        if transcription.diarizingRecordingID == recordingID {
+            return "Identifying speakers…"
+        }
+        switch status {
+        case .pending:   return "Waiting to transcribe…"
+        case .running:   return "Transcribing…"
+        case .completed: return "Transcript ready"
+        case .failed:    return "Transcription failed"
+        }
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        // While the offline re-diarize is in flight the transcript is done
+        // but speaker labels aren't — show a spinner, not the green check,
+        // to match the "Identifying speakers…" label.
+        if transcription.diarizingRecordingID == recordingID {
+            ProgressView().controlSize(.small)
+        } else {
+            switch status {
+            case .completed:
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+            case .failed:
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
+            default:
+                ProgressView().controlSize(.small)
+            }
         }
     }
 }

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -208,6 +208,13 @@ struct RenameRecordingSheet: View {
         // bind ESC to Discard — the whole point of this change is that
         // dismissing the sheet must never throw audio away.
         .onExitCommand { save() }
+        // SwiftUI can reuse this sheet's @State for a later recording.
+        // Drop the previous pick so applyFolder() cannot file the new
+        // recording under the last one.
+        .onChange(of: initialRecording.id) { _, _ in
+            userEditedFolder = false
+            selectedFolder = liveRecording.folder
+        }
         // Catch any suggestion that landed in the store between this view's
         // init (which snapshotted `initialRecording.title`) and `onChange`
         // being installed — otherwise a Save could write the stale default

--- a/MilaTests/ObsidianExportSequencingTests.swift
+++ b/MilaTests/ObsidianExportSequencingTests.swift
@@ -191,6 +191,47 @@ final class ObsidianExportSequencingTests: XCTestCase {
                        "a recording trashed mid-flight must not be filed")
     }
 
+    // MARK: - Discard un-exports
+
+    /// The export already landed before the user hit Discard — the note has to
+    /// come back out of the vault, or discarding is something the app visibly
+    /// ignored.
+    func test_discardNote_removes_an_already_exported_note() async throws {
+        let rec = addRecording()
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path), "precondition")
+
+        exporter.discardNote(for: rec)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "the note for a discarded recording is still in the vault")
+    }
+
+    /// The other ordering: Discard lands while the summary is still running,
+    /// so the export hasn't happened yet and must never happen.
+    func test_discard_before_the_summary_lands_blocks_the_export() async throws {
+        let rec = addRecording()
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        exporter.discardNote(for: rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a summary landing after Discard must not file the note")
+        XCTAssertFalse(exporter.isPending(rec.id))
+    }
+
+    /// Nothing was ever written for this recording — removal is a no-op rather
+    /// than a delete of whatever happens to share the name.
+    func test_discardNote_is_a_noop_when_nothing_was_exported() {
+        let rec = addRecording()
+        XCTAssertNil(exporter.discardNote(for: rec))
+    }
+
     /// The hook fires exactly once per attempt: a second export for the same
     /// recording only happens on a second, deliberate summarize attempt.
     func test_hook_fires_once_per_attempt() async throws {

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -491,6 +491,34 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         XCTAssertFalse(coordinator.autoSuggestingIDs.contains(rec.id))
     }
 
+    /// Discard has to reach the vault, not just the store. Covers the wiring
+    /// `MilaApp` installs — without it the coordinator deletes the recording
+    /// and leaves its exported note behind.
+    func test_cancelAndDiscard_removes_the_obsidian_note() async throws {
+        let vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        let suite = "PostRecordingCoordinatorSendTests.obsidian.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { UserDefaults().removePersistentDomain(forName: suite) }
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        settings.enabled = true
+        settings.subfolder = ""
+        XCTAssertTrue(settings.setVault(vault))
+        let exporter = ObsidianExporter(settings: settings, defaults: defaults)
+        coordinator.obsidianExporter = exporter
+
+        let rec = addCompletedRecording(text: "the transcript text")
+        let note = try XCTUnwrap(exporter.export(rec), "precondition: the note was written")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: note.path))
+
+        coordinator.present(rec)
+        coordinator.cancelAndDiscard()
+
+        XCTAssertTrue(store.recordings.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: note.path),
+                       "discarding the recording must take its note out of the vault")
+    }
+
     // MARK: - Helpers
 
     /// Wait up to `timeoutSeconds` (default 5) for `condition` to hold, polling

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -459,6 +459,38 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         XCTAssertEqual(captured, .inline)
     }
 
+    /// A recording saved under a meeting name the user typed must not be
+    /// auto-titled: the baseline guard in `applyAutoSuggestedTitle` can't
+    /// protect it (the baseline IS the user's title), so the CLI suggestion
+    /// would replace the name they chose.
+    func test_present_skips_auto_title_when_the_user_named_the_recording() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.named.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.named.\(#function)")
+        let llm = LLMSettings(defaults: suite,
+                              apiKeyKeychainKey: "PostRecordingCoordinatorSendTests.named.\(#function)")
+        llm.tool = .claude
+        llm.nameGenerationEnabled = true
+
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
+                callCount += 1
+                return "An LLM Title"
+            })
+
+        var rec = addCompletedRecording(text: "the transcript text")
+        rec.title = "Weekly Sync"
+        store.update(rec)
+
+        coordinator.present(rec, titleWasUserProvided: true)
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertEqual(callCount, 0, "the auto-title CLI must not run for a user-named recording")
+        XCTAssertEqual(store.recordings.first(where: { $0.id == rec.id })?.title, "Weekly Sync")
+        XCTAssertFalse(coordinator.autoSuggestingIDs.contains(rec.id))
+    }
+
     // MARK: - Helpers
 
     /// Wait up to `timeoutSeconds` (default 5) for `condition` to hold, polling

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -134,8 +134,6 @@ final class QuickActionsControllerTests: XCTestCase {
     }
 
     func test_nextRecordingFolder_defaults_to_all_transcriptions() {
-        UserDefaults.standard.set("Stale Folder", forKey: "quickActions.nextRecordingFolder")
-        defer { UserDefaults.standard.removeObject(forKey: "quickActions.nextRecordingFolder") }
         let fresh = QuickActionsController(
             session: RecordingSession(),
             store: store,
@@ -147,6 +145,48 @@ final class QuickActionsControllerTests: XCTestCase {
                 llm: LLMSettings(defaults: UserDefaults(suiteName: "QuickActionsControllerTests.llm2")!)))
         XCTAssertNil(fresh.nextRecordingFolder,
                      "next-recording folder must default to All Transcriptions, not a persisted folder")
+    }
+
+    /// A folder chosen for one recording is one-shot: stop must not leave
+    /// it selected for the next recording in the same launch.
+    func test_stopRecording_clears_nextRecordingFolder() async throws {
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        let url = store.freshAudioURL(suggestedName: "FolderClear")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.4)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        store.createFolder("Work")
+        controller.nextRecordingFolder = "Work"
+        controller.nextRecordingTitle = "Weekly Sync"
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+
+        XCTAssertNil(controller.nextRecordingFolder,
+                     "nextRecordingFolder must reset after save")
+        XCTAssertEqual(controller.nextRecordingTitle, "",
+                       "nextRecordingTitle must reset after save")
+        let stored = try XCTUnwrap(store.recordings.first { $0.audioFileName == url.lastPathComponent })
+        XCTAssertEqual(stored.folder, "Work")
+        XCTAssertEqual(stored.title, "Weekly Sync")
+    }
+
+    /// A folder name that isn't already in the store list still gets
+    /// registered via assign (new folder / case-insensitive match).
+    func test_stopRecording_registers_a_brand_new_folder() async throws {
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        let url = store.freshAudioURL(suggestedName: "NewFolder")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.4)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        controller.nextRecordingFolder = "Brand New"
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+
+        XCTAssertTrue(store.folders.contains("Brand New"))
+        let stored = try XCTUnwrap(store.recordings.first { $0.audioFileName == url.lastPathComponent })
+        XCTAssertEqual(stored.folder, "Brand New")
     }
 
     // MARK: - Resolved recording title (meeting name override)

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -203,6 +203,46 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertEqual(stored.folder, "Brand New")
     }
 
+    /// A meeting name typed before recording survives the stop: the rename
+    /// sheet's background auto-title job must not hand it to the LLM and
+    /// write the suggestion back over it.
+    func test_stopRecording_does_not_auto_title_a_user_named_recording() async throws {
+        let suite = UserDefaults(suiteName: "QuickActionsControllerTests.autoTitle")!
+        suite.removePersistentDomain(forName: "QuickActionsControllerTests.autoTitle")
+        let llm = LLMSettings(defaults: suite,
+                              apiKeyKeychainKey: "QuickActionsControllerTests.autoTitle")
+        llm.tool = .claude
+        llm.nameGenerationEnabled = true
+
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
+                callCount += 1
+                return "An LLM Title"
+            })
+        let named = QuickActionsController(session: session,
+                                           store: store,
+                                           transcription: service,
+                                           languageSettings: languageSettings,
+                                           postRecording: coordinator)
+
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        let url = store.freshAudioURL(suggestedName: "UserNamed")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.4)
+        await named.startFakeRecordingForTesting(outputURL: url)
+        named.nextRecordingTitle = "Weekly Sync"
+
+        await named.stopRecording()
+        await named.awaitFinalizeTails()
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertEqual(callCount, 0, "the auto-title CLI must not run for a user-named recording")
+        let stored = try XCTUnwrap(store.recordings.first { $0.audioFileName == url.lastPathComponent })
+        XCTAssertEqual(stored.title, "Weekly Sync")
+    }
+
     // MARK: - Resolved recording title (meeting name override)
 
     /// An empty or whitespace-only meeting name falls back to the

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -171,6 +171,20 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertEqual(stored.title, "Weekly Sync")
     }
 
+    /// `session.stop()` returning nil never reaches the successful-path
+    /// clear, so title/folder would otherwise stick for the next recording.
+    func test_failed_stop_clears_nextRecording_title_and_folder() async {
+        controller.nextRecordingFolder = "Work"
+        controller.nextRecordingTitle = "Weekly Sync"
+        XCTAssertFalse(controller.isRecording)
+
+        await controller.stopRecording()
+
+        XCTAssertNil(controller.nextRecordingFolder)
+        XCTAssertEqual(controller.nextRecordingTitle, "")
+        XCTAssertTrue(store.recordings.isEmpty)
+    }
+
     /// A folder name that isn't already in the store list still gets
     /// registered via assign (new folder / case-insensitive match).
     func test_stopRecording_registers_a_brand_new_folder() async throws {

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -133,6 +133,42 @@ final class QuickActionsControllerTests: XCTestCase {
             "a 600s file against a 1200s clock IS a real short capture — the point is that a pause must not produce this shape")
     }
 
+    func test_nextRecordingFolder_defaults_to_all_transcriptions() {
+        UserDefaults.standard.set("Stale Folder", forKey: "quickActions.nextRecordingFolder")
+        defer { UserDefaults.standard.removeObject(forKey: "quickActions.nextRecordingFolder") }
+        let fresh = QuickActionsController(
+            session: RecordingSession(),
+            store: store,
+            transcription: service,
+            languageSettings: languageSettings,
+            postRecording: PostRecordingCoordinator(
+                store: store,
+                transcription: service,
+                llm: LLMSettings(defaults: UserDefaults(suiteName: "QuickActionsControllerTests.llm2")!)))
+        XCTAssertNil(fresh.nextRecordingFolder,
+                     "next-recording folder must default to All Transcriptions, not a persisted folder")
+    }
+
+    // MARK: - Resolved recording title (meeting name override)
+
+    /// An empty or whitespace-only meeting name falls back to the
+    /// auto-generated date-stamped default title.
+    func test_resolvedRecordingTitle_falls_back_to_default_when_empty() {
+        let def = "Recording · Jul 20, 2026"
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "", defaultTitle: def), def)
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "   \n\t", defaultTitle: def), def)
+    }
+
+    /// A non-empty meeting name wins over the default and is trimmed of
+    /// surrounding whitespace.
+    func test_resolvedRecordingTitle_prefers_trimmed_user_title() {
+        let def = "Recording · Jul 20, 2026"
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "Weekly Sync", defaultTitle: def),
+                       "Weekly Sync")
+        XCTAssertEqual(QuickActionsController.resolvedRecordingTitle(userProvided: "  Weekly Sync  ", defaultTitle: def),
+                       "Weekly Sync")
+    }
+
     // MARK: - File import → enqueue → transcribe
 
     func test_transcribe_file_adds_recording_and_kicks_off_transcription() async throws {

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -18,6 +18,44 @@ final class RecordingStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Orphan recovery
+
+    /// A capture that never received a frame must not come back. `AVAudioFile`
+    /// reserves a 4 KB header block on open, so an empty WAV is 4096 bytes —
+    /// well over the old 512-byte "skip empty files" guard, which is why every
+    /// empty capture reappeared as a `Recovered recording` row that transcribed
+    /// to nothing and settled at `.failed`.
+    func test_empty_orphan_wav_is_not_recovered() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(Recording(title: "Real", source: .microphone, audioFileName: "real.wav"))
+        let empty = store.recordingsDirectory.appendingPathComponent("empty-capture.wav")
+        try Data(count: RecordingStore.emptyWAVByteCount).write(to: empty)
+
+        let relaunched = RecordingStore(rootDirectory: tempRoot)
+
+        XCTAssertEqual(relaunched.recordings.map(\.title), ["Real"],
+                       "an empty capture was resurrected as a phantom recording")
+        XCTAssertTrue(relaunched.consumePendingRecoveryIDs().isEmpty,
+                      "an empty capture must not be enqueued for transcription either")
+    }
+
+    /// The other half of the same guard: a crashed recording that DID capture
+    /// audio still has to be recovered. Its header is unfinalized (it claims
+    /// zero frames), so the size on disk is the only usable signal.
+    func test_orphan_wav_with_audio_is_still_recovered() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        store.add(Recording(title: "Real", source: .microphone, audioFileName: "real.wav"))
+        let crashed = store.recordingsDirectory.appendingPathComponent("crashed.wav")
+        try Data(count: RecordingStore.emptyWAVByteCount + 1).write(to: crashed)
+
+        let relaunched = RecordingStore(rootDirectory: tempRoot)
+
+        XCTAssertEqual(relaunched.recordings.count, 2)
+        XCTAssertEqual(relaunched.recordings.first(where: { $0.audioFileName == "crashed.wav" })?.status,
+                       .pending)
+        XCTAssertEqual(relaunched.consumePendingRecoveryIDs().count, 1)
+    }
+
     func test_store_persists_recordings_across_instances() throws {
         let first = RecordingStore(rootDirectory: tempRoot)
         XCTAssertTrue(first.recordings.isEmpty)


### PR DESCRIPTION
Part of the #99 split (roadmap in that PR). Largest of the live-recording UX slices, but self-contained.

## What

Destination controls in the three places you'd naturally name or file a recording:

- **Home** — a "Save to" folder picker and an optional meeting name, so both are set *before* you start.
- **Live recording header** — the same pair, editable mid-recording. Both are applied when the recording is saved, so changing either at any point up to Stop takes effect.
- **Recording detail view** — an inline folder menu in the meta line, mirroring the sidebar's context-menu assignment but reachable from the open recording.
- **Post-stop rename sheet** — a folder picker with an inline "New Folder…" field.

It also fixes a bug: **the folder was lost when a recording was renamed after stop.**

## Deliberate design choices, in case you'd decide differently

**The folder and meeting name are per-session, not persisted.** `nextRecordingFolder` / `nextRecordingTitle` reset on launch and the title clears after each save. A folder picked for one meeting silently becoming the default for the next felt like the worse failure mode — you'd only notice weeks of recordings landed in the wrong place after the fact. There's a test pinning this (`test_nextRecordingFolder_defaults_to_all_transcriptions`) so it can't regress by accident. Easy to flip if you'd rather it were sticky.

**`resolvedRecordingTitle` is pure and `static`** so the fallback-to-date-stamped-default logic is unit-testable without standing up a recording session.

## The isolation, and why it's in this PR

A SwiftUI `Menu` is backed by an NSMenu that runs a **nested modal event-tracking runloop** while it's open. If that menu lives in a view body that re-renders at transcript or progress cadence, the menu host gets reconciled mid-tracking and the whole app beachballs.

Every one of the folder menus above sits in exactly such a body — the live recording screen, the detail view during an active transcription, the rename sheet while the batch transcribe runs. So adding the feature naively *introduces* a hang. The controls are pulled into `Mila/Views/RecordingFolderControls.swift` as leaves that observe only `RecordingStore` and `QuickActionsController` — never `LiveTranscriber` / `TranscriptionService` / `LiveAISession`. Same rationale as the existing `RecordingElapsedLabel` isolating `RecordingSession`.

For the same reason the rename sheet no longer holds `@EnvironmentObject transcription`. The status row is extracted into a private `RenameTranscriptionStatusRow`, so progress ticks re-render that small leaf instead of the entire sheet (including its folder `Menu`).

I'd rather not split the isolation out into its own PR — on its own it's a refactor with no visible motivation, and landing the feature without it ships a known hang.

## The rename bug

Two causes, both fixed here:

1. SwiftUI reuses the sheet's `@State` across presentations, so the `init`-seeded folder went stale. The sheet now mirrors the stored recording's folder until the user picks one in the sheet, at which point mirroring stops so their choice isn't clobbered.
2. `applyFolder()` now runs on **every** exit path (plain Save and Send-to-LLM), not just some.

## Tests

`QuickActionsControllerTests` gains coverage for the non-persistence default and both branches of `resolvedRecordingTitle` (empty/whitespace falls back, non-empty wins and is trimmed). Suite passes, and `make build` succeeds.

## Note on verification

I could not run the **UI test** target locally — the XCUITest runner fails on my machine with "Timed out while enabling automation mode", which reproduces on a clean checkout of `main`, so it looks environmental. The beachball fix in particular is worth a reviewer confirming by hand: open the folder menu on the live recording screen while a transcription is running.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Choose a destination folder for the next recording.
  - Add an optional meeting name before or during recording.
  - Move existing recordings between folders or create a new folder from recording details.
  - Select a folder while renaming recordings, including when saving or sending.
  - View and edit recording name and destination details during live recording.

- **Bug Fixes**
  - Recording names now ignore surrounding whitespace and use an automatic title when left blank.
  - User-provided recording names are preserved without automatic replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci: re-trigger linked-issue check -->
