### PR TITLE
feat(mcp): mila-mcp — an MCP stdio server over Mila's transcriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ A macOS (Swift/SwiftUI) local transcription app built on whisper.cpp, with optio
   - `Mila/Resources/DiarizationModels/` — bundled pyannote speaker diarization model weights (~31 MB)
   - `MilaTests/` — unit tests
   - `Packages/TranscriptionCore/` — cross-platform Swift package: WhisperEngine (whisper.cpp bindings), WAVReader, WER calculator, and E2E transcription test fixtures
+  - `Packages/MilaKit/` — zero-dependency Swift package shared by the app and the `mila-mcp` helper: TranscriptFormatter, the read-only `StoredRecording` mirror of recordings.json, `MilaStoreReader`, the live-transcript snapshot schema, and the MCP tool handlers
+  - `MilaMCP/` — the `mila-mcp` executable (MCP stdio server over Mila's transcriptions), embedded at `Mila.app/Contents/MacOS/mila-mcp`; see `docs/mcp.md`
   - `scripts/` — release/build scripts (make-dmg.sh, etc.)
 
 ## Conventions
@@ -46,9 +48,14 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
 - For verification/setup state that should survive app restarts, persist a `verified` flag alongside the verified parameter values (path). On launch, restore only if current values match the persisted ones.
 - Computed `status` properties must check `verificationStatus` before `lastVerifyResult` -- the persisted verified state should take precedence over nil in-memory verify results on launch.
 
+### MCP server (mila-mcp) and MilaKit
+- The app persists two cross-process contracts for the embedded MCP helper: `store-location.json` (written by `RecordingStore` on init + relocate — where recordings.json currently lives) and `live/current.json` (the live-transcript sidecar written during recording by `LiveTranscriptSidecarWriter`). Both live at the DEFAULT app-support root and deliberately do not travel with a relocated recordings folder.
+- **Any change to what `Recording.encode(to:)` writes into recordings.json must be mirrored in MilaKit's `StoredRecording`** — `StoredRecordingDriftTests` in MilaTests is the tripwire. Keep `StoredRecording` decoding lenient (`decodeIfPresent` + defaults) so an older helper survives a newer app's schema.
+- MilaKit must stay dependency-free (in particular: no TranscriptionCore) — it links into `mila-mcp`, which must not drag in the whisper xcframework. Tool logic lives in `MilaMCPToolHandlers` (pure JSON), not in the executable.
+
 ### Tests
 - `TranscriptionService` now requires a `diarizationSettings:` parameter. In tests, always pass `DiarizationSettings(defaults: .init(suiteName: "TestClassName.diarization")!)` to isolate from user defaults.
-- Run tests with `make test` or via Xcode.
+- Run tests with `make test` or via Xcode. Package tests: `make package-test` (TranscriptionCore + MilaKit).
 
 ## Release Process
 - **Release notes are REQUIRED, first.** Every release must add

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "  models-coreml-tiny - Download ggml-tiny + sibling -encoder.mlmodelc into ~/.cache/whisper-coreml-test/ (for CI ANE verification test)"
 	@echo "  dmg           - Build a release DMG (VERSION=<x.y.z>) suitable for upload"
 	@echo "  e2e           - Run E2E transcription tests (requires ggml-tiny.bin)"
-	@echo "  package-test  - Run TranscriptionCore package unit tests"
+	@echo "  package-test  - Run TranscriptionCore + MilaKit package unit tests"
 	@echo "  bundle-diarization - Produce the bundled Python + pyannote.audio runtime under Mila/Resources/PythonRuntime/"
 	@echo "  clean         - Remove generated project and build artifacts"
 
@@ -118,6 +118,7 @@ models-coreml-tiny:
 
 package-test:
 	cd Packages/TranscriptionCore && swift test
+	cd Packages/MilaKit && swift test
 
 # Produces Mila/Resources/PythonRuntime/ — a relocatable Python
 # 3.11 with pyannote.audio (and deps) pre-installed, minus torch which

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import OSLog
+import MilaKit
 
 private let postRecordingLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
                                       category: "PostRecordingCoordinator")

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -124,6 +124,11 @@ final class QuickActionsController: ObservableObject {
     /// diarizer work so the final utterance's speaker label lands
     /// before the transcript is saved.
     var liveDiarizer: LiveSpeakerDiarizer?
+    /// Set after init by MilaApp. `stopRecording` closes the on-disk
+    /// live-transcript sidecar with the saved recording's id so external
+    /// pollers (mila-mcp) can hand off from the live feed to the stored
+    /// transcript.
+    var liveSidecarWriter: LiveTranscriptSidecarWriter?
 
     /// True only while `stopRecording` is running its inline LIVE-PIPELINE
     /// drain — the short, bounded window where it flushes the transcriber
@@ -558,6 +563,7 @@ final class QuickActionsController: ObservableObject {
             // over either way, so its notes must not carry into the next
             // recording.
             liveAISettings?.meetingContext = ""
+            liveSidecarWriter?.finish(recordingID: nil)
             isFinalizingRecording = false
             activeJob = .none
             return
@@ -637,6 +643,11 @@ final class QuickActionsController: ObservableObject {
             speakerNames: liveTranscriber?.speakerNames ?? [:]
         )
         store.add(recording)
+        // The recording is persisted — close the live sidecar with its id
+        // so an external poller's next get_live_transcript sees
+        // `completed` + the handoff id (the inline drain below keeps
+        // updating the STORED recording, which is what the handoff reads).
+        liveSidecarWriter?.finish(recordingID: recording.id)
         activeJob = .none
         if sleepReason != nil {
             sleepInterruption = SleepInterruption(

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -254,6 +254,10 @@ struct MilaApp: App {
     @StateObject private var speakerDirectory: SpeakerDirectory
     /// Applies double-clicked `.milaconfig` files (with a confirmation sheet).
     @StateObject private var configImporter: MilaConfigImporter
+    /// Mirrors the live transcript to `live/current.json` for external
+    /// tools (mila-mcp). Not observed by any view; held as a StateObject
+    /// purely so it survives SwiftUI re-inits like the other singletons.
+    @StateObject private var liveSidecarWriter: LiveTranscriptSidecarWriter
     @StateObject private var updater = UpdaterViewModel()
 
     init() {
@@ -459,6 +463,12 @@ struct MilaApp: App {
         actions.liveDiarizer = liveDiar
         actions.summarizer = summarizer
         actions.storageSettings = storage
+        // Live-transcript sidecar for external tools (mila-mcp). Anchored
+        // to the store's original root so tests / UI-test temp stores stay
+        // isolated from the user's real app-support directory.
+        let sidecarWriter = LiveTranscriptSidecarWriter(root: store.originalRootDirectory)
+        sidecarWriter.cleanupAtLaunch()
+        actions.liveSidecarWriter = sidecarWriter
         let meetingSettings = MeetingDetectionSettings()
         let detector = MeetingDetector()
         let promptCoordinator = MeetingPromptCoordinator(
@@ -510,6 +520,7 @@ struct MilaApp: App {
         _voiceMemosImporter = StateObject(wrappedValue: vmImporter)
         _speakerDirectory = StateObject(wrappedValue: SpeakerDirectory())
         _configImporter = StateObject(wrappedValue: configImporter)
+        _liveSidecarWriter = StateObject(wrappedValue: sidecarWriter)
         let dictationController = DictationController(store: store,
                                                       transcription: svc,
                                                       hotkeySettings: hotkeys,
@@ -1068,6 +1079,7 @@ struct MilaApp: App {
         // drain belongs here (sleep/lock/quit path) or to
         // `stopRecording` (Stop-button path).
         let actionsRef: QuickActionsController? = actions
+        let sidecarWriter = liveSidecarWriter
 
         var feedTask: Task<Void, Never>?
         var aiEnabledCancellable: AnyCancellable?
@@ -1123,10 +1135,19 @@ struct MilaApp: App {
                     // to a recording that never ran the LLM loop.
                     // Cursor flagged on c95d2bb.
                     aiSession.cancel()
+                    // Still surface the recording to external pollers
+                    // (mila-mcp): they get an honest "recording, but no
+                    // live text on this hardware" status instead of
+                    // silence.
+                    sidecarWriter.begin(title: nil, source: nil, liveAvailable: false)
                     os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
                         .log("wireLiveAIPipeline: .recording skipped — hardware below Live AI bar (model=\(aiSettings.capabilities.marketingName, privacy: .public))")
                     continue
                 }
+                // Open the live-transcript sidecar for this recording so
+                // external tools (mila-mcp) can follow the meeting; the
+                // feed loop below streams content into it.
+                sidecarWriter.begin(title: nil, source: nil, liveAvailable: true)
                 // Live transcription runs on every recording — it's how
                 // the recording UI shows the live transcript pane even
                 // when AI mode is off. Apply the user's tick-interval
@@ -1215,7 +1236,7 @@ struct MilaApp: App {
                     }
 
                 feedTask?.cancel()
-                feedTask = Task { @MainActor [weak transcriber, weak diarizer, weak aiSession, aiSettings, llmSettingsRef] in
+                feedTask = Task { @MainActor [weak transcriber, weak diarizer, weak aiSession, weak sidecarWriter, aiSettings, llmSettingsRef] in
                     var lastFed = ""
                     guard let transcriber else { return }
                     for await _ in transcriber.$segments.values {
@@ -1236,6 +1257,14 @@ struct MilaApp: App {
                         if let diarizer {
                             transcriber.applySpeakerLabels(diarizer.intervals)
                         }
+                        // Mirror the tick to the on-disk live sidecar
+                        // (throttled + deduped inside the writer).
+                        let liveSegments = transcriber.segments.map {
+                            TranscriptSegment(start: $0.startSeconds, end: $0.endSeconds,
+                                              text: $0.text, speaker: $0.speaker)
+                        }
+                        sidecarWriter?.update(segments: liveSegments,
+                                              speakerNames: transcriber.speakerNames)
                         if aiActive {
                             let text = transcriber.formattedTranscript
                             if text != lastFed, !text.isEmpty {
@@ -1318,6 +1347,11 @@ struct MilaApp: App {
                     // `stopRecording`, which owns finalize and cancels the
                     // session itself once its snapshot is stored.
                     aiSession.cancel()
+                    // Close the live sidecar with no handoff id — this
+                    // teardown path (sleep/lock/quit/cancelAll) has no
+                    // saved Recording yet; the Stop-button path closes
+                    // it from stopRecording with the real id instead.
+                    sidecarWriter.finish(recordingID: nil)
                 }
                 // Note: no aiSession.cancel() out here, outside the branch
                 // above — this handler fires during `session.stop()`,

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import OSLog
 import TranscriptionCore
+import MilaKit
 
 private let liveLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LiveTranscriber")
 

--- a/Mila/MCP/LiveTranscriptSidecarWriter.swift
+++ b/Mila/MCP/LiveTranscriptSidecarWriter.swift
@@ -1,0 +1,159 @@
+import Foundation
+import OSLog
+import TranscriptionCore
+import MilaKit
+
+private let sidecarLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                category: "LiveTranscriptSidecar")
+
+/// Mirrors the in-progress recording's live transcript to
+/// `<app-support>/Mila/live/current.json` so external tools (mila-mcp)
+/// can follow the meeting in real time. The live transcript otherwise
+/// exists only in `LiveTranscriber`'s memory until Stop.
+///
+/// Writes are throttled (content ticks arrive per whisper pass) and
+/// atomic (temp + rename via `.atomic`), so a concurrent reader always
+/// sees a complete document. A heartbeat refreshes `updatedAt` every few
+/// seconds while recording so a reader can distinguish "meeting is quiet"
+/// from "app died mid-meeting".
+@MainActor
+final class LiveTranscriptSidecarWriter: ObservableObject {
+
+    private let root: URL
+    private let minWriteInterval: TimeInterval
+    private let heartbeatInterval: TimeInterval
+
+    private var snapshot: LiveTranscriptSnapshot?
+    private var lastWriteAt: Date = .distantPast
+    private var trailingWriteTask: Task<Void, Never>?
+    private var heartbeatTask: Task<Void, Never>?
+
+    /// `root` is the directory holding the `live/` subdirectory — the
+    /// default app-support root in production, a temp dir in tests.
+    init(root: URL = StoreLocationPointer.defaultRoot(),
+         minWriteInterval: TimeInterval = 1.5,
+         heartbeatInterval: TimeInterval = 5) {
+        self.root = root
+        self.minWriteInterval = minWriteInterval
+        self.heartbeatInterval = heartbeatInterval
+    }
+
+    /// Call once at app launch: a leftover `recording` snapshot means the
+    /// app died mid-recording — rewrite it as `interrupted` so a poller
+    /// doesn't sit on a transcript that will never grow. (Crash recovery
+    /// re-transcribes the orphan WAV through the normal batch queue.)
+    func cleanupAtLaunch() {
+        guard var stale = LiveTranscriptSnapshot.read(root: root),
+              stale.state == .recording else { return }
+        stale.state = .interrupted
+        stale.revision += 1
+        stale.updatedAt = Date()
+        do {
+            try stale.write(root: root)
+            sidecarLog.log("marked leftover live snapshot interrupted (session \(stale.sessionID, privacy: .public))")
+        } catch {
+            sidecarLog.error("cleanupAtLaunch write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Start a new session snapshot. `liveAvailable: false` records that
+    /// the capture is running but no live transcript will appear (the
+    /// low-end-hardware gate) — external pollers get an honest status
+    /// instead of a silent, forever-empty transcript.
+    func begin(title: String?, source: String?, liveAvailable: Bool) {
+        cancelTimers()
+        let now = Date()
+        snapshot = LiveTranscriptSnapshot(liveTranscriptAvailable: liveAvailable,
+                                          recordingStartedAt: now,
+                                          updatedAt: now,
+                                          title: title,
+                                          source: source?.isEmpty == false ? source : nil)
+        writeNow()
+        startHeartbeat()
+    }
+
+    /// Content tick: replace segments + speaker names. Bumps `revision`
+    /// only when something actually changed (the `$segments` feed fires
+    /// on every reassignment, changed or not), and coalesces bursts down
+    /// to one write per `minWriteInterval` with a guaranteed trailing
+    /// write so the last tick of a burst always lands.
+    func update(segments: [TranscriptSegment], speakerNames: [String: String]) {
+        guard var current = snapshot, current.state == .recording else { return }
+        let mapped = segments.map {
+            LiveTranscriptSnapshot.Segment(start: $0.start, end: $0.end,
+                                           text: $0.text, speaker: $0.speaker)
+        }
+        guard mapped != current.segments || speakerNames != current.speakerNames else { return }
+        current.segments = mapped
+        current.speakerNames = speakerNames
+        current.revision += 1
+        snapshot = current
+        scheduleWrite()
+    }
+
+    /// Final write for this session. Pass the saved recording's id on the
+    /// normal Stop path (poller handoff to `get_transcript`); nil when
+    /// there's nothing to hand off (failed stop, sleep/lock teardown).
+    /// The completed snapshot stays on disk until the next `begin`.
+    func finish(recordingID: UUID?) {
+        cancelTimers()
+        guard var current = snapshot, current.state == .recording else { return }
+        current.state = .completed
+        current.finalRecordingID = recordingID
+        current.revision += 1
+        snapshot = current
+        writeNow()
+        snapshot = nil
+    }
+
+    // MARK: - Write scheduling
+
+    private func scheduleWrite() {
+        let elapsed = Date().timeIntervalSince(lastWriteAt)
+        if elapsed >= minWriteInterval {
+            trailingWriteTask?.cancel()
+            trailingWriteTask = nil
+            writeNow()
+        } else if trailingWriteTask == nil {
+            let delay = minWriteInterval - elapsed
+            trailingWriteTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                self.trailingWriteTask = nil
+                self.writeNow()
+            }
+        }
+    }
+
+    private func writeNow() {
+        guard var current = snapshot else { return }
+        current.updatedAt = Date()
+        snapshot = current
+        lastWriteAt = Date()
+        do {
+            try current.write(root: root)
+        } catch {
+            sidecarLog.error("live snapshot write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func startHeartbeat() {
+        heartbeatTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let interval = self?.heartbeatInterval else { return }
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                guard !Task.isCancelled, let self, self.snapshot?.state == .recording else { continue }
+                // Refresh updatedAt (liveness) without touching revision
+                // (content cursor) — quiet meetings stay cheap to poll.
+                self.writeNow()
+            }
+        }
+    }
+
+    private func cancelTimers() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        trailingWriteTask?.cancel()
+        trailingWriteTask = nil
+    }
+}

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import OSLog
+import MilaKit
 
 private let recStoreLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "RecordingStore")
 
@@ -131,6 +132,7 @@ final class RecordingStore: ObservableObject {
         load()
         loadFolders()
         loadTombstones()
+        writeStoreLocationPointer()
     }
 
     /// Switch the recordings directory to `newDirectory`. Clears the
@@ -168,6 +170,25 @@ final class RecordingStore: ObservableObject {
         self.pendingRecoveryIDs = []
         load()
         loadFolders()
+        writeStoreLocationPointer()
+    }
+
+    /// Mirror the resolved store paths into `store-location.json` at the
+    /// original root so external tools (mila-mcp) can find the store even
+    /// when the user relocated the recordings directory — the relocation
+    /// itself lives in a security-scoped bookmark another process can't
+    /// resolve. Always written at the ORIGINAL root: on the default path
+    /// that's Application Support/Mila, and test instances (temp roots)
+    /// stay isolated automatically.
+    private func writeStoreLocationPointer() {
+        let pointer = StoreLocationPointer(recordingsDirectory: recordingsDirectory.path,
+                                           storeFile: storeURL.path,
+                                           updatedAt: Date())
+        do {
+            try pointer.write(to: originalRootDirectory)
+        } catch {
+            recStoreLog.error("failed to write store-location pointer: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func audioURL(for recording: Recording) -> URL {

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -114,8 +114,11 @@ final class RecordingStore: ObservableObject {
     /// `relocateRecordings(to: nil)` can revert to the original
     /// default-path layout (json files sit alongside the `Recordings/`
     /// subdir, matching the historical shape that pre-v1.7 builds
-    /// shipped).
-    private let originalRootDirectory: URL
+    /// shipped). Exposed (read-only) so app-state siblings that must NOT
+    /// travel with a relocated recordings folder — the store-location
+    /// pointer, the live-transcript sidecar — anchor to the same root,
+    /// keeping test instances (temp roots) isolated automatically.
+    let originalRootDirectory: URL
 
     init(rootDirectory: URL) {
         self.originalRootDirectory = rootDirectory

--- a/Mila/Transcription/TranscriptSegment+Formatter.swift
+++ b/Mila/Transcription/TranscriptSegment+Formatter.swift
@@ -1,0 +1,4 @@
+import TranscriptionCore
+import MilaKit
+
+extension TranscriptSegment: SpeakerTextSegment {}

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -3,6 +3,7 @@ import AVKit
 import AppKit
 import TranscriptionCore
 import UniformTypeIdentifiers
+import MilaKit
 
 struct RecordingDetailView: View {
     let recording: Recording

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import MilaKit
 
 /// Shown the moment a recording is added — i.e. as soon as recording stops,
 /// in parallel with transcription. The user can type a title and Save at any

--- a/Mila/Views/SendToLLMSheet.swift
+++ b/Mila/Views/SendToLLMSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MilaKit
 
 /// Sheet shown when the user right-clicks a recording and picks
 /// "Send to <LLM>…". Surfaces the prompt that will be sent (editable for

--- a/MilaMCP/MilaMCPMain.swift
+++ b/MilaMCP/MilaMCPMain.swift
@@ -13,7 +13,12 @@ import MilaKit
 struct MilaMCPMain {
 
     static func main() async throws {
-        let handlers = MilaMCPToolHandlers()
+        // MILA_ROOT overrides the app-support root — for tests and
+        // debugging against a fixture store; unset in normal use.
+        let root = ProcessInfo.processInfo.environment["MILA_ROOT"]
+            .map { URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? StoreLocationPointer.defaultRoot()
+        let handlers = MilaMCPToolHandlers(root: root)
 
         let tools: [Tool] = try MilaMCPToolHandlers.toolSpecs.map { spec in
             let schemaData = try JSONSerialization.data(withJSONObject: spec.inputSchema)

--- a/MilaMCP/MilaMCPMain.swift
+++ b/MilaMCP/MilaMCPMain.swift
@@ -1,0 +1,73 @@
+import Foundation
+import MCP
+import MilaKit
+
+/// mila-mcp — MCP stdio server exposing Mila's transcriptions to Claude
+/// (Claude Code / Claude Desktop). Register once with:
+///
+///     claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp
+///
+/// All tool logic lives in MilaKit's `MilaMCPToolHandlers` (pure
+/// JSON-in/JSON-out); this file is only the SDK/transport shell.
+@main
+struct MilaMCPMain {
+
+    static func main() async throws {
+        let handlers = MilaMCPToolHandlers()
+
+        let tools: [Tool] = try MilaMCPToolHandlers.toolSpecs.map { spec in
+            let schemaData = try JSONSerialization.data(withJSONObject: spec.inputSchema)
+            let schema = try JSONDecoder().decode(Value.self, from: schemaData)
+            return Tool(name: spec.name, description: spec.description, inputSchema: schema)
+        }
+
+        let server = Server(
+            name: "mila",
+            version: appVersion(),
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: tools)
+        }
+
+        await server.withMethodHandler(CallTool.self) { params in
+            do {
+                let arguments = try jsonObject(from: params.arguments)
+                let result = try handlers.handle(tool: params.name, arguments: arguments)
+                return CallTool.Result(content: [.text(result)], isError: false)
+            } catch {
+                return CallTool.Result(content: [.text(String(describing: error))],
+                                       isError: true)
+            }
+        }
+
+        try await server.start(transport: StdioTransport())
+        await server.waitUntilCompleted()
+    }
+
+    /// Bridge the SDK's `Value` arguments into the Foundation JSON tree
+    /// the handler layer consumes.
+    private static func jsonObject(from arguments: [String: Value]?) throws -> [String: Any] {
+        guard let arguments, !arguments.isEmpty else { return [:] }
+        let data = try JSONEncoder().encode(arguments)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return object as? [String: Any] ?? [:]
+    }
+
+    /// The helper ships inside Mila.app — report the app's version when
+    /// we can find it (…/Mila.app/Contents/MacOS/mila-mcp → Info.plist),
+    /// so `initialize` handshakes identify the build.
+    private static func appVersion() -> String {
+        let binary = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
+        let infoPlist = binary
+            .deletingLastPathComponent()   // MacOS
+            .deletingLastPathComponent()   // Contents
+            .appendingPathComponent("Info.plist")
+        if let info = NSDictionary(contentsOf: infoPlist),
+           let version = info["CFBundleShortVersionString"] as? String {
+            return version
+        }
+        return "dev"
+    }
+}

--- a/MilaTests/LiveTranscriptSidecarWriterTests.swift
+++ b/MilaTests/LiveTranscriptSidecarWriterTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import TranscriptionCore
+import MilaKit
+@testable import Mila
+
+@MainActor
+final class LiveTranscriptSidecarWriterTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUp() {
+        super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SidecarTests-\(UUID())", isDirectory: true)
+    }
+
+    override func tearDown() {
+        if let root { try? FileManager.default.removeItem(at: root) }
+        super.tearDown()
+    }
+
+    private func snapshot() -> LiveTranscriptSnapshot? {
+        LiveTranscriptSnapshot.read(root: root)
+    }
+
+    private func segs(_ texts: String...) -> [TranscriptSegment] {
+        texts.enumerated().map { i, t in
+            TranscriptSegment(start: Double(i), end: Double(i + 1), text: t,
+                              speaker: "SPEAKER_00")
+        }
+    }
+
+    func test_begin_writes_recording_snapshot() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: "meeting", liveAvailable: true)
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .recording)
+        XCTAssertTrue(snap.liveTranscriptAvailable)
+        XCTAssertEqual(snap.revision, 1)
+        XCTAssertEqual(snap.source, "meeting")
+        XCTAssertTrue(snap.segments.isEmpty)
+    }
+
+    func test_update_bumps_revision_and_writes_content() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: ["SPEAKER_00": "Dana"])
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.revision, 2)
+        XCTAssertEqual(snap.segments.map(\.text), ["hello"])
+        XCTAssertEqual(snap.speakerNames, ["SPEAKER_00": "Dana"])
+    }
+
+    func test_unchanged_update_does_not_bump_revision() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        XCTAssertEqual(try XCTUnwrap(snapshot()).revision, 2)
+    }
+
+    func test_trailing_write_lands_after_throttle_window() async throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0.15)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        // Two updates inside one throttle window: the second must land via
+        // the trailing write, not be dropped.
+        writer.update(segments: segs("one"), speakerNames: [:])
+        writer.update(segments: segs("one", "two"), speakerNames: [:])
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.segments.map(\.text), ["one", "two"])
+        XCTAssertEqual(snap.revision, 3)
+    }
+
+    func test_finish_marks_completed_with_handoff_id_and_stops_updates() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("hello"), speakerNames: [:])
+        let recordingID = UUID()
+        writer.finish(recordingID: recordingID)
+
+        var snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .completed)
+        XCTAssertEqual(snap.finalRecordingID, recordingID)
+
+        // Snapshot stays on disk (poller handoff) and later updates are ignored.
+        writer.update(segments: segs("late"), speakerNames: [:])
+        snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.state, .completed)
+        XCTAssertEqual(snap.segments.map(\.text), ["hello"])
+    }
+
+    func test_gated_hardware_snapshot_reports_live_unavailable() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: false)
+        XCTAssertFalse(try XCTUnwrap(snapshot()).liveTranscriptAvailable)
+    }
+
+    func test_cleanup_at_launch_marks_leftover_recording_interrupted() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        // Simulate a crash: a fresh writer (new process) finds the stale file.
+        let relaunched = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        relaunched.cleanupAtLaunch()
+        XCTAssertEqual(try XCTUnwrap(snapshot()).state, .interrupted)
+    }
+
+    func test_new_session_gets_fresh_session_id() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        let first = try XCTUnwrap(snapshot()).sessionID
+        writer.finish(recordingID: nil)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        let second = try XCTUnwrap(snapshot()).sessionID
+        XCTAssertNotEqual(first, second)
+    }
+}

--- a/MilaTests/RecordingStoreTests.swift
+++ b/MilaTests/RecordingStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MilaKit
 @testable import Mila
 
 @MainActor
@@ -596,5 +597,30 @@ final class RecordingStoreTests: XCTestCase {
         store.add(voiceMemoImport("a", fromFolderID: "FOLDER-1"))
         XCTAssertEqual(store.softDeleteVoiceMemos(fromFolderID: "FOLDER-UNKNOWN"), 0)
         XCTAssertFalse(store.recordings.first?.isTrashed ?? true)
+    }
+
+    // MARK: - Store-location pointer (mila-mcp discovery contract)
+
+    func test_init_writes_store_location_pointer_at_root() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory, store.recordingsDirectory.path)
+        XCTAssertEqual(pointer.storeFile, store.storeURL.path)
+    }
+
+    func test_relocate_updates_pointer_and_reset_restores_it() throws {
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let custom = tempRoot.appendingPathComponent("Elsewhere", isDirectory: true)
+
+        store.relocateRecordings(to: custom)
+        var pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory, custom.path)
+        XCTAssertEqual(pointer.storeFile,
+                       custom.appendingPathComponent("recordings.json").path)
+
+        store.relocateRecordings(to: nil)
+        pointer = try XCTUnwrap(StoreLocationPointer.read(from: tempRoot))
+        XCTAssertEqual(pointer.recordingsDirectory,
+                       store.defaultRecordingsDirectory.path)
     }
 }

--- a/MilaTests/StoredRecordingDriftTests.swift
+++ b/MilaTests/StoredRecordingDriftTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import TranscriptionCore
+import MilaKit
+@testable import Mila
+
+/// Guards the cross-process contract between the app's `Recording`
+/// (what `RecordingStore.persist()` writes into recordings.json) and
+/// MilaKit's read-only `StoredRecording` mirror (what mila-mcp decodes).
+/// If a field is added to `Recording`'s encoder, this test is the tripwire
+/// reminding you to mirror it in `StoredRecording`.
+final class StoredRecordingDriftTests: XCTestCase {
+
+    private func storeEncoder() -> JSONEncoder {
+        // Must match RecordingStore.persist().
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+
+    private func storeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func test_fully_populated_recording_round_trips_into_stored_recording() throws {
+        let id = UUID()
+        let created = Date(timeIntervalSince1970: 1_700_000_000)
+        let deleted = Date(timeIntervalSince1970: 1_700_000_500)
+        let recording = Recording(
+            id: id,
+            title: "Weekly sync",
+            createdAt: created,
+            duration: 123.5,
+            source: .meeting,
+            audioFileName: "Weekly sync.wav",
+            status: .completed,
+            language: "en",
+            modelName: "large-v3",
+            segments: [
+                TranscriptSegment(start: 0, end: 2, text: "hello", speaker: "SPEAKER_00"),
+                TranscriptSegment(start: 2, end: 4, text: "hi there", speaker: "SPEAKER_01"),
+            ],
+            fullText: "hello hi there",
+            deletedAt: deleted,
+            folder: "Work",
+            appName: "zoom.us",
+            summary: "A summary.",
+            actionItems: [ActionItem(id: "a1", text: "Ship it", speaker: "SPEAKER_00",
+                                     timestampSeconds: 3, source: .llmInferred,
+                                     addedAt: created)],
+            voiceMemoUniqueID: "VM-1",
+            voiceMemoFolderUUID: "VMF-1",
+            speakerNames: ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"]
+        )
+
+        let data = try storeEncoder().encode([recording])
+        let stored = try storeDecoder().decode([StoredRecording].self, from: data)
+        XCTAssertEqual(stored.count, 1)
+        let s = try XCTUnwrap(stored.first)
+
+        XCTAssertEqual(s.id, id)
+        XCTAssertEqual(s.title, "Weekly sync")
+        XCTAssertEqual(s.createdAt, created)
+        XCTAssertEqual(s.duration, 123.5, accuracy: 0.001)
+        XCTAssertEqual(s.source, RecordingSource.meeting.rawValue)
+        XCTAssertEqual(s.audioFileName, "Weekly sync.wav")
+        XCTAssertEqual(s.status, TranscriptionStatus.completed.rawValue)
+        XCTAssertEqual(s.language, "en")
+        XCTAssertEqual(s.modelName, "large-v3")
+        XCTAssertEqual(s.segments.count, 2)
+        XCTAssertEqual(s.segments[0].text, "hello")
+        XCTAssertEqual(s.segments[0].speaker, "SPEAKER_00")
+        XCTAssertEqual(s.segments[1].start, 2, accuracy: 0.001)
+        XCTAssertEqual(s.segments[1].end, 4, accuracy: 0.001)
+        XCTAssertEqual(s.deletedAt, deleted)
+        XCTAssertTrue(s.isTrashed)
+        XCTAssertEqual(s.folder, "Work")
+        XCTAssertEqual(s.appName, "zoom.us")
+        XCTAssertEqual(s.summary, "A summary.")
+        XCTAssertEqual(s.actionItems?.count, 1)
+        XCTAssertEqual(s.actionItems?.first?.text, "Ship it")
+        XCTAssertEqual(s.actionItems?.first?.speaker, "SPEAKER_00")
+        XCTAssertEqual(s.actionItems?.first?.timestampSeconds, 3)
+        XCTAssertEqual(s.speakerNames, ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"])
+        // fullText is deliberately NOT encoded by the app (sidecar .txt owns it).
+        XCTAssertNil(s.legacyFullText)
+        XCTAssertEqual(s.transcriptFileName, "Weekly sync.txt")
+        XCTAssertEqual(s.summaryFileName, "Weekly sync.summary.txt")
+        XCTAssertEqual(s.speakerDisplayNames, ["Daniel", "John Doe"])
+    }
+
+    func test_minimal_recording_decodes_with_defaults() throws {
+        let recording = Recording(title: "Bare", source: .microphone,
+                                  audioFileName: "bare.wav")
+        let data = try storeEncoder().encode([recording])
+        let s = try XCTUnwrap(storeDecoder().decode([StoredRecording].self, from: data).first)
+        XCTAssertEqual(s.title, "Bare")
+        XCTAssertEqual(s.status, TranscriptionStatus.pending.rawValue)
+        // speakerNames is omitted from JSON when empty — mirror defaults to [:].
+        XCTAssertEqual(s.speakerNames, [:])
+        XCTAssertNil(s.deletedAt)
+        XCTAssertFalse(s.isTrashed)
+        XCTAssertEqual(s.segments.count, 0)
+        XCTAssertNil(s.actionItems)
+    }
+
+    func test_legacy_inline_fulltext_decodes() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","title":"Old","createdAt":"2023-01-01T00:00:00Z",
+        "duration":1,"source":"microphone","audioFileName":"old.wav","status":"completed",
+        "language":"he","segments":[],"fullText":"inline legacy text"}]
+        """
+        let s = try XCTUnwrap(storeDecoder()
+            .decode([StoredRecording].self, from: Data(json.utf8)).first)
+        XCTAssertEqual(s.legacyFullText, "inline legacy text")
+    }
+}

--- a/MilaTests/TranscriptFormatterTests.swift
+++ b/MilaTests/TranscriptFormatterTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TranscriptionCore
+import MilaKit
 @testable import Mila
 
 final class TranscriptFormatterTests: XCTestCase {

--- a/Packages/MilaKit/Package.swift
+++ b/Packages/MilaKit/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "MilaKit",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "MilaKit", targets: ["MilaKit"]),
+    ],
+    targets: [
+        .target(name: "MilaKit"),
+        .testTarget(
+            name: "MilaKitTests",
+            dependencies: ["MilaKit"]
+        ),
+    ]
+)

--- a/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
+++ b/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// On-disk snapshot of the in-progress recording's live transcript —
+/// `<app-support>/Mila/live/current.json`. Written by the app
+/// (`LiveTranscriptSidecarWriter`) on every live-transcript tick and read
+/// by mila-mcp's `get_live_transcript` tool, so an external Claude session
+/// can follow a meeting while it happens.
+///
+/// Freshness contract: `revision` bumps on every CONTENT change (segments
+/// or speaker names) and is the poller's cheap "anything new?" cursor.
+/// `updatedAt` is a liveness heartbeat, refreshed every few seconds even
+/// when nothing was said — a `recording` snapshot whose heartbeat is stale
+/// means the app crashed or hung mid-meeting. `sessionID` is minted fresh
+/// per recording so a poller can tell "same meeting, nothing new" apart
+/// from "a different meeting whose counters happen to line up".
+public struct LiveTranscriptSnapshot: Codable {
+
+    public enum State: String, Codable {
+        /// A recording is in progress; segments may still grow.
+        case recording
+        /// The recording ended normally; `finalRecordingID` points at the
+        /// saved recording. Kept on disk until the next recording begins
+        /// so a poller can't miss the handoff.
+        case completed
+        /// A leftover `recording` snapshot found at app launch — the app
+        /// died mid-recording. Crash recovery re-transcribes the audio
+        /// separately; the live feed is over.
+        case interrupted
+    }
+
+    public typealias Segment = StoredRecording.Segment
+
+    public var version: Int
+    public var sessionID: UUID
+    public var state: State
+    /// False when the recording runs on hardware below the live-AI bar:
+    /// the meeting is being captured, but no live transcript will appear
+    /// until it completes.
+    public var liveTranscriptAvailable: Bool
+    public var recordingStartedAt: Date
+    public var updatedAt: Date
+    /// Monotonic within a session; bumps only on content changes.
+    public var revision: Int
+    public var title: String?
+    /// Raw `RecordingSource` value, when known.
+    public var source: String?
+    public var segments: [Segment]
+    public var speakerNames: [String: String]
+    /// Set when `state == .completed` — the saved recording's UUID, for
+    /// handoff to `get_transcript`.
+    public var finalRecordingID: UUID?
+
+    public init(version: Int = 1,
+                sessionID: UUID = UUID(),
+                state: State = .recording,
+                liveTranscriptAvailable: Bool = true,
+                recordingStartedAt: Date,
+                updatedAt: Date,
+                revision: Int = 1,
+                title: String? = nil,
+                source: String? = nil,
+                segments: [Segment] = [],
+                speakerNames: [String: String] = [:],
+                finalRecordingID: UUID? = nil) {
+        self.version = version
+        self.sessionID = sessionID
+        self.state = state
+        self.liveTranscriptAvailable = liveTranscriptAvailable
+        self.recordingStartedAt = recordingStartedAt
+        self.updatedAt = updatedAt
+        self.revision = revision
+        self.title = title
+        self.source = source
+        self.segments = segments
+        self.speakerNames = speakerNames
+        self.finalRecordingID = finalRecordingID
+    }
+
+    /// Heartbeat age beyond which a `recording` snapshot is reported stale.
+    public static let staleAfter: TimeInterval = 20
+
+    public static let directoryName = "live"
+    public static let fileName = "current.json"
+
+    public static func fileURL(root: URL = StoreLocationPointer.defaultRoot()) -> URL {
+        root.appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(fileName)
+    }
+
+    public static func read(root: URL = StoreLocationPointer.defaultRoot()) -> LiveTranscriptSnapshot? {
+        guard let data = try? Data(contentsOf: fileURL(root: root)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(LiveTranscriptSnapshot.self, from: data)
+    }
+
+    public func write(root: URL = StoreLocationPointer.defaultRoot()) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(self)
+        let url = Self.fileURL(root: root)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        // .atomic = write-to-temp + rename, so a concurrent reader always
+        // sees a complete JSON document.
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Segments a poller hasn't fully seen. Returns from ONE BEFORE
+    /// `index` — the last segment the client already has is re-sent
+    /// because the live merge can rewrite the trailing segment's text as
+    /// more audio context arrives; the client replaces its copy.
+    public func segments(sinceIndex index: Int) -> [Segment] {
+        let start = max(0, min(index - 1, segments.count))
+        return Array(segments[start...])
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
+++ b/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
@@ -1,0 +1,414 @@
+import Foundation
+
+/// The mila-mcp tool surface, implemented as a pure JSON-in / JSON-out
+/// layer with no MCP-SDK types — the executable's transport wiring stays
+/// a thin shell (and swappable for a hand-rolled JSON-RPC loop if the SDK
+/// ever misbehaves), and everything here is unit-testable in-process.
+public struct MilaMCPToolHandlers {
+
+    public enum ToolError: Error, CustomStringConvertible {
+        case unknownTool(String)
+        case invalidArguments(String)
+        case notFound(String)
+        case storeUnavailable(String)
+
+        public var description: String {
+            switch self {
+            case .unknownTool(let name): return "Unknown tool: \(name)"
+            case .invalidArguments(let msg): return "Invalid arguments: \(msg)"
+            case .notFound(let msg): return msg
+            case .storeUnavailable(let msg):
+                return "Mila's recording store could not be read (\(msg)). "
+                    + "Has the Mila app run at least once on this Mac?"
+            }
+        }
+    }
+
+    public struct ToolSpec {
+        public let name: String
+        public let description: String
+        /// JSON Schema for the tool's arguments, as a JSON object tree
+        /// ([String: Any]), ready to re-encode into any transport's type.
+        public let inputSchema: [String: Any]
+    }
+
+    /// Root under which `store-location.json` and `live/current.json`
+    /// live — the default Mila app-support directory in production, a
+    /// temp fixture in tests.
+    private let root: URL
+    private let now: () -> Date
+
+    public init(root: URL = StoreLocationPointer.defaultRoot(),
+                now: @escaping () -> Date = Date.init) {
+        self.root = root
+        self.now = now
+    }
+
+    // MARK: - Tool definitions
+
+    public static let toolSpecs: [ToolSpec] = [
+        ToolSpec(
+            name: "list_recordings",
+            description: """
+            List Mila recordings (meetings, voice memos, app-audio captures), newest first by \
+            default. Filter by speaker display name to find conversations with a specific \
+            person — e.g. the last meeting with John Doe is list_recordings(speaker: "john \
+            doe", limit: 1). Trashed recordings are excluded.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "query": ["type": "string",
+                              "description": "Substring match over title, app name, and folder."],
+                    "speaker": ["type": "string",
+                                "description": "Case-insensitive substring over the recording's speaker display names (as renamed by the user)."],
+                    "folder": ["type": "string", "description": "Filter to a folder by name."],
+                    "source": ["type": "string",
+                               "enum": ["microphone", "systemAudio", "meeting", "voiceMemo"],
+                               "description": "Filter by capture source."],
+                    "after": ["type": "string",
+                              "description": "ISO 8601 date; only recordings created at/after this instant."],
+                    "before": ["type": "string",
+                               "description": "ISO 8601 date; only recordings created at/before this instant."],
+                    "sort": ["type": "string", "enum": ["created_at", "duration", "title"],
+                             "description": "Sort key (default created_at)."],
+                    "order": ["type": "string", "enum": ["asc", "desc"],
+                              "description": "Sort order (default desc)."],
+                    "limit": ["type": "integer", "description": "Max results (default 20, max 100)."],
+                ],
+            ]
+        ),
+        ToolSpec(
+            name: "get_transcript",
+            description: """
+            Fetch one recording's full transcript with speaker names resolved (e.g. "John \
+            Doe: …"), plus its summary and action items when available. Pass the id from \
+            list_recordings/search_transcripts; omit it for the latest completed recording.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "id": ["type": "string",
+                           "description": "Recording UUID. Omit for the latest completed recording."],
+                    "include_summary": ["type": "boolean",
+                                        "description": "Include summary + action items (default true)."],
+                    "max_chars": ["type": "integer",
+                                  "description": "Truncate the transcript to this many characters."],
+                ],
+            ]
+        ),
+        ToolSpec(
+            name: "search_transcripts",
+            description: """
+            Full-text search over recording titles and transcript text (case- and \
+            diacritic-insensitive). Returns matching recordings with short context snippets; \
+            follow up with get_transcript for the full text.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "query": ["type": "string", "description": "Text to search for."],
+                    "speaker": ["type": "string",
+                                "description": "Only search recordings featuring this speaker display name."],
+                    "sort": ["type": "string", "enum": ["relevance", "created_at"],
+                             "description": "relevance = match count, ties newest-first (default)."],
+                    "order": ["type": "string", "enum": ["asc", "desc"],
+                              "description": "Sort order (default desc)."],
+                    "limit": ["type": "integer", "description": "Max results (default 10)."],
+                ],
+                "required": ["query"],
+            ]
+        ),
+        ToolSpec(
+            name: "get_live_transcript",
+            description: """
+            Read the in-progress Mila recording's live transcript. To follow a meeting, poll \
+            this every 15-20 seconds passing back the returned session_id, revision (as \
+            since_revision) and next_segment_index (as since_segment_index): unchanged \
+            meetings answer with a tiny {changed:false}, and changed ones return only the new \
+            segments (the last previously-seen segment is re-sent because live transcription \
+            may rewrite it — replace your copy). When status becomes "completed", stop \
+            polling and call get_transcript with the returned final_recording_id.
+            """,
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "session_id": ["type": "string",
+                                   "description": "The session_id from the previous poll. A mismatch means a new recording started; the full new transcript is returned."],
+                    "since_revision": ["type": "integer",
+                                       "description": "The revision from the previous poll; equal revision short-circuits to {changed:false}."],
+                    "since_segment_index": ["type": "integer",
+                                            "description": "The next_segment_index from the previous poll; only segments from one before this index are returned."],
+                ],
+            ]
+        ),
+    ]
+
+    // MARK: - Dispatch
+
+    /// Execute a tool call. Returns the result as a JSON string.
+    public func handle(tool: String, arguments: [String: Any]) throws -> String {
+        switch tool {
+        case "list_recordings": return try listRecordings(arguments)
+        case "get_transcript": return try getTranscript(arguments)
+        case "search_transcripts": return try searchTranscripts(arguments)
+        case "get_live_transcript": return try getLiveTranscript(arguments)
+        default: throw ToolError.unknownTool(tool)
+        }
+    }
+
+    // MARK: - Tools
+
+    private func listRecordings(_ args: [String: Any]) throws -> String {
+        let reader = MilaStoreReader(root: root)
+        let filter = MilaStoreReader.Filter(
+            query: args["query"] as? String,
+            speaker: args["speaker"] as? String,
+            folder: args["folder"] as? String,
+            source: args["source"] as? String,
+            after: try date(args, "after"),
+            before: try date(args, "before")
+        )
+        let sort = try enumArg(args, "sort", MilaStoreReader.SortKey.self) ?? .createdAt
+        let order = try enumArg(args, "order", MilaStoreReader.SortOrder.self) ?? .desc
+        let limit = min(args["limit"] as? Int ?? 20, 100)
+        let recordings: [StoredRecording]
+        do {
+            recordings = try reader.listRecordings(filter: filter, sort: sort,
+                                                   order: order, limit: limit)
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+        return try json([
+            "count": recordings.count,
+            "recordings": recordings.map { summaryObject(for: $0) },
+        ])
+    }
+
+    private func getTranscript(_ args: [String: Any]) throws -> String {
+        let reader = MilaStoreReader(root: root)
+        let recording: StoredRecording
+        do {
+            if let idString = args["id"] as? String {
+                guard let id = UUID(uuidString: idString) else {
+                    throw ToolError.invalidArguments("id must be a UUID, got \"\(idString)\"")
+                }
+                guard let found = try reader.recording(id: id) else {
+                    throw ToolError.notFound("No recording with id \(id.uuidString)")
+                }
+                recording = found
+            } else {
+                guard let latest = try reader.latestCompletedRecording() else {
+                    throw ToolError.notFound("No completed recordings exist yet")
+                }
+                recording = latest
+            }
+        } catch let error as ToolError {
+            throw error
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+
+        var transcript = reader.namedTranscript(for: recording)
+        var truncated = false
+        if let maxChars = args["max_chars"] as? Int, maxChars > 0, transcript.count > maxChars {
+            transcript = String(transcript.prefix(maxChars))
+            truncated = true
+        }
+        var result = summaryObject(for: recording)
+        result["language"] = recording.language
+        result["transcript"] = transcript
+        result["transcript_truncated"] = truncated
+        if recording.status != "completed" {
+            result["note"] = "Transcription status is \"\(recording.status)\" — the transcript may be partial."
+        }
+        if (args["include_summary"] as? Bool) ?? true {
+            if let summary = recording.summary, !summary.isEmpty {
+                result["summary"] = summary
+            }
+            if let items = recording.actionItems, !items.isEmpty {
+                result["action_items"] = items.map { item in
+                    var obj: [String: Any] = ["text": item.text]
+                    if let speaker = item.speaker {
+                        obj["speaker"] = recording.speakerNames[speaker] ?? speaker
+                    }
+                    return obj
+                }
+            }
+        }
+        return try json(result)
+    }
+
+    private func searchTranscripts(_ args: [String: Any]) throws -> String {
+        guard let query = args["query"] as? String, !query.isEmpty else {
+            throw ToolError.invalidArguments("query is required")
+        }
+        let reader = MilaStoreReader(root: root)
+        let sort = try enumArg(args, "sort", MilaStoreReader.SearchSortKey.self) ?? .relevance
+        let order = try enumArg(args, "order", MilaStoreReader.SortOrder.self) ?? .desc
+        let limit = min(args["limit"] as? Int ?? 10, 100)
+        let hits: [MilaStoreReader.SearchHit]
+        do {
+            hits = try reader.searchTranscripts(query: query,
+                                                speaker: args["speaker"] as? String,
+                                                sort: sort, order: order, limit: limit)
+        } catch {
+            throw ToolError.storeUnavailable(String(describing: error))
+        }
+        return try json([
+            "count": hits.count,
+            "results": hits.map { hit -> [String: Any] in
+                var obj = summaryObject(for: hit.recording)
+                obj["match_count"] = hit.matchCount
+                obj["snippets"] = hit.snippets
+                return obj
+            },
+        ])
+    }
+
+    private func getLiveTranscript(_ args: [String: Any]) throws -> String {
+        guard let snapshot = LiveTranscriptSnapshot.read(root: root) else {
+            return try json(["status": "not_recording"])
+        }
+
+        switch snapshot.state {
+        case .interrupted:
+            return try json([
+                "status": "not_recording",
+                "last_session": "interrupted",
+                "note": "The app stopped unexpectedly during the last recording; its audio is re-transcribed in the background — check list_recordings.",
+            ])
+        case .completed, .recording:
+            break
+        }
+
+        var result: [String: Any] = [
+            "session_id": snapshot.sessionID.uuidString,
+            "revision": snapshot.revision,
+            "recording_started_at": iso(snapshot.recordingStartedAt),
+            "updated_at": iso(snapshot.updatedAt),
+        ]
+        if let title = snapshot.title { result["title"] = title }
+        if let source = snapshot.source { result["source"] = source }
+
+        if snapshot.state == .completed {
+            result["status"] = "completed"
+            if let finalID = snapshot.finalRecordingID {
+                result["final_recording_id"] = finalID.uuidString
+                result["note"] = "The recording ended. Call get_transcript with final_recording_id for the authoritative transcript (speaker labels may improve after the post-stop pass)."
+            } else {
+                result["note"] = "The recording ended without a saved transcript handoff; check list_recordings for the newest entry."
+            }
+            return try json(result)
+        }
+
+        // state == .recording
+        guard snapshot.liveTranscriptAvailable else {
+            result["status"] = "recording_live_unavailable"
+            result["elapsed_seconds"] = Int(now().timeIntervalSince(snapshot.recordingStartedAt))
+            result["note"] = "A recording is in progress, but live transcription is disabled on this hardware — no text will appear until it completes. Poll occasionally for status \"completed\" instead of expecting segments."
+            return try json(result)
+        }
+        let heartbeatAge = now().timeIntervalSince(snapshot.updatedAt)
+        let status = heartbeatAge > LiveTranscriptSnapshot.staleAfter ? "stale" : "recording"
+        result["status"] = status
+        result["elapsed_seconds"] = Int(now().timeIntervalSince(snapshot.recordingStartedAt))
+        if status == "stale" {
+            result["note"] = "The live snapshot hasn't been refreshed in \(Int(heartbeatAge))s — the Mila app may have crashed or hung; this transcript may be incomplete and won't grow."
+        }
+
+        let clientSession = (args["session_id"] as? String).flatMap(UUID.init(uuidString:))
+        let sameSession = clientSession == snapshot.sessionID
+        if let clientSession, clientSession != snapshot.sessionID {
+            result["new_session"] = true
+        }
+
+        // Cheap no-change short-circuit — only valid within the same session.
+        if sameSession, let sinceRevision = args["since_revision"] as? Int,
+           sinceRevision == snapshot.revision {
+            return try json([
+                "status": status,
+                "session_id": snapshot.sessionID.uuidString,
+                "revision": snapshot.revision,
+                "changed": false,
+            ])
+        }
+        result["changed"] = true
+        result["speaker_names"] = snapshot.speakerNames
+        result["next_segment_index"] = snapshot.segments.count
+
+        if sameSession, let sinceIndex = args["since_segment_index"] as? Int {
+            result["new_segments"] = snapshot.segments(sinceIndex: sinceIndex)
+                .map(segmentObject(for:))
+        } else {
+            // First poll (or a new session): full transcript + all segments.
+            result["new_segments"] = snapshot.segments.map(segmentObject(for:))
+            result["transcript"] = TranscriptFormatter.plainText(
+                segments: snapshot.segments,
+                fallback: snapshot.segments.map(\.text)
+                    .joined(separator: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                names: snapshot.speakerNames
+            )
+        }
+        return try json(result)
+    }
+
+    // MARK: - Helpers
+
+    private func summaryObject(for recording: StoredRecording) -> [String: Any] {
+        var obj: [String: Any] = [
+            "id": recording.id.uuidString,
+            "title": recording.title,
+            "created_at": iso(recording.createdAt),
+            "duration_seconds": Int(recording.duration.rounded()),
+            "source": recording.source,
+            "status": recording.status,
+            "speakers": recording.speakerDisplayNames,
+            "has_summary": !(recording.summary ?? "").isEmpty,
+        ]
+        if let folder = recording.folder { obj["folder"] = folder }
+        if let appName = recording.appName { obj["app_name"] = appName }
+        return obj
+    }
+
+    private func segmentObject(for segment: LiveTranscriptSnapshot.Segment) -> [String: Any] {
+        var obj: [String: Any] = [
+            "start": segment.start,
+            "end": segment.end,
+            "text": segment.text,
+        ]
+        if let speaker = segment.speaker { obj["speaker"] = speaker }
+        return obj
+    }
+
+    private func json(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object,
+                                              options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func iso(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private func date(_ args: [String: Any], _ key: String) throws -> Date? {
+        guard let raw = args[key] as? String else { return nil }
+        let formatter = ISO8601DateFormatter()
+        if let parsed = formatter.date(from: raw) { return parsed }
+        // Accept plain dates too ("2026-07-15").
+        formatter.formatOptions = [.withFullDate]
+        if let parsed = formatter.date(from: raw) { return parsed }
+        throw ToolError.invalidArguments("\(key) must be an ISO 8601 date, got \"\(raw)\"")
+    }
+
+    private func enumArg<E: RawRepresentable>(_ args: [String: Any], _ key: String,
+                                              _ type: E.Type) throws -> E?
+        where E.RawValue == String {
+        guard let raw = args[key] as? String else { return nil }
+        guard let value = E(rawValue: raw) else {
+            throw ToolError.invalidArguments("\(key) has unsupported value \"\(raw)\"")
+        }
+        return value
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/MilaStoreReader.swift
+++ b/Packages/MilaKit/Sources/MilaKit/MilaStoreReader.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// Read-only access to Mila's recording store for external processes
+/// (mila-mcp). Resolves the store location via `StoreLocationPointer`,
+/// falling back to the default app-support layout when no pointer exists
+/// (the app hasn't run since the pointer feature shipped). Every call
+/// re-reads from disk — the store is small, the app's writes are atomic,
+/// and freshness beats caching for a live assistant.
+public struct MilaStoreReader {
+
+    public let recordingsDirectory: URL
+    public let storeFileURL: URL
+
+    public init(recordingsDirectory: URL, storeFileURL: URL) {
+        self.recordingsDirectory = recordingsDirectory
+        self.storeFileURL = storeFileURL
+    }
+
+    /// Resolve from the pointer file at `root`, or fall back to the
+    /// historical default layout (`<root>/recordings.json` +
+    /// `<root>/Recordings/`).
+    public init(root: URL = StoreLocationPointer.defaultRoot()) {
+        if let pointer = StoreLocationPointer.read(from: root) {
+            self.init(recordingsDirectory: URL(fileURLWithPath: pointer.recordingsDirectory,
+                                               isDirectory: true),
+                      storeFileURL: URL(fileURLWithPath: pointer.storeFile))
+        } else {
+            self.init(recordingsDirectory: root.appendingPathComponent("Recordings",
+                                                                       isDirectory: true),
+                      storeFileURL: root.appendingPathComponent("recordings.json"))
+        }
+    }
+
+    // MARK: - Loading
+
+    public func loadRecordings() throws -> [StoredRecording] {
+        let data = try Data(contentsOf: storeFileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([StoredRecording].self, from: data)
+    }
+
+    /// Plain transcript text: sidecar `.txt` → legacy inline text →
+    /// joined segments (same fallback chain as the app's load path).
+    public func transcriptText(for recording: StoredRecording) -> String {
+        let url = recordingsDirectory.appendingPathComponent(recording.transcriptFileName)
+        if let text = try? String(contentsOf: url, encoding: .utf8), !text.isEmpty {
+            return text
+        }
+        if let legacy = recording.legacyFullText, !legacy.isEmpty { return legacy }
+        return recording.segments.map(\.text).joined()
+    }
+
+    /// Speaker-named transcript — the app's canonical rendering
+    /// (`SPEAKER_00:` prefixes resolved through `speakerNames`, same-speaker
+    /// turns collapsed).
+    public func namedTranscript(for recording: StoredRecording) -> String {
+        TranscriptFormatter.plainText(
+            segments: recording.segments,
+            fallback: transcriptText(for: recording)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            names: recording.speakerNames
+        )
+    }
+
+    // MARK: - Listing
+
+    public struct Filter {
+        /// Substring over title, appName, and folder.
+        public var query: String?
+        /// Substring over resolved speaker display names.
+        public var speaker: String?
+        public var folder: String?
+        /// Raw `RecordingSource` value (`microphone` / `systemAudio` / …).
+        public var source: String?
+        public var after: Date?
+        public var before: Date?
+
+        public init(query: String? = nil, speaker: String? = nil, folder: String? = nil,
+                    source: String? = nil, after: Date? = nil, before: Date? = nil) {
+            self.query = query
+            self.speaker = speaker
+            self.folder = folder
+            self.source = source
+            self.after = after
+            self.before = before
+        }
+    }
+
+    public enum SortKey: String {
+        case createdAt = "created_at"
+        case duration
+        case title
+    }
+
+    public enum SortOrder: String {
+        case asc, desc
+    }
+
+    /// Non-trashed recordings matching `filter`, sorted and capped.
+    public func listRecordings(filter: Filter = Filter(),
+                               sort: SortKey = .createdAt,
+                               order: SortOrder = .desc,
+                               limit: Int = 20) throws -> [StoredRecording] {
+        var results = try loadRecordings().filter { rec in
+            guard !rec.isTrashed else { return false }
+            if let q = filter.query, !q.isEmpty {
+                let haystacks = [rec.title, rec.appName ?? "", rec.folder ?? ""]
+                guard haystacks.contains(where: { $0.localizedStandardContains(q) }) else {
+                    return false
+                }
+            }
+            if let speaker = filter.speaker, !speaker.isEmpty {
+                guard rec.speakerDisplayNames.contains(where: {
+                    $0.localizedStandardContains(speaker)
+                }) else { return false }
+            }
+            if let folder = filter.folder, !folder.isEmpty {
+                guard rec.folder?.localizedStandardContains(folder) == true else { return false }
+            }
+            if let source = filter.source, !source.isEmpty {
+                guard rec.source == source else { return false }
+            }
+            if let after = filter.after, rec.createdAt < after { return false }
+            if let before = filter.before, rec.createdAt > before { return false }
+            return true
+        }
+        results.sort { a, b in
+            let ascending: Bool
+            switch sort {
+            case .createdAt: ascending = a.createdAt < b.createdAt
+            case .duration: ascending = a.duration < b.duration
+            case .title:
+                ascending = a.title.localizedCaseInsensitiveCompare(b.title) == .orderedAscending
+            }
+            return order == .asc ? ascending : !ascending
+        }
+        return Array(results.prefix(max(0, limit)))
+    }
+
+    /// Latest non-trashed completed recording, if any.
+    public func latestCompletedRecording() throws -> StoredRecording? {
+        try listRecordings(limit: Int.max).first { $0.status == "completed" }
+    }
+
+    public func recording(id: UUID) throws -> StoredRecording? {
+        try loadRecordings().first { $0.id == id }
+    }
+
+    // MARK: - Search
+
+    public struct SearchHit {
+        public let recording: StoredRecording
+        /// Total case-insensitive matches across title + transcript.
+        public let matchCount: Int
+        /// Up to a few matching lines with one line of context each side.
+        public let snippets: [String]
+    }
+
+    public enum SearchSortKey: String {
+        case relevance
+        case createdAt = "created_at"
+    }
+
+    /// Case/diacritic-insensitive full-text search over titles and
+    /// transcript text of non-trashed recordings.
+    public func searchTranscripts(query: String,
+                                  speaker: String? = nil,
+                                  sort: SearchSortKey = .relevance,
+                                  order: SortOrder = .desc,
+                                  limit: Int = 10) throws -> [SearchHit] {
+        let recordings = try listRecordings(filter: Filter(speaker: speaker), limit: Int.max)
+        var hits: [SearchHit] = []
+        for rec in recordings {
+            let transcript = namedTranscript(for: rec)
+            let titleMatches = matchCount(of: query, in: rec.title)
+            let lines = transcript.components(separatedBy: .newlines)
+            var textMatches = 0
+            var snippets: [String] = []
+            for (i, line) in lines.enumerated() {
+                let n = matchCount(of: query, in: line)
+                guard n > 0 else { continue }
+                textMatches += n
+                if snippets.count < 3 {
+                    let context = lines[max(0, i - 1)...min(lines.count - 1, i + 1)]
+                    snippets.append(context.joined(separator: "\n"))
+                }
+            }
+            let total = titleMatches + textMatches
+            guard total > 0 else { continue }
+            hits.append(SearchHit(recording: rec, matchCount: total, snippets: snippets))
+        }
+        hits.sort { a, b in
+            let ascending: Bool
+            switch sort {
+            case .relevance:
+                if a.matchCount != b.matchCount {
+                    ascending = a.matchCount < b.matchCount
+                } else {
+                    ascending = a.recording.createdAt < b.recording.createdAt
+                }
+            case .createdAt:
+                ascending = a.recording.createdAt < b.recording.createdAt
+            }
+            return order == .asc ? ascending : !ascending
+        }
+        return Array(hits.prefix(max(0, limit)))
+    }
+
+    private func matchCount(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let found = haystack.range(of: needle,
+                                         options: [.caseInsensitive, .diacriticInsensitive],
+                                         range: searchRange) {
+            count += 1
+            searchRange = found.upperBound..<haystack.endIndex
+        }
+        return count
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/StoreLocationPointer.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoreLocationPointer.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Cross-process contract telling external tools (mila-mcp) where the
+/// recording store currently lives. The app's relocated-recordings feature
+/// stores the user's choice as a security-scoped bookmark in UserDefaults,
+/// which a separate process can't resolve — so RecordingStore mirrors the
+/// resolved paths into this small JSON file at the DEFAULT app-support root
+/// on every launch and relocation.
+public struct StoreLocationPointer: Codable, Equatable {
+    public var version: Int
+    /// Directory holding the audio files + sidecars (`.txt`/`.srt`/…).
+    public var recordingsDirectory: String
+    /// Full path of `recordings.json`.
+    public var storeFile: String
+    public var updatedAt: Date
+
+    public init(version: Int = 1, recordingsDirectory: String, storeFile: String, updatedAt: Date) {
+        self.version = version
+        self.recordingsDirectory = recordingsDirectory
+        self.storeFile = storeFile
+        self.updatedAt = updatedAt
+    }
+
+    public static let fileName = "store-location.json"
+
+    /// The default Mila app-support root (`~/Library/Application Support/Mila`).
+    public static func defaultRoot() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask)[0]
+        return appSupport.appendingPathComponent("Mila", isDirectory: true)
+    }
+
+    public static func read(from root: URL = defaultRoot()) -> StoreLocationPointer? {
+        let url = root.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(StoreLocationPointer.self, from: data)
+    }
+
+    public func write(to root: URL = defaultRoot()) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try data.write(to: root.appendingPathComponent(Self.fileName), options: .atomic)
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Decoding is deliberately lenient (`decodeIfPresent` + defaults) so an
 /// older helper never chokes on a newer app's additions.
 public struct StoredRecording: Codable, Identifiable {
-    public struct Segment: Codable, SpeakerTextSegment {
+    public struct Segment: Codable, Equatable, SpeakerTextSegment {
         public var start: Double
         public var end: Double
         public var text: String

--- a/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
+++ b/Packages/MilaKit/Sources/MilaKit/StoredRecording.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Read-only mirror of one entry in the app's `recordings.json`.
+///
+/// The app's `Recording` type stays in the app target (its init is
+/// referenced across dozens of files); this mirror exists so the external
+/// mila-mcp helper can decode the store without linking app code. Every
+/// field the app encodes must decode here — guarded by
+/// `StoredRecordingDriftTests` in MilaTests, which encodes a fully
+/// populated app `Recording` and asserts this type round-trips it.
+/// Decoding is deliberately lenient (`decodeIfPresent` + defaults) so an
+/// older helper never chokes on a newer app's additions.
+public struct StoredRecording: Codable, Identifiable {
+    public struct Segment: Codable, SpeakerTextSegment {
+        public var start: Double
+        public var end: Double
+        public var text: String
+        public var speaker: String?
+
+        public init(start: Double, end: Double, text: String, speaker: String? = nil) {
+            self.start = start
+            self.end = end
+            self.text = text
+            self.speaker = speaker
+        }
+
+        private enum CodingKeys: String, CodingKey { case start, end, text, speaker }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            start = try c.decodeIfPresent(Double.self, forKey: .start) ?? 0
+            end = try c.decodeIfPresent(Double.self, forKey: .end) ?? 0
+            text = try c.decodeIfPresent(String.self, forKey: .text) ?? ""
+            speaker = try c.decodeIfPresent(String.self, forKey: .speaker)
+        }
+    }
+
+    public struct ActionItem: Codable {
+        public var text: String
+        public var speaker: String?
+        public var timestampSeconds: Double?
+
+        public init(text: String, speaker: String? = nil, timestampSeconds: Double? = nil) {
+            self.text = text
+            self.speaker = speaker
+            self.timestampSeconds = timestampSeconds
+        }
+
+        private enum CodingKeys: String, CodingKey { case text, speaker, timestampSeconds }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            text = try c.decodeIfPresent(String.self, forKey: .text) ?? ""
+            speaker = try c.decodeIfPresent(String.self, forKey: .speaker)
+            timestampSeconds = try c.decodeIfPresent(Double.self, forKey: .timestampSeconds)
+        }
+    }
+
+    public var id: UUID
+    public var title: String
+    public var createdAt: Date
+    public var duration: Double
+    /// Raw value of the app's `RecordingSource` (`microphone` /
+    /// `systemAudio` / `meeting` / `voiceMemo`). Kept as a string so a
+    /// future source added by the app doesn't fail the decode.
+    public var source: String
+    public var audioFileName: String
+    /// Raw value of the app's `TranscriptionStatus` (`pending` / `running`
+    /// / `completed` / `failed`).
+    public var status: String
+    public var language: String
+    public var modelName: String?
+    public var segments: [Segment]
+    public var deletedAt: Date?
+    public var folder: String?
+    public var appName: String?
+    public var summary: String?
+    public var actionItems: [ActionItem]?
+    /// Raw diarizer ID (`SPEAKER_00`) → user-assigned display name.
+    public var speakerNames: [String: String]
+    /// Inline transcript on legacy records only; current records keep the
+    /// text in the `.txt` sidecar and omit this key.
+    public var legacyFullText: String?
+
+    public var isTrashed: Bool { deletedAt != nil }
+
+    /// Sidecar names, derived from `audioFileName` the same way the app does.
+    public var transcriptFileName: String {
+        (audioFileName as NSString).deletingPathExtension + ".txt"
+    }
+    public var summaryFileName: String {
+        (audioFileName as NSString).deletingPathExtension + ".summary.txt"
+    }
+
+    /// Display names of this recording's diarized speakers (raw IDs
+    /// resolved through `speakerNames`; unnamed IDs stay raw), in
+    /// first-spoken order.
+    public var speakerDisplayNames: [String] {
+        var seen = Set<String>()
+        var names: [String] = []
+        for seg in segments {
+            guard let raw = seg.speaker else { continue }
+            let resolved = speakerNames[raw] ?? raw
+            if seen.insert(resolved).inserted { names.append(resolved) }
+        }
+        return names
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, createdAt, duration, source, audioFileName,
+             status, language, modelName, segments, deletedAt, folder, appName,
+             summary, actionItems, speakerNames
+        case legacyFullText = "fullText"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? .distantPast
+        duration = try c.decodeIfPresent(Double.self, forKey: .duration) ?? 0
+        source = try c.decodeIfPresent(String.self, forKey: .source) ?? ""
+        audioFileName = try c.decodeIfPresent(String.self, forKey: .audioFileName) ?? ""
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? ""
+        language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
+        modelName = try c.decodeIfPresent(String.self, forKey: .modelName)
+        segments = try c.decodeIfPresent([Segment].self, forKey: .segments) ?? []
+        deletedAt = try c.decodeIfPresent(Date.self, forKey: .deletedAt)
+        folder = try c.decodeIfPresent(String.self, forKey: .folder)
+        appName = try c.decodeIfPresent(String.self, forKey: .appName)
+        summary = try c.decodeIfPresent(String.self, forKey: .summary)
+        actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems)
+        speakerNames = try c.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
+        legacyFullText = try c.decodeIfPresent(String.self, forKey: .legacyFullText)
+    }
+
+    public init(id: UUID = UUID(), title: String, createdAt: Date, duration: Double = 0,
+                source: String = "microphone", audioFileName: String, status: String = "completed",
+                language: String = "en", modelName: String? = nil, segments: [Segment] = [],
+                deletedAt: Date? = nil, folder: String? = nil, appName: String? = nil,
+                summary: String? = nil, actionItems: [ActionItem]? = nil,
+                speakerNames: [String: String] = [:], legacyFullText: String? = nil) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.duration = duration
+        self.source = source
+        self.audioFileName = audioFileName
+        self.status = status
+        self.language = language
+        self.modelName = modelName
+        self.segments = segments
+        self.deletedAt = deletedAt
+        self.folder = folder
+        self.appName = appName
+        self.summary = summary
+        self.actionItems = actionItems
+        self.speakerNames = speakerNames
+        self.legacyFullText = legacyFullText
+    }
+}

--- a/Packages/MilaKit/Sources/MilaKit/TranscriptFormatter.swift
+++ b/Packages/MilaKit/Sources/MilaKit/TranscriptFormatter.swift
@@ -1,7 +1,16 @@
 import Foundation
-import TranscriptionCore
 
-enum TranscriptFormatter {
+/// Minimal shape TranscriptFormatter needs from a transcript segment.
+/// Both the app's `TranscriptSegment` (TranscriptionCore) and MilaKit's own
+/// stored/live segment types conform, so the formatter lives here without
+/// dragging the whisper.cpp-linked TranscriptionCore into the MCP helper.
+public protocol SpeakerTextSegment {
+    var text: String { get }
+    /// Raw diarizer ID (`SPEAKER_00`), nil when diarization didn't run.
+    var speaker: String? { get }
+}
+
+public enum TranscriptFormatter {
 
     /// Plain-text rendering of `segments` suitable for the clipboard or for
     /// piping into an LLM prompt. When any segment carries a speaker label
@@ -17,8 +26,9 @@ enum TranscriptFormatter {
     ///
     /// Matches the SRT exporter's prefix format so the clipboard text and
     /// the on-disk `.srt` use the same speaker labels.
-    static func plainText(segments: [TranscriptSegment], fallback: String,
-                          names: [String: String] = [:]) -> String {
+    public static func plainText<S: SpeakerTextSegment>(
+        segments: [S], fallback: String, names: [String: String] = [:]
+    ) -> String {
         guard segments.contains(where: { $0.speaker != nil }) else { return fallback }
 
         var lines: [String] = []

--- a/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import MilaKit
+
+final class MilaMCPToolHandlersTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPHandlerTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("Recordings", isDirectory: true),
+            withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func handlers(now: Date = Date()) -> MilaMCPToolHandlers {
+        MilaMCPToolHandlers(root: root, now: { now })
+    }
+
+    private func call(_ tool: String, _ args: [String: Any] = [:],
+                      now: Date = Date()) throws -> [String: Any] {
+        let raw = try handlers(now: now).handle(tool: tool, arguments: args)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any])
+    }
+
+    private func seedStore(_ recordings: [StoredRecording]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(recordings)
+            .write(to: root.appendingPathComponent("recordings.json"))
+    }
+
+    private func meeting(_ title: String, daysAgo: Double,
+                         speakerNames: [String: String] = [:],
+                         summary: String? = nil) -> StoredRecording {
+        StoredRecording(title: title,
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_000 - daysAgo * 86_400),
+                        duration: 300, source: "meeting",
+                        audioFileName: "\(title).wav", status: "completed",
+                        segments: [
+                            .init(start: 0, end: 3, text: "shalom everyone", speaker: "SPEAKER_00"),
+                            .init(start: 3, end: 6, text: "let's begin", speaker: "SPEAKER_01"),
+                        ],
+                        summary: summary, speakerNames: speakerNames)
+    }
+
+    private func liveSnapshot(sessionID: UUID = UUID(), state: LiveTranscriptSnapshot.State = .recording,
+                              revision: Int = 3, liveAvailable: Bool = true,
+                              updatedAt: Date = Date(),
+                              segments: [LiveTranscriptSnapshot.Segment]? = nil,
+                              finalRecordingID: UUID? = nil) throws -> LiveTranscriptSnapshot {
+        let snap = LiveTranscriptSnapshot(
+            sessionID: sessionID, state: state, liveTranscriptAvailable: liveAvailable,
+            recordingStartedAt: updatedAt.addingTimeInterval(-120), updatedAt: updatedAt,
+            revision: revision,
+            segments: segments ?? [
+                .init(start: 0, end: 2, text: "first", speaker: "SPEAKER_00"),
+                .init(start: 2, end: 4, text: "second", speaker: "SPEAKER_00"),
+                .init(start: 4, end: 6, text: "third", speaker: "SPEAKER_01"),
+            ],
+            speakerNames: ["SPEAKER_00": "Dana"],
+            finalRecordingID: finalRecordingID)
+        try snap.write(root: root)
+        return snap
+    }
+
+    // MARK: - list / get / search via raw JSON args
+
+    func test_list_recordings_speaker_filter_and_shape() throws {
+        try seedStore([
+            meeting("With John", daysAgo: 1, speakerNames: ["SPEAKER_01": "John Doe"]),
+            meeting("Other", daysAgo: 0),
+        ])
+        let result = try call("list_recordings", ["speaker": "john", "limit": 5])
+        XCTAssertEqual(result["count"] as? Int, 1)
+        let first = try XCTUnwrap((result["recordings"] as? [[String: Any]])?.first)
+        XCTAssertEqual(first["title"] as? String, "With John")
+        XCTAssertEqual(first["speakers"] as? [String], ["SPEAKER_00", "John Doe"])
+        XCTAssertEqual(first["has_summary"] as? Bool, false)
+    }
+
+    func test_list_recordings_rejects_bad_sort_and_date() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("list_recordings", ["sort": "bogus"]))
+        XCTAssertThrowsError(try call("list_recordings", ["after": "not-a-date"]))
+    }
+
+    func test_get_transcript_latest_with_names_and_summary() throws {
+        try seedStore([
+            meeting("Latest", daysAgo: 0,
+                    speakerNames: ["SPEAKER_00": "Dana", "SPEAKER_01": "John Doe"],
+                    summary: "Quick sync."),
+            meeting("Older", daysAgo: 2),
+        ])
+        let result = try call("get_transcript")
+        XCTAssertEqual(result["title"] as? String, "Latest")
+        XCTAssertEqual(result["transcript"] as? String,
+                       "Dana: shalom everyone\nJohn Doe: let's begin")
+        XCTAssertEqual(result["summary"] as? String, "Quick sync.")
+    }
+
+    func test_get_transcript_max_chars_truncates() throws {
+        try seedStore([meeting("Long", daysAgo: 0)])
+        let result = try call("get_transcript", ["max_chars": 10])
+        XCTAssertEqual((result["transcript"] as? String)?.count, 10)
+        XCTAssertEqual(result["transcript_truncated"] as? Bool, true)
+    }
+
+    func test_get_transcript_unknown_id_throws_not_found() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("get_transcript", ["id": UUID().uuidString]))
+        XCTAssertThrowsError(try call("get_transcript", ["id": "not-a-uuid"]))
+    }
+
+    func test_search_requires_query() throws {
+        try seedStore([meeting("A", daysAgo: 0)])
+        XCTAssertThrowsError(try call("search_transcripts"))
+        let result = try call("search_transcripts", ["query": "begin"])
+        XCTAssertEqual(result["count"] as? Int, 1)
+    }
+
+    func test_unknown_tool_throws() {
+        XCTAssertThrowsError(try call("bogus_tool"))
+    }
+
+    // MARK: - get_live_transcript
+
+    func test_live_no_snapshot_is_not_recording() throws {
+        XCTAssertEqual(try call("get_live_transcript")["status"] as? String, "not_recording")
+    }
+
+    func test_live_first_poll_returns_full_transcript_and_cursor() throws {
+        let snap = try liveSnapshot()
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "recording")
+        XCTAssertEqual(result["session_id"] as? String, snap.sessionID.uuidString)
+        XCTAssertEqual(result["revision"] as? Int, 3)
+        XCTAssertEqual(result["next_segment_index"] as? Int, 3)
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 3)
+        XCTAssertEqual(result["transcript"] as? String,
+                       "Dana: first second\nSPEAKER_01: third")
+    }
+
+    func test_live_same_revision_short_circuits() throws {
+        let snap = try liveSnapshot(revision: 3)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 3,
+        ])
+        XCTAssertEqual(result["changed"] as? Bool, false)
+        XCTAssertNil(result["new_segments"])
+    }
+
+    func test_live_delta_resends_last_seen_segment() throws {
+        let snap = try liveSnapshot(revision: 4)
+        // Client saw 2 segments; snapshot now has 3 → resend segment 2 + new segment 3.
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 2,
+            "since_segment_index": 2,
+        ])
+        XCTAssertEqual(result["changed"] as? Bool, true)
+        let texts = (result["new_segments"] as? [[String: Any]])?.compactMap { $0["text"] as? String }
+        XCTAssertEqual(texts, ["second", "third"])
+        XCTAssertEqual(result["next_segment_index"] as? Int, 3)
+    }
+
+    func test_live_session_mismatch_returns_new_session_full_set() throws {
+        _ = try liveSnapshot(revision: 3)
+        let result = try call("get_live_transcript", [
+            "session_id": UUID().uuidString,   // stale cursor from a previous meeting
+            "since_revision": 3,
+            "since_segment_index": 99,
+        ])
+        XCTAssertEqual(result["new_session"] as? Bool, true)
+        XCTAssertEqual(result["changed"] as? Bool, true)
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 3)
+        XCTAssertNotNil(result["transcript"])
+    }
+
+    func test_live_stale_heartbeat_reports_stale() throws {
+        let now = Date()
+        _ = try liveSnapshot(updatedAt: now.addingTimeInterval(-60))
+        let result = try call("get_live_transcript", now: now)
+        XCTAssertEqual(result["status"] as? String, "stale")
+    }
+
+    func test_live_gated_hardware_reports_unavailable() throws {
+        _ = try liveSnapshot(liveAvailable: false)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "recording_live_unavailable")
+    }
+
+    func test_live_completed_hands_off_final_recording_id() throws {
+        let finalID = UUID()
+        _ = try liveSnapshot(state: .completed, finalRecordingID: finalID)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "completed")
+        XCTAssertEqual(result["final_recording_id"] as? String, finalID.uuidString)
+    }
+
+    func test_live_interrupted_reports_not_recording_with_hint() throws {
+        _ = try liveSnapshot(state: .interrupted)
+        let result = try call("get_live_transcript")
+        XCTAssertEqual(result["status"] as? String, "not_recording")
+        XCTAssertEqual(result["last_session"] as? String, "interrupted")
+    }
+}

