### PR TITLE
docs: document beta releases / Sparkle beta channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,3 +78,21 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
   that toolchain is not part of this repository. Forks that want notarized
   builds should sign with their own Apple Developer ID and publish their own
   appcast (see `SUFeedURL` / `SUPublicEDKey` in `project.yml`).
+
+### Beta releases (Sparkle beta channel)
+- Publishing a beta takes nothing extra: set `MARKETING_VERSION` to a
+  pre-release version (e.g. `1.9.2-beta.1`), add
+  `RELEASE_NOTES/v1.9.2-beta.1.md`, and tag `v1.9.2-beta.1`. There is **no**
+  Jenkins parameter and **no** manual appcast edit.
+- Beta-ness is derived from the `MARKETING_VERSION` string by the signing
+  pipeline: a bare `X.Y.Z` becomes a normal GitHub Release with no
+  `<sparkle:channel>` (offered to everyone); any `-suffix` becomes a GitHub
+  Release with `prerelease=true` and an appcast item tagged
+  `<sparkle:channel>beta</sparkle:channel>`, offered only to users who ticked
+  Settings → Updates → "Enable beta version".
+- `beta` is the **only** channel the app's Sparkle delegate recognises
+  (`allowedChannels(for:)` in `Mila/App/MilaApp.swift` returns `["beta"]` or
+  `[]`), so `-alpha` / `-rc` versions are tagged `beta` too — there is no
+  separate alpha or rc channel.
+- An appcast item that should be a beta but is missing the channel tag is
+  offered to every user (this happened with 1.9.2-beta.1 on 2026-07-30).


### PR DESCRIPTION
## Why

The **Release Process** section of `CLAUDE.md` documents version bumping and release notes but said nothing about beta releases or the Sparkle beta channel.

On 2026-07-30, `v1.9.2-beta.1` was offered to *every* user because its appcast item lacked `<sparkle:channel>beta</sparkle:channel>`. The signing pipeline has since been fixed to derive beta-ness automatically from the `MARKETING_VERSION` string, so it's worth writing down what the (now zero-step) beta flow actually is.

## What

Adds a short `### Beta releases (Sparkle beta channel)` subsection:

- Publishing a beta = set `MARKETING_VERSION` to a pre-release version + add the matching `RELEASE_NOTES/` file + tag `vX.Y.Z-beta.N`. No Jenkins parameter, no manual appcast edit.
- Bare `X.Y.Z` → no `<sparkle:channel>`, offered to everyone; any `-suffix` → `prerelease=true` + `<sparkle:channel>beta</sparkle:channel>`, offered only to users who enabled Settings → Updates → "Enable beta version".
- `beta` is the only channel `allowedChannels(for:)` in `Mila/App/MilaApp.swift` recognises, so `-alpha` / `-rc` are tagged `beta` too.

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for publishing beta releases through the Sparkle beta channel.
  * Documented prerelease versioning, release notes, tagging, and beta-channel behavior.
  * Clarified how alpha and release-candidate versions are handled.
  * Noted that beta appcast items without a channel tag may be offered to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->