### PR TITLE
fix(updates): fold the Updates tab into General; refuse untagged betas for opted-out users

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -157,14 +157,33 @@ final class UpdaterViewModel: NSObject, ObservableObject,
     /// A plain `1.9.2` — or an empty/unknown string, which must never be
     /// treated as a beta — is not a pre-release.
     ///
-    /// The hyphen is required so a stable version that merely *contains* one of
-    /// these substrings (a hypothetical "1.0.0" build named `Alpharetta`) isn't
-    /// misread. Kept `static`, `nonisolated` and side-effect-free so it's
-    /// callable from Sparkle's nonisolated delegate callbacks and unit-testable
-    /// without constructing an updater (see `UpdaterPrereleaseGuardTests`).
+    /// The marker has to be a *complete* token, guarded on both sides, because
+    /// anything we can't positively classify must fail open:
+    /// - a leading `-`, so a build named `Alpharetta` (`1.0.0 Alpharetta`) or a
+    ///   `-superbeta` suffix isn't misread;
+    /// - and nothing but a non-letter after it, so an unknown label like
+    ///   `1.0.0-betamax` or `1.0.0-alphabet` is treated as unclassifiable
+    ///   (allowed) rather than silently refused. A digit still counts as a
+    ///   terminator so the common `1.9.2-beta1` spelling keeps matching,
+    ///   alongside `-beta`, `-beta.1` and `-beta-1`.
+    ///
+    /// Kept `static`, `nonisolated` and side-effect-free so it's callable from
+    /// Sparkle's nonisolated delegate callbacks and unit-testable without
+    /// constructing an updater (see `UpdaterPrereleaseGuardTests`).
     nonisolated static func isPrerelease(_ shortVersionString: String) -> Bool {
         let v = shortVersionString.lowercased()
-        return ["-beta", "-alpha", "-rc"].contains { v.contains($0) }
+        return ["-beta", "-alpha", "-rc"].contains { marker in
+            var searchStart = v.startIndex
+            while let hit = v.range(of: marker, range: searchStart..<v.endIndex) {
+                // A complete token: end-of-string, or followed by something
+                // that isn't a letter (`.`, `-`, `+`, a digit, whitespace…).
+                if hit.upperBound == v.endIndex || !v[hit.upperBound].isLetter {
+                    return true
+                }
+                searchStart = hit.upperBound
+            }
+            return false
+        }
     }
 
     /// Defensive, client-side beta gate — the last line of defence in front of

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -35,8 +35,18 @@ final class UpdaterViewModel: NSObject, ObservableObject,
     private(set) var controller: SPUStandardUpdaterController!
     @Published var canCheckForUpdates = false
 
+    /// Mirrors Sparkle's own `automaticallyChecksForUpdates` (persisted by
+    /// Sparkle in the host bundle's defaults — we deliberately do NOT keep a
+    /// second user default for it, per `SPUUpdater.h`). Kept in sync via KVO so
+    /// the Settings toggle reflects changes Sparkle makes itself (e.g. the
+    /// second-launch permission prompt). Write through
+    /// `setAutomaticallyChecksForUpdates(_:)`.
+    @Published var automaticallyChecksForUpdates = true
+
     /// UserDefaults key for the "Enable beta version" opt-in. Read live by
-    /// `allowedChannels(for:)` and written by the toggle in Settings → Updates.
+    /// `allowedChannels(for:)` and by the pre-release guard in
+    /// `updater(_:shouldProceedWithUpdate:updateCheck:)`; written by the toggle
+    /// in Settings → General ▸ Updates.
     static let betaChannelDefaultsKey = "updates.betaChannel"
 
     /// The update we want the custom popup to show. Non-nil iff a scheduled
@@ -69,6 +79,9 @@ final class UpdaterViewModel: NSObject, ObservableObject,
         controller.updater.publisher(for: \.canCheckForUpdates)
             .receive(on: DispatchQueue.main)
             .assign(to: &$canCheckForUpdates)