--- a/Packages/MilaKit/Tests/MilaKitTests/MilaStoreReaderTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/MilaStoreReaderTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import MilaKit
+
+final class MilaStoreReaderTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaKitTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: - Fixtures
+
+    private func writeStore(_ recordings: [StoredRecording],
+                            recordingsDir: URL? = nil,
+                            storeFile: URL? = nil) throws -> MilaStoreReader {
+        let recsDir = recordingsDir ?? root.appendingPathComponent("Recordings", isDirectory: true)
+        let store = storeFile ?? root.appendingPathComponent("recordings.json")
+        try FileManager.default.createDirectory(at: recsDir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(recordings).write(to: store)
+        return MilaStoreReader(recordingsDirectory: recsDir, storeFileURL: store)
+    }
+
+    private func rec(_ title: String, daysAgo: Double, duration: Double = 60,
+                     source: String = "meeting", status: String = "completed",
+                     folder: String? = nil, appName: String? = nil,
+                     deleted: Bool = false,
+                     segments: [StoredRecording.Segment] = [],
+                     speakerNames: [String: String] = [:]) -> StoredRecording {
+        StoredRecording(title: title,
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_000 - daysAgo * 86_400),
+                        duration: duration, source: source,
+                        audioFileName: "\(title).wav", status: status,
+                        segments: segments,
+                        deletedAt: deleted ? Date(timeIntervalSince1970: 1_700_000_001) : nil,
+                        folder: folder, appName: appName,
+                        speakerNames: speakerNames)
+    }
+
+    private func johnSegments() -> [StoredRecording.Segment] {
+        [.init(start: 0, end: 2, text: "hello team", speaker: "SPEAKER_00"),
+         .init(start: 2, end: 5, text: "hi, thanks for joining", speaker: "SPEAKER_01")]
+    }
+
+    // MARK: - Pointer resolution
+
+    func test_pointer_resolution_follows_relocated_store() throws {
+        let custom = root.appendingPathComponent("Custom", isDirectory: true)
+        try FileManager.default.createDirectory(at: custom, withIntermediateDirectories: true)
+        try StoreLocationPointer(recordingsDirectory: custom.path,
+                                 storeFile: custom.appendingPathComponent("recordings.json").path,
+                                 updatedAt: Date()).write(to: root)
+
+        let reader = MilaStoreReader(root: root)
+        XCTAssertEqual(reader.recordingsDirectory.path, custom.path)
+        XCTAssertEqual(reader.storeFileURL.lastPathComponent, "recordings.json")
+        XCTAssertEqual(reader.storeFileURL.deletingLastPathComponent().path, custom.path)
+    }
+
+    func test_missing_pointer_falls_back_to_default_layout() {
+        let reader = MilaStoreReader(root: root)
+        XCTAssertEqual(reader.recordingsDirectory.path,
+                       root.appendingPathComponent("Recordings").path)
+        XCTAssertEqual(reader.storeFileURL.path,
+                       root.appendingPathComponent("recordings.json").path)
+    }
+
+    // MARK: - Listing
+
+    func test_list_excludes_trashed_and_sorts_newest_first() throws {
+        let reader = try writeStore([
+            rec("Old", daysAgo: 3),
+            rec("New", daysAgo: 1),
+            rec("Trashed", daysAgo: 0, deleted: true),
+        ])
+        let listed = try reader.listRecordings()
+        XCTAssertEqual(listed.map(\.title), ["New", "Old"])
+    }
+
+    func test_speaker_filter_is_case_insensitive_over_display_names() throws {
+        let reader = try writeStore([
+            rec("With John", daysAgo: 1, segments: johnSegments(),
+                speakerNames: ["SPEAKER_01": "John Doe"]),
+            rec("Without", daysAgo: 0, segments: johnSegments()),
+        ])
+        let hits = try reader.listRecordings(filter: .init(speaker: "john doe"))
+        XCTAssertEqual(hits.map(\.title), ["With John"])
+    }
+
+    func test_source_and_date_filters() throws {
+        let reader = try writeStore([
+            rec("Mic", daysAgo: 1, source: "microphone"),
+            rec("Meeting", daysAgo: 2, source: "meeting"),
+        ])
+        XCTAssertEqual(try reader.listRecordings(filter: .init(source: "microphone")).map(\.title),
+                       ["Mic"])
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000 - 1.5 * 86_400)
+        XCTAssertEqual(try reader.listRecordings(filter: .init(after: cutoff)).map(\.title),
+                       ["Mic"])
+        XCTAssertEqual(try reader.listRecordings(filter: .init(before: cutoff)).map(\.title),
+                       ["Meeting"])
+    }
+
+    func test_sort_by_duration_and_title_with_order() throws {
+        let reader = try writeStore([
+            rec("Bravo", daysAgo: 1, duration: 30),
+            rec("alpha", daysAgo: 2, duration: 90),
+        ])
+        XCTAssertEqual(try reader.listRecordings(sort: .duration, order: .desc).map(\.title),
+                       ["alpha", "Bravo"])
+        XCTAssertEqual(try reader.listRecordings(sort: .title, order: .asc).map(\.title),
+                       ["alpha", "Bravo"])
+    }
+
+    func test_limit_caps_results() throws {
+        let reader = try writeStore((0..<5).map { rec("R\($0)", daysAgo: Double($0)) })
+        XCTAssertEqual(try reader.listRecordings(limit: 2).count, 2)
+    }
+
+    func test_latest_completed_skips_pending() throws {
+        let reader = try writeStore([
+            rec("Pending", daysAgo: 0, status: "pending"),
+            rec("Done", daysAgo: 1),
+        ])
+        XCTAssertEqual(try reader.latestCompletedRecording()?.title, "Done")
+    }
+
+    // MARK: - Transcript rendering
+
+    func test_transcript_prefers_sidecar_txt() throws {
+        let recording = rec("Side", daysAgo: 0, segments: johnSegments())
+        let reader = try writeStore([recording])
+        try "sidecar text".write(
+            to: reader.recordingsDirectory.appendingPathComponent("Side.txt"),
+            atomically: true, encoding: .utf8)
+        XCTAssertEqual(reader.transcriptText(for: recording), "sidecar text")
+    }
+
+    func test_transcript_falls_back_to_segments_join() throws {
+        let recording = rec("NoSidecar", daysAgo: 0, segments: johnSegments())
+        let reader = try writeStore([recording])
+        XCTAssertEqual(reader.transcriptText(for: recording),
+                       "hello teamhi, thanks for joining")
+    }
+
+    func test_named_transcript_resolves_speaker_names() throws {
+        let recording = rec("Named", daysAgo: 0, segments: johnSegments(),
+                            speakerNames: ["SPEAKER_00": "Daniel", "SPEAKER_01": "John Doe"])
+        let reader = try writeStore([recording])
+        XCTAssertEqual(reader.namedTranscript(for: recording),
+                       "Daniel: hello team\nJohn Doe: hi, thanks for joining")
+    }
+
+    // MARK: - Search
+
+    func test_search_matches_transcript_with_snippets_and_relevance() throws {
+        let hitRec = rec("Roadmap", daysAgo: 1, segments: [
+            .init(start: 0, end: 1, text: "the roadmap looks solid", speaker: "SPEAKER_00"),
+            .init(start: 1, end: 2, text: "ship the roadmap next week", speaker: "SPEAKER_01"),
+        ])
+        let missRec = rec("Standup", daysAgo: 0, segments: [
+            .init(start: 0, end: 1, text: "nothing to report", speaker: "SPEAKER_00"),
+        ])
+        let reader = try writeStore([hitRec, missRec])
+        let hits = try reader.searchTranscripts(query: "roadmap")
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits.first?.recording.title, "Roadmap")
+        // Title match + two transcript matches.
+        XCTAssertEqual(hits.first?.matchCount, 3)
+        XCTAssertFalse(hits.first?.snippets.isEmpty ?? true)
+    }
+
+    func test_search_sort_by_relevance_then_recency() throws {
+        let often = rec("Often", daysAgo: 5, segments: [
+            .init(start: 0, end: 1, text: "kafka kafka kafka", speaker: "SPEAKER_00"),
+        ])
+        let once = rec("Once", daysAgo: 0, segments: [
+            .init(start: 0, end: 1, text: "kafka maybe", speaker: "SPEAKER_00"),
+        ])
+        let reader = try writeStore([often, once])
+        XCTAssertEqual(try reader.searchTranscripts(query: "kafka").map(\.recording.title),
+                       ["Often", "Once"])
+        XCTAssertEqual(try reader.searchTranscripts(query: "kafka", sort: .createdAt)
+            .map(\.recording.title), ["Once", "Often"])
+    }
+}

