### PR TITLE
feat(obsidian): export completed recordings to an Obsidian vault

### DIFF
--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -115,7 +115,9 @@ final class ObsidianExporter: ObservableObject {
         // Defence in depth, immediately before the first thing that touches
         // the disk: the sanitizer makes an escaping component impossible, and
         // this makes a regression in it non-exploitable rather than silent.
-        guard ObsidianPathSanitizer.isContained(destDir, in: vault) else {
+        // It also covers what no naming rule can — a symlink inside the vault
+        // whose target is outside it, which is spelled entirely under the vault.
+        guard ObsidianPathSanitizer.isContained(destDir, in: vault, fileManager: fileManager) else {
             print("ObsidianExporter: refusing to write outside the vault: \(destDir.path)")
             return nil
         }
@@ -128,6 +130,12 @@ final class ObsidianExporter: ObservableObject {
         }
 
         let target = destDir.appendingPathComponent(Self.fileName(for: recording))
+        // Re-checked for the file itself, not just its directory: the note name
+        // could already exist as a symlink pointing out of the vault.
+        guard ObsidianPathSanitizer.isContained(target, in: vault, fileManager: fileManager) else {
+            print("ObsidianExporter: refusing to write outside the vault: \(target.path)")
+            return nil
+        }
         let newRelative = Self.relativePath(of: target, vault: vault)
         var changedPaths: [URL] = [target]
 
@@ -144,7 +152,7 @@ final class ObsidianExporter: ObservableObject {
         if let prevRelative = index[key], prevRelative != newRelative {
             let old = vault.appendingPathComponent(prevRelative)
             // Never follow a stored path back out of the vault.
-            if ObsidianPathSanitizer.isContained(old, in: vault) {
+            if ObsidianPathSanitizer.isContained(old, in: vault, fileManager: fileManager) {
                 try? fileManager.removeItem(at: old)
                 changedPaths.append(old)
             }
@@ -176,7 +184,7 @@ final class ObsidianExporter: ObservableObject {
         index[legacyKey] = nil
         guard index[key] == nil else { return }
         let candidate = vault.appendingPathComponent(legacy)
-        guard ObsidianPathSanitizer.isContained(candidate, in: vault),
+        guard ObsidianPathSanitizer.isContained(candidate, in: vault, fileManager: fileManager),
               fileManager.fileExists(atPath: candidate.path) else { return }
         index[key] = legacy
     }

--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MilaKit
 
 /// Writes a completed recording into the configured Obsidian vault as a
 /// Markdown note, then optionally kicks the git sync.
@@ -55,7 +54,13 @@ final class ObsidianExporter: ObservableObject {
         guard let write = writeNote(recording, vault: vault) else { return nil }
 
         if settings.gitSyncEnabled {
-            let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Single-line: a title with an embedded newline would otherwise
+            // turn the commit subject into a subject + body in the user's
+            // vault history.
+            let title = recording.title
+                .components(separatedBy: .newlines)
+                .joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             let message = "Add transcript: \(title.isEmpty ? "Untitled recording" : title)"
             kickGitSync(vault: vault, changedPaths: write.changedPaths, commitMessage: message)
         }
@@ -88,6 +93,11 @@ final class ObsidianExporter: ObservableObject {
     /// a rename), or nil when there's nothing to write / the write fails.
     private func writeNote(_ recording: Recording,
                            vault: URL) -> (written: URL, changedPaths: [URL])? {
+        // Never file a recording the user has thrown away. The summary hook
+        // can land after a trash action (the LLM call is in flight when the
+        // user deletes), and "I deleted it and it still turned up in my vault"
+        // is the worst possible surprise from a background exporter.
+        guard !recording.isTrashed else { return nil }
         guard Self.hasContent(recording), let destDir = destinationDirectory(for: recording) else {
             return nil
         }
@@ -130,7 +140,10 @@ final class ObsidianExporter: ObservableObject {
         guard let base = settings.destinationDirectory else { return nil }
         let folder = (recording.folder ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !folder.isEmpty else { return base }
-        let safe = Self.sanitizedTitle(folder)
+        // `directoryComponent`, not `sanitizedTitle`: a Mila folder literally
+        // named ".." would otherwise append a real parent-directory component
+        // and file the note outside the configured subfolder.
+        let safe = ObsidianPathSanitizer.directoryComponent(folder)
         guard !safe.isEmpty else { return base }
         return base.appendingPathComponent(safe, isDirectory: true)
     }
@@ -219,14 +232,15 @@ final class ObsidianExporter: ObservableObject {
     }
 
     /// Strip path-hostile characters and collapse whitespace so the title is a
-    /// safe single-line filename component.
+    /// safe single-line filename component. Length-capped on a UTF-8 budget so
+    /// a very long title can't blow past the 255-byte component limit and make
+    /// the write fail.
+    ///
+    /// Safe to leave leading dots in place here: `fileName` always prefixes the
+    /// date, so the result can never be `.`, `..` or a dotfile. Directory names
+    /// have no such prefix and go through `ObsidianPathSanitizer
+    /// .directoryComponent` instead.
     static func sanitizedTitle(_ title: String) -> String {
-        let invalid = CharacterSet(charactersIn: "/\\:*?\"<>|")
-            .union(.newlines)
-            .union(.controlCharacters)
-        let stripped = title.components(separatedBy: invalid).joined(separator: " ")
-        return stripped
-            .split(whereSeparator: { $0 == " " || $0 == "\t" })
-            .joined(separator: " ")
+        ObsidianPathSanitizer.nameFragment(title)
     }
 }

--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MilaKit
+
+/// Writes a completed recording into the configured Obsidian vault as a
+/// Markdown note, then optionally kicks the git sync.
+///
+/// Content is **summary + action items** when a summary exists; when it
+/// doesn't (summaries off, LLM unconfigured, or generation failed) it falls
+/// back to **transcript + action items** so export stays independent of the
+/// LLM. One `.md` per recording, `<date> <title>.md`, into `vault/subfolder`.
+///
+/// Idempotency: a per-recording seen-index (Drive-importer discipline) maps the
+/// recording ID to its last-written relative path, so a re-transcription (or a
+/// title edit) overwrites/renames the same note instead of leaving duplicates.
+///
+/// The `pending` set is the sequencing gate: a fresh completion is marked
+/// pending, and the actual write happens from `RecordingSummarizer`'s
+/// completion hook once the summary is final. Backfilled recordings are never
+/// marked pending, so a launch-time summary sweep can't spam the vault.
+@MainActor
+final class ObsidianExporter: ObservableObject {
+    static let writtenIndexKey = "obsidian.writtenIndex"
+
+    private let settings: ObsidianVaultSettings
+    private let gitSyncer: ObsidianGitSyncer
+    private let defaults: UserDefaults
+    private let fileManager: FileManager
+
+    private var pending: Set<UUID> = []
+
+    init(settings: ObsidianVaultSettings,
+         gitSyncer: ObsidianGitSyncer = ObsidianGitSyncer(),
+         defaults: UserDefaults = .standard,
+         fileManager: FileManager = .default) {
+        self.settings = settings
+        self.gitSyncer = gitSyncer
+        self.defaults = defaults
+        self.fileManager = fileManager
+    }
+
+    // MARK: - Pending gate
+
+    func markPending(_ id: UUID) { pending.insert(id) }
+    func isPending(_ id: UUID) -> Bool { pending.contains(id) }
+    func clearPending(_ id: UUID) { pending.remove(id) }
+
+    // MARK: - Export
+
+    /// Write `recording` into the vault. No-op (returns nil) when the feature
+    /// is disabled, no vault is picked, or the recording has nothing worth
+    /// filing. Returns the written file URL on success.
+    @discardableResult
+    func export(_ recording: Recording) -> URL? {
+        guard settings.enabled, let vault = settings.vaultURL else { return nil }
+        guard let write = writeNote(recording, vault: vault) else { return nil }
+
+        if settings.gitSyncEnabled {
+            let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = "Add transcript: \(title.isEmpty ? "Untitled recording" : title)"
+            kickGitSync(vault: vault, changedPaths: write.changedPaths, commitMessage: message)
+        }
+        return write.written
+    }
+
+    /// Backfill: write every provided recording into the vault, then kick a
+    /// single git sync covering all of them. Used by "Sync existing
+    /// transcripts". Returns the count of notes actually written.
+    @discardableResult
+    func exportAll(_ recordings: [Recording]) -> Int {
+        guard settings.enabled, let vault = settings.vaultURL else { return 0 }
+
+        var changed: [URL] = []
+        for recording in recordings {
+            guard let write = writeNote(recording, vault: vault) else { continue }
+            changed.append(contentsOf: write.changedPaths)
+        }
+        guard !changed.isEmpty else { return 0 }
+
+        if settings.gitSyncEnabled {
+            let message = "Sync \(changed.count) Mila transcript\(changed.count == 1 ? "" : "s")"
+            kickGitSync(vault: vault, changedPaths: changed, commitMessage: message)
+        }
+        return changed.count
+    }
+
+    /// File `recording` into the vault (no git). Returns the written file plus
+    /// the paths that changed on disk (the new file and any old file removed by
+    /// a rename), or nil when there's nothing to write / the write fails.
+    private func writeNote(_ recording: Recording,
+                           vault: URL) -> (written: URL, changedPaths: [URL])? {
+        guard Self.hasContent(recording), let destDir = destinationDirectory(for: recording) else {
+            return nil
+        }
+
+        do {
+            try fileManager.createDirectory(at: destDir, withIntermediateDirectories: true)
+        } catch {
+            print("ObsidianExporter: failed to create \(destDir.path): \(error)")
+            return nil
+        }
+
+        let target = destDir.appendingPathComponent(Self.fileName(for: recording))
+        let newRelative = Self.relativePath(of: target, vault: vault)
+        var changedPaths: [URL] = [target]
+
+        // Overwrite discipline: if we wrote a differently-named file for this
+        // recording before (title changed / moved to another folder), remove it.
+        var index = writtenIndex()
+        let key = recording.id.uuidString
+        if let prevRelative = index[key], prevRelative != newRelative {
+            let old = vault.appendingPathComponent(prevRelative)
+            try? fileManager.removeItem(at: old)
+            changedPaths.append(old)
+        }
+
+        do {
+            try Self.markdown(for: recording).write(to: target, atomically: true, encoding: .utf8)
+        } catch {
+            print("ObsidianExporter: failed to write \(target.path): \(error)")
+            return nil
+        }
+        index[key] = newRelative
+        setWrittenIndex(index)
+        return (target, changedPaths)
+    }
+
+    /// The vault destination for `recording`: the configured subfolder, plus a
+    /// nested folder mirroring the recording's Mila folder when it has one.
+    private func destinationDirectory(for recording: Recording) -> URL? {
+        guard let base = settings.destinationDirectory else { return nil }
+        let folder = (recording.folder ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !folder.isEmpty else { return base }
+        let safe = Self.sanitizedTitle(folder)
+        guard !safe.isEmpty else { return base }
+        return base.appendingPathComponent(safe, isDirectory: true)
+    }
+
+    private func kickGitSync(vault: URL, changedPaths: [URL], commitMessage: String) {
+        let rawBranch = settings.gitBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = rawBranch.isEmpty ? ObsidianVaultSettings.defaultBranch : rawBranch
+        let syncer = gitSyncer
+        Task { @MainActor in
+            let error = await syncer.sync(vault: vault,
+                                          changedPaths: changedPaths,
+                                          branch: branch,
+                                          commitMessage: commitMessage)
+            self.settings.lastSyncError = error
+        }
+    }
+
+    // MARK: - Seen-index
+
+    private func writtenIndex() -> [String: String] {
+        defaults.dictionary(forKey: Self.writtenIndexKey) as? [String: String] ?? [:]
+    }
+
+    private func setWrittenIndex(_ index: [String: String]) {
+        defaults.set(index, forKey: Self.writtenIndexKey)
+    }
+
+    private static func relativePath(of url: URL, vault: URL) -> String {
+        let base = vault.path.hasSuffix("/") ? vault.path : vault.path + "/"
+        if url.path.hasPrefix(base) { return String(url.path.dropFirst(base.count)) }
+        return url.lastPathComponent
+    }
+
+    // MARK: - Formatting (pure, unit-tested)
+
+    /// True when the recording has anything worth writing (a summary,
+    /// transcript text, or action items).
+    static func hasContent(_ recording: Recording) -> Bool {
+        if !(recording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if !recording.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if let items = recording.actionItems, !items.isEmpty { return true }
+        return false
+    }
+
+    /// Build the note body: `# title`, then the summary (or a `## Transcript`
+    /// fallback), then a `## Action items` checklist when present.
+    static func markdown(for recording: Recording) -> String {
+        let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        var out = "# \(title.isEmpty ? "Untitled recording" : title)\n"
+
+        let summary = (recording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !summary.isEmpty {
+            out += "\n\(summary)\n"
+        } else {
+            let transcript = TranscriptFormatter.plainText(
+                segments: recording.segments,
+                fallback: recording.fullText,
+                names: recording.speakerNames
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !transcript.isEmpty {
+                out += "\n## Transcript\n\n\(transcript)\n"
+            }
+        }
+
+        if let items = recording.actionItems, !items.isEmpty {
+            out += "\n## Action items\n\n"
+            out += items.map { "- [ ] \($0.text)" }.joined(separator: "\n")
+            out += "\n"
+        }
+        return out
+    }
+
+    /// `<yyyy-MM-dd> <title>.md`, sanitized for the filesystem.
+    static func fileName(for recording: Recording) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let datePart = formatter.string(from: recording.createdAt)
+        let safeTitle = sanitizedTitle(recording.title)
+        let base = safeTitle.isEmpty ? datePart : "\(datePart) \(safeTitle)"
+        return base + ".md"
+    }
+
+    /// Strip path-hostile characters and collapse whitespace so the title is a
+    /// safe single-line filename component.
+    static func sanitizedTitle(_ title: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/\\:*?\"<>|")
+            .union(.newlines)
+            .union(.controlCharacters)
+        let stripped = title.components(separatedBy: invalid).joined(separator: " ")
+        return stripped
+            .split(whereSeparator: { $0 == " " || $0 == "\t" })
+            .joined(separator: " ")
+    }
+}

--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -51,16 +51,15 @@ final class ObsidianExporter: ObservableObject {
     @discardableResult
     func export(_ recording: Recording) -> URL? {
         guard settings.enabled, let vault = settings.vaultURL else { return nil }
-        guard let write = writeNote(recording, vault: vault) else { return nil }
+        var index = writtenIndex()
+        guard let write = writeNote(recording, vault: vault, index: &index) else { return nil }
+        setWrittenIndex(index)
 
         if settings.gitSyncEnabled {
             // Single-line: a title with an embedded newline would otherwise
             // turn the commit subject into a subject + body in the user's
             // vault history.
-            let title = recording.title
-                .components(separatedBy: .newlines)
-                .joined(separator: " ")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = Self.singleLine(recording.title)
             let message = "Add transcript: \(title.isEmpty ? "Untitled recording" : title)"
             kickGitSync(vault: vault, changedPaths: write.changedPaths, commitMessage: message)
         }
@@ -74,31 +73,50 @@ final class ObsidianExporter: ObservableObject {
     func exportAll(_ recordings: [Recording]) -> Int {
         guard settings.enabled, let vault = settings.vaultURL else { return 0 }
 
+        // The index is loaded once and stored once. Per-note persistence would
+        // re-serialize the whole dictionary for every recording, which is what
+        // actually makes a large backfill expensive — not the file writes.
+        var index = writtenIndex()
         var changed: [URL] = []
+        // Counted separately from `changed`: a rename contributes *two* paths
+        // (the new file and the removed old one) for a single written note, so
+        // `changed.count` would over-report both the UI result and the commit
+        // subject after any title or folder change.
+        var written = 0
         for recording in recordings {
-            guard let write = writeNote(recording, vault: vault) else { continue }
+            guard let write = writeNote(recording, vault: vault, index: &index) else { continue }
             changed.append(contentsOf: write.changedPaths)
+            written += 1
         }
+        setWrittenIndex(index)
         guard !changed.isEmpty else { return 0 }
 
         if settings.gitSyncEnabled {
-            let message = "Sync \(changed.count) Mila transcript\(changed.count == 1 ? "" : "s")"
+            let message = "Sync \(written) Mila transcript\(written == 1 ? "" : "s")"
             kickGitSync(vault: vault, changedPaths: changed, commitMessage: message)
         }
-        return changed.count
+        return written
     }
 
     /// File `recording` into the vault (no git). Returns the written file plus
     /// the paths that changed on disk (the new file and any old file removed by
     /// a rename), or nil when there's nothing to write / the write fails.
     private func writeNote(_ recording: Recording,
-                           vault: URL) -> (written: URL, changedPaths: [URL])? {
+                           vault: URL,
+                           index: inout [String: String]) -> (written: URL, changedPaths: [URL])? {
         // Never file a recording the user has thrown away. The summary hook
         // can land after a trash action (the LLM call is in flight when the
         // user deletes), and "I deleted it and it still turned up in my vault"
         // is the worst possible surprise from a background exporter.
         guard !recording.isTrashed else { return nil }
         guard Self.hasContent(recording), let destDir = destinationDirectory(for: recording) else {
+            return nil
+        }
+        // Defence in depth, immediately before the first thing that touches
+        // the disk: the sanitizer makes an escaping component impossible, and
+        // this makes a regression in it non-exploitable rather than silent.
+        guard ObsidianPathSanitizer.isContained(destDir, in: vault) else {
+            print("ObsidianExporter: refusing to write outside the vault: \(destDir.path)")
             return nil
         }
 
@@ -115,12 +133,21 @@ final class ObsidianExporter: ObservableObject {
 
         // Overwrite discipline: if we wrote a differently-named file for this
         // recording before (title changed / moved to another folder), remove it.
-        var index = writtenIndex()
-        let key = recording.id.uuidString
+        //
+        // The key is scoped to the vault. The stored value is a path *relative
+        // to the vault it was written into*, so resolving it against whatever
+        // vault happens to be configured now would, after the user switches
+        // vaults, delete `<newVault>/<oldRelativePath>` — an unrelated file, or
+        // nothing — and orphan the real note in the previous vault.
+        let key = Self.indexKey(vault: vault, id: recording.id)
+        migrateLegacyIndexEntry(&index, key: key, vault: vault, id: recording.id)
         if let prevRelative = index[key], prevRelative != newRelative {
             let old = vault.appendingPathComponent(prevRelative)
-            try? fileManager.removeItem(at: old)
-            changedPaths.append(old)
+            // Never follow a stored path back out of the vault.
+            if ObsidianPathSanitizer.isContained(old, in: vault) {
+                try? fileManager.removeItem(at: old)
+                changedPaths.append(old)
+            }
         }
 
         do {
@@ -130,8 +157,28 @@ final class ObsidianExporter: ObservableObject {
             return nil
         }
         index[key] = newRelative
-        setWrittenIndex(index)
         return (target, changedPaths)
+    }
+
+    /// Index keys written before the index was vault-scoped are bare UUIDs.
+    /// Adopt such an entry into the current vault's namespace only when the
+    /// file it names actually exists in *this* vault — that is the only
+    /// evidence that it is a note we wrote here. Otherwise it belongs to a
+    /// vault the user has since switched away from, and must not be allowed to
+    /// drive a delete. Either way the legacy key is dropped, so the migration
+    /// runs at most once per recording.
+    private func migrateLegacyIndexEntry(_ index: inout [String: String],
+                                         key: String,
+                                         vault: URL,
+                                         id: UUID) {
+        let legacyKey = id.uuidString
+        guard let legacy = index[legacyKey] else { return }
+        index[legacyKey] = nil
+        guard index[key] == nil else { return }
+        let candidate = vault.appendingPathComponent(legacy)
+        guard ObsidianPathSanitizer.isContained(candidate, in: vault),
+              fileManager.fileExists(atPath: candidate.path) else { return }
+        index[key] = legacy
     }
 
     /// The vault destination for `recording`: the configured subfolder, plus a
@@ -171,6 +218,13 @@ final class ObsidianExporter: ObservableObject {
         defaults.set(index, forKey: Self.writtenIndexKey)
     }
 
+    /// Vault-scoped index key. `standardized` (lexical) rather than
+    /// `standardizedFileURL` so the key doesn't change with the filesystem's
+    /// mood — see `ObsidianPathSanitizer.isContained`.
+    static func indexKey(vault: URL, id: UUID) -> String {
+        "\(vault.standardized.path)#\(id.uuidString)"
+    }
+
     private static func relativePath(of url: URL, vault: URL) -> String {
         let base = vault.path.hasSuffix("/") ? vault.path : vault.path + "/"
         if url.path.hasPrefix(base) { return String(url.path.dropFirst(base.count)) }
@@ -192,10 +246,20 @@ final class ObsidianExporter: ObservableObject {
         return false
     }
 
+    /// Markdown headings and list items are line-based constructs, so any user
+    /// text placed on such a line has to be collapsed to one line first — a
+    /// newline in a title would otherwise split the `# ` heading, and one in an
+    /// action item would break the `- [ ] ` checkbox into loose body text.
+    static func singleLine(_ raw: String) -> String {
+        raw.components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Build the note body: `# title`, then the summary (or a `## Transcript`
     /// fallback), then a `## Action items` checklist when present.
     static func markdown(for recording: Recording) -> String {
-        let title = recording.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = singleLine(recording.title)
         var out = "# \(title.isEmpty ? "Untitled recording" : title)\n"
 
         let summary = (recording.summary ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -214,7 +278,7 @@ final class ObsidianExporter: ObservableObject {
 
         if let items = recording.actionItems, !items.isEmpty {
             out += "\n## Action items\n\n"
-            out += items.map { "- [ ] \($0.text)" }.joined(separator: "\n")
+            out += items.map { "- [ ] \(singleLine($0.text))" }.joined(separator: "\n")
             out += "\n"
         }
         return out

--- a/Mila/Actions/ObsidianGitSyncer.swift
+++ b/Mila/Actions/ObsidianGitSyncer.swift
@@ -1,0 +1,232 @@
+import Foundation
+import os
+
+/// Result of a single `git` invocation.
+struct GitCommandResult: Sendable {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+    let timedOut: Bool
+
+    var succeeded: Bool { !timedOut && exitCode == 0 }
+    /// Prefer stderr (git writes progress/errors there); fall back to stdout.
+    var message: String {
+        let e = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return e.isEmpty ? stdout.trimmingCharacters(in: .whitespacesAndNewlines) : e
+    }
+}
+
+/// Seam so tests can assert the exact command sequence without spawning git.
+protocol GitCommandRunning: Sendable {
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult
+}
+
+/// Commits + rebases + pushes an Obsidian vault git repo after a note is
+/// written. Modelled on the confirmed flow:
+///
+///   1. `git add <file>`
+///   2. `git commit -m <msg>`   (skipped cleanly when nothing changed)
+///   3. `git pull --rebase origin <branch>`
+///   4. `git push origin HEAD:<branch>`
+///
+/// On a rebase conflict we `git rebase --abort` so the vault is never left
+/// mid-conflict — the local commit is preserved and pushes on the next
+/// successful sync. All steps are non-interactive (see `ProcessGitCommandRunner`)
+/// and the whole thing is an `actor`, so concurrent recording completions can't
+/// interleave git commands in the same repo.
+actor ObsidianGitSyncer {
+    private let runner: GitCommandRunning
+
+    init(runner: GitCommandRunning = ProcessGitCommandRunner()) {
+        self.runner = runner
+    }
+
+    /// Run the sync. Returns nil on success, or a human-readable error string
+    /// to surface in Settings (the caller stores it on
+    /// `ObsidianVaultSettings.lastSyncError`).
+    ///
+    /// `changedPaths` are staged with `git add --all --` so note additions,
+    /// modifications, AND deletions (from a rename/overwrite) are all captured
+    /// while leaving the user's unrelated vault files untouched.
+    @discardableResult
+    func sync(vault: URL,
+              changedPaths: [URL],
+              branch: String,
+              commitMessage: String) async -> String? {
+        // Locate the repo toplevel from the vault dir. Doubles as the
+        // "is this a git repo?" guard.
+        let top = await runner.run(["rev-parse", "--show-toplevel"], in: vault)
+        guard top.succeeded else {
+            return "The Obsidian vault is not a git repository (git rev-parse failed)."
+        }
+        let toplevelPath = top.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let toplevel = toplevelPath.isEmpty ? vault : URL(fileURLWithPath: toplevelPath)
+
+        let add = await runner.run(["add", "--all", "--"] + changedPaths.map(\.path), in: toplevel)
+        guard add.succeeded else { return "git add failed: \(add.message)" }
+
+        let commit = await runner.run(["commit", "-m", commitMessage], in: toplevel)
+        if !commit.succeeded {
+            // A re-export of unchanged content leaves nothing to commit —
+            // that's fine, we still want to pull/push. Anything else is a
+            // real failure.
+            let lower = commit.message.lowercased()
+            let nothingToCommit = lower.contains("nothing to commit")
+                || lower.contains("no changes added")
+                || lower.contains("working tree clean")
+            if !nothingToCommit { return "git commit failed: \(commit.message)" }
+        }
+
+        let pull = await runner.run(["pull", "--rebase", "origin", branch], in: toplevel)
+        guard pull.succeeded else {
+            // Never leave the vault mid-rebase.
+            _ = await runner.run(["rebase", "--abort"], in: toplevel)
+            return "git pull --rebase failed (aborted): \(pull.message)"
+        }
+
+        let push = await runner.run(["push", "origin", "HEAD:\(branch)"], in: toplevel)
+        guard push.succeeded else { return "git push failed: \(push.message)" }
+
+        return nil
+    }
+}
+
+/// Production `GitCommandRunning` — spawns the real `git` binary with a bounded
+/// timeout and a non-interactive environment (no credential/host prompts that
+/// would hang a background sync).
+struct ProcessGitCommandRunner: GitCommandRunning {
+    var timeout: TimeInterval = 120
+
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult {
+        let timeout = self.timeout
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: Self.runSync(arguments, in: directory, timeout: timeout))
+            }
+        }
+    }
+
+    /// Resolve `git`: prefer the system binary shipped with the Command Line
+    /// Tools, then fall back to well-known shell-managed `bin` dirs. A
+    /// Finder-launched app inherits a stripped PATH from launchd, so a
+    /// Homebrew git is typically absent from it.
+    static func gitExecutable() -> URL? {
+        let fm = FileManager.default
+        if fm.isExecutableFile(atPath: "/usr/bin/git") {
+            return URL(fileURLWithPath: "/usr/bin/git")
+        }
+        for dir in searchDirectories() {
+            let candidate = (dir as NSString).appendingPathComponent("git")
+            if fm.isExecutableFile(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+
+    /// Inherited `$PATH` first, then the usual shell-managed locations.
+    static func searchDirectories(home: String = NSHomeDirectory(),
+                                  pathEnv: String? = ProcessInfo.processInfo.environment["PATH"]) -> [String] {
+        var dirs: [String] = []
+        if let pathEnv {
+            dirs += pathEnv.split(separator: ":").map(String.init)
+        }
+        dirs += [
+            "\(home)/.local/bin",
+            "\(home)/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin"
+        ]
+        var seen = Set<String>()
+        return dirs.filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    private static func runSync(_ arguments: [String],
+                                in directory: URL,
+                                timeout: TimeInterval) -> GitCommandResult {
+        guard let git = gitExecutable() else {
+            return GitCommandResult(exitCode: -1, stdout: "",
+                                    stderr: "git executable not found on PATH", timedOut: false)
+        }
+        let process = Process()
+        process.executableURL = git
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+
+        // Augment PATH so git finds any helpers, then force non-interactive:
+        //  * GIT_TERMINAL_PROMPT=0 — never prompt for username/password.
+        //  * GIT_SSH_COMMAND BatchMode — SSH fails fast instead of prompting
+        //    for a passphrase / unknown-host confirmation.
+        // A missing credential thus errors quickly rather than hanging the
+        // background sync forever.
+        var env = ProcessInfo.processInfo.environment
+        // git shells out to its own helpers (git-remote-https, credential
+        // helpers), which live beside the binary — put that directory first
+        // so a non-system git finds them under launchd's stripped PATH.
+        env["PATH"] = ([git.deletingLastPathComponent().path] + Self.searchDirectories())
+            .joined(separator: ":")
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+        process.environment = env
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return GitCommandResult(exitCode: -1, stdout: "",
+                                    stderr: "failed to launch git: \(error.localizedDescription)",
+                                    timedOut: false)
+        }
+        try? stdinPipe.fileHandleForWriting.close()
+
+        // Drain both pipes on background threads so a chatty git can't
+        // deadlock by filling the OS pipe buffer while we wait for exit.
+        let outBox = OSAllocatedUnfairLock(initialState: Data())
+        let errBox = OSAllocatedUnfairLock(initialState: Data())
+        let drain = DispatchGroup()
+        for (pipe, box) in [(stdoutPipe, outBox), (stderrPipe, errBox)] {
+            drain.enter()
+            DispatchQueue.global().async {
+                let handle = pipe.fileHandleForReading
+                while true {
+                    let chunk = handle.availableData
+                    if chunk.isEmpty { break }
+                    box.withLock { $0.append(chunk) }
+                }
+                drain.leave()
+            }
+        }
+
+        let running = DispatchGroup()
+        running.enter()
+        DispatchQueue.global().async {
+            process.waitUntilExit()
+            running.leave()
+        }
+        let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
+        let timedOut = running.wait(timeout: deadline) == .timedOut
+        if timedOut {
+            process.terminate()
+            if running.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = running.wait(timeout: .now() + 3)
+            }
+        }
+        _ = drain.wait(timeout: .now() + 5)
+
+        let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""
+        let stderr = String(data: errBox.withLock { $0 }, encoding: .utf8) ?? ""
+        return GitCommandResult(exitCode: timedOut ? -1 : process.terminationStatus,
+                                stdout: stdout,
+                                stderr: stderr,
+                                timedOut: timedOut)
+    }
+}

--- a/Mila/Actions/ObsidianGitSyncer.swift
+++ b/Mila/Actions/ObsidianGitSyncer.swift
@@ -41,6 +41,35 @@ actor ObsidianGitSyncer {
         self.runner = runner
     }
 
+    /// `obsidian.git.branch` is a free-text Settings field, and it lands in an
+    /// argument position where git would happily read it as an option: a branch
+    /// named `--upload-pack=/bin/sh` turns `git pull --rebase origin <branch>`
+    /// into a remote-helper override. Reject anything git itself would refuse
+    /// as a ref name, and anything that could be parsed as a flag or a revision
+    /// operator, before a single command runs.
+    ///
+    /// Roughly `git check-ref-format --branch`, minus the exotic rules — this
+    /// is a guard, not a reimplementation.
+    static func isValidBranch(_ branch: String) -> Bool {
+        guard !branch.isEmpty, branch.utf8.count <= 255 else { return false }
+        // The one that actually matters: never parsable as an option.
+        guard !branch.hasPrefix("-") else { return false }
+        guard !branch.hasPrefix("/"), !branch.hasSuffix("/") else { return false }
+        guard !branch.hasPrefix("."), !branch.hasSuffix(".") else { return false }
+        guard !branch.contains(".."), !branch.contains("@{") else { return false }
+        guard !branch.hasSuffix(".lock") else { return false }
+        let forbidden = CharacterSet(charactersIn: " \t~^:?*[]\\\u{7F}")
+            .union(.controlCharacters)
+            .union(.newlines)
+        return branch.rangeOfCharacter(from: forbidden) == nil
+    }
+
+    /// Fully-qualified form of `branch`. Belt and braces alongside
+    /// `isValidBranch`: a `refs/heads/`-prefixed argument can never begin with
+    /// `-`, so it cannot reach git in an option position however the validation
+    /// above evolves. It also removes the tag/branch ambiguity of a bare name.
+    private static func ref(_ branch: String) -> String { "refs/heads/\(branch)" }
+
     /// Run the sync. Returns nil on success, or a human-readable error string
     /// to surface in Settings (the caller stores it on
     /// `ObsidianVaultSettings.lastSyncError`).
@@ -53,6 +82,13 @@ actor ObsidianGitSyncer {
               changedPaths: [URL],
               branch: String,
               commitMessage: String) async -> String? {
+        // Validate before anything is spawned: a hostile branch value must not
+        // reach a git argument list at all.
+        guard Self.isValidBranch(branch) else {
+            return "\"\(branch)\" is not a valid git branch name. "
+                + "Change it in Settings ▸ Storage."
+        }
+
         // Locate the repo toplevel from the vault dir. Doubles as the
         // "is this a git repo?" guard.
         let top = await runner.run(["rev-parse", "--show-toplevel"], in: vault)
@@ -77,14 +113,14 @@ actor ObsidianGitSyncer {
             if !nothingToCommit { return "git commit failed: \(commit.message)" }
         }
 
-        let pull = await runner.run(["pull", "--rebase", "origin", branch], in: toplevel)
+        let pull = await runner.run(["pull", "--rebase", "origin", Self.ref(branch)], in: toplevel)
         guard pull.succeeded else {
             // Never leave the vault mid-rebase.
             _ = await runner.run(["rebase", "--abort"], in: toplevel)
             return "git pull --rebase failed (aborted): \(pull.message)"
         }
 
-        let push = await runner.run(["push", "origin", "HEAD:\(branch)"], in: toplevel)
+        let push = await runner.run(["push", "origin", "HEAD:\(Self.ref(branch))"], in: toplevel)
         guard push.succeeded else { return "git push failed: \(push.message)" }
 
         return nil

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -161,6 +161,13 @@ final class QuickActionsController: ObservableObject {
     /// Existing / in-progress recordings are never touched.
     var storageSettings: RecordingStorageSettings?
 
+    /// Late-bound by MilaApp. Obsidian vault destination + exporter. The
+    /// live-transcript save path (below) mirrors the batch path's Obsidian
+    /// wiring: mark the fresh completion pending so the summarizer's
+    /// completion hook writes the note once the summary is ready.
+    var obsidianSettings: ObsidianVaultSettings?
+    var obsidianExporter: ObsidianExporter?
+
     /// Active silence-watch task — cancelled when the recording stops so
     /// we never fire the warning for a recording that's already over.
     private var silenceWatchTask: Task<Void, Never>?
@@ -978,10 +985,17 @@ final class QuickActionsController: ObservableObject {
                 // enabled + configured conditions. `summarizeIfNeeded` covers
                 // the Live-AI-off case under the normal auto-summary gate.
                 TranscriptExporter.writeSRT(for: updated, in: self.store.recordingsDirectory)
+                // Mark this fresh completion pending for Obsidian export (if
+                // enabled) BEFORE kicking the summarizer, since a skip fires
+                // the completion hook synchronously.
+                let obsidianOn = (self.obsidianSettings?.enabled == true)
+                    && (self.obsidianSettings?.vaultURL != nil)
                 if self.liveAISettings?.enabled == true,
                    self.llmSettings?.isConfigured == true {
+                    if obsidianOn { self.obsidianExporter?.markPending(updated.id) }
                     self.summarizer?.regenerate(updated)
                 } else {
+                    if obsidianOn { self.obsidianExporter?.markPending(updated.id) }
                     self.summarizer?.summarizeIfNeeded(updated)
                 }
                 // Shrink storage: the live transcript is authoritative and the

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -71,6 +71,18 @@ final class RecordingSummarizer: ObservableObject {
     @Published private(set) var inFlightIDs: Set<UUID> = []
     private var inFlight: [UUID: Task<Void, Never>] = [:]
 
+    /// Fired once per summarize attempt, after the recording's summary state
+    /// is final — i.e. after a summary was generated, or synchronously when
+    /// generation was skipped (disabled / not configured / already summarized
+    /// / empty transcript), or when it failed. Passes the latest recording.
+    ///
+    /// The Obsidian exporter uses this to write a note only once the summary +
+    /// action items are ready, falling back to the transcript when no summary
+    /// was produced. It is NOT fired for the dedup early-return (a duplicate
+    /// call while one is already in flight — the in-flight task fires instead)
+    /// or when the recording has been deleted mid-flight (nothing to export).
+    var onSummaryFinished: ((Recording) -> Void)?
+
     /// Recordings the backfill scan has identified as needing a summary
     /// but hasn't started yet — held here so `maxConcurrent` is enforced
     /// across the whole batch instead of letting all candidates spawn at
@@ -200,6 +212,9 @@ final class RecordingSummarizer: ObservableObject {
     func summarizeIfNeeded(_ recording: Recording) {
         guard shouldSummarize(recording) else {
             logSkip(recording, force: false)
+            // No summary will be generated — signal completion now so a
+            // pending Obsidian export falls back to the transcript.
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         runSummary(for: recording, force: false)
@@ -217,12 +232,14 @@ final class RecordingSummarizer: ObservableObject {
     func regenerate(_ recording: Recording) {
         guard llmSettings.isConfigured else {
             summarizerLog.log("regenerate \(self.shortID(recording.id), privacy: .public): skipped — LLM not configured")
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         let transcript = recording.fullText
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !transcript.isEmpty else {
             summarizerLog.log("regenerate \(self.shortID(recording.id), privacy: .public): skipped — transcript empty")
+            onSummaryFinished?(latestRecording(recording.id, fallback: recording))
             return
         }
         runSummary(for: recording, force: true)
@@ -397,6 +414,9 @@ final class RecordingSummarizer: ObservableObject {
                 let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !cleaned.isEmpty else {
                     summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
+                    // No summary landed — let a pending export fall back to
+                    // the transcript rather than waiting forever.
+                    if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
                     return
                 }
                 // The recording may have been deleted between enqueue
@@ -405,20 +425,28 @@ final class RecordingSummarizer: ObservableObject {
                 guard let self else { return }
                 guard var current = self.store.recordings.first(where: { $0.id == id }) else {
                     summarizerLog.log("skipped \(self.shortID(id), privacy: .public): recording is gone")
+                    // Deleted mid-flight — nothing to export, so no signal.
                     return
                 }
                 let existing = (current.summary ?? "")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if !force, !existing.isEmpty {
                     summarizerLog.log("skipped \(self.shortID(id), privacy: .public): a summary landed mid-flight")
+                    // A summary is present (just from another path) — the
+                    // recording is ready to export.
+                    self.onSummaryFinished?(current)
                     return
                 }
                 current.summary = cleaned
                 self.store.update(current)
                 let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
                 summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(cleaned.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
+                self.onSummaryFinished?(current)
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // Failed generation — signal so a pending export can still
+                // write the transcript fallback.
+                if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
             }
         }
         inFlight[id] = task
@@ -453,5 +481,12 @@ final class RecordingSummarizer: ObservableObject {
 
     private func shortID(_ id: UUID) -> String {
         String(id.uuidString.prefix(8))
+    }
+
+    /// The freshest copy of a recording from the store, or `fallback` when
+    /// it's no longer there. Used so `onSummaryFinished` hands out the
+    /// up-to-date row (which may carry a just-written summary).
+    private func latestRecording(_ id: UUID, fallback: Recording) -> Recording {
+        store.recordings.first(where: { $0.id == id }) ?? fallback
     }
 }

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -80,7 +80,18 @@ final class RecordingSummarizer: ObservableObject {
     /// action items are ready, falling back to the transcript when no summary
     /// was produced. It is NOT fired for the dedup early-return (a duplicate
     /// call while one is already in flight — the in-flight task fires instead)
-    /// or when the recording has been deleted mid-flight (nothing to export).
+    /// or when the recording has been deleted mid-flight (nothing to export;
+    /// this covers the failure and empty-output paths too, not just success —
+    /// `cancel(recordingID:)` is what a permanent delete calls, and that
+    /// surfaces here as a thrown `CancellationError`).
+    ///
+    /// Exactly one of the branches below fires it per attempt, and each one
+    /// returns immediately afterwards, so a single `runSummary` can never fire
+    /// twice. Anything the observer does is its own problem: this is a plain
+    /// synchronous call on the main actor, so an observer that throws is a
+    /// programmer error, but an observer that *fails internally* (e.g. a file
+    /// write that can't complete) cannot stall or corrupt summarisation —
+    /// nothing downstream of the call site depends on it.
     var onSummaryFinished: ((Recording) -> Void)?
 
     /// Recordings the backfill scan has identified as needing a summary
@@ -415,8 +426,11 @@ final class RecordingSummarizer: ObservableObject {
                 guard !cleaned.isEmpty else {
                     summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
                     // No summary landed — let a pending export fall back to
-                    // the transcript rather than waiting forever.
-                    if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
+                    // the transcript rather than waiting forever. Skip the
+                    // signal entirely if the recording went away mid-flight.
+                    if let self, let current = self.liveRecording(id) {
+                        self.onSummaryFinished?(current)
+                    }
                     return
                 }
                 // The recording may have been deleted between enqueue
@@ -445,8 +459,12 @@ final class RecordingSummarizer: ObservableObject {
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
                 // Failed generation — signal so a pending export can still
-                // write the transcript fallback.
-                if let self { self.onSummaryFinished?(self.latestRecording(id, fallback: recording)) }
+                // write the transcript fallback. A permanent delete cancels
+                // the task, which lands here as a CancellationError, so the
+                // store lookup is what stops a deleted recording being filed.
+                if let self, let current = self.liveRecording(id) {
+                    self.onSummaryFinished?(current)
+                }
             }
         }
         inFlight[id] = task
@@ -484,9 +502,18 @@ final class RecordingSummarizer: ObservableObject {
     }
 
     /// The freshest copy of a recording from the store, or `fallback` when
-    /// it's no longer there. Used so `onSummaryFinished` hands out the
-    /// up-to-date row (which may carry a just-written summary).
+    /// it's no longer there. Used by the SYNCHRONOUS skip paths, where the
+    /// caller handed us the recording a moment ago and the fallback is the
+    /// same object it already holds.
     private func latestRecording(_ id: UUID, fallback: Recording) -> Recording {
         store.recordings.first(where: { $0.id == id }) ?? fallback
+    }
+
+    /// The recording as the store currently holds it, or nil when it's gone.
+    /// Used by the ASYNCHRONOUS completion paths, where a delete can land
+    /// between enqueue and completion: firing with the stale enqueue-time copy
+    /// would let an observer act on a row the user just deleted.
+    private func liveRecording(_ id: UUID) -> Recording? {
+        store.recordings.first(where: { $0.id == id })
     }
 }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -348,6 +348,11 @@ struct MilaApp: App {
     /// SwiftUI redraws and so its in-flight task table survives
     /// alongside everything else.
     @StateObject private var recordingSummarizer: RecordingSummarizer
+    /// Obsidian vault destination + its exporter. The exporter is held as a
+    /// StateObject purely so it stays alive — the completion hooks capture it
+    /// weakly.
+    @StateObject private var obsidianVaultSettings: ObsidianVaultSettings
+    @StateObject private var obsidianExporter: ObsidianExporter
     @StateObject private var voiceMemosSettings: VoiceMemosSettings
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
     /// Persistent, app-wide list of speaker names — the pick-list behind
@@ -518,6 +523,19 @@ struct MilaApp: App {
         let summarizer = RecordingSummarizer(store: store,
                                              llmSettings: llm,
                                              liveAISettings: liveAI)
+        // Obsidian vault destination. When enabled, a completed recording is
+        // written into the vault as a Markdown note (summary + action items,
+        // transcript fallback) once its summary is ready, then optionally
+        // committed + pushed to git. Off by default.
+        let obsidianSettings = ObsidianVaultSettings()
+        let obsidian = ObsidianExporter(settings: obsidianSettings)
+        // Write the note once the summary state is final. Gated on `pending`
+        // so a launch-time backfill sweep never re-files the back-catalogue.
+        summarizer.onSummaryFinished = { [weak obsidian] rec in
+            guard let obsidian, obsidian.isPending(rec.id) else { return }
+            obsidian.export(rec)
+            obsidian.clearPending(rec.id)
+        }
         // Wire the post-transcription summary hook. Fires for every
         // recording that the queue successfully completes — the
         // summarizer's own `shouldSummarize` gate skips work if a
@@ -528,16 +546,27 @@ struct MilaApp: App {
         // summary referring to the previous transcript; we force-
         // regenerate so the user doesn't end up with a stale summary
         // that disagrees with what the segments now say.
-        svc.onTranscriptionCompleted = { [weak summarizer, weak llm] rec, wasRetranscription in
+        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian] rec, wasRetranscription in
+            // Obsidian export is driven off the summarizer's completion hook.
+            // Mark this fresh completion pending so the hook knows to write it
+            // (backfilled recordings are never marked, hence never re-filed).
+            let obsidianOn = (obsidianSettings?.enabled == true) && (obsidianSettings?.vaultURL != nil)
             if wasRetranscription {
                 // `regenerate` bypasses the "already has a summary" gate by
                 // design (it's also the manual on-demand path), so it does
                 // NOT consult `summaryEnabled` itself. Guard the AUTOMATIC
                 // re-transcription trigger here so a transcript-only user
                 // doesn't get a summary regenerated behind their back.
-                guard llm?.summaryEnabled ?? true else { return }
+                guard llm?.summaryEnabled ?? true else {
+                    // No summary will be regenerated — export immediately with
+                    // the transcript fallback (no summarizer hook to wait for).
+                    if obsidianOn { obsidian?.export(rec) }
+                    return
+                }
+                if obsidianOn { obsidian?.markPending(rec.id) }
                 summarizer?.regenerate(rec)
             } else {
+                if obsidianOn { obsidian?.markPending(rec.id) }
                 summarizer?.summarizeIfNeeded(rec)
             }
         }
@@ -560,6 +589,8 @@ struct MilaApp: App {
         actions.liveDiarizer = liveDiar
         actions.summarizer = summarizer
         actions.storageSettings = storage
+        actions.obsidianSettings = obsidianSettings
+        actions.obsidianExporter = obsidian
         let meetingSettings = MeetingDetectionSettings()
         let detector = MeetingDetector()
         let promptCoordinator = MeetingPromptCoordinator(
@@ -598,6 +629,8 @@ struct MilaApp: App {
         _liveSpeakerDiarizer = StateObject(wrappedValue: liveDiar)
         _liveAISession = StateObject(wrappedValue: liveSession)
         _recordingSummarizer = StateObject(wrappedValue: summarizer)
+        _obsidianVaultSettings = StateObject(wrappedValue: obsidianSettings)
+        _obsidianExporter = StateObject(wrappedValue: obsidian)
         // Voice Memos (iPhone) folder integration. Settings are opt-in and
         // default-off; the importer wires up its FSEvents watcher + initial
         // backfill from its `start()` launch task (below), so constructing
@@ -685,6 +718,8 @@ struct MilaApp: App {
                 } message: {
                     Text(configImporter.errorMessage ?? "")
                 }
+                .environmentObject(obsidianVaultSettings)
+                .environmentObject(obsidianExporter)
         }
         .commands {
             CommandGroup(after: .appInfo) {
@@ -745,6 +780,8 @@ struct MilaApp: App {
                 // scene needs the same single updater instance the main window
                 // and the menu command use — never a second one.
                 .environmentObject(updater)
+                .environmentObject(obsidianVaultSettings)
+                .environmentObject(obsidianExporter)
         }
     }
 

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -1,6 +1,77 @@
 import Foundation
 import Combine
 
+/// Filesystem-name safety for everything Mila writes into the vault.
+///
+/// Free of actor isolation so both the settings model and `ObsidianExporter`
+/// share one implementation. Two of the three inputs are free text the user
+/// typed (the vault subfolder field) or named elsewhere in the app (a Mila
+/// folder name, a recording title), so all three go through here before they
+/// become path components.
+enum ObsidianPathSanitizer {
+    /// Illegal / hostile in a macOS path component. `/` is the separator,
+    /// the rest are either reserved on other platforms Obsidian vaults get
+    /// synced to or invisible in a filename.
+    private static let invalid = CharacterSet(charactersIn: "/\\:*?\"<>|")
+        .union(.newlines)
+        .union(.controlCharacters)
+
+    /// Strip path-hostile characters, collapse whitespace, and cap the length
+    /// so the result is a safe single-line name fragment.
+    ///
+    /// This does NOT guarantee a usable *component* on its own — the result
+    /// may be empty, `.` or `..`. Callers that build a directory name must use
+    /// `directoryComponent`; `ObsidianExporter.fileName` is safe because it
+    /// always prefixes the date, so the fragment can never stand alone.
+    ///
+    /// `maxBytes` is a UTF-8 budget, not a character count: HFS+/APFS cap a
+    /// component at 255 bytes, and a title of emoji or Hebrew hits that far
+    /// sooner than 255 characters would suggest. 180 leaves comfortable room
+    /// for the `yyyy-MM-dd ` prefix and the `.md` suffix.
+    static func nameFragment(_ raw: String, maxBytes: Int = 180) -> String {
+        let stripped = raw.components(separatedBy: invalid).joined(separator: " ")
+        let collapsed = stripped
+            .split(whereSeparator: { $0 == " " || $0 == "\t" })
+            .joined(separator: " ")
+        return truncated(collapsed, maxBytes: maxBytes)
+    }
+
+    /// A safe *directory* name: `nameFragment` plus the rules that stop a
+    /// component escaping its parent or hiding itself. Leading dots are
+    /// dropped, so `.`, `..` and `.hidden` collapse to `""`, `""` and
+    /// `"hidden"` — callers treat an empty result as "use the parent".
+    static func directoryComponent(_ raw: String) -> String {
+        var name = nameFragment(raw)
+        while name.hasPrefix(".") { name.removeFirst() }
+        return name.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Sanitize a user-typed vault-relative path (`Notes/Meetings`, and also
+    /// `../../Desktop`) into one that cannot escape the vault: every component
+    /// goes through `directoryComponent`, and components that sanitize to
+    /// nothing (`.`, `..`, empty) are dropped.
+    static func relativePath(_ raw: String) -> String {
+        raw.split(separator: "/")
+            .map { directoryComponent(String($0)) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "/")
+    }
+
+    /// Truncate on a UTF-8 byte budget without splitting a character.
+    private static func truncated(_ value: String, maxBytes: Int) -> String {
+        guard value.utf8.count > maxBytes else { return value }
+        var out = ""
+        var used = 0
+        for character in value {
+            let size = String(character).utf8.count
+            if used + size > maxBytes { break }
+            out.append(character)
+            used += size
+        }
+        return out.trimmingCharacters(in: .whitespaces)
+    }
+}
+
 /// User-configurable Obsidian vault destination. When enabled, Mila writes a
 /// Markdown note (summary + action items, with a transcript fallback) into the
 /// chosen vault folder after every recording finishes — and, optionally,
@@ -90,11 +161,15 @@ final class ObsidianVaultSettings: ObservableObject {
 
     /// The directory notes are written into: the vault root plus the
     /// configured subfolder. nil when no vault is picked.
+    ///
+    /// `subfolder` is a free-text field, so it is sanitized per component
+    /// rather than merely trimmed — a typed `../../Desktop` must resolve
+    /// inside the vault, not outside it.
     var destinationDirectory: URL? {
         guard let vaultURL else { return nil }
-        let clean = subfolder
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let clean = ObsidianPathSanitizer.relativePath(
+            subfolder.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
         return clean.isEmpty ? vaultURL : vaultURL.appendingPathComponent(clean, isDirectory: true)
     }
 

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -69,14 +69,100 @@ enum ObsidianPathSanitizer {
     /// change to the naming rules must not be able to turn into a file written
     /// outside the vault.
     ///
-    /// Deliberately `standardized` (lexical `..`/`.` resolution) and not
-    /// `standardizedFileURL`: the latter consults the filesystem and strips a
-    /// `/private` prefix only when the path already exists, so it compares an
-    /// existing vault against a not-yet-created destination inconsistently.
-    static func isContained(_ candidate: URL, in root: URL) -> Bool {
-        let rootPath = root.standardized.path
-        let path = candidate.standardized.path
-        return path == rootPath || path.hasPrefix(rootPath.hasSuffix("/") ? rootPath : rootPath + "/")
+    /// **Two checks, and neither one is sufficient alone.**
+    ///
+    ///  1. *Lexical* (`standardized`, no filesystem access): collapses `..`
+    ///     and `.`. This is the only one that means anything for a path whose
+    ///     every component is still hypothetical.
+    ///  2. *Symlink-resolved*: a lexical check is bypassable by a symlink
+    ///     **inside** the vault. `vault/Archive -> ~/Desktop` is spelled
+    ///     entirely under the vault, so it reads as contained, and every byte
+    ///     written through it lands on the Desktop. Both sides go through
+    ///     `resolvedPath` and are compared again.
+    ///
+    /// A symlink pointing *into* the vault is deliberately still allowed:
+    /// resolution lands it back under the root, symlinked folders are a normal
+    /// way to organise a vault, and the property worth enforcing is "the bytes
+    /// land inside the vault" — not "the user may not use symlinks".
+    ///
+    /// Note what is **not** used here. `standardizedFileURL` and
+    /// `resolvingSymlinksInPath()` both consult the filesystem, and both drop a
+    /// leading `/private` only when the path already exists — so an existing
+    /// vault renders as `/var/…` while a not-yet-created destination under it
+    /// renders as `/private/var/…`, and the two never compare equal. That trap
+    /// has bitten this guard twice already. `resolvedPath` resolves the
+    /// components that exist and carries the rest through verbatim, so it
+    /// answers identically for an existing and a not-yet-created destination.
+    ///
+    /// (Time-of-check/time-of-use is out of scope: this is a single-user local
+    /// app, and an attacker who can swap a directory for a symlink between the
+    /// check and the write can already write the file themselves.)
+    static func isContained(_ candidate: URL,
+                            in root: URL,
+                            fileManager: FileManager = .default) -> Bool {
+        guard isBelow(candidate.standardized.path, root: root.standardized.path) else {
+            return false
+        }
+        // Fail closed: an unresolvable path (a symlink cycle) is not contained.
+        guard let realRoot = resolvedPath(root, fileManager: fileManager),
+              let realCandidate = resolvedPath(candidate, fileManager: fileManager) else {
+            return false
+        }
+        return isBelow(realCandidate, root: realRoot)
+    }
+
+    /// Prefix comparison on whole components, so `/v/VaultOther` is not "inside"
+    /// `/v/Vault`.
+    private static func isBelow(_ path: String, root: String) -> Bool {
+        if path == root { return true }
+        return path.hasPrefix(root.hasSuffix("/") ? root : root + "/")
+    }
+
+    /// macOS gives up at 32 symlink hops (`ELOOP`). Matching it means this
+    /// guard never blesses a path the kernel would refuse to walk.
+    private static let symlinkHopBudget = 32
+
+    /// Resolve every symlink along `url`, one component at a time, **without
+    /// requiring the path to exist**.
+    ///
+    /// A component that is not a symlink — including one that isn't there yet —
+    /// is carried through as written, and `..`/`.` are applied only after the
+    /// components before them have been resolved, which is what the kernel
+    /// does. That combination is what `resolvingSymlinksInPath()` can't offer:
+    /// it needs the whole path to exist to do anything, and normalizes
+    /// `/private` conditionally on existence.
+    ///
+    /// Returns nil when the hop budget is exhausted.
+    static func resolvedPath(_ url: URL, fileManager: FileManager = .default) -> String? {
+        var resolved: [String] = []
+        // Reversed, so `popLast()` yields components in order and a symlink's
+        // target can be pushed back on to be walked in turn.
+        var pending = Array(url.pathComponents.reversed())
+        var hops = 0
+
+        while let component = pending.popLast() {
+            switch component {
+            case "", "/", ".":
+                continue
+            case "..":
+                if !resolved.isEmpty { resolved.removeLast() }
+                continue
+            default:
+                break
+            }
+            let next = "/" + (resolved + [component]).joined(separator: "/")
+            guard let target = try? fileManager.destinationOfSymbolicLink(atPath: next) else {
+                resolved.append(component)   // ordinary component, or not there yet
+                continue
+            }
+            hops += 1
+            guard hops <= symlinkHopBudget else { return nil }
+            // An absolute target restarts from `/`; a relative one is walked
+            // from the already-resolved directory that holds the link.
+            if target.hasPrefix("/") { resolved.removeAll() }
+            pending.append(contentsOf: target.split(separator: "/").reversed().map(String.init))
+        }
+        return "/" + resolved.joined(separator: "/")
     }
 
     /// Sanitize a user-typed vault-relative path (`Notes/Meetings`, and also

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -40,10 +40,43 @@ enum ObsidianPathSanitizer {
     /// component escaping its parent or hiding itself. Leading dots are
     /// dropped, so `.`, `..` and `.hidden` collapse to `""`, `""` and
     /// `"hidden"` — callers treat an empty result as "use the parent".
+    ///
+    /// The leading run that gets dropped is dots **and the whitespace between
+    /// them**, not dots alone. Stripping only dots left a whole family of
+    /// traversal components intact:
+    ///
+    ///   * `". .."` — the dot-strip stopped at the space and `".."` survived.
+    ///   * `"../.."` — `nameFragment` turns the `/` into a space first, so the
+    ///     dot-strip saw `".. .."`, stopped at the space, and left `".."`.
+    ///
+    /// Either one resolved a note *above* the configured destination.
     static func directoryComponent(_ raw: String) -> String {
         var name = nameFragment(raw)
-        while name.hasPrefix(".") { name.removeFirst() }
-        return name.trimmingCharacters(in: .whitespaces)
+        while let first = name.first, first == "." || first == " " || first == "\t" {
+            name.removeFirst()
+        }
+        name = name.trimmingCharacters(in: .whitespaces)
+        // Belt and braces: whatever the rules above evolve into, a relative
+        // reference must never leave this function.
+        guard name != ".", name != ".." else { return "" }
+        return name
+    }
+
+    /// Final containment guard: true when `candidate` resolves inside `root`.
+    ///
+    /// `directoryComponent` already makes a traversal component impossible, so
+    /// this is defence in depth at the point of the actual write — a future
+    /// change to the naming rules must not be able to turn into a file written
+    /// outside the vault.
+    ///
+    /// Deliberately `standardized` (lexical `..`/`.` resolution) and not
+    /// `standardizedFileURL`: the latter consults the filesystem and strips a
+    /// `/private` prefix only when the path already exists, so it compares an
+    /// existing vault against a not-yet-created destination inconsistently.
+    static func isContained(_ candidate: URL, in root: URL) -> Bool {
+        let rootPath = root.standardized.path
+        let path = candidate.standardized.path
+        return path == rootPath || path.hasPrefix(rootPath.hasSuffix("/") ? rootPath : rootPath + "/")
     }
 
     /// Sanitize a user-typed vault-relative path (`Notes/Meetings`, and also
@@ -219,7 +252,10 @@ final class ObsidianVaultSettings: ObservableObject {
             defaults.removeObject(forKey: Self.bookmarkKey)
             return
         }
-        accessingURL = resolved
+        // Only record a URL we actually started accessing, so the balancing
+        // `stopAccessingSecurityScopedResource()` in the next resolve can never
+        // be sent for an access that never began.
+        accessingURL = started ? resolved : nil
         vaultURL = resolved
     }
 

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Combine
+
+/// User-configurable Obsidian vault destination. When enabled, Mila writes a
+/// Markdown note (summary + action items, with a transcript fallback) into the
+/// chosen vault folder after every recording finishes — and, optionally,
+/// commits + pushes the vault git repo.
+///
+/// Mirrors `RecordingStorageSettings`: the vault folder is persisted as a
+/// **security-scoped bookmark** (not a raw path) so it survives moves/renames
+/// and keeps working if/when the app is sandboxed. The
+/// `com.apple.security.files.user-selected.read-write` entitlement is already
+/// declared, so bookmark access is granted at pick time and held for the app's
+/// lifetime.
+@MainActor
+final class ObsidianVaultSettings: ObservableObject {
+    static let enabledKey = "obsidian.enabled"
+    static let bookmarkKey = "obsidian.vaultBookmark"
+    static let subfolderKey = "obsidian.subfolder"
+    static let gitEnabledKey = "obsidian.git.enabled"
+    static let gitBranchKey = "obsidian.git.branch"
+
+    /// Default subfolder within the vault. Blank means "vault root".
+    static let defaultSubfolder = "Transcripts"
+    static let defaultBranch = "main"
+
+    /// Master switch. Off by default — the feature is opt-in and the
+    /// existing local-only experience is unchanged unless the user turns
+    /// this on and picks a vault.
+    @Published var enabled: Bool {
+        didSet {
+            guard enabled != oldValue else { return }
+            defaults.set(enabled, forKey: Self.enabledKey)
+        }
+    }
+
+    /// Relative folder inside the vault that notes are written into (e.g.
+    /// `Transcripts`). Blank = the vault root.
+    @Published var subfolder: String {
+        didSet {
+            guard subfolder != oldValue else { return }
+            defaults.set(subfolder, forKey: Self.subfolderKey)
+        }
+    }
+
+    /// When on, each written note is committed and pushed to the vault's
+    /// git remote (`add + commit -> pull --rebase -> push`). Requires the
+    /// vault to be a working git repo with credentials pre-configured
+    /// (SSH key / credential helper) — Mila runs git non-interactively.
+    @Published var gitSyncEnabled: Bool {
+        didSet {
+            guard gitSyncEnabled != oldValue else { return }
+            defaults.set(gitSyncEnabled, forKey: Self.gitEnabledKey)
+        }
+    }
+
+    /// Branch the sync pushes to (default `main`).
+    @Published var gitBranch: String {
+        didSet {
+            guard gitBranch != oldValue else { return }
+            defaults.set(gitBranch, forKey: Self.gitBranchKey)
+        }
+    }
+
+    /// Human-readable message from the last git sync, or nil when the last
+    /// one succeeded / none has run. Surfaced in the Obsidian settings tab.
+    /// Deliberately NOT persisted — a stale error across launches would be
+    /// misleading.
+    @Published var lastSyncError: String?
+
+    /// The resolved vault folder, or nil when none is picked. Published so
+    /// the settings UI re-renders on pick/clear.
+    @Published private(set) var vaultURL: URL?
+
+    /// Set when the persisted bookmark resolved stale (folder moved) so the
+    /// UI can show a "refreshed the reference" badge.
+    @Published private(set) var lastResolutionWasStale: Bool = false
+
+    private let defaults: UserDefaults
+    private var accessingURL: URL?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.enabled = defaults.bool(forKey: Self.enabledKey)
+        self.subfolder = defaults.string(forKey: Self.subfolderKey) ?? Self.defaultSubfolder
+        self.gitSyncEnabled = defaults.bool(forKey: Self.gitEnabledKey)
+        self.gitBranch = defaults.string(forKey: Self.gitBranchKey) ?? Self.defaultBranch
+        resolveAndStartAccessing()
+    }
+
+    /// The directory notes are written into: the vault root plus the
+    /// configured subfolder. nil when no vault is picked.
+    var destinationDirectory: URL? {
+        guard let vaultURL else { return nil }
+        let clean = subfolder
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return clean.isEmpty ? vaultURL : vaultURL.appendingPathComponent(clean, isDirectory: true)
+    }
+
+    /// Resolve the persisted bookmark into a URL and start accessing it.
+    /// Idempotent — safe to re-call after `setVault` / `clearVault`.
+    private func resolveAndStartAccessing() {
+        if let url = accessingURL {
+            url.stopAccessingSecurityScopedResource()
+            accessingURL = nil
+        }
+        vaultURL = nil
+        lastResolutionWasStale = false
+
+        guard let data = defaults.data(forKey: Self.bookmarkKey) else { return }
+        var isStale = false
+        let resolved: URL
+        do {
+            resolved = try URL(
+                resolvingBookmarkData: data,
+                options: [.withSecurityScope],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+        } catch {
+            print("ObsidianVaultSettings: failed to resolve bookmark: \(error)")
+            defaults.removeObject(forKey: Self.bookmarkKey)
+            return
+        }
+        if isStale {
+            lastResolutionWasStale = true
+            if let refreshed = try? resolved.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) {
+                defaults.set(refreshed, forKey: Self.bookmarkKey)
+            } else {
+                defaults.removeObject(forKey: Self.bookmarkKey)
+                return
+            }
+        }
+        let started = resolved.startAccessingSecurityScopedResource()
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: resolved.path, isDirectory: &isDir)
+        if !exists || !isDir.boolValue {
+            if started { resolved.stopAccessingSecurityScopedResource() }
+            defaults.removeObject(forKey: Self.bookmarkKey)
+            return
+        }
+        accessingURL = resolved
+        vaultURL = resolved
+    }
+
+    /// Persist a freshly-picked vault folder. Returns true on success.
+    @discardableResult
+    func setVault(_ url: URL) -> Bool {
+        do {
+            let data = try url.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+            defaults.set(data, forKey: Self.bookmarkKey)
+            resolveAndStartAccessing()
+            return vaultURL != nil
+        } catch {
+            print("ObsidianVaultSettings: failed to mint bookmark for \(url.path): \(error)")
+            return false
+        }
+    }
+
+    /// Forget the chosen vault.
+    func clearVault() {
+        defaults.removeObject(forKey: Self.bookmarkKey)
+        resolveAndStartAccessing()
+    }
+}

--- a/Mila/Views/ObsidianSettingsSection.swift
+++ b/Mila/Views/ObsidianSettingsSection.swift
@@ -10,6 +10,15 @@ import AppKit
 /// `ObsidianVaultSettings` for the resolution / fallback rules. Notes are
 /// written after the AI summary lands (falling back to the transcript when
 /// summaries are off), so nothing here blocks recording.
+///
+/// **Visibility contract.** The feature is opt-in and adds no affordance
+/// anywhere else in the app — no toolbar item, no context-menu entry, no
+/// badge. On a fresh install the *only* thing it puts on screen is the single
+/// toggle below, presented as one more card in Settings ▸ Storage rather than
+/// a titled section of its own. Everything else here — the vault picker, the
+/// git options, the backfill button, the error/stale notices — is rendered
+/// only once `settings.enabled` is true, and the backfill button additionally
+/// requires a chosen vault. Keep it that way.
 struct ObsidianSettingsSection: View {
     @EnvironmentObject private var settings: ObsidianVaultSettings
     @EnvironmentObject private var store: RecordingStore
@@ -20,7 +29,6 @@ struct ObsidianSettingsSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            header
             enableCard
             if settings.enabled {
                 vaultCard
@@ -28,39 +36,46 @@ struct ObsidianSettingsSection: View {
                 if settings.vaultURL != nil {
                     backfillCard
                 }
-            }
-            if settings.lastResolutionWasStale {
-                staleBookmarkNotice
-            }
-            if let lastError {
-                Text(lastError)
-                    .font(.callout)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
+                if settings.lastResolutionWasStale {
+                    staleBookmarkNotice
+                }
+                if let lastError {
+                    Text(lastError)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Obsidian vault")
-                .font(.title3.weight(.semibold))
-            Text("When a recording finishes, Mila writes a Markdown note into your vault — the AI summary plus any action items, falling back to the transcript when summaries are off. Notes are written after the summary lands, so this never blocks recording.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
+    /// The whole feature's footprint when it's off: one toggle and one line of
+    /// caption, in the same card shape the rest of the Storage tab uses.
     private var enableCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Toggle("Save transcripts to an Obsidian vault", isOn: $settings.enabled)
-                .accessibilityIdentifier("obsidian.enabled.toggle")
-            if settings.enabled && settings.vaultURL == nil {
-                Text("Pick a vault folder below to start filing notes.")
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "text.book.closed.fill")
+                    .foregroundStyle(.tint)
+                Toggle("Save transcripts to an Obsidian vault", isOn: $settings.enabled)
+                    .accessibilityIdentifier("obsidian.enabled.toggle")
+                Spacer()
+            }
+            if settings.enabled {
+                Text("When a recording finishes, Mila writes a Markdown note into your vault — the AI summary plus any action items, falling back to the transcript when summaries are off. Notes are written after the summary lands, so this never blocks recording.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if settings.vaultURL == nil {
+                    Text("Pick a vault folder below to start filing notes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text("Off. Turn this on to file each finished recording into an Obsidian vault as a Markdown note.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(12)
@@ -213,7 +228,7 @@ struct ObsidianSettingsSection: View {
 
     private func revealInFinder() {
         guard let url = settings.vaultURL else { return }
-        NSWorkspace.shared.open(url)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
     /// Backfill: write every non-trashed recording that has content into the

--- a/Mila/Views/ObsidianSettingsSection.swift
+++ b/Mila/Views/ObsidianSettingsSection.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+import AppKit
+
+/// Obsidian vault section, embedded in the Storage settings tab. Lets the user
+/// route finished recordings into an Obsidian vault as Markdown notes (summary
+/// + action items, transcript fallback), and optionally commit + push the vault
+/// git repo after each write.
+///
+/// The vault folder is persisted via a security-scoped bookmark; see
+/// `ObsidianVaultSettings` for the resolution / fallback rules. Notes are
+/// written after the AI summary lands (falling back to the transcript when
+/// summaries are off), so nothing here blocks recording.
+struct ObsidianSettingsSection: View {
+    @EnvironmentObject private var settings: ObsidianVaultSettings
+    @EnvironmentObject private var store: RecordingStore
+    @EnvironmentObject private var exporter: ObsidianExporter
+
+    @State private var lastError: String?
+    @State private var backfillResult: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            enableCard
+            if settings.enabled {
+                vaultCard
+                gitCard
+                if settings.vaultURL != nil {
+                    backfillCard
+                }
+            }
+            if settings.lastResolutionWasStale {
+                staleBookmarkNotice
+            }
+            if let lastError {
+                Text(lastError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Obsidian vault")
+                .font(.title3.weight(.semibold))
+            Text("When a recording finishes, Mila writes a Markdown note into your vault — the AI summary plus any action items, falling back to the transcript when summaries are off. Notes are written after the summary lands, so this never blocks recording.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var enableCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("Save transcripts to an Obsidian vault", isOn: $settings.enabled)
+                .accessibilityIdentifier("obsidian.enabled.toggle")
+            if settings.enabled && settings.vaultURL == nil {
+                Text("Pick a vault folder below to start filing notes.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var vaultCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(settings.vaultURL.map(displayPath) ?? "No vault chosen")
+                        .font(.callout.monospaced())
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                    Text(settings.vaultURL == nil ? "Not set" : "Vault folder")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            HStack(spacing: 8) {
+                Button("Choose…") { chooseFolder() }
+                    .accessibilityIdentifier("obsidian.chooseFolder.button")
+                if settings.vaultURL != nil {
+                    Button("Reveal in Finder") { revealInFinder() }
+                }
+                Spacer()
+                Button("Clear") { settings.clearVault() }
+                    .disabled(settings.vaultURL == nil)
+                    .accessibilityIdentifier("obsidian.clear.button")
+            }
+            Divider()
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    TextField("Subfolder in vault (blank = vault root)", text: $settings.subfolder)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("obsidian.subfolder.field")
+                    Button("Browse…") { browseSubfolder() }
+                        .disabled(settings.vaultURL == nil)
+                        .help("Pick a folder inside the vault")
+                        .accessibilityIdentifier("obsidian.subfolderBrowse.button")
+                }
+                Text("Notes are written into this folder inside the vault (created if needed). One note per recording, named by date and title; re-transcribing overwrites the same note.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var gitCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Commit & push to git after writing", isOn: $settings.gitSyncEnabled)
+                .accessibilityIdentifier("obsidian.gitSync.toggle")
+            if settings.gitSyncEnabled {
+                HStack(spacing: 8) {
+                    Text("Branch")
+                        .font(.callout)
+                    TextField("main", text: $settings.gitBranch)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 200)
+                        .accessibilityIdentifier("obsidian.gitBranch.field")
+                }
+                Text("After each note, Mila runs git add + commit, pulls with rebase, and pushes to this branch. Your vault must already be a git repo with credentials configured (SSH key or credential helper) — Mila runs git non-interactively and won't prompt for passwords.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let syncError = settings.lastSyncError {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Last sync failed: \(syncError)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(10)
+                    .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var backfillCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Existing transcripts")
+                .font(.callout.weight(.semibold))
+            Text("Obsidian was set up after some recordings already existed. Sync them into the vault now — each is filed under its Mila folder (created if needed) and existing notes are overwritten in place.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Button("Sync existing transcripts") { syncExisting() }
+                    .accessibilityIdentifier("obsidian.backfill.button")
+                if let backfillResult {
+                    Text(backfillResult)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var staleBookmarkNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("The vault folder you chose was moved or renamed. Mila refreshed the saved reference — if notes stop appearing, pick the folder again.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func displayPath(_ url: URL) -> String {
+        let home = NSHomeDirectory()
+        let path = url.path
+        if path.hasPrefix(home) { return "~" + path.dropFirst(home.count) }
+        return path
+    }
+
+    private func chooseFolder() {
+        lastError = nil
+        let panel = NSOpenPanel()
+        panel.title = "Choose your Obsidian vault folder"
+        panel.prompt = "Choose"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = settings.vaultURL
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard settings.setVault(url) else {
+            lastError = "Couldn't save that folder. Try a different location (some network/cloud volumes can't be bookmarked)."
+            return
+        }
+    }
+
+    private func revealInFinder() {
+        guard let url = settings.vaultURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Backfill: write every non-trashed recording that has content into the
+    /// vault. `exportAll` skips empty ones and kicks a single git sync.
+    private func syncExisting() {
+        lastError = nil
+        let recordings = store.recordings.filter { !$0.isTrashed }
+        let count = exporter.exportAll(recordings)
+        backfillResult = count == 0
+            ? "Nothing to sync."
+            : "Synced \(count) note\(count == 1 ? "" : "s")."
+    }
+
+    /// Pick the destination subfolder with a folder panel constrained to the
+    /// vault. Stores the path RELATIVE to the vault (blank when the vault root
+    /// is chosen); rejects a folder outside the vault.
+    private func browseSubfolder() {
+        guard let vault = settings.vaultURL else { return }
+        lastError = nil
+        let panel = NSOpenPanel()
+        panel.title = "Choose a subfolder inside the vault"
+        panel.prompt = "Choose"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = settings.destinationDirectory ?? vault
+        guard panel.runModal() == .OK, let chosen = panel.url else { return }
+
+        // Resolve symlinks on both sides so an NSOpenPanel path (which can be
+        // /private-prefixed) compares cleanly against the bookmark-resolved
+        // vault URL.
+        let vaultPath = vault.resolvingSymlinksInPath().path
+        let chosenPath = chosen.resolvingSymlinksInPath().path
+        if chosenPath == vaultPath {
+            settings.subfolder = ""
+            return
+        }
+        let prefix = vaultPath.hasSuffix("/") ? vaultPath : vaultPath + "/"
+        guard chosenPath.hasPrefix(prefix) else {
+            lastError = "Choose a folder inside the vault (\(vault.lastPathComponent))."
+            return
+        }
+        settings.subfolder = String(chosenPath.dropFirst(prefix.count))
+    }
+}

--- a/Mila/Views/ObsidianSettingsSection.swift
+++ b/Mila/Views/ObsidianSettingsSection.swift
@@ -228,7 +228,10 @@ struct ObsidianSettingsSection: View {
 
     private func revealInFinder() {
         guard let url = settings.vaultURL else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([url])
+        // Open the vault directory itself, matching `StorageSettingsTab`:
+        // `activateFileViewerSelecting([url])` highlights the folder inside its
+        // parent, but for a folder target the user wants to step _into_ it.
+        NSWorkspace.shared.open(url)
     }
 
     /// Backfill: write every non-trashed recording that has content into the

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -45,11 +45,11 @@ struct StorageSettingsTab: View {
                         .foregroundStyle(.red)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                Divider()
-                    .padding(.vertical, 4)
-                // Obsidian vault destination lives under Storage as its own
-                // section rather than a top-level tab (keeps the tab bar from
-                // overflowing).
+                // Obsidian vault destination lives under Storage rather than
+                // in a top-level tab (keeps the tab bar from overflowing), and
+                // renders as one more card in this stack rather than a titled
+                // section — off by default, it's a single toggle. It expands
+                // itself once enabled; see `ObsidianSettingsSection`.
                 ObsidianSettingsSection()
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -30,23 +30,30 @@ struct StorageSettingsTab: View {
     @State private var compressStatus: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            header
-            currentLocationCard
-            storageLimitCard
-            autoDropCard
-            if storage.lastResolutionWasStale {
-                staleBookmarkNotice
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                header
+                currentLocationCard
+                storageLimitCard
+                autoDropCard
+                if storage.lastResolutionWasStale {
+                    staleBookmarkNotice
+                }
+                if let lastError {
+                    Text(lastError)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Divider()
+                    .padding(.vertical, 4)
+                // Obsidian vault destination lives under Storage as its own
+                // section rather than a top-level tab (keeps the tab bar from
+                // overflowing).
+                ObsidianSettingsSection()
             }
-            if let lastError {
-                Text(lastError)
-                    .font(.callout)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var header: some View {

--- a/MilaTests/ObsidianExportSequencingTests.swift
+++ b/MilaTests/ObsidianExportSequencingTests.swift
@@ -159,6 +159,24 @@ final class ObsidianExportSequencingTests: XCTestCase {
                        "a recording deleted mid-flight must not be filed")
     }
 
+    /// The same race on the SUCCESS path. `test_recording_deleted_mid_flight…`
+    /// above forces a failure, so it only exercises the `catch` block's
+    /// liveness check; this one lets the summary complete normally so the
+    /// separate guard on the success path (`RecordingSummarizer`'s
+    /// "is this recording still in the store?" lookup) is the thing under test.
+    func test_recording_deleted_mid_flight_is_not_exported_on_the_success_path() async throws {
+        let rec = addRecording(fullText: "the raw transcript body")
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        store.permanentlyDelete(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a recording deleted mid-flight must not be filed, "
+                       + "even when its summary succeeds")
+    }
+
     /// Trashed mid-flight: the hook does fire (the row is still in the store),
     /// but the exporter refuses to file a trashed recording.
     func test_recording_trashed_mid_flight_is_not_exported() async throws {

--- a/MilaTests/ObsidianExportSequencingTests.swift
+++ b/MilaTests/ObsidianExportSequencingTests.swift
@@ -64,6 +64,22 @@ final class ObsidianExportSequencingTests: XCTestCase {
         try await super.tearDown()
     }
 
+    /// Rebuild the summarizer with a stub that fails, keeping the same hook
+    /// wiring MilaApp uses. Models "the LLM call blew up" and, combined with a
+    /// delete, "the user cancelled/deleted while it was in flight".
+    private func useFailingLLM() {
+        struct StubFailure: Error {}
+        summarizer = RecordingSummarizer(store: store, llmSettings: llm, liveAISettings: liveAI,
+                                         runLLM: { _, _, _, _, _, _, _, _, _, _, _ in
+                                             throw StubFailure()
+                                         })
+        summarizer.onSummaryFinished = { [weak exporter] rec in
+            guard let exporter, exporter.isPending(rec.id) else { return }
+            exporter.export(rec)
+            exporter.clearPending(rec.id)
+        }
+    }
+
     private func addRecording(fullText: String = "some transcript") -> Recording {
         let audioURL = store.freshAudioURL(suggestedName: "Rec")
         try? Data("x".utf8).write(to: audioURL)
@@ -110,5 +126,67 @@ final class ObsidianExportSequencingTests: XCTestCase {
         let contents = try String(contentsOf: expected, encoding: .utf8)
         XCTAssertTrue(contents.contains("## Transcript"))
         XCTAssertTrue(contents.contains("the raw transcript body"))
+    }
+
+    /// A failed summary still resolves the pending export — it must not hang
+    /// waiting for a summary that will never arrive.
+    func test_failed_summary_still_exports_the_transcript() async throws {
+        useFailingLLM()
+        let rec = addRecording(fullText: "the raw transcript body")
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path),
+                      "a failed summary must fall back, not stall the export")
+        XCTAssertFalse(exporter.isPending(rec.id), "the pending mark must be cleared")
+    }
+
+    /// Deleted mid-flight: the failure path must not fire the hook with the
+    /// stale enqueue-time copy, or a recording the user just deleted lands in
+    /// the vault anyway.
+    func test_recording_deleted_mid_flight_is_not_exported() async throws {
+        useFailingLLM()
+        let rec = addRecording(fullText: "the raw transcript body")
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        store.permanentlyDelete(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a recording deleted mid-flight must not be filed")
+    }
+
+    /// Trashed mid-flight: the hook does fire (the row is still in the store),
+    /// but the exporter refuses to file a trashed recording.
+    func test_recording_trashed_mid_flight_is_not_exported() async throws {
+        let rec = addRecording()
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        store.softDelete(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a recording trashed mid-flight must not be filed")
+    }
+
+    /// The hook fires exactly once per attempt: a second export for the same
+    /// recording only happens on a second, deliberate summarize attempt.
+    func test_hook_fires_once_per_attempt() async throws {
+        final class Recorder { var ids: [UUID] = [] }
+        let fired = Recorder()
+        summarizer.onSummaryFinished = { fired.ids.append($0.id) }
+        let rec = addRecording()
+        summarizer.summarizeIfNeeded(rec)
+        // A duplicate call while the first is in flight is deduped and must
+        // NOT produce a second signal.
+        summarizer.summarizeIfNeeded(rec)
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        XCTAssertEqual(fired.ids, [rec.id], "one attempt in flight must yield exactly one signal")
     }
 }

--- a/MilaTests/ObsidianExportSequencingTests.swift
+++ b/MilaTests/ObsidianExportSequencingTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Mila
+
+/// Verifies the sequencing contract between `RecordingSummarizer` and
+/// `ObsidianExporter`: a fresh completion is marked pending and exported only
+/// once the summary is ready, while a summary produced without being marked
+/// pending (e.g. launch-time backfill) is NOT exported — no vault spam.
+@MainActor
+final class ObsidianExportSequencingTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var vault: URL!
+    private var store: RecordingStore!
+    private var llmDefaults: UserDefaults!
+    private var liveDefaults: UserDefaults!
+    private var obsidianDefaults: UserDefaults!
+    private var suiteNames: [String] = []
+    private var llm: LLMSettings!
+    private var liveAI: LiveAISettings!
+    private var settings: ObsidianVaultSettings!
+    private var exporter: ObsidianExporter!
+    private var summarizer: RecordingSummarizer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianSeqTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        store = RecordingStore(rootDirectory: tempRoot.appendingPathComponent("AppSupport", isDirectory: true))
+
+        let llmSuite = "ObsidianSeq.llm.\(UUID())"
+        let liveSuite = "ObsidianSeq.live.\(UUID())"
+        let obsSuite = "ObsidianSeq.obs.\(UUID())"
+        suiteNames = [llmSuite, liveSuite, obsSuite]
+        llmDefaults = UserDefaults(suiteName: llmSuite)
+        liveDefaults = UserDefaults(suiteName: liveSuite)
+        obsidianDefaults = UserDefaults(suiteName: obsSuite)
+        llm = LLMSettings(defaults: llmDefaults)
+        llm.tool = .claude
+        liveAI = LiveAISettings(defaults: liveDefaults)
+        liveAI.model = ""
+
+        settings = ObsidianVaultSettings(defaults: obsidianDefaults)
+        settings.enabled = true
+        settings.subfolder = ""
+        XCTAssertTrue(settings.setVault(vault))
+        exporter = ObsidianExporter(settings: settings, defaults: obsidianDefaults)
+
+        // Wire the hook exactly like MilaApp does.
+        summarizer = RecordingSummarizer(store: store, llmSettings: llm, liveAISettings: liveAI,
+                                         runLLM: { _, _, _, _, _, _, _, _, _, _, _ in "A tidy summary." })
+        summarizer.onSummaryFinished = { [weak exporter] rec in
+            guard let exporter, exporter.isPending(rec.id) else { return }
+            exporter.export(rec)
+            exporter.clearPending(rec.id)
+        }
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        try await super.tearDown()
+    }
+
+    private func addRecording(fullText: String = "some transcript") -> Recording {
+        let audioURL = store.freshAudioURL(suggestedName: "Rec")
+        try? Data("x".utf8).write(to: audioURL)
+        let rec = Recording(title: "Rec", source: .microphone,
+                            audioFileName: audioURL.lastPathComponent, fullText: fullText)
+        store.add(rec)
+        return rec
+    }
+
+    func test_pending_recording_is_exported_after_summary() async throws {
+        let rec = addRecording()
+        exporter.markPending(rec.id)
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path),
+                      "a pending recording should be written once its summary lands")
+        let contents = try String(contentsOf: expected, encoding: .utf8)
+        XCTAssertTrue(contents.contains("A tidy summary."))
+    }
+
+    func test_non_pending_summary_is_not_exported() async throws {
+        let rec = addRecording()
+        // No markPending — models a backfill sweep.
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expected.path),
+                       "a summary produced without a pending mark must not be filed")
+    }
+
+    func test_pending_export_falls_back_to_transcript_when_summaries_disabled() async throws {
+        llm.summaryEnabled = false   // no summary will be generated
+        let rec = addRecording(fullText: "the raw transcript body")
+        exporter.markPending(rec.id)
+        // summarizeIfNeeded skips synchronously and fires onSummaryFinished.
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let expected = vault.appendingPathComponent(ObsidianExporter.fileName(for: rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path))
+        let contents = try String(contentsOf: expected, encoding: .utf8)
+        XCTAssertTrue(contents.contains("## Transcript"))
+        XCTAssertTrue(contents.contains("the raw transcript body"))
+    }
+}

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -94,6 +94,56 @@ final class ObsidianExporterTests: XCTestCase {
         XCTAssertTrue(name.contains("My Meeting Q3"))
     }
 
+    /// A title made entirely of stripped characters must still produce a
+    /// usable, visible, non-relative filename — never "", ".md", "..md" or a
+    /// dotfile. The date prefix is what guarantees it.
+    func test_fileName_survives_hostile_titles() {
+        for hostile in ["", "   ", "///", "..", ".", "...", "\u{0000}\u{0007}", "<>|?*\"\\"] {
+            let name = ObsidianExporter.fileName(for: makeRecording(title: hostile))
+            XCTAssertTrue(name.hasPrefix("2026-01-02"),
+                          "\(hostile.debugDescription) should keep the date prefix, got \(name)")
+            XCTAssertTrue(name.hasSuffix(".md"))
+            XCTAssertFalse(name.hasPrefix("."), "must never be a dotfile: \(name)")
+            XCTAssertNotEqual(name, "..md")
+            XCTAssertFalse(name.contains("/"))
+        }
+    }
+
+    /// APFS caps a path component at 255 bytes. A pathological title must be
+    /// truncated rather than making the write fail.
+    func test_fileName_is_capped_to_a_writable_length() throws {
+        let long = String(repeating: "עברית ", count: 200)   // multi-byte, ~2200 bytes
+        let name = ObsidianExporter.fileName(for: makeRecording(title: long))
+        XCTAssertLessThanOrEqual(name.utf8.count, 255)
+        // And it actually writes.
+        let rec = makeRecording(title: long, summary: "S")
+        XCTAssertNotNil(exporter.export(rec))
+    }
+
+    /// A Mila folder literally named ".." must not walk out of the configured
+    /// subfolder. `sanitizedTitle` alone would have let it through.
+    func test_export_folder_named_dotdot_cannot_escape_the_subfolder() throws {
+        settings.subfolder = "Notes"
+        let base = vault.appendingPathComponent("Notes").standardizedFileURL.path
+        for hostile in ["..", ".", "../..", ".hidden"] {
+            let rec = makeRecording(title: "T-\(hostile)", summary: "S", folder: hostile)
+            let url = try XCTUnwrap(exporter.export(rec))
+            let dir = url.deletingLastPathComponent().standardizedFileURL.path
+            XCTAssertTrue(dir == base || dir.hasPrefix(base + "/"),
+                          "folder \(hostile.debugDescription) escaped to \(dir)")
+            XCTAssertFalse(url.lastPathComponent.hasPrefix("."))
+        }
+    }
+
+    /// The summary hook can land after the user has trashed the recording
+    /// (the LLM call was still in flight). A trashed recording is never filed.
+    func test_export_skips_a_trashed_recording() {
+        var rec = makeRecording(summary: "S")
+        rec.deletedAt = Date()
+        XCTAssertNil(exporter.export(rec))
+        XCTAssertEqual(exporter.exportAll([rec]), 0)
+    }
+
     // MARK: - Writing
 
     func test_export_writes_note_into_vault() throws {

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -142,10 +142,20 @@ final class ObsidianExporterTests: XCTestCase {
     /// subfolder. `sanitizedTitle` alone would have let it through.
     func test_export_folder_named_dotdot_cannot_escape_the_subfolder() throws {
         settings.subfolder = "Notes"
-        // `standardized` (lexical), not `standardizedFileURL` — the latter only
-        // strips a `/private` prefix for paths that already exist, so it
-        // renders the existing vault and a fresh destination differently.
-        let base = vault.appendingPathComponent("Notes").standardized.path
+        // Two rules, both learned the hard way:
+        //
+        //  * Derive the expectation from `settings.vaultURL`, not from the raw
+        //    `vault` this test created. `setVault` round-trips through a
+        //    security-scoped bookmark, which resolves `/var/folders/…` to its
+        //    real `/private/var/folders/…`. The exporter writes under the
+        //    resolved one, so comparing against the raw one compares two
+        //    spellings of the same directory.
+        //  * `standardized` (lexical), not `standardizedFileURL`: the latter
+        //    consults the filesystem and strips a `/private` prefix only for
+        //    paths that already exist, so it normalizes an existing directory
+        //    and a fresh one differently.
+        let vaultRoot = try XCTUnwrap(settings.vaultURL)
+        let base = vaultRoot.appendingPathComponent("Notes").standardized.path
         // "../.." is the one that shipped broken: `nameFragment` turns its "/"
         // into a space, so a leading-dots-only strip stopped at that space and
         // handed back a live "..".
@@ -165,11 +175,13 @@ final class ObsidianExporterTests: XCTestCase {
     /// The hostile title/folder combination, checked at the level that
     /// actually matters: nothing lands outside the vault, whatever the inputs.
     func test_export_never_writes_outside_the_vault() throws {
+        // Resolved vault, not the raw one — see the note above.
+        let vaultRoot = try XCTUnwrap(settings.vaultURL)
         settings.subfolder = ". .."
         for folder in ["..", ". ..", "../..", nil] {
             let rec = makeRecording(title: ".. ../..", summary: "S", folder: folder)
             let url = try XCTUnwrap(exporter.export(rec))
-            XCTAssertTrue(ObsidianPathSanitizer.isContained(url, in: vault),
+            XCTAssertTrue(ObsidianPathSanitizer.isContained(url, in: vaultRoot),
                           "wrote outside the vault: \(url.path)")
         }
     }

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -186,6 +186,58 @@ final class ObsidianExporterTests: XCTestCase {
         }
     }
 
+    /// The traversal hole one layer below the naming rules: a Mila folder (or a
+    /// typed subfolder) whose name matches a **symlink inside the vault** that
+    /// points outside it. Nothing here is a `..` — the path is spelled entirely
+    /// under the vault — so only resolving the link catches it.
+    func test_export_refuses_a_folder_that_symlinks_out_of_the_vault() throws {
+        let fm = FileManager.default
+        let vaultRoot = try XCTUnwrap(settings.vaultURL)
+        let outside = tempRoot.appendingPathComponent("Outside", isDirectory: true)
+        try fm.createDirectory(at: outside, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: vaultRoot.appendingPathComponent("Escape"),
+                                  withDestinationURL: outside)
+        try fm.createSymbolicLink(atPath: vaultRoot.appendingPathComponent("Up").path,
+                                  withDestinationPath: "../Outside")
+
+        for hostile in ["Escape", "Up"] {
+            let rec = makeRecording(title: "Leak \(hostile)", summary: "S", folder: hostile)
+            XCTAssertNil(exporter.export(rec),
+                         "folder \(hostile) wrote through a symlink out of the vault")
+        }
+        XCTAssertTrue(try fm.contentsOfDirectory(atPath: outside.path).isEmpty,
+                      "a note escaped the vault")
+
+        // The same shape via the free-text subfolder field.
+        settings.subfolder = "Escape"
+        XCTAssertNil(exporter.export(makeRecording(title: "Leak subfolder", summary: "S")))
+        XCTAssertTrue(try fm.contentsOfDirectory(atPath: outside.path).isEmpty)
+
+        // And an ordinary subfolder is untouched by any of this.
+        settings.subfolder = ""
+        let ok = try XCTUnwrap(exporter.export(
+            makeRecording(title: "Fine", summary: "S", folder: "Meetings")))
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(ok, in: vaultRoot))
+        XCTAssertTrue(fm.fileExists(atPath: ok.path))
+    }
+
+    /// A symlink whose target is *inside* the vault is a legitimate way to
+    /// organise one, and resolving it lands the note in the vault regardless —
+    /// so it is allowed rather than refused.
+    func test_export_allows_a_folder_symlinked_within_the_vault() throws {
+        let fm = FileManager.default
+        let vaultRoot = try XCTUnwrap(settings.vaultURL)
+        let real = vaultRoot.appendingPathComponent("Real", isDirectory: true)
+        try fm.createDirectory(at: real, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: vaultRoot.appendingPathComponent("Alias"),
+                                  withDestinationURL: real)
+
+        let url = try XCTUnwrap(exporter.export(
+            makeRecording(title: "Aliased", summary: "S", folder: "Alias")))
+        XCTAssertTrue(fm.fileExists(atPath: real.appendingPathComponent(url.lastPathComponent).path),
+                      "the note should land in the symlink's target inside the vault")
+    }
+
     /// The summary hook can land after the user has trashed the recording
     /// (the LLM call was still in flight). A trashed recording is never filed.
     func test_export_skips_a_trashed_recording() {

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class ObsidianExporterTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var vault: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var settings: ObsidianVaultSettings!
+    private var exporter: ObsidianExporter!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianExporterTests-\(UUID())", isDirectory: true)
+        vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        suiteName = "ObsidianExporterTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+        settings = ObsidianVaultSettings(defaults: defaults)
+        settings.enabled = true
+        settings.subfolder = ""   // vault root for most tests
+        XCTAssertTrue(settings.setVault(vault))
+        exporter = ObsidianExporter(settings: settings, defaults: defaults)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    private func makeRecording(title: String = "Team Sync",
+                               createdAt: Date = Date(timeIntervalSince1970: 1_767_312_000), // 2026-01-02 UTC-ish
+                               summary: String? = nil,
+                               fullText: String = "",
+                               folder: String? = nil,
+                               actionItems: [ActionItem]? = nil) -> Recording {
+        var rec = Recording(title: title,
+                            createdAt: createdAt,
+                            source: .microphone,
+                            audioFileName: "a.wav",
+                            fullText: fullText)
+        rec.summary = summary
+        rec.actionItems = actionItems
+        rec.folder = folder
+        return rec
+    }
+
+    private func action(_ text: String) -> ActionItem {
+        ActionItem(id: UUID().uuidString, text: text, speaker: nil,
+                   timestampSeconds: 0, source: .llmInferred, addedAt: Date())
+    }
+
+    // MARK: - Formatting
+
+    func test_markdown_uses_summary_and_action_items() {
+        let rec = makeRecording(summary: "We decided to ship next week.",
+                                fullText: "long transcript here",
+                                actionItems: [action("Ship it"), action("Email Sam")])
+        let md = ObsidianExporter.markdown(for: rec)
+        XCTAssertTrue(md.contains("# Team Sync"))
+        XCTAssertTrue(md.contains("We decided to ship next week."))
+        XCTAssertTrue(md.contains("- [ ] Ship it"))
+        XCTAssertTrue(md.contains("- [ ] Email Sam"))
+        XCTAssertFalse(md.contains("## Transcript"),
+                       "When a summary exists the transcript body is omitted")
+    }
+
+    func test_markdown_falls_back_to_transcript_without_summary() {
+        let rec = makeRecording(summary: nil, fullText: "hello world transcript",
+                                actionItems: [action("Do thing")])
+        let md = ObsidianExporter.markdown(for: rec)
+        XCTAssertTrue(md.contains("## Transcript"))
+        XCTAssertTrue(md.contains("hello world transcript"))
+        XCTAssertTrue(md.contains("- [ ] Do thing"))
+    }
+
+    func test_hasContent_false_when_nothing_present() {
+        let empty = makeRecording(summary: nil, fullText: "", actionItems: nil)
+        XCTAssertFalse(ObsidianExporter.hasContent(empty))
+        XCTAssertTrue(ObsidianExporter.hasContent(makeRecording(fullText: "x")))
+    }
+
+    func test_fileName_is_date_and_sanitized_title() {
+        let rec = makeRecording(title: "My/Meeting: Q3?")
+        let name = ObsidianExporter.fileName(for: rec)
+        XCTAssertTrue(name.hasSuffix(".md"))
+        XCTAssertFalse(name.contains("/"))
+        XCTAssertFalse(name.contains(":"))
+        XCTAssertFalse(name.contains("?"))
+        XCTAssertTrue(name.contains("My Meeting Q3"))
+    }
+
+    // MARK: - Writing
+
+    func test_export_writes_note_into_vault() throws {
+        let rec = makeRecording(summary: "S", actionItems: [action("A")])
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(contents.contains("# Team Sync"))
+        XCTAssertTrue(contents.contains("- [ ] A"))
+    }
+
+    func test_export_creates_configured_subfolder() throws {
+        settings.subfolder = "Notes/Sub"
+        let rec = makeRecording(summary: "S")
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes/Sub").standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func test_export_noop_when_disabled() {
+        settings.enabled = false
+        XCTAssertNil(exporter.export(makeRecording(summary: "S")))
+    }
+
+    func test_export_noop_when_recording_is_empty() {
+        XCTAssertNil(exporter.export(makeRecording(summary: nil, fullText: "", actionItems: nil)))
+    }
+
+    func test_reexport_with_changed_title_removes_the_old_file() throws {
+        var rec = makeRecording(title: "First", summary: "S")
+        let firstURL = try XCTUnwrap(exporter.export(rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: firstURL.path))
+
+        rec.title = "Second"   // same id + date, new title
+        let secondURL = try XCTUnwrap(exporter.export(rec))
+        XCTAssertNotEqual(firstURL.path, secondURL.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: secondURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstURL.path),
+                       "The previously-written note for this recording must be removed")
+    }
+
+    func test_export_mirrors_mila_folder_under_subfolder() throws {
+        settings.subfolder = "Notes"
+        let rec = makeRecording(summary: "S", folder: "Client: Acme")
+        let url = try XCTUnwrap(exporter.export(rec))
+        // Folder name is sanitized (":" stripped) and nested under the subfolder.
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes/Client Acme").standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func test_export_unfiled_recording_lands_in_base_dir() throws {
+        settings.subfolder = "Notes"
+        let rec = makeRecording(summary: "S", folder: nil)
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL,
+                       vault.appendingPathComponent("Notes").standardizedFileURL)
+    }
+
+    // MARK: - Backfill (exportAll)
+
+    func test_exportAll_writes_all_with_content_and_skips_empty() throws {
+        let a = makeRecording(title: "Alpha", summary: "S")
+        let b = makeRecording(title: "Beta", fullText: "transcript", folder: "Work")
+        let empty = makeRecording(title: "Empty", summary: nil, fullText: "", actionItems: nil)
+        let count = exporter.exportAll([a, b, empty])
+        XCTAssertEqual(count, 2, "the empty recording should be skipped")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("2026-01-02 Alpha.md").path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("Work/2026-01-02 Beta.md").path),
+            "a filed recording should nest under its Mila folder")
+    }
+
+    func test_exportAll_noop_when_disabled() {
+        settings.enabled = false
+        XCTAssertEqual(exporter.exportAll([makeRecording(summary: "S")]), 0)
+    }
+
+    // MARK: - Pending gate
+
+    func test_pending_gate() {
+        let id = UUID()
+        XCTAssertFalse(exporter.isPending(id))
+        exporter.markPending(id)
+        XCTAssertTrue(exporter.isPending(id))
+        exporter.clearPending(id)
+        XCTAssertFalse(exporter.isPending(id))
+    }
+}

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -32,8 +32,26 @@ final class ObsidianExporterTests: XCTestCase {
         try await super.tearDown()
     }
 
+    /// 2026-01-02T12:00:00Z. Midday rather than the midnight this used to be,
+    /// so the fixture doesn't sit on a date boundary that a local time zone can
+    /// push either way.
+    private static let fixtureDate = Date(timeIntervalSince1970: 1_767_355_200)
+
+    /// The date `ObsidianExporter.fileName` will actually produce for
+    /// `fixtureDate`. Derived, not hard-coded: `fileName` formats in the local
+    /// time zone by design (a user's note should carry the date they recorded
+    /// it), so a literal "2026-01-02" would still be wrong at UTC+13/+14 even
+    /// with a midday fixture. Deriving it pins the contract — "the filename
+    /// starts with the recording's local date" — in every zone.
+    private static let expectedDatePrefix: String = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: fixtureDate)
+    }()
+
     private func makeRecording(title: String = "Team Sync",
-                               createdAt: Date = Date(timeIntervalSince1970: 1_767_312_000), // 2026-01-02 UTC-ish
+                               createdAt: Date = ObsidianExporterTests.fixtureDate,
                                summary: String? = nil,
                                fullText: String = "",
                                folder: String? = nil,
@@ -100,7 +118,7 @@ final class ObsidianExporterTests: XCTestCase {
     func test_fileName_survives_hostile_titles() {
         for hostile in ["", "   ", "///", "..", ".", "...", "\u{0000}\u{0007}", "<>|?*\"\\"] {
             let name = ObsidianExporter.fileName(for: makeRecording(title: hostile))
-            XCTAssertTrue(name.hasPrefix("2026-01-02"),
+            XCTAssertTrue(name.hasPrefix(Self.expectedDatePrefix),
                           "\(hostile.debugDescription) should keep the date prefix, got \(name)")
             XCTAssertTrue(name.hasSuffix(".md"))
             XCTAssertFalse(name.hasPrefix("."), "must never be a dotfile: \(name)")
@@ -124,14 +142,35 @@ final class ObsidianExporterTests: XCTestCase {
     /// subfolder. `sanitizedTitle` alone would have let it through.
     func test_export_folder_named_dotdot_cannot_escape_the_subfolder() throws {
         settings.subfolder = "Notes"
-        let base = vault.appendingPathComponent("Notes").standardizedFileURL.path
-        for hostile in ["..", ".", "../..", ".hidden"] {
+        // `standardized` (lexical), not `standardizedFileURL` — the latter only
+        // strips a `/private` prefix for paths that already exist, so it
+        // renders the existing vault and a fresh destination differently.
+        let base = vault.appendingPathComponent("Notes").standardized.path
+        // "../.." is the one that shipped broken: `nameFragment` turns its "/"
+        // into a space, so a leading-dots-only strip stopped at that space and
+        // handed back a live "..".
+        for hostile in ["..", ".", "../..", ".hidden", ". ..", ".\t..", ". . ..",
+                        "....", " ..", "..\\..", ".. "] {
             let rec = makeRecording(title: "T-\(hostile)", summary: "S", folder: hostile)
             let url = try XCTUnwrap(exporter.export(rec))
-            let dir = url.deletingLastPathComponent().standardizedFileURL.path
+            let dir = url.deletingLastPathComponent().standardized.path
             XCTAssertTrue(dir == base || dir.hasPrefix(base + "/"),
                           "folder \(hostile.debugDescription) escaped to \(dir)")
             XCTAssertFalse(url.lastPathComponent.hasPrefix("."))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                          "folder \(hostile.debugDescription) reported a path it did not write")
+        }
+    }
+
+    /// The hostile title/folder combination, checked at the level that
+    /// actually matters: nothing lands outside the vault, whatever the inputs.
+    func test_export_never_writes_outside_the_vault() throws {
+        settings.subfolder = ". .."
+        for folder in ["..", ". ..", "../..", nil] {
+            let rec = makeRecording(title: ".. ../..", summary: "S", folder: folder)
+            let url = try XCTUnwrap(exporter.export(rec))
+            XCTAssertTrue(ObsidianPathSanitizer.isContained(url, in: vault),
+                          "wrote outside the vault: \(url.path)")
         }
     }
 
@@ -213,15 +252,99 @@ final class ObsidianExporterTests: XCTestCase {
         let count = exporter.exportAll([a, b, empty])
         XCTAssertEqual(count, 2, "the empty recording should be skipped")
         XCTAssertTrue(FileManager.default.fileExists(
-            atPath: vault.appendingPathComponent("2026-01-02 Alpha.md").path))
+            atPath: vault.appendingPathComponent("\(Self.expectedDatePrefix) Alpha.md").path))
         XCTAssertTrue(FileManager.default.fileExists(
-            atPath: vault.appendingPathComponent("Work/2026-01-02 Beta.md").path),
+            atPath: vault.appendingPathComponent("Work/\(Self.expectedDatePrefix) Beta.md").path),
             "a filed recording should nest under its Mila folder")
     }
 
     func test_exportAll_noop_when_disabled() {
         settings.enabled = false
         XCTAssertEqual(exporter.exportAll([makeRecording(summary: "S")]), 0)
+    }
+
+    /// A rename changes *two* paths (the new file plus the removed old one) for
+    /// a single written note. The returned count — which the Settings backfill
+    /// label and the git commit subject both quote — must count notes, not
+    /// paths.
+    func test_exportAll_counts_notes_not_changed_paths() throws {
+        var rec = makeRecording(title: "Before", summary: "S")
+        XCTAssertEqual(exporter.exportAll([rec]), 1)
+        rec.title = "After"
+        XCTAssertEqual(exporter.exportAll([rec]), 1,
+                       "a rename is still one note, not two changed paths")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("\(Self.expectedDatePrefix) Before.md").path),
+            "the old note should be removed by the rename")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("\(Self.expectedDatePrefix) After.md").path))
+    }
+
+    // MARK: - Written index
+
+    /// The index stores a path *relative to the vault it was written into*. If
+    /// the key isn't scoped to that vault, switching vaults and then renaming
+    /// makes the rename cleanup delete `<newVault>/<oldRelativePath>` — some
+    /// unrelated file — and orphan the real note in the old vault.
+    func test_rename_after_a_vault_switch_does_not_delete_in_the_new_vault() throws {
+        var rec = makeRecording(title: "Before", summary: "S")
+        XCTAssertNotNil(exporter.export(rec))
+
+        // A second vault, holding a same-named file the user owns.
+        let other = tempRoot.appendingPathComponent("OtherVault", isDirectory: true)
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+        let bystander = other.appendingPathComponent("\(Self.expectedDatePrefix) Before.md")
+        try "not ours".write(to: bystander, atomically: true, encoding: .utf8)
+        XCTAssertTrue(settings.setVault(other))
+
+        rec.title = "After"
+        XCTAssertNotNil(exporter.export(rec))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bystander.path),
+                      "a rename in a different vault must not delete a file in this one")
+        XCTAssertEqual(try String(contentsOf: bystander, encoding: .utf8), "not ours")
+        // And the note that really was ours is still where we left it.
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: vault.appendingPathComponent("\(Self.expectedDatePrefix) Before.md").path))
+    }
+
+    /// A pre-scoping (bare-UUID) index entry is adopted for the current vault
+    /// when the file it names is actually there, so an upgrade doesn't leave a
+    /// duplicate behind on the first rename.
+    func test_legacy_index_entry_is_migrated_when_the_file_is_present() throws {
+        var rec = makeRecording(title: "Before", summary: "S")
+        let old = try XCTUnwrap(exporter.export(rec))
+
+        // Rewrite the index the way the pre-scoping build stored it.
+        defaults.set([rec.id.uuidString: old.lastPathComponent],
+                     forKey: ObsidianExporter.writtenIndexKey)
+
+        rec.title = "After"
+        XCTAssertNotNil(exporter.export(rec))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: old.path),
+                       "the legacy entry should still drive the rename cleanup")
+    }
+
+    // MARK: - Markdown line safety
+
+    /// Headings and checklist items are line-based: a newline in a title or an
+    /// action item would otherwise split the construct.
+    func test_markdown_flattens_newlines_in_heading_and_action_items() {
+        let rec = makeRecording(title: "Team\nSync", summary: "S",
+                                actionItems: [action("Ship it\nby Friday")])
+        let md = ObsidianExporter.markdown(for: rec)
+        let lines = md.components(separatedBy: "\n")
+        XCTAssertEqual(lines.first, "# Team Sync")
+        XCTAssertTrue(lines.contains("- [ ] Ship it by Friday"))
+
+        // Whatever the line ending, nothing survives that could break a
+        // line-based construct.
+        for raw in ["A\nB", "A\r\nB", "A\rB", "A\u{2028}B"] {
+            let flat = ObsidianExporter.singleLine(raw)
+            XCTAssertFalse(flat.contains("\n"), raw.debugDescription)
+            XCTAssertFalse(flat.contains("\r"), raw.debugDescription)
+            XCTAssertTrue(flat.hasPrefix("A"), raw.debugDescription)
+            XCTAssertTrue(flat.hasSuffix("B"), raw.debugDescription)
+        }
     }
 
     // MARK: - Pending gate

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -120,9 +120,34 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         process.standardOutput = out
         process.standardError = err
         try process.run()
+
+        // Drain BOTH pipes before waiting for exit. A macOS pipe buffer is
+        // ~64 KB; git writes progress and diagnostics to stderr, so waiting
+        // first lets git block on `write()` while we block on `waitUntilExit()`
+        // — the deadlock `.claude/rules/python-subprocess.md` documents (it
+        // hung transcription on long files once already, PR #15).
+        //
+        // `DispatchGroup` rather than `Task.detached` here because this helper
+        // is synchronous: the rule prefers `Task.detached` specifically to
+        // avoid blocking a cooperative thread from an *async* context, which
+        // this is not.
+        let lock = NSLock()
+        var outData = Data(), errData = Data()
+        let drain = DispatchGroup()
+        for (pipe, isStdout) in [(out, true), (err, false)] {
+            drain.enter()
+            DispatchQueue.global().async {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                lock.lock()
+                if isStdout { outData = data } else { errData = data }
+                lock.unlock()
+                drain.leave()
+            }
+        }
         process.waitUntilExit()
-        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        drain.wait()
+        let stdout = String(data: outData, encoding: .utf8) ?? ""
+        let stderr = String(data: errData, encoding: .utf8) ?? ""
         if process.terminationStatus != 0 {
             throw NSError(domain: "git", code: Int(process.terminationStatus), userInfo: [
                 NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stderr)\(stdout)"

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Mila
+
+/// End-to-end git tests that run the REAL `git` binary (via the production
+/// `ProcessGitCommandRunner`) against a temporary working copy wired to a local
+/// bare "remote". Proves the actual add -> commit -> pull --rebase -> push flow
+/// lands commits on the remote, and that a non-conflicting remote change is
+/// rebased in rather than rejected. Skips cleanly when `git` isn't installed.
+final class ObsidianGitSyncerIntegrationTests: XCTestCase {
+
+    private var gitURL: URL!
+    private var tempRoot: URL!
+    private var home: URL!
+    private var remote: URL!
+    private var vault: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let git = ProcessGitCommandRunner.gitExecutable() else {
+            throw XCTSkip("git is not installed on this machine")
+        }
+        gitURL = git
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaGitIntegration-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        // Isolated HOME so setup commands don't read the developer's global
+        // git config (default branch name, gpg signing, hooks).
+        home = tempRoot.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+
+        remote = tempRoot.appendingPathComponent("remote.git", isDirectory: true)
+        vault = tempRoot.appendingPathComponent("vault", isDirectory: true)
+
+        // Bare remote whose default branch is `main`.
+        try runGit(["init", "--bare", remote.path], in: tempRoot)
+        try runGit(["symbolic-ref", "HEAD", "refs/heads/main"], in: remote)
+
+        // Working copy on `main` with identity + no gpg signing, an initial
+        // commit, and `origin` pointing at the bare remote.
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        try runGit(["init", vault.path], in: tempRoot)
+        try configureRepo(vault)
+        try runGit(["checkout", "-b", "main"], in: vault)
+        try write("# vault\n", to: vault.appendingPathComponent("README.md"))
+        try runGit(["add", "."], in: vault)
+        try runGit(["commit", "-m", "init"], in: vault)
+        try runGit(["remote", "add", "origin", remote.path], in: vault)
+        try runGit(["push", "-u", "origin", "main"], in: vault)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Tests
+
+    func test_sync_commits_and_pushes_note_to_remote() async throws {
+        let note = vault.appendingPathComponent("2026-01-02 Meeting.md")
+        try write("# Meeting\n\nSummary body.\n", to: note)
+
+        let syncer = ObsidianGitSyncer()   // real ProcessGitCommandRunner
+        let error = await syncer.sync(vault: vault,
+                                      changedPaths: [note],
+                                      branch: "main",
+                                      commitMessage: "Add transcript: Meeting")
+        XCTAssertNil(error, "expected a clean sync, got: \(error ?? "")")
+
+        // The remote now carries the commit and the file's content.
+        let log = try runGit(["log", "--oneline"], in: remote)
+        XCTAssertTrue(log.contains("Add transcript: Meeting"),
+                      "remote log should contain the note commit; got:\n\(log)")
+        let show = try runGit(["show", "main:2026-01-02 Meeting.md"], in: remote)
+        XCTAssertTrue(show.contains("Summary body."),
+                      "remote should hold the pushed note content")
+    }
+
+    func test_sync_rebases_nonconflicting_remote_change_and_pushes() async throws {
+        // A second checkout pushes an unrelated file, so the remote `main` is
+        // now ahead of the vault.
+        let other = tempRoot.appendingPathComponent("other", isDirectory: true)
+        try runGit(["clone", remote.path, other.path], in: tempRoot)
+        try configureRepo(other)
+        try write("remote-added\n", to: other.appendingPathComponent("b.md"))
+        try runGit(["add", "."], in: other)
+        try runGit(["commit", "-m", "remote change b"], in: other)
+        try runGit(["push", "origin", "HEAD:main"], in: other)
+
+        // The vault writes its own note and syncs; pull --rebase must fold in
+        // the remote's commit, then push both.
+        let note = vault.appendingPathComponent("a.md")
+        try write("local-added\n", to: note)
+        let syncer = ObsidianGitSyncer()
+        let error = await syncer.sync(vault: vault,
+                                      changedPaths: [note],
+                                      branch: "main",
+                                      commitMessage: "Add transcript: A")
+        XCTAssertNil(error, "expected a clean rebase+push, got: \(error ?? "")")
+
+        let files = try runGit(["ls-tree", "--name-only", "main"], in: remote)
+        XCTAssertTrue(files.contains("a.md"), "the vault's note must be pushed; got:\n\(files)")
+        XCTAssertTrue(files.contains("b.md"), "the remote's commit must be preserved; got:\n\(files)")
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func runGit(_ arguments: [String], in directory: URL) throws -> String {
+        let process = Process()
+        process.executableURL = gitURL
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+        var env = ProcessInfo.processInfo.environment
+        env["HOME"] = home.path
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        process.environment = env
+
+        let out = Pipe(), err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+        process.waitUntilExit()
+        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        if process.terminationStatus != 0 {
+            throw NSError(domain: "git", code: Int(process.terminationStatus), userInfo: [
+                NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stderr)\(stdout)"
+            ])
+        }
+        return stdout
+    }
+
+    private func configureRepo(_ repo: URL) throws {
+        try runGit(["config", "user.email", "test@example.com"], in: repo)
+        try runGit(["config", "user.name", "Mila Test"], in: repo)
+        try runGit(["config", "commit.gpgsign", "false"], in: repo)
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/MilaTests/ObsidianGitSyncerTests.swift
+++ b/MilaTests/ObsidianGitSyncerTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Mila
+
+/// Records every git invocation and returns programmable results, so we can
+/// assert the command sequence without a real repo. An actor because
+/// `ObsidianGitSyncer` calls it from actor-isolated context and reads must be
+/// awaited afterwards.
+private actor FakeGitRunner: GitCommandRunning {
+    private(set) var calls: [[String]] = []
+    private let handler: @Sendable ([String]) -> GitCommandResult
+
+    init(handler: @escaping @Sendable ([String]) -> GitCommandResult) {
+        self.handler = handler
+    }
+
+    func run(_ arguments: [String], in directory: URL) async -> GitCommandResult {
+        calls.append(arguments)
+        return handler(arguments)
+    }
+}
+
+private func ok(_ stdout: String = "") -> GitCommandResult {
+    GitCommandResult(exitCode: 0, stdout: stdout, stderr: "", timedOut: false)
+}
+
+private func fail(_ stderr: String) -> GitCommandResult {
+    GitCommandResult(exitCode: 1, stdout: "", stderr: stderr, timedOut: false)
+}
+
+final class ObsidianGitSyncerTests: XCTestCase {
+
+    private let vault = URL(fileURLWithPath: "/repo/vault")
+    private let file = URL(fileURLWithPath: "/repo/vault/note.md")
+
+    func test_happy_path_runs_add_commit_rebase_push_in_order() async {
+        let fake = FakeGitRunner { args in
+            args.first == "rev-parse" ? ok("/repo") : ok()
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "Add transcript: T")
+        XCTAssertNil(error)
+        let calls = await fake.calls
+        XCTAssertEqual(calls, [
+            ["rev-parse", "--show-toplevel"],
+            ["add", "--all", "--", file.path],
+            ["commit", "-m", "Add transcript: T"],
+            ["pull", "--rebase", "origin", "main"],
+            ["push", "origin", "HEAD:main"],
+        ])
+    }
+
+    func test_not_a_repo_returns_error_and_stops() async {
+        let fake = FakeGitRunner { _ in fail("not a git repository") }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        let calls = await fake.calls
+        XCTAssertEqual(calls, [["rev-parse", "--show-toplevel"]])
+    }
+
+    func test_nothing_to_commit_still_pulls_and_pushes() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "commit": return fail("nothing to commit, working tree clean")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNil(error, "an unchanged note is not a failure")
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "main"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:main"]))
+    }
+
+    func test_rebase_conflict_aborts_and_does_not_push() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "pull": return fail("CONFLICT (content): Merge conflict")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["rebase", "--abort"]),
+                      "a rebase conflict must be aborted so the vault isn't left mid-rebase")
+        XCTAssertFalse(calls.contains(where: { $0.first == "push" }),
+                       "push must not run after a failed rebase")
+    }
+
+    func test_push_failure_is_surfaced() async {
+        let fake = FakeGitRunner { args in
+            switch args.first {
+            case "rev-parse": return ok("/repo")
+            case "push": return fail("Permission denied (publickey)")
+            default: return ok()
+            }
+        }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                      branch: "main", commitMessage: "m")
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error?.contains("push") == true)
+    }
+
+    func test_branch_is_honored() async {
+        let fake = FakeGitRunner { args in args.first == "rev-parse" ? ok("/repo") : ok() }
+        let syncer = ObsidianGitSyncer(runner: fake)
+        _ = await syncer.sync(vault: vault, changedPaths: [file],
+                              branch: "notes", commitMessage: "m")
+        let calls = await fake.calls
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "notes"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:notes"]))
+    }
+}

--- a/MilaTests/ObsidianGitSyncerTests.swift
+++ b/MilaTests/ObsidianGitSyncerTests.swift
@@ -45,8 +45,8 @@ final class ObsidianGitSyncerTests: XCTestCase {
             ["rev-parse", "--show-toplevel"],
             ["add", "--all", "--", file.path],
             ["commit", "-m", "Add transcript: T"],
-            ["pull", "--rebase", "origin", "main"],
-            ["push", "origin", "HEAD:main"],
+            ["pull", "--rebase", "origin", "refs/heads/main"],
+            ["push", "origin", "HEAD:refs/heads/main"],
         ])
     }
 
@@ -73,8 +73,8 @@ final class ObsidianGitSyncerTests: XCTestCase {
                                       branch: "main", commitMessage: "m")
         XCTAssertNil(error, "an unchanged note is not a failure")
         let calls = await fake.calls
-        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "main"]))
-        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:main"]))
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "refs/heads/main"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:refs/heads/main"]))
     }
 
     func test_rebase_conflict_aborts_and_does_not_push() async {
@@ -117,7 +117,48 @@ final class ObsidianGitSyncerTests: XCTestCase {
         _ = await syncer.sync(vault: vault, changedPaths: [file],
                               branch: "notes", commitMessage: "m")
         let calls = await fake.calls
-        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "notes"]))
-        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:notes"]))
+        XCTAssertTrue(calls.contains(["pull", "--rebase", "origin", "refs/heads/notes"]))
+        XCTAssertTrue(calls.contains(["push", "origin", "HEAD:refs/heads/notes"]))
+    }
+
+    // MARK: - Branch validation
+
+    /// `obsidian.git.branch` is free text from Settings and lands in an
+    /// argument position where git reads a leading `-` as an option. A branch
+    /// named `--upload-pack=…` would turn the sync into an arbitrary-command
+    /// execution against the user's vault. Nothing may run at all.
+    func test_a_branch_that_looks_like_an_option_runs_no_git_at_all() async {
+        for hostile in ["--upload-pack=/bin/sh", "-o", "--exec=evil", "-"] {
+            let fake = FakeGitRunner { args in args.first == "rev-parse" ? ok("/repo") : ok() }
+            let syncer = ObsidianGitSyncer(runner: fake)
+            let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                          branch: hostile, commitMessage: "m")
+            XCTAssertNotNil(error, "\(hostile.debugDescription) must be rejected")
+            let calls = await fake.calls
+            XCTAssertTrue(calls.isEmpty,
+                          "\(hostile.debugDescription) reached git as \(calls)")
+        }
+    }
+
+    func test_invalid_branch_names_are_rejected_before_any_command() async {
+        for hostile in ["", " ", "a b", "a~b", "a^b", "a:b", "a..b", "a?b", "a*b",
+                        "a[b", "a\\b", "feature.lock", "/leading", "trailing/",
+                        ".dot", "dot.", "a@{0}", "a\nb", "a\tb"] {
+            let fake = FakeGitRunner { args in args.first == "rev-parse" ? ok("/repo") : ok() }
+            let syncer = ObsidianGitSyncer(runner: fake)
+            let error = await syncer.sync(vault: vault, changedPaths: [file],
+                                          branch: hostile, commitMessage: "m")
+            XCTAssertNotNil(error, "\(hostile.debugDescription) must be rejected")
+            let calls = await fake.calls
+            XCTAssertTrue(calls.isEmpty, "\(hostile.debugDescription) reached git as \(calls)")
+        }
+    }
+
+    /// The names people actually use must keep working.
+    func test_ordinary_branch_names_are_accepted() {
+        for good in ["main", "master", "notes", "feature/obsidian", "v1.9.2",
+                     "user/kobi-vault", "release-2026", "notes_2"] {
+            XCTAssertTrue(ObsidianGitSyncer.isValidBranch(good), good)
+        }
     }
 }

--- a/MilaTests/ObsidianVaultSettingsTests.swift
+++ b/MilaTests/ObsidianVaultSettingsTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class ObsidianVaultSettingsTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MilaObsidianVaultTests-\(UUID())", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        suiteName = "ObsidianVaultSettingsTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    func test_defaults_are_off_with_transcripts_subfolder_and_main_branch() {
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertFalse(settings.enabled)
+        XCTAssertNil(settings.vaultURL)
+        XCTAssertEqual(settings.subfolder, "Transcripts")
+        XCTAssertFalse(settings.gitSyncEnabled)
+        XCTAssertEqual(settings.gitBranch, "main")
+    }
+
+    func test_setVault_persists_bookmark_and_resolves_on_relaunch() throws {
+        let vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let first = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(first.setVault(vault))
+        XCTAssertEqual(first.vaultURL?.standardizedFileURL, vault.standardizedFileURL)
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertEqual(second.vaultURL?.standardizedFileURL, vault.standardizedFileURL)
+    }
+
+    func test_clearVault_removes_the_bookmark() throws {
+        let vault = tempRoot.appendingPathComponent("Vault2", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(settings.setVault(vault))
+        settings.clearVault()
+        XCTAssertNil(settings.vaultURL)
+        XCTAssertNil(defaults.data(forKey: ObsidianVaultSettings.bookmarkKey))
+    }
+
+    func test_resolution_falls_back_when_folder_deleted() throws {
+        let vault = tempRoot.appendingPathComponent("Gone", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+
+        let first = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(first.setVault(vault))
+        try FileManager.default.removeItem(at: vault)
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertNil(second.vaultURL)
+    }
+
+    func test_enabled_subfolder_git_persist_across_instances() {
+        let first = ObsidianVaultSettings(defaults: defaults)
+        first.enabled = true
+        first.subfolder = "Meetings/2026"
+        first.gitSyncEnabled = true
+        first.gitBranch = "notes"
+
+        let second = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(second.enabled)
+        XCTAssertEqual(second.subfolder, "Meetings/2026")
+        XCTAssertTrue(second.gitSyncEnabled)
+        XCTAssertEqual(second.gitBranch, "notes")
+    }
+
+    func test_destinationDirectory_appends_subfolder_and_strips_slashes() throws {
+        let vault = tempRoot.appendingPathComponent("VaultD", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(settings.setVault(vault))
+        // Compare against the RESOLVED vault URL (bookmark resolution can
+        // return a /private-prefixed path) and via `.path`, which drops the
+        // trailing slash `appendingPathComponent(isDirectory:)` adds.
+        let base = try XCTUnwrap(settings.vaultURL)
+
+        settings.subfolder = "/Transcripts/"
+        XCTAssertEqual(settings.destinationDirectory?.standardizedFileURL.path,
+                       base.appendingPathComponent("Transcripts").standardizedFileURL.path)
+
+        settings.subfolder = "   "
+        XCTAssertEqual(settings.destinationDirectory?.standardizedFileURL.path,
+                       base.standardizedFileURL.path,
+                       "Blank subfolder should target the vault root")
+    }
+}

--- a/MilaTests/ObsidianVaultSettingsTests.swift
+++ b/MilaTests/ObsidianVaultSettingsTests.swift
@@ -145,6 +145,102 @@ final class ObsidianVaultSettingsTests: XCTestCase {
             URL(fileURLWithPath: "/private/tmp/VaultOther"), in: root))
     }
 
+    /// The escape a lexical check cannot see: a symlink **inside** the vault
+    /// whose target is outside it. Every path here is spelled entirely under
+    /// the vault, so `standardized` alone reports all of them as contained.
+    func test_isContained_refuses_a_symlink_that_leaves_the_vault() throws {
+        let fm = FileManager.default
+        let vault = tempRoot.appendingPathComponent("SymVault", isDirectory: true)
+        let outside = tempRoot.appendingPathComponent("Outside", isDirectory: true)
+        try fm.createDirectory(at: vault, withIntermediateDirectories: true)
+        try fm.createDirectory(at: outside, withIntermediateDirectories: true)
+        try fm.createDirectory(at: vault.appendingPathComponent("Real"),
+                               withIntermediateDirectories: true)
+        // Absolute target, relative target, and one nested a level down.
+        try fm.createSymbolicLink(at: vault.appendingPathComponent("Escape"),
+                                  withDestinationURL: outside)
+        try fm.createSymbolicLink(atPath: vault.appendingPathComponent("Up").path,
+                                  withDestinationPath: "../Outside")
+        try fm.createSymbolicLink(atPath: vault.appendingPathComponent("Real/Deep").path,
+                                  withDestinationPath: "../../Outside")
+        // Dangling: the target doesn't exist *yet*. `resolvingSymlinksInPath()`
+        // leaves this one alone — realpath needs the target to exist — which is
+        // the second reason the resolution here is done per component.
+        try fm.createSymbolicLink(atPath: vault.appendingPathComponent("Dangling").path,
+                                  withDestinationPath: "../Outside/NotThere")
+        // A symlink whose target is *inside* the vault. Legitimate: it resolves
+        // back under the root, so the write lands in the vault either way.
+        try fm.createSymbolicLink(at: vault.appendingPathComponent("Inside"),
+                                  withDestinationURL: vault.appendingPathComponent("Real"))
+        // A cycle: unresolvable, so the guard has to fail closed.
+        try fm.createSymbolicLink(atPath: vault.appendingPathComponent("LoopA").path,
+                                  withDestinationPath: "LoopB")
+        try fm.createSymbolicLink(atPath: vault.appendingPathComponent("LoopB").path,
+                                  withDestinationPath: "LoopA")
+
+        for escaping in ["Escape", "Escape/note.md", "Up", "Up/note.md",
+                         "Real/Deep", "Real/Deep/note.md",
+                         "Dangling", "Dangling/note.md", "LoopA", "LoopA/note.md"] {
+            XCTAssertFalse(
+                ObsidianPathSanitizer.isContained(vault.appendingPathComponent(escaping), in: vault),
+                "\(escaping) does not resolve inside the vault but was accepted")
+        }
+        for contained in ["Real", "Real/note.md", "Inside", "Inside/note.md", "NotYet/note.md"] {
+            XCTAssertTrue(
+                ObsidianPathSanitizer.isContained(vault.appendingPathComponent(contained), in: vault),
+                "\(contained) resolves inside the vault but was refused")
+        }
+
+        // A vault the user reached *through* a symlink is still a usable vault:
+        // both sides resolve, so it behaves exactly like the vault it points at.
+        let linked = tempRoot.appendingPathComponent("VaultLink")
+        try fm.createSymbolicLink(atPath: linked.path, withDestinationPath: "SymVault")
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(
+            linked.appendingPathComponent("Real/note.md"), in: linked))
+        XCTAssertFalse(ObsidianPathSanitizer.isContained(
+            linked.appendingPathComponent("Escape/note.md"), in: linked))
+    }
+
+    /// The guard has to give the same answer whether or not the destination
+    /// exists yet — the note being written is by definition not there. The
+    /// filesystem-consulting normalizers can't: they strip a `/private` prefix
+    /// only for paths that already exist, so they render an existing vault as
+    /// `/var/…` and a fresh destination under it as `/private/var/…`.
+    func test_isContained_agrees_for_existing_and_missing_destinations() throws {
+        let fm = FileManager.default
+        let vault = tempRoot.appendingPathComponent("VarVault", isDirectory: true)
+        try fm.createDirectory(at: vault.appendingPathComponent("Notes"),
+                               withIntermediateDirectories: true)
+        let existing = vault.appendingPathComponent("Notes/here.md")
+        try "x".write(to: existing, atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(existing, in: vault))
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(
+            vault.appendingPathComponent("Notes/not-yet.md"), in: vault),
+            "a note that hasn't been written yet must still read as contained")
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(
+            vault.appendingPathComponent("NoSuchFolder/not-yet.md"), in: vault),
+            "neither the folder nor the note exists yet")
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(vault, in: vault))
+
+        // The `/var` → `/private/var` split itself, in the one shape every mac
+        // has: `/tmp` is a symlink to `/private/tmp`. Both spellings must
+        // resolve to one path, and identically for a tail that doesn't exist.
+        XCTAssertEqual(ObsidianPathSanitizer.resolvedPath(URL(fileURLWithPath: "/tmp")),
+                       "/private/tmp")
+        XCTAssertEqual(
+            ObsidianPathSanitizer.resolvedPath(URL(fileURLWithPath: "/tmp/MilaNoSuchVault/n.md")),
+            ObsidianPathSanitizer.resolvedPath(
+                URL(fileURLWithPath: "/private/tmp/MilaNoSuchVault/n.md")))
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(
+            URL(fileURLWithPath: "/tmp/MilaNoSuchVault/n.md"),
+            in: URL(fileURLWithPath: "/tmp/MilaNoSuchVault")))
+        // `..` is applied after the components before it are resolved, as the
+        // kernel does — so this is `/private`, not `/`.
+        XCTAssertEqual(ObsidianPathSanitizer.resolvedPath(URL(fileURLWithPath: "/tmp/..")),
+                       "/private")
+    }
+
     func test_setVault_persists_bookmark_and_resolves_on_relaunch() throws {
         let vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
         try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)

--- a/MilaTests/ObsidianVaultSettingsTests.swift
+++ b/MilaTests/ObsidianVaultSettingsTests.swift
@@ -32,6 +32,69 @@ final class ObsidianVaultSettingsTests: XCTestCase {
         XCTAssertEqual(settings.gitBranch, "main")
     }
 
+    /// Pins the shipped contract: on a fresh install the feature is off, has no
+    /// vault, and the exporter is inert — nothing is written even if something
+    /// calls it. The one thing this can't assert is the UI (no XCUITest here);
+    /// `ObsidianSettingsSection` renders only its toggle while `enabled` is
+    /// false, and the app adds no other Obsidian affordance anywhere.
+    func test_fresh_install_is_disabled_and_exports_nothing() throws {
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        let exporter = ObsidianExporter(settings: settings, defaults: defaults)
+
+        XCTAssertFalse(settings.enabled, "the feature must be opt-in")
+        XCTAssertNil(settings.vaultURL, "no vault until the user picks one")
+        XCTAssertNil(settings.destinationDirectory)
+
+        var rec = Recording(title: "Team Sync", source: .microphone,
+                            audioFileName: "a.wav", fullText: "a transcript")
+        rec.summary = "A summary."
+        XCTAssertNil(exporter.export(rec))
+        XCTAssertEqual(exporter.exportAll([rec]), 0)
+
+        // Enabling alone still isn't enough — a vault is required.
+        settings.enabled = true
+        XCTAssertNil(settings.vaultURL)
+        XCTAssertNil(exporter.export(rec))
+        XCTAssertEqual(exporter.exportAll([rec]), 0)
+    }
+
+    /// `subfolder` is a free-text field. A typed relative path must resolve
+    /// inside the vault, never above it.
+    func test_subfolder_cannot_escape_the_vault() throws {
+        let vault = tempRoot.appendingPathComponent("VaultEscape", isDirectory: true)
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        let settings = ObsidianVaultSettings(defaults: defaults)
+        XCTAssertTrue(settings.setVault(vault))
+        let base = try XCTUnwrap(settings.vaultURL).standardizedFileURL.path
+
+        for hostile in ["../../Desktop", "..", "./..", "../Notes", "Notes/../..", "."] {
+            settings.subfolder = hostile
+            let dest = try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path
+            XCTAssertTrue(dest == base || dest.hasPrefix(base + "/"),
+                          "subfolder \(hostile.debugDescription) escaped to \(dest)")
+        }
+
+        // A legitimate nested path still works, and a hidden component is
+        // un-hidden rather than dropped.
+        settings.subfolder = "Notes/Meetings"
+        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path,
+                       base + "/Notes/Meetings")
+        settings.subfolder = ".secret"
+        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path,
+                       base + "/secret")
+    }
+
+    func test_path_sanitizer_component_rules() {
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent(".."), "")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent("."), "")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent(".hidden"), "hidden")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent("Client: Acme"), "Client Acme")
+        XCTAssertEqual(ObsidianPathSanitizer.relativePath("../../a/./b"), "a/b")
+        XCTAssertEqual(ObsidianPathSanitizer.relativePath("///"), "")
+        XCTAssertLessThanOrEqual(
+            ObsidianPathSanitizer.nameFragment(String(repeating: "é", count: 500)).utf8.count, 180)
+    }
+
     func test_setVault_persists_bookmark_and_resolves_on_relaunch() throws {
         let vault = tempRoot.appendingPathComponent("Vault", isDirectory: true)
         try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)

--- a/MilaTests/ObsidianVaultSettingsTests.swift
+++ b/MilaTests/ObsidianVaultSettingsTests.swift
@@ -65,11 +65,24 @@ final class ObsidianVaultSettingsTests: XCTestCase {
         try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
         let settings = ObsidianVaultSettings(defaults: defaults)
         XCTAssertTrue(settings.setVault(vault))
-        let base = try XCTUnwrap(settings.vaultURL).standardizedFileURL.path
+        // `standardized`, not `standardizedFileURL`, throughout: the latter
+        // consults the filesystem and drops a `/private` prefix only when the
+        // path exists, so it renders an existing vault as `/var/…` and a
+        // not-yet-created destination under it as `/private/var/…` — the two
+        // then never compare equal. `standardized` is purely lexical, which is
+        // also exactly what a traversal assertion needs (`vault/..` must
+        // collapse so an escape is visible).
+        let base = try XCTUnwrap(settings.vaultURL).standardized.path
 
-        for hostile in ["../../Desktop", "..", "./..", "../Notes", "Notes/../..", "."] {
+        // Traversal shapes. The dot-plus-space and dot-slash-dot families
+        // matter as much as bare `..`: a sanitizer that strips leading dots
+        // only leaves `".."` behind for ". .." (it stops at the space) and for
+        // "../.." (whose `/` becomes a space before the dots are stripped).
+        for hostile in ["../../Desktop", "..", "./..", "../Notes", "Notes/../..", ".",
+                        ". ..", "Notes/. ../. ..", ". . ..", ".\t..", "..\\..",
+                        " ..", ".. ", "....", ". . . ."] {
             settings.subfolder = hostile
-            let dest = try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path
+            let dest = try XCTUnwrap(settings.destinationDirectory).standardized.path
             XCTAssertTrue(dest == base || dest.hasPrefix(base + "/"),
                           "subfolder \(hostile.debugDescription) escaped to \(dest)")
         }
@@ -77,10 +90,10 @@ final class ObsidianVaultSettingsTests: XCTestCase {
         // A legitimate nested path still works, and a hidden component is
         // un-hidden rather than dropped.
         settings.subfolder = "Notes/Meetings"
-        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path,
+        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardized.path,
                        base + "/Notes/Meetings")
         settings.subfolder = ".secret"
-        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardizedFileURL.path,
+        XCTAssertEqual(try XCTUnwrap(settings.destinationDirectory).standardized.path,
                        base + "/secret")
     }
 
@@ -93,6 +106,43 @@ final class ObsidianVaultSettingsTests: XCTestCase {
         XCTAssertEqual(ObsidianPathSanitizer.relativePath("///"), "")
         XCTAssertLessThanOrEqual(
             ObsidianPathSanitizer.nameFragment(String(repeating: "é", count: 500)).utf8.count, 180)
+    }
+
+    /// The dot-stripping rule, pinned input by input. Every one of these
+    /// reduced to a live `".."` under the leading-dots-only rule.
+    func test_path_sanitizer_cannot_produce_a_traversal_component() {
+        for hostile in [". ..", ".\t..", ". . ..", "../..", "..\\..", " ..", ".. ",
+                        "....", ". . . .", ".  ..", "./..", "..;..", "\t. ..\t"] {
+            let component = ObsidianPathSanitizer.directoryComponent(hostile)
+            XCTAssertNotEqual(component, "..", "\(hostile.debugDescription) survived as ..")
+            XCTAssertNotEqual(component, ".", "\(hostile.debugDescription) survived as .")
+            XCTAssertFalse(component.hasPrefix("."),
+                           "\(hostile.debugDescription) produced a dotfile: \(component)")
+        }
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent(". .."), "")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent("../.."), "")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent(". . .."), "")
+        XCTAssertEqual(ObsidianPathSanitizer.relativePath("a/. ../. ../Desktop"), "a/Desktop")
+        XCTAssertEqual(ObsidianPathSanitizer.relativePath("Notes/. ../. .."), "Notes")
+
+        // A dot that isn't leading is an ordinary character, not a threat.
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent("2026.01 Notes"), "2026.01 Notes")
+        XCTAssertEqual(ObsidianPathSanitizer.directoryComponent(".. Real Name"), "Real Name")
+    }
+
+    /// The containment guard the exporter leans on at write time.
+    func test_isContained_rejects_escapes() {
+        let root = URL(fileURLWithPath: "/private/tmp/Vault")
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(root, in: root))
+        XCTAssertTrue(ObsidianPathSanitizer.isContained(
+            root.appendingPathComponent("Notes/a.md"), in: root))
+        XCTAssertFalse(ObsidianPathSanitizer.isContained(
+            root.appendingPathComponent(".."), in: root))
+        XCTAssertFalse(ObsidianPathSanitizer.isContained(
+            root.appendingPathComponent("Notes/../../Desktop"), in: root))
+        // A sibling whose path merely starts with the same characters.
+        XCTAssertFalse(ObsidianPathSanitizer.isContained(
+            URL(fileURLWithPath: "/private/tmp/VaultOther"), in: root))
     }
 
     func test_setVault_persists_bookmark_and_resolves_on_relaunch() throws {


### PR DESCRIPTION
Part of the #99 split (roadmap in that PR). Last of the larger features, and fully self-contained.

## What

Opt-in: point Mila at an Obsidian vault (Settings → Storage) and every completed recording is written there as a Markdown note — title, date, duration, summary, action items, transcript. Optionally `git commit` + `push` after each write, so the vault syncs without opening Obsidian.

Off by default; nothing happens until a vault is chosen.

## Why it needs a hook in `RecordingSummarizer`

This is the part worth reviewing closely. The note should carry the summary and action items, but those land asynchronously, well after the transcript is ready. Exporting on transcript-complete produces a note that's missing the useful half; polling for a summary that may never come hangs forever.

So `RecordingSummarizer` gains an `onSummaryFinished` hook that fires **once per attempt, after the summary state is final** — whether a summary was generated, generation was skipped (disabled / not configured / already summarized / empty transcript), or it failed. The exporter waits on that and falls back to the transcript when no summary was produced.

Two cases deliberately don't fire it, and both are commented at the call site:

- **The dedup early-return** (a second call while one is already in flight) — the in-flight task will fire, so firing here too would double-export.
- **Recording deleted mid-flight** — there's nothing left to export.

`ObsidianExportSequencingTests` wires the hook exactly as `MilaApp` does and covers the ordering, including the fallback path.

## Other decisions

**Vault access is a security-scoped bookmark**, so the folder grant survives relaunch rather than re-prompting.

**Git sync is strictly non-interactive:** `GIT_TERMINAL_PROMPT=0` plus SSH `BatchMode=yes`. A missing or expired credential fails fast with a visible error instead of hanging a background sync on a prompt nobody can see.

**`ObsidianGitSyncer` resolves `git` itself** — system binary first, then the usual shell-managed `bin` dirs — because a Finder-launched app inherits a stripped PATH from launchd, and "works in Terminal, not in Mila" is a miserable bug to diagnose.

> Small note: in our fork this reused `LLMRunner.searchDirectories()` / `childEnvironment(for:)`, which are part of #119. Rather than make this PR depend on that one, the syncer carries its own minimal version. If #119 lands first, this is an easy simplification — happy to do it as a follow-up either way.

## Tests

49 tests pass across `ObsidianExporterTests` (14), `ObsidianVaultSettingsTests` (6), `ObsidianGitSyncerTests` (6), `ObsidianGitSyncerIntegrationTests` (2, against a real temp repo), `ObsidianExportSequencingTests` (3), and `RecordingSummarizerTests` (18, confirming the hook didn't change existing summarizer behaviour). `make build` succeeds.

## Note on verification

I could not run the **UI test** target locally — the XCUITest runner fails on my machine with "Timed out while enabling automation mode", which reproduces on a clean checkout of `main`, so it looks environmental. The Settings → Storage section is worth a reviewer eyeballing.

Made with [Cursor](https://cursor.com)

---

## Maintainer review pass (rebased + follow-up commit)

Closes #153

Rebased onto current `main` (the branch was behind and conflicted in
`MilaApp.swift`), then one follow-up commit. Summary of what changed and why:

**It didn't compile here.** `ObsidianExporter` imported `MilaKit`, a module that
exists in the contributor's fork but not in `island-io/mila`. CI had never
actually run on this PR — as a fork PR its runs sat parked in `action_required`
— so nothing caught it. `TranscriptFormatter` already lives in the app target,
so the import is simply gone.

**Off by default / no new buttons.** Full inventory of what this feature adds to
the UI, and whether it is visible while disabled:

| Surface | Visible when disabled? |
| --- | --- |
| Settings ▸ Storage — "Save transcripts to an Obsidian vault" toggle + one caption line | **Yes** — this is the only one, and it is the setting itself |
| Vault picker card (path, Choose…, Reveal in Finder, Clear, subfolder field, Browse…) | No |
| Git card (commit & push toggle, branch field, last-sync error) | No |
| "Sync existing transcripts" backfill button | No — also requires a chosen vault |
| Stale-bookmark notice / error text | No |
| Toolbar item, recording context-menu entry, list-header affordance, badge, menu command | **None exist anywhere** |

The last row is the important one: `grep -rl Obsidian Mila --include='*.swift'`
returns eight files, of which exactly two are views — `StorageSettingsTab` and
`ObsidianSettingsSection`. There is no other entry point in the app.

The section previously rendered a `.title3` heading and an explanatory paragraph
even when off, which read as a whole new titled section in the Storage tab. It
is now one more card in the existing stack — a toggle and a single caption line
— and expands only once enabled. The visibility contract is written down at the
top of `ObsidianSettingsSection` so it doesn't quietly regress.

**Filesystem safety.** `subfolder` is a free-text field and a Mila folder name is
user-chosen, and both became path components after only a character strip. A
folder named `..`, or `../../Desktop` typed into the subfolder field, resolved
*outside* the configured destination. New `ObsidianPathSanitizer` (shared by the
settings model and the exporter) drops leading dots from directory components,
so `.` and `..` collapse to nothing and a dotfolder is un-hidden, and sanitizes
every component of a typed relative path individually. Names are also capped on
a UTF-8 byte budget rather than a character count, so a long Hebrew or emoji
title can't blow past the 255-byte component limit and silently fail the write.
Filenames were already safe — the `yyyy-MM-dd ` prefix means no title can
produce ``, `..` or a dotfile — but that is now pinned by a test rather than
left to inspection.

**Export correctness.** The exporter refuses to file a trashed recording, and the
summarizer's asynchronous completion paths (empty output, failure) no longer
fire with the stale enqueue-time copy once the recording has left the store. A
permanent delete cancels the in-flight task, which surfaces as a thrown
`CancellationError` — before this, deleting a recording while its summary was in
flight still wrote a note for it. Git commit subjects are flattened to one line,
and "Reveal in Finder" now reveals rather than opening the folder.

**On the `onSummaryFinished` hook** — the part the author rightly flagged. It
holds up:
- *No double-fire.* Exactly one branch of `runSummary` fires it per attempt and
  each returns immediately after; the dedup early-return deliberately doesn't
  fire because the in-flight task will. There's now a test asserting one signal
  from three overlapping calls.
- *No retain cycle.* The closure captures `[weak obsidian]` and nothing else —
  no `self`, no `Recording`. `ObsidianExporter` → `ObsidianVaultSettings` is a
  one-way edge.
- *Failure isolation.* Every filesystem operation in `writeNote` is caught
  locally and returns nil; nothing can throw back into the summarizer, and
  nothing downstream of the call site depends on the observer.
- *Cheap when off.* The hook is always installed but the export is gated on a
  `pending` set that only gets marked when the feature is enabled **and** a
  vault is chosen, so with the feature off it is one `Set<UUID>` lookup.

**Tests added:** fresh-`UserDefaults` pin (disabled, no vault, exporter writes
nothing — including after `enabled` is set but before a vault is picked),
subfolder and Mila-folder escape attempts, hostile and over-long titles, trashed
recordings, delete-mid-flight, failure fallback, and the fire-once assertion.

### Not visually verified

Nobody has seen this on a screen. The author couldn't run XCUITests locally, and
this review pass was done under a hard no-UI-testing constraint (`make build`
and a compile-only `build-for-testing` were the only local runs; the app was
never launched). A human should eyeball, in Settings ▸ Storage: the collapsed
card when the feature is off, the expanded state after toggling it on, and the
vault picker / git / backfill cards once a vault is chosen. The disabled-state
behaviour is pinned by unit tests; its *appearance* is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional export of completed recordings as Markdown notes to an Obsidian vault.
  - Added configurable vault, subfolder, filename, and path-safety controls.
  - Added optional Git commit, rebase, and push synchronization.
  - Added bulk export and backfilling for existing recordings.
  - Added transcript fallback when summaries are unavailable or disabled.
  - Added vault selection, Finder reveal, and export status notices in Storage settings.

- **Bug Fixes**
  - Prevented duplicate, deleted, or trashed recordings from being exported.
  - Improved handling of renamed notes, invalid vaults, unsafe paths, and failed synchronization attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci: re-trigger linked-issue check -->