+        controller.updater.publisher(for: \.automaticallyChecksForUpdates)
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$automaticallyChecksForUpdates)
 
         // UI-test seam: force the "What's New" popup to appear with fixture
         // release-notes content, without needing a live appcast / a newer
@@ -87,6 +100,13 @@ final class UpdaterViewModel: NSObject, ObservableObject,
                 """
             )
         }
+    }
+
+    /// Write-through for the "Automatically check for updates" toggle. Sparkle
+    /// persists the value itself; the KVO mirror above pushes it back into
+    /// `automaticallyChecksForUpdates` so the UI stays consistent.
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        controller.updater.automaticallyChecksForUpdates = enabled
     }
 
     /// User picked "Check for Updates…" from the menu. Flag it so the
@@ -129,6 +149,68 @@ final class UpdaterViewModel: NSObject, ObservableObject,
     /// toggle takes effect on the next check — no relaunch needed.
     nonisolated func allowedChannels(for updater: SPUUpdater) -> Set<String> {
         UserDefaults.standard.bool(forKey: Self.betaChannelDefaultsKey) ? ["beta"] : []
+    }
+
+    /// Pure version classifier: does this marketing version string denote a
+    /// pre-release? Matches the `-beta` / `-alpha` / `-rc` suffix conventions
+    /// this project actually tags with (`1.9.2-beta.1`), case-insensitively.
+    /// A plain `1.9.2` — or an empty/unknown string, which must never be
+    /// treated as a beta — is not a pre-release.
+    ///
+    /// The hyphen is required so a stable version that merely *contains* one of
+    /// these substrings (a hypothetical "1.0.0" build named `Alpharetta`) isn't
+    /// misread. Kept `static`, `nonisolated` and side-effect-free so it's
+    /// callable from Sparkle's nonisolated delegate callbacks and unit-testable
+    /// without constructing an updater (see `UpdaterPrereleaseGuardTests`).
+    nonisolated static func isPrerelease(_ shortVersionString: String) -> Bool {
+        let v = shortVersionString.lowercased()
+        return ["-beta", "-alpha", "-rc"].contains { v.contains($0) }
+    }
+
+    /// Defensive, client-side beta gate — the last line of defence in front of
+    /// `allowedChannels(for:)`.
+    ///
+    /// Channel filtering is only as good as the appcast: an item tagged
+    /// `<sparkle:channel>beta</sparkle:channel>` is hidden from users who
+    /// haven't opted in, but an item that is a beta and *forgot* the tag lands
+    /// in the DEFAULT channel and is therefore offered to everyone. That is
+    /// exactly what happened when `1.9.2-beta.1` was published without the
+    /// channel element: every stable user was offered a beta regardless of the
+    /// opt-in. The feed and the publishing pipeline were fixed separately —
+    /// this hook makes the client refuse such an item anyway, so a single
+    /// mis-tagged release can't push betas at people again.
+    ///
+    /// `shouldProceedWithUpdate` is the right hook: per `SPUUpdaterDelegate.h`,
+    /// throwing here means "the user is not shown this updateItem nor is the
+    /// update downloaded or installed" — it gates *offering* the update, unlike
+    /// `didFindValidUpdate` (informational, too late) or the user-driver hooks
+    /// (which only choose which UI presents an update that's already been
+    /// accepted). It runs for both scheduled and user-initiated checks.
+    nonisolated func updater(
+        _ updater: SPUUpdater,
+        shouldProceedWithUpdate updateItem: SUAppcastItem,
+        updateCheck: SPUUpdateCheck
+    ) throws {
+        guard !UserDefaults.standard.bool(forKey: Self.betaChannelDefaultsKey) else { return }
+        // Check both: `displayVersionString` is the marketing version users see
+        // (`1.9.2-beta.1`), but a feed may only carry `sparkle:version`.
+        let candidates = [updateItem.displayVersionString, updateItem.versionString]
+        guard candidates.contains(where: { Self.isPrerelease($0) }) else { return }
+
+        os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "MilaApp")
+            .error("""
+            Refusing update \(updateItem.displayVersionString, privacy: .public) \
+            (\(updateItem.versionString, privacy: .public)): it is a pre-release \
+            and this user has not opted into the beta channel. The appcast item \
+            is probably missing <sparkle:channel>beta</sparkle:channel>.
+            """)
+        throw NSError(
+            domain: "io.island.mila.updates",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey:
+                "\(updateItem.displayVersionString) is a pre-release build. "
+                + "Enable “Receive beta versions” in Settings ▸ General to install betas."]
+        )
     }
 
     /// Sparkle found a newer valid version. Capture its release notes for the
@@ -639,6 +721,11 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
                 .environmentObject(configImporter)
+                // Settings ▸ General shows the Sparkle-backed
+                // "Automatically check for updates" toggle, so the Settings
+                // scene needs the same single updater instance the main window
+                // and the menu command use — never a second one.
+                .environmentObject(updater)
         }
     }
 

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import AppKit
 import Carbon.HIToolbox
 
 enum SettingsTab: Int, Hashable {
-    case hotkeys, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage, updates
+    case general, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage
 }
 
 @Observable
@@ -14,13 +14,13 @@ final class SettingsNavigation {
 
 /// Standard `Settings` scene. Opened via `Cmd+,` from the menu bar.
 struct SettingsView: View {
-    @State private var selectedTab: SettingsTab = .hotkeys
+    @State private var selectedTab: SettingsTab = .general
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            HotkeysSettingsTab()
-                .tabItem { Label("Hotkeys", systemImage: "command") }
-                .tag(SettingsTab.hotkeys)
+            GeneralSettingsTab()
+                .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(SettingsTab.general)
             AudioSettingsTab()
                 .tabItem { Label("Audio", systemImage: "mic") }
                 .tag(SettingsTab.audio)
@@ -45,9 +45,6 @@ struct SettingsView: View {
             StorageSettingsTab()
                 .tabItem { Label("Storage", systemImage: "externaldrive") }
                 .tag(SettingsTab.storage)
-            UpdatesSettingsTab()
-                .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
-                .tag(SettingsTab.updates)
         }
         .frame(width: 560, height: 560)
         .padding(20)
@@ -57,55 +54,6 @@ struct SettingsView: View {
                 SettingsNavigation.shared.pendingTab = nil
             }
         }
-    }
-}
-
-// MARK: - Updates
-
-/// Settings → Updates. Shows the current version and the opt-in beta channel.
-/// The toggle writes `UpdaterViewModel.betaChannelDefaultsKey`, which the
-/// Sparkle updater delegate (`allowedChannels(for:)`) reads to decide whether
-/// to offer `<sparkle:channel>beta</sparkle:channel>` appcast items.
-private struct UpdatesSettingsTab: View {
-    @AppStorage(UpdaterViewModel.betaChannelDefaultsKey) private var betaChannel = false
-
-    private var versionString: String {
-        let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-        return "\(v) (\(b))"
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Updates")
-                .font(.title3.weight(.semibold))
-            Text("Mila checks for updates automatically and installs them with your approval. You're on version \(versionString).")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Divider()
-
-            Toggle(isOn: $betaChannel) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Enable beta version of Mila")
-                    Text("Receive pre-release builds with the newest features before they ship to everyone. Betas can be less stable. Turn this off to stay on stable releases — you'll move back to stable the next time a stable version ships.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .toggleStyle(.switch)
-            .accessibilityIdentifier("updates.beta.toggle")
-
-            Text("After enabling, choose “Check for Updates…” from the Mila menu to fetch the latest beta right away.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -250,7 +198,13 @@ private struct AudioSettingsTab: View {
 
 // MARK: - Hotkeys
 
-private struct HotkeysSettingsTab: View {
+/// Settings → General. Dictation hotkeys plus the small Updates group (auto
+/// update check + nested beta opt-in). The Updates group used to be its own
+/// tab; it was folded in here because a single toggle and a version string
+/// didn't justify a tenth tab — and the tab strip had already overflowed into
+/// AppKit's ">>" overflow chevron at that width, which is what made the
+/// Updates tab look "disabled" (see PR discussion).
+private struct GeneralSettingsTab: View {
     @EnvironmentObject private var hotkeys: HotkeySettings
 
     /// The action whose hotkey the user is currently re-recording. Nil when
@@ -300,6 +254,10 @@ private struct HotkeysSettingsTab: View {
                     .font(.callout)
                     .foregroundStyle(.red)
             }
+
+            Divider().padding(.vertical, 4)
+
+            UpdatesSettingsSection()
 
             Spacer()
         }
@@ -361,6 +319,64 @@ private struct HotkeysSettingsTab: View {
     private func resetToDefault(_ action: HotkeyAction) {
         hotkeys.resetToDefault(action)
         lastError = nil
+    }
+}
+
+/// The Updates group inside Settings → General: Sparkle's own
+/// "automatically check" preference, with the beta-channel opt-in nested
+/// underneath it, plus the running version.
+///
+/// The auto-check checkbox is bound straight through to the ONE
+/// `SPUUpdater` the app owns (via the injected `UpdaterViewModel`) — Sparkle
+/// persists that value itself, so we deliberately keep no parallel user
+/// default for it. The beta checkbox writes
+/// `UpdaterViewModel.betaChannelDefaultsKey`, which the updater delegate reads
+/// both in `allowedChannels(for:)` (channel filtering) and in
+/// `updater(_:shouldProceedWithUpdate:updateCheck:)` (the defensive
+/// pre-release guard).
+private struct UpdatesSettingsSection: View {
+    @EnvironmentObject private var updater: UpdaterViewModel
+    @AppStorage(UpdaterViewModel.betaChannelDefaultsKey) private var betaChannel = false
+
+    private var versionString: String {
+        let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(v) (\(b))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Updates")
+                .font(.title3.weight(.semibold))
+
+            Toggle("Automatically check for updates", isOn: Binding(
+                get: { updater.automaticallyChecksForUpdates },
+                set: { updater.setAutomaticallyChecksForUpdates($0) }
+            ))
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("updates.autoCheck.toggle")
+
+            // Nested under the auto-check box: the beta opt-in. Deliberately
+            // NOT disabled when auto-check is off — a user with automatic
+            // checks disabled can still opt into betas and fetch one by hand
+            // with "Check for Updates…".
+            VStack(alignment: .leading, spacing: 2) {
+                Toggle("Receive beta versions of Mila", isOn: $betaChannel)
+                    .toggleStyle(.checkbox)
+                    .accessibilityIdentifier("updates.beta.toggle")
+                Text("Receive pre-release builds with the newest features before they ship to everyone. Betas can be less stable. Turn this off to stay on stable releases — you'll move back to stable the next time a stable version ships.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.leading, 20)
+
+            Text("You're on version \(versionString). After changing these, choose “Check for Updates…” from the Mila menu to check right away.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/MilaTests/UpdaterPrereleaseGuardTests.swift
+++ b/MilaTests/UpdaterPrereleaseGuardTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Mila
+
+/// Unit tests for the client-side pre-release guard that backs
+/// `UpdaterViewModel.updater(_:shouldProceedWithUpdate:updateCheck:)`.
+///
+/// Context: `1.9.2-beta.1` was published to the appcast without
+/// `<sparkle:channel>beta</sparkle:channel>`, so channel filtering
+/// (`allowedChannels(for:)`) couldn't hide it and every user was offered a beta
+/// regardless of the opt-in. The delegate now also refuses any update whose
+/// version *looks* like a pre-release when the user hasn't opted in, so a
+/// mis-tagged feed item can't do that again.
+///
+/// `UpdaterViewModel` itself is deliberately NOT instantiated here — its `init`
+/// builds a real `SPUStandardUpdaterController` and starts Sparkle's scheduled
+/// poll. The classification logic is a pure static function precisely so it can
+/// be tested without any of that.
+final class UpdaterPrereleaseGuardTests: XCTestCase {
+
+    // MARK: - Version classification
+
+    func test_stableVersionIsNotPrerelease() {
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.9.2"))
+    }
+
+    func test_betaVersionIsPrerelease() {
+        XCTAssertTrue(UpdaterViewModel.isPrerelease("1.9.2-beta.1"))
+    }
+
+    /// Case-insensitive: the tag casing in a feed is not something the client
+    /// gets to rely on.
+    func test_uppercaseBetaVersionIsPrerelease() {
+        XCTAssertTrue(UpdaterViewModel.isPrerelease("1.9.2-BETA.2"))
+    }
+
+    func test_releaseCandidateIsPrerelease() {
+        XCTAssertTrue(UpdaterViewModel.isPrerelease("1.10.0-rc.1"))
+    }
+
+    func test_alphaIsPrerelease() {
+        XCTAssertTrue(UpdaterViewModel.isPrerelease("2.0.0-Alpha"))
+    }
+
+    /// An empty / unknown version string must never be treated as a beta —
+    /// failing closed here would block legitimate stable updates for everyone.
+    func test_emptyVersionIsNotPrerelease() {
+        XCTAssertFalse(UpdaterViewModel.isPrerelease(""))
+    }
+
+    /// The hyphen is load-bearing: a stable version that merely contains one of
+    /// the marker words is not a pre-release.
+    func test_stableVersionContainingMarkerWordIsNotPrerelease() {
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0 Alpharetta"))
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.2.3 (arcade)"))
+    }
+
+    // MARK: - Beta opt-in default
+
+    private func freshDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "UpdaterPrereleaseGuardTests.\(name)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    /// The guard only fires for users who have NOT opted in, so the default
+    /// value of the opt-in key matters: it must be false (opted out) for a
+    /// user who has never touched the checkbox.
+    func test_betaChannelOptInDefaultsToFalse() {
+        let defaults = freshDefaults()
+        XCTAssertNil(defaults.object(forKey: UpdaterViewModel.betaChannelDefaultsKey))
+        XCTAssertFalse(defaults.bool(forKey: UpdaterViewModel.betaChannelDefaultsKey))
+    }
+
+    /// Sanity-check the two halves compose the way the delegate uses them:
+    /// opted out + pre-release version means "refuse"; anything else means
+    /// "proceed". (The delegate itself reads `.standard`, which tests must not
+    /// touch, so the composition is exercised against an isolated suite here.)
+    func test_refusalConditionMatchesOptInAndVersion() {
+        let defaults = freshDefaults()
+
+        func wouldRefuse(_ version: String) -> Bool {
+            !defaults.bool(forKey: UpdaterViewModel.betaChannelDefaultsKey)
+                && UpdaterViewModel.isPrerelease(version)
+        }
+
+        // Opted out (default): betas refused, stable allowed.
+        XCTAssertTrue(wouldRefuse("1.9.2-beta.1"))
+        XCTAssertFalse(wouldRefuse("1.9.2"))
+
+        // Opted in: nothing is refused.
+        defaults.set(true, forKey: UpdaterViewModel.betaChannelDefaultsKey)
+        XCTAssertFalse(wouldRefuse("1.9.2-beta.1"))
+        XCTAssertFalse(wouldRefuse("1.9.2"))
+    }
+}

--- a/MilaTests/UpdaterPrereleaseGuardTests.swift
+++ b/MilaTests/UpdaterPrereleaseGuardTests.swift
@@ -52,6 +52,44 @@ final class UpdaterPrereleaseGuardTests: XCTestCase {
     func test_stableVersionContainingMarkerWordIsNotPrerelease() {
         XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0 Alpharetta"))
         XCTAssertFalse(UpdaterViewModel.isPrerelease("1.2.3 (arcade)"))
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0-superbeta"))
+    }
+
+    /// …and so is the *trailing* boundary. A label that merely starts with a
+    /// marker is a different, unknown token — and unknown must fail OPEN, not
+    /// get refused as a beta. Regression guard for the substring matcher that
+    /// classified `-betamax` as a pre-release.
+    func test_unknownLabelStartingWithMarkerIsNotPrerelease() {
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0-betamax"))
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0-alphabet"))
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("1.0.0-rcon"))
+        XCTAssertFalse(UpdaterViewModel.isPrerelease("2.0.0-BETAMAX"))
+    }
+
+    /// The trailing guard must not cost us real spellings: any non-letter
+    /// (including a digit) terminates the marker token.
+    func test_markerTokenTerminatorsStillMatch() {
+        for version in [
+            "1.9.2-beta",     // end of string
+            "1.9.2-beta1",    // digit
+            "1.9.2-beta.1",   // dot
+            "1.9.2-beta-1",   // hyphen
+            "1.9.2-beta+42",  // build metadata
+            "1.10.0-rc",
+            "1.10.0-rc2",
+            "2.0.0-alpha.3",
+        ] {
+            XCTAssertTrue(
+                UpdaterViewModel.isPrerelease(version),
+                "\(version) should be classified as a pre-release"
+            )
+        }
+    }
+
+    /// A string can hold both an unknown marker-prefixed label and a real
+    /// marker token; the scan must keep looking past the first near-miss.
+    func test_markerFoundAfterANearMissStillMatches() {
+        XCTAssertTrue(UpdaterViewModel.isPrerelease("1.0.0-betamax-beta.2"))
     }
 
     // MARK: - Beta opt-in default

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ running through `whisper.cpp` (GPU via Metal).
   copy/share transcript, RTL rendering for Hebrew.
 - **Auto-discard accidental clips** — very short recordings with no speech are
   dropped automatically (threshold configurable in **Settings → Storage**).
-- **Opt into pre-release builds** via **Settings → Updates**.
+- **Opt into pre-release builds** via **Settings → General → Updates**.
 
 ## System requirements
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ running through `whisper.cpp` (GPU via Metal).
 - **Dictate in two languages** with separate global hotkeys:
     - `⌘2` — English dictation (OpenAI `large-v3-turbo`)
     - `⌘3` — Hebrew dictation (ivrit.ai `large-v3`)
-  Both hotkeys are user-configurable in **Settings → Hotkeys**.
+  Both hotkeys are user-configurable in **Settings → General**.
 - **Transcribe on-device** with ivrit.ai `large-v3` (Hebrew) or OpenAI
   `large-v3-turbo` (English / multilingual). Audio never leaves your Mac.
 - **Transcribe on a remote server** — point Mila at any OpenAI-compatible


### PR DESCRIPTION
Closes #131
Closes #132

## 1. The Updates tab is gone; its contents live in General

Settings → **Updates** rendered greyed-out with an "odd expand button". That isn't a bug in the tab's content — it's tab-strip **overflow**:

`SettingsView` pins its `TabView` to `.frame(width: 560, height: 560)` while declaring 10 `tabItem`s. Measuring the labels at the 13pt system font plus icon and item padding gives **~845 pt** of tab items in a **560 pt** strip, and AppKit's `NSTabView` handles that by collapsing the trailing items into a `>>` overflow menu — which is both the "expand button" and why the last tab reads as inactive.

**This is general, not Updates-specific, and it may affect other tabs:** even at 9 tabs the strip measures **~758 pt**, so the overflow chevron does **not** disappear just because this PR removes a tab — "Storage" / "Voice Memos" will now be the ones getting collapsed. Any tab appended at the end lands in the overflow. I deliberately did **not** widen the frame here: it relayouts every single tab and I can't do visual verification in this session (see below). Worth a follow-up with a human looking at the window.

What changed:

- `UpdatesSettingsTab` deleted, along with its `TabView` entry and the `SettingsTab.updates` case. Nothing referenced the tab from UI tests.
- The former **Hotkeys** tab is renamed **General** (`gearshape`), keeping its "Dictation hotkeys" section, and gains a small **Updates** group at the bottom. A single toggle plus a version string didn't justify a tenth tab, and this keeps the count going *down* rather than up.
- README's pointer updated to "Settings → General → Updates". Historical `RELEASE_NOTES/*` left alone — they describe what shipped at the time.

## 2. The beta opt-in moved, it didn't disappear

The new Updates group has:

- **"Automatically check for updates"** — bound straight through to Sparkle's own `SPUUpdater.automaticallyChecksForUpdates` on the single `UpdaterViewModel` the app already owns (now injected into the `Settings` scene too). Sparkle persists that value itself, so there is no parallel user default and no second updater instance. Kept in sync with a KVO publisher, like the existing `canCheckForUpdates` mirror, so the checkbox also reflects changes Sparkle makes on its own.
- **"Receive beta versions of Mila"** nested/indented directly underneath, still `@AppStorage(UpdaterViewModel.betaChannelDefaultsKey)`, still defaulting to **false**, keeping the existing explanatory caption and the `updates.beta.toggle` accessibility identifier. It stays *enabled* when auto-check is off — a user with automatic checks disabled can still opt in and fetch a beta by hand with "Check for Updates…".
- The running version, `CFBundleShortVersionString (CFBundleVersion)`, as before.

## 3. Defensive guard: a mis-tagged appcast item can no longer push betas

**Incident context.** `1.9.2-beta.1` was published to the appcast **without** `<sparkle:channel>beta</sparkle:channel>`. An item with no channel element belongs to the *default* channel, so Sparkle offered it to everyone — including every user who never enabled the opt-in. The feed has been hand-fixed and the pipeline cause is being handled separately; this is the client half.

The only client gate was `allowedChannels(for:)`, and channel filtering is only as good as the feed: it can hide a beta that is *tagged*, never one that forgot the tag. So the delegate now also implements:

```swift
nonisolated func updater(_ updater: SPUUpdater,
                         shouldProceedWithUpdate updateItem: SUAppcastItem,
                         updateCheck: SPUUpdateCheck) throws
```

**Why this hook.** `SPUUpdaterDelegate.h` states that throwing here means "the user is not shown this `updateItem` nor is the update downloaded or installed" — it genuinely gates *offering* the update, and it runs for both scheduled and user-initiated checks. The alternatives don't fit: `didFindValidUpdate` is informational and fires too late; the `SPUStandardUserDriverDelegate` hooks (including the `shouldHandleShowingScheduledUpdate` one this app already uses) only choose *which UI* presents an update that has already been accepted; and `bestValidUpdateInAppcast:` is the documented-discouraged path for exactly this use case ("consider `allowedChannelsForUpdater:` instead") and would mean reimplementing Sparkle's own best-item selection.

Classification is a pure static function, `UpdaterViewModel.isPrerelease(_:)`, matching `-beta` / `-alpha` / `-rc` case-insensitively as **complete tokens, guarded on both sides**. It **fails open** on anything it can't classify — a plain `1.9.2`, an empty or unknown version string — so it can never block a legitimate stable update.

The marker needs a leading `-`, so `1.0.0 Alpharetta` or a `-superbeta` suffix isn't misread, *and* it must be followed by end-of-string or a non-letter, so an unknown label like `1.0.0-betamax` / `-alphabet` / `-rcon` stays unclassifiable and therefore allowed. The right-hand guard was added during review: the original code checked only the left side while its comment claimed both, so those three strings were classified as prereleases and **refused** — failing closed, the exact opposite of the documented contract.

A digit counts as a terminator rather than requiring a delimiter, so the common `1.9.2-beta1` and `1.10.0-rc2` spellings keep matching; requiring `.`/`-`/EOS would have introduced a worse regression than the bug being fixed. The scan also continues past a near-miss, so `1.0.0-betamax-beta.2` still classifies correctly. Both `displayVersionString` and `versionString` are checked, since a feed may only carry `sparkle:version`. Refusals are logged to the existing subsystem with a hint that the appcast item is probably missing its channel element.

`MilaTests/UpdaterPrereleaseGuardTests.swift` covers `"1.9.2"` false, `"1.9.2-beta.1"` true, `"1.9.2-BETA.2"` true, `"1.10.0-rc.1"` true, `""` false, plus an alpha case, the contains-but-no-hyphen cases, the opt-in default, and the composed refusal condition. Review added the right-boundary cases: `-betamax` / `-alphabet` / `-rcon` false, one positive per terminator (`-beta1`, `-beta.1`, `-beta-1`, bare `-beta`), and the near-miss-then-match case. It uses an isolated `UserDefaults(suiteName:)` per the repo convention and never touches `.standard`. `UpdaterViewModel` itself is never constructed in the tests — its `init` builds a real `SPUStandardUpdaterController` and starts Sparkle's poll, which is precisely why the logic was extracted as a pure static.

## Verified vs. left to CI

*(Updated after review: rebased onto `5395bb0`; CI green on the final head.)*

**Verified locally:**
- `make build` — clean.
- `xcodebuild build-for-testing -scheme Mila -destination 'platform=macOS'` — `TEST BUILD SUCCEEDED`, so the new test file and both test targets compile.
- The overflow diagnosis above was measured offline (AppKit text metrics for the tab labels), not guessed.

**NOT verified locally — CI and a human need to cover it:**
- ~~**No test was executed.**~~ **Now covered:** CI has run the full suite green on the final head, `UpdaterPrereleaseGuardTests` included.
- **No UI test was run and the app was never launched** — another agent owned the visual-verification slot on this machine and local XCUITest runs are off-limits here. So the *appearance* of the new General tab (nesting/indent of the two checkboxes, whether the added group fits the 560 pt height without clipping, and whether the overflow chevron now swallows Storage/Voice Memos) is **unconfirmed** and wants a human eyeball.
- **The Sparkle guard path was not exercised end-to-end.** It needs a real appcast serving an untagged pre-release item to observe the refusal; only the classification logic is under test.

## Conflicts

Touches the same two spots in `Mila/Views/SettingsView.swift` as #145 (`feat/unified-ai-settings-tab`, which merges the LLM and Live AI tabs into one "AI" tab): the `SettingsTab` enum and the `TabView` body. Confirmed to conflict — but only on the enum declaration line; git auto-merges the `TabView` body correctly. Resolution is to keep both changes: `case general, audio, models, ai, speakers, meetings, voiceMemos, storage`. Whichever merges second should rebase.

**Correction to the tab-strip arithmetic above.** The ~845 pt / ~758 pt figures in this PR were derived offline from AppKit text metrics and are wrong. #138 measured the real geometry from the accessibility tree: the ten items occupy a **599 pt** run, and the strip is laid out across the padded 740 pt window, not the 560 pt frame. So this PR removing one tab *would* on its own have been enough to clear the `>>` overflow — the claim above that it would not is incorrect. #138 widens the frame to 700 pt regardless, for headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update controls to **Settings → General**, including automatic update checks and beta-channel opt-in.
  * Added the current app version to the Updates section.
  * Combined general preferences, hotkeys, and update options in one tab.
* **Bug Fixes**
  * Prevented pre-release updates from being offered when beta updates are disabled.
  * Kept update preferences synchronized across the app.
* **Documentation**
  * Updated setup guidance for the new Settings navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