--- a/Packages/MilaKit/Tests/MilaKitTests/TranscriptFormatterTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/TranscriptFormatterTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import MilaKit
+
+private struct Seg: SpeakerTextSegment {
+    var text: String
+    var speaker: String?
+}
+
+final class MilaKitTranscriptFormatterTests: XCTestCase {
+
+    func test_no_speakers_returns_fallback() {
+        let segments = [Seg(text: "hello", speaker: nil), Seg(text: "world", speaker: nil)]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: "hello world"),
+                       "hello world")
+    }
+
+    func test_speaker_turns_collapse_and_prefix() {
+        let segments = [
+            Seg(text: "hi", speaker: "SPEAKER_00"),
+            Seg(text: "there", speaker: "SPEAKER_00"),
+            Seg(text: "hey", speaker: "SPEAKER_01"),
+        ]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: ""),
+                       "SPEAKER_00: hi there\nSPEAKER_01: hey")
+    }
+
+    func test_names_resolve_and_merge_identically_named_ids() {
+        let segments = [
+            Seg(text: "one", speaker: "SPEAKER_00"),
+            Seg(text: "two", speaker: "SPEAKER_01"),
+        ]
+        let names = ["SPEAKER_00": "Dana", "SPEAKER_01": "Dana"]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: "", names: names),
+                       "Dana: one two")
+    }
+
+    func test_empty_segments_skipped_and_unlabeled_segment_kept_bare() {
+        let segments = [
+            Seg(text: "  ", speaker: "SPEAKER_00"),
+            Seg(text: "spoken", speaker: "SPEAKER_00"),
+            Seg(text: "aside", speaker: nil),
+        ]
+        XCTAssertEqual(TranscriptFormatter.plainText(segments: segments, fallback: ""),
+                       "SPEAKER_00: spoken\naside")
+    }
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,102 @@
+# Using Mila with Claude (MCP)
+
+Mila ships an MCP server — `mila-mcp`, embedded in the app bundle — that
+lets any Claude session (Claude Code, Claude Desktop) read your
+transcriptions: past recordings with resolved speaker names, and the
+live transcript of a meeting **while it's still happening**.
+
+Everything stays local: the server reads Mila's own on-disk store; no
+audio or text leaves your Mac unless you ask Claude to do something
+with it.
+
+## Setup (once)
+
+Claude Code:
+
+```bash
+claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp
+```
+
+Claude Desktop — add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mila": {
+      "command": "/Applications/Mila.app/Contents/MacOS/mila-mcp"
+    }
+  }
+}
+```
+
+Optionally install the bundled skill so Claude knows the workflows
+without being told (see `skills/mila-meetings/`):
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R skills/mila-meetings ~/.claude/skills/
+```
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `list_recordings` | List/filter recordings — by speaker display name, title/app/folder text, source, date range; sortable by date/duration/title. |
+| `get_transcript` | One recording's full speaker-named transcript + summary + action items. Omit `id` for the latest completed recording. |
+| `search_transcripts` | Full-text search over titles + transcripts with context snippets; relevance or date sort. |
+| `get_live_transcript` | The in-progress recording's transcript, with a polling cursor for cheap deltas. |
+
+## Reading past recordings
+
+Just ask, e.g.:
+
+> Read my last transcription with John Doe and summarize it.
+
+Claude calls `list_recordings(speaker: "john doe", limit: 1)` and then
+`get_transcript(id: …)`. Speaker filters match the display names you
+assigned in Mila's rename popover — unnamed speakers stay `SPEAKER_NN`.
+
+## Following a live meeting
+
+1. Start a recording in Mila (any mode with the live transcript pane —
+   mic, system audio, or meeting).
+2. In a Claude session:
+
+> Follow my current Mila meeting via the mila MCP server. Poll
+> get_live_transcript with the cursor every ~15–20 seconds; whenever
+> something new lands, suggest in one or two sentences what I should
+> say next. When the status becomes "completed", fetch the final
+> transcript and give me a summary.
+
+How the polling works under the hood:
+
+- Each recording session has a `session_id`; the snapshot carries a
+  `revision` that bumps only when content changes. Claude echoes
+  `session_id`, `since_revision`, and `since_segment_index` back on each
+  poll.
+- Nothing new → a tiny `{changed: false}` response.
+- New content → only the new segments (the last previously-seen segment
+  is re-sent, since live transcription may rewrite it; Claude replaces
+  its copy).
+- A `session_id` mismatch means a new recording started between polls —
+  Claude gets the new meeting's transcript from the top with
+  `new_session: true`.
+- `status` values: `recording` (keep polling), `stale` (the app stopped
+  updating the snapshot — likely crashed), `recording_live_unavailable`
+  (recording on hardware where live transcription is gated off — wait
+  for completion), `completed` (stop polling; `final_recording_id`
+  hands off to `get_transcript`), `not_recording`.
+
+## How it finds your data
+
+- `~/Library/Application Support/Mila/store-location.json` — written by
+  the app on every launch and whenever you relocate the recordings
+  folder (Settings ▸ Storage), so the server follows the move.
+- `~/Library/Application Support/Mila/live/current.json` — the live
+  transcript sidecar, written during recording (throttled, atomic) and
+  closed with the saved recording's id at Stop.
+
+If the app has never run (no pointer file), the server falls back to
+the default layout. Changes to the `recordings.json` schema must be
+mirrored in MilaKit's `StoredRecording` — `StoredRecordingDriftTests`
+guards this.

--- a/project.yml
+++ b/project.yml
@@ -103,6 +103,8 @@ settings:
 packages:
   TranscriptionCore:
     path: Packages/TranscriptionCore
+  MilaKit:
+    path: Packages/MilaKit
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     revision: 066e75a8b3e99962685d6a90cdd5293ebffd9261
@@ -206,6 +208,8 @@ targets:
     dependencies:
       - package: TranscriptionCore
         product: TranscriptionCore
+      - package: MilaKit
+        product: MilaKit
       - package: Sparkle
         product: Sparkle
     settings:
@@ -222,6 +226,8 @@ targets:
       - target: Mila
       - package: TranscriptionCore
         product: TranscriptionCore
+      - package: MilaKit
+        product: MilaKit
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"

--- a/project.yml
+++ b/project.yml
@@ -108,6 +108,11 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     revision: 066e75a8b3e99962685d6a90cdd5293ebffd9261
+  # MCP Swift SDK for the mila-mcp helper (stdio server exposing
+  # transcriptions to Claude). Pinned exactly, like Sparkle.
+  MCP:
+    url: https://github.com/modelcontextprotocol/swift-sdk
+    exactVersion: 0.12.1
     
 targets:
   Mila:
@@ -212,9 +217,45 @@ targets:
         product: MilaKit
       - package: Sparkle
         product: Sparkle
+      # Build-order only: the post-build script below copies the helper
+      # into Contents/MacOS. Not linked (it's an executable, not a lib).
+      - target: mila-mcp
+        link: false
+        embed: false
     settings:
       base:
         OTHER_LDFLAGS: "$(inherited) -framework Accelerate -framework Metal -framework MetalKit"
+    postBuildScripts:
+      # Ship the MCP helper inside the app bundle so users can register it
+      # with `claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp`.
+      # Runs before the app's code-sign step, so the copy is covered by the
+      # bundle seal; the helper binary carries its own signature from its
+      # target build (and make-dmg.sh's --deep re-sign covers DMGs).
+      - name: Embed mila-mcp helper
+        script: |
+          cp -f "$BUILT_PRODUCTS_DIR/mila-mcp" "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/mila-mcp"
+        inputFiles:
+          - $(BUILT_PRODUCTS_DIR)/mila-mcp
+        outputFiles:
+          - $(TARGET_BUILD_DIR)/$(EXECUTABLE_FOLDER_PATH)/mila-mcp
+
+  mila-mcp:
+    type: tool
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: MilaMCP
+    dependencies:
+      - package: MilaKit
+        product: MilaKit
+      - package: MCP
+        product: MCP
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.island.whisper.IslandWhisper.mcp
+        # The SDK's ServiceLifecycle/NIO deps use Swift 6 features; our
+        # own sources stay on the project-wide 5.10 language mode.
+        GENERATE_INFOPLIST_FILE: NO
 
   MilaTests:
     type: bundle.unit-test

--- a/skills/mila-meetings/SKILL.md
+++ b/skills/mila-meetings/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: mila-meetings
+description: >
+  Work with Mila transcriptions via the mila MCP server — summarize or
+  search past recordings/meetings ("my last meeting with John"), and
+  follow the current in-progress meeting in real time to suggest what
+  to say next. Use whenever the user mentions Mila, their recordings,
+  meeting transcripts, or asks for live meeting help.
+---
+
+# Mila meetings
+
+Mila is the user's local macOS transcription app. The `mila` MCP server
+exposes its recordings. If its tools (`list_recordings`,
+`get_transcript`, `search_transcripts`, `get_live_transcript`) are not
+available, tell the user to register the server once:
+`claude mcp add mila -- /Applications/Mila.app/Contents/MacOS/mila-mcp`
+
+## Past recordings
+
+- "Last meeting with <name>" → `list_recordings(speaker: "<name>", limit: 1)`,
+  then `get_transcript(id: …)`. Speaker matching is a case-insensitive
+  substring over the display names the user assigned in Mila; if it
+  finds nothing, retry with a shorter fragment (first name), then fall
+  back to `search_transcripts(query: "<name>")` — the name may appear
+  in the text or title rather than the speaker labels.
+- "What did we say about X" → `search_transcripts(query: "X")`, then
+  `get_transcript` on the interesting hits.
+- Recordings may be long. For summarization, `get_transcript` already
+  returns a stored `summary` when one exists — read it before deciding
+  to re-summarize from the raw transcript. Transcripts may be in any
+  language (often Hebrew); answer in the user's language.
+
+## Live meeting assistant
+
+When the user asks to follow the current meeting / act as a live
+assistant:
+
+1. Call `get_live_transcript` with no arguments. If `status` is
+   `not_recording`, tell the user to start a Mila recording and
+   offer to check again shortly.
+2. Poll in a loop every ~15–20 seconds, passing back the previous
+   response's `session_id`, `revision` as `since_revision`, and
+   `next_segment_index` as `since_segment_index`.
+   - `{changed: false}` → nothing new; keep waiting silently.
+   - New segments → the first returned segment replaces the last one
+     you already had (live transcription rewrites it); the rest append.
+
+   **Output ordering (critical):** in harnesses that hide text written
+   between tool calls, anything you write before your next tool call is
+   LOST to the user. In every loop turn: poll, **arm the next wake-up
+   timer first** (background sleep / scheduled wakeup), and only then
+   write the echo/answer as the turn's FINAL message with no tool calls
+   after it. Never end a loop turn with a placeholder like "(listening)"
+   after the real content — the placeholder is all the user will see.
+3. Only speak up when the new content warrants it. Default output per
+   update: one or two sentences of "what to say next" — a concrete
+   suggestion the user could actually say, plus (only when useful) a
+   one-line reason. Don't re-summarize the whole meeting every tick.
+   Match the meeting's language.
+4. Special statuses:
+   - `recording_live_unavailable`: no live text will appear on this
+     hardware — say so and stop polling frequently; check occasionally
+     for `completed`.
+   - `stale`: warn that Mila seems to have stopped updating (possible
+     crash); the transcript won't grow.
+   - `new_session: true`: a different recording started — confirm with
+     the user before following the new one.
+5. On `status: completed`: stop polling, call
+   `get_transcript(id: final_recording_id)`, and close with a short
+   summary + action items.


### PR DESCRIPTION
Part of the #99 split (roadmap in that PR). Kept as one unit per your note that the MCP server and the MilaKit extraction are best reviewed together — but the first two commits are a self-contained refactor and I'm happy to split them out if you'd rather land those first.

## What

An MCP stdio server, `mila-mcp`, embedded at `Mila.app/Contents/MacOS/mila-mcp`. It gives an agent read-only access to your transcriptions: list, search, fetch a transcript (speaker-named), and read the transcript of a recording **that's still in progress**.

Setup and the full tool reference are in `docs/mcp.md`. `skills/mila-meetings/SKILL.md` is an agent skill built on top of it.

## Commits, in review order

1. **Extract MilaKit; move TranscriptFormatter behind `SpeakerTextSegment`** — pure refactor, no behaviour change. Formatting logic moves into the new package behind a protocol so both the app's `TranscriptSegment` and the helper's `StoredRecording.Segment` can use it, instead of the helper reimplementing it and drifting.
2. **Store-location pointer + read-only store access** — `RecordingStore` writes `store-location.json`; `MilaStoreReader` reads recordings.json without the app running.
3. **Live-transcript sidecar** — mirrors the in-progress transcript to `live/current.json` during recording.
4. **The `mila-mcp` executable** — thin stdio loop; all tool logic lives in `MilaMCPToolHandlers`.
5. **Docs, agent skill, Makefile target, CLAUDE.md notes.**

## Design constraints worth knowing about

**MilaKit is dependency-free, deliberately.** It must not pull in TranscriptionCore, because it links into `mila-mcp` and that helper must not drag the whisper xcframework into its binary. This is why `TranscriptFormatter` moved behind a protocol rather than just being made public where it was.

**Tool logic lives in `MilaMCPToolHandlers`, not in the executable.** The handlers are pure JSON-in/JSON-out, so they're testable without spawning a process — `MilaMCPToolHandlersTests` covers them directly.

**The two cross-process contracts live at the DEFAULT app-support root and deliberately do not travel with a relocated recordings folder.** If they moved with the store, the helper would have no fixed place to start looking. `store-location.json` is the indirection that makes relocation work at all.

**`StoredRecording` is a mirror of recordings.json and can drift.** Anything `Recording.encode(to:)` writes has to be mirrored there. `StoredRecordingDriftTests` is the tripwire for that, and `StoredRecording` decodes leniently (`decodeIfPresent` + defaults) so an older helper survives a newer app's schema rather than failing to parse.

## Tests

- **MilaKit package: 33 tests** — `MilaStoreReaderTests` (pointer resolution and relocation, sorting, filters, search relevance and snippets, speaker-name resolution, sidecar-vs-segments transcript fallback), `MilaMCPToolHandlersTests`, `TranscriptFormatterTests`.
- **App: 61 tests** across `LiveTranscriptSidecarWriterTests`, `StoredRecordingDriftTests`, `RecordingStoreTests`, `TranscriptFormatterTests`.

Both `make build` and `make package-test` pass.

## One note on the diff

The sidecar's per-tick call maps `LiveSegment -> TranscriptSegment` inline in `MilaApp`. In our fork that mapping was centralised as `LiveTranscriber.transcriptSegments`, but that property is @DanielSolomon's work from #85, so I've left it out rather than duplicate his commit here. If #85 lands first, this call site should switch to `transcriber.transcriptSegments` and the inline map goes away.

## Note on verification

I could not run the **UI test** target locally — the XCUITest runner fails on my machine with "Timed out while enabling automation mode", which reproduces on a clean checkout of `main`, so it looks environmental. Unit and package tests are verified.

Made with [Cursor](https://cursor.com)

