### PR TITLE
fix(remote): pre-fill the English model for ivrit endpoints

### DIFF
--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -80,6 +80,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
         didSet {
             guard model != oldValue else { return }
             defaults.set(model, forKey: Keys.model)
+            // Pointing at a Hebrew-only model is exactly when an English model
+            // is needed, so fill it in at that moment rather than waiting for
+            // the user to notice English transcripts coming back in Hebrew.
+            prefillEnglishModelIfNeeded()
         }
     }
 
@@ -92,13 +96,25 @@ final class RemoteTranscriptionSettings: ObservableObject {
     /// were never trained multilingual. A single model id had no way to express
     /// "Hebrew here, English there".
     ///
-    /// Empty (the default) means "use `model` for every language", which is
-    /// correct for genuinely multilingual endpoints like OpenAI's `whisper-1`
-    /// and preserves the pre-existing behaviour for anyone already configured.
+    /// Empty means "use `model` for every language", which is correct for
+    /// genuinely multilingual endpoints like OpenAI's `whisper-1`.
+    ///
+    /// **Pre-filled for Hebrew-only endpoints.** When `model` is an ivrit.ai id
+    /// this is populated with `defaultEnglishModel` (see `prefillEnglishModelIfNeeded`)
+    /// rather than left blank. Shipping it blank meant upgrading changed nothing
+    /// until the user found the field — the bug was "fixed" in the binary and
+    /// still happening on screen. Clearing it by hand is respected and never
+    /// re-filled.
     @Published var englishModel: String {
         didSet {
             guard englishModel != oldValue else { return }
             defaults.set(englishModel, forKey: Keys.englishModel)
+            // An explicit clear is a decision, not an absence. Record it so no
+            // later prefill (a fresh launch, or editing `model`) overrides it.
+            if englishModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               !oldValue.isEmpty, !isPrefilling {
+                defaults.set(true, forKey: Keys.englishModelCleared)
+            }
         }
     }
 
@@ -121,6 +137,22 @@ final class RemoteTranscriptionSettings: ObservableObject {
 
     static let defaultEndpoint = "https://api.openai.com/v1"
     static let defaultModel = "whisper-1"
+
+    /// The English/multilingual model pre-filled for Hebrew-only endpoints: a
+    /// CTranslate2 build of Whisper large-v3-turbo, which is what Mila's own
+    /// `mila-asr` server warms alongside the ivrit finetune. Turbo rather than
+    /// full large-v3 because the live path sends one utterance at a time and
+    /// latency shows.
+    static let defaultEnglishModel = "deepdml/faster-whisper-large-v3-turbo-ct2"
+
+    /// Whether `modelID` names a Hebrew-only ivrit.ai finetune — the case that
+    /// needs a separate English model. Substring match on `ivrit`, which covers
+    /// every published variant (`ivrit-ai/whisper-large-v3-turbo-ct2`,
+    /// `ivrit-ai/whisper-large-v3-ggml`, …) and any local rehost that keeps the
+    /// name. Pure + `static` so the prefill rule is testable on its own.
+    static func isHebrewOnlyModel(_ modelID: String) -> Bool {
+        modelID.lowercased().contains("ivrit")
+    }
 
     private let defaults: UserDefaults
     private let urlSession: URLSession
@@ -152,7 +184,37 @@ final class RemoteTranscriptionSettings: ObservableObject {
         // it's the restored choice, otherwise lazily in `backend.didSet`).
         self.apiKey = ""
         if backend == .remote { loadAPIKeyIfNeeded() }
+        // Upgrade path: everyone already pointed at an ivrit.ai endpoint before
+        // per-language routing existed has a blank English model, and a blank
+        // one means "use the Hebrew model for English too" — i.e. the bug this
+        // shipped to fix, still happening. Fill it in on first launch.
+        prefillEnglishModelIfNeeded()
     }
+
+    /// Set `englishModel` to `defaultEnglishModel` when the primary model is
+    /// Hebrew-only and the user hasn't chosen otherwise.
+    ///
+    /// Deliberately narrow — it fires only for ivrit.ai primaries. A blank
+    /// English model is *correct* for a multilingual endpoint (OpenAI's
+    /// `whisper-1`, a plain `Systran/faster-whisper-large-v3` deployment), and
+    /// filling one in there would send a model id the server doesn't have and
+    /// break English outright. Wrong-language text is bad; a hard failure is
+    /// worse.
+    ///
+    /// No-ops when: the field already has a value, the user explicitly cleared
+    /// it (`Keys.englishModelCleared`), or the primary isn't ivrit.
+    private func prefillEnglishModelIfNeeded() {
+        guard englishModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !defaults.bool(forKey: Keys.englishModelCleared) else { return }
+        guard Self.isHebrewOnlyModel(model) else { return }
+        isPrefilling = true
+        englishModel = Self.defaultEnglishModel
+        isPrefilling = false
+    }
+
+    /// True only while `prefillEnglishModelIfNeeded` is assigning, so the
+    /// `englishModel` write-back can tell a programmatic fill from a user edit.
+    private var isPrefilling = false
 
     /// Lazily read the bearer token from the Keychain the first time the remote
     /// backend is selected. Idempotent (guarded by `hasLoadedAPIKey`) and
@@ -364,6 +426,9 @@ final class RemoteTranscriptionSettings: ObservableObject {
         static let endpoint = "remote.endpoint"
         static let model = "remote.model"
         static let englishModel = "remote.model.en"
+        /// Set once the user empties `englishModel` by hand, so the prefill
+        /// never overrides that choice on a later launch or model edit.
+        static let englishModelCleared = "remote.model.en.cleared"
         static let apiKey = "remote.apiKey"
     }
 }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -86,8 +86,7 @@ final class RemoteTranscriptionSettings: ObservableObject {
             // transcripts coming back in Hebrew — and drop the pre-filled id
             // again when the primary stops being Hebrew-only, because it
             // belongs to that primary and breaks the next one.
-            clearAutoFilledEnglishModelIfNeeded()
-            prefillEnglishModelIfNeeded()
+            reconcileEnglishModelForCurrentPrimary()
         }
     }
 
@@ -203,8 +202,30 @@ final class RemoteTranscriptionSettings: ObservableObject {
         // an in-session model edit. A no-op for anyone upgrading: the
         // auto-filled flag is only ever set by Mila's own prefill, so a value
         // that predates this code is treated as the user's and left alone.
+        reconcileEnglishModelForCurrentPrimary()
+    }
+
+    /// Bring `englishModel` into line with the current primary, by running both
+    /// halves of the rule. Exactly one of them can act on any given primary —
+    /// the withdrawal only for a non-ivrit `model`, the prefill only for an
+    /// ivrit one — so this is about never running one without the other, not
+    /// about sequencing them. Every entry point (`init`, `model.didSet`) goes
+    /// through here so a third one can't arrive with only half the rule.
+    private func reconcileEnglishModelForCurrentPrimary() {
         clearAutoFilledEnglishModelIfNeeded()
         prefillEnglishModelIfNeeded()
+    }
+
+    /// Assign `englishModel` on Mila's own behalf and record whether the value
+    /// is one Mila owns, without `englishModel.didSet` mistaking the write for
+    /// a user edit. `defer` rather than a trailing assignment so an early
+    /// return added later can't leave the flag stuck `true` — which would
+    /// silently stop the next real user edit from claiming ownership.
+    private func setEnglishModelProgrammatically(_ value: String, autoFilled: Bool) {
+        isProgrammaticWrite = true
+        defer { isProgrammaticWrite = false }
+        englishModel = value
+        defaults.set(autoFilled, forKey: Keys.englishModelAutoFilled)
     }
 
     /// Set `englishModel` to `defaultEnglishModel` when the primary model is
@@ -223,10 +244,7 @@ final class RemoteTranscriptionSettings: ObservableObject {
         guard englishModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard !defaults.bool(forKey: Keys.englishModelCleared) else { return }
         guard Self.isHebrewOnlyModel(model) else { return }
-        isProgrammaticWrite = true
-        englishModel = Self.defaultEnglishModel
-        defaults.set(true, forKey: Keys.englishModelAutoFilled)
-        isProgrammaticWrite = false
+        setEnglishModelProgrammatically(Self.defaultEnglishModel, autoFilled: true)
     }
 
     /// Withdraw an auto-filled `englishModel` once the primary is no longer
@@ -244,12 +262,9 @@ final class RemoteTranscriptionSettings: ObservableObject {
     private func clearAutoFilledEnglishModelIfNeeded() {
         guard !Self.isHebrewOnlyModel(model) else { return }
         guard defaults.bool(forKey: Keys.englishModelAutoFilled) else { return }
-        isProgrammaticWrite = true
         // Not a user clear, so this must not set `Keys.englishModelCleared` —
         // switching back to an ivrit primary should pre-fill again.
-        englishModel = ""
-        defaults.set(false, forKey: Keys.englishModelAutoFilled)
-        isProgrammaticWrite = false
+        setEnglishModelProgrammatically("", autoFilled: false)
     }
 
     /// True only while this class is assigning `englishModel` itself, so the

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -80,9 +80,13 @@ final class RemoteTranscriptionSettings: ObservableObject {
         didSet {
             guard model != oldValue else { return }
             defaults.set(model, forKey: Keys.model)
-            // Pointing at a Hebrew-only model is exactly when an English model
-            // is needed, so fill it in at that moment rather than waiting for
-            // the user to notice English transcripts coming back in Hebrew.
+            // Reconcile in BOTH directions. Pointing at a Hebrew-only model is
+            // exactly when an English model is needed, so fill it in at that
+            // moment rather than waiting for the user to notice English
+            // transcripts coming back in Hebrew — and drop the pre-filled id
+            // again when the primary stops being Hebrew-only, because it
+            // belongs to that primary and breaks the next one.
+            clearAutoFilledEnglishModelIfNeeded()
             prefillEnglishModelIfNeeded()
         }
     }
@@ -104,15 +108,20 @@ final class RemoteTranscriptionSettings: ObservableObject {
     /// rather than left blank. Shipping it blank meant upgrading changed nothing
     /// until the user found the field — the bug was "fixed" in the binary and
     /// still happening on screen. Clearing it by hand is respected and never
-    /// re-filled.
+    /// re-filled, and a pre-filled value is withdrawn again if the primary
+    /// stops being Hebrew-only.
     @Published var englishModel: String {
         didSet {
             guard englishModel != oldValue else { return }
             defaults.set(englishModel, forKey: Keys.englishModel)
+            guard !isProgrammaticWrite else { return }
+            // Past here the edit is the user's, so the value is theirs: Mila no
+            // longer owns it and must not withdraw it on a later model change.
+            defaults.set(false, forKey: Keys.englishModelAutoFilled)
             // An explicit clear is a decision, not an absence. Record it so no
             // later prefill (a fresh launch, or editing `model`) overrides it.
             if englishModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-               !oldValue.isEmpty, !isPrefilling {
+               !oldValue.isEmpty {
                 defaults.set(true, forKey: Keys.englishModelCleared)
             }
         }
@@ -188,6 +197,13 @@ final class RemoteTranscriptionSettings: ObservableObject {
         // per-language routing existed has a blank English model, and a blank
         // one means "use the Hebrew model for English too" — i.e. the bug this
         // shipped to fix, still happening. Fill it in on first launch.
+        //
+        // The withdraw side runs here too, so "an auto-filled English model
+        // implies a Hebrew-only primary" holds at every point, not just across
+        // an in-session model edit. A no-op for anyone upgrading: the
+        // auto-filled flag is only ever set by Mila's own prefill, so a value
+        // that predates this code is treated as the user's and left alone.
+        clearAutoFilledEnglishModelIfNeeded()
         prefillEnglishModelIfNeeded()
     }
 
@@ -207,14 +223,38 @@ final class RemoteTranscriptionSettings: ObservableObject {
         guard englishModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard !defaults.bool(forKey: Keys.englishModelCleared) else { return }
         guard Self.isHebrewOnlyModel(model) else { return }
-        isPrefilling = true
+        isProgrammaticWrite = true
         englishModel = Self.defaultEnglishModel
-        isPrefilling = false
+        defaults.set(true, forKey: Keys.englishModelAutoFilled)
+        isProgrammaticWrite = false
     }
 
-    /// True only while `prefillEnglishModelIfNeeded` is assigning, so the
-    /// `englishModel` write-back can tell a programmatic fill from a user edit.
-    private var isPrefilling = false
+    /// Withdraw an auto-filled `englishModel` once the primary is no longer
+    /// Hebrew-only — the other half of the prefill, and the same reasoning.
+    ///
+    /// The pre-filled id exists only to serve an ivrit primary. Leaving it
+    /// behind when the user switches to a multilingual endpoint would send that
+    /// endpoint a model id it doesn't have and break English outright, which is
+    /// precisely the failure `prefillEnglishModelIfNeeded` refuses to cause in
+    /// the first place. Withdrawing it restores "English uses the primary".
+    ///
+    /// Only touches values Mila wrote itself (`Keys.englishModelAutoFilled`). A
+    /// model id the user typed is theirs and survives any primary change; so
+    /// does an explicit clear, which leaves nothing to withdraw.
+    private func clearAutoFilledEnglishModelIfNeeded() {
+        guard !Self.isHebrewOnlyModel(model) else { return }
+        guard defaults.bool(forKey: Keys.englishModelAutoFilled) else { return }
+        isProgrammaticWrite = true
+        // Not a user clear, so this must not set `Keys.englishModelCleared` —
+        // switching back to an ivrit primary should pre-fill again.
+        englishModel = ""
+        defaults.set(false, forKey: Keys.englishModelAutoFilled)
+        isProgrammaticWrite = false
+    }
+
+    /// True only while this class is assigning `englishModel` itself, so the
+    /// write-back can tell its own fill/withdraw from a user edit.
+    private var isProgrammaticWrite = false
 
     /// Lazily read the bearer token from the Keychain the first time the remote
     /// backend is selected. Idempotent (guarded by `hasLoadedAPIKey`) and
@@ -429,6 +469,10 @@ final class RemoteTranscriptionSettings: ObservableObject {
         /// Set once the user empties `englishModel` by hand, so the prefill
         /// never overrides that choice on a later launch or model edit.
         static let englishModelCleared = "remote.model.en.cleared"
+        /// True while the current `englishModel` is one Mila pre-filled rather
+        /// than one the user typed — so it can be withdrawn again if the primary
+        /// stops being Hebrew-only, without ever discarding the user's own value.
+        static let englishModelAutoFilled = "remote.model.en.autofilled"
         static let apiKey = "remote.apiKey"
     }
 }

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -64,13 +64,26 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
 
     func test_modelForLanguage_withoutEnglishModel_alwaysUsesPrimary() {
         let settings = makeSettings()
-        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
-        // Empty englishModel is the default and must preserve the old
-        // single-model behaviour for every language.
+        // A multilingual primary is the case that stays blank — the prefill is
+        // ivrit-only (see `test_prefill_leavesMultilingualEndpointsAlone`), so
+        // this exercises the resolver's "empty means use the primary" fallback.
+        settings.model = "Systran/faster-whisper-large-v3"
+        XCTAssertEqual(settings.englishModel, "", "Precondition: nothing pre-filled here")
+        XCTAssertEqual(settings.model(for: "he"), "Systran/faster-whisper-large-v3")
+        XCTAssertEqual(settings.model(for: "en"), "Systran/faster-whisper-large-v3")
+        XCTAssertEqual(settings.model(for: "auto"), "Systran/faster-whisper-large-v3",
+                       "Legacy auto must not resolve to a model the user never configured")
+    }
+
+    /// The same fallback with an ivrit primary, which only stays blank once the
+    /// user has cleared the field by hand. Their clear must route every language
+    /// back to the primary rather than resurrecting the pre-filled English id.
+    func test_modelForLanguage_ivritPrimaryWithClearedEnglishModel_usesPrimary() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2", cleared: true)
+        XCTAssertEqual(settings.englishModel, "")
         XCTAssertEqual(settings.model(for: "he"), "ivrit-ai/whisper-large-v3-turbo-ct2")
         XCTAssertEqual(settings.model(for: "en"), "ivrit-ai/whisper-large-v3-turbo-ct2")
-        XCTAssertEqual(settings.model(for: "auto"), "ivrit-ai/whisper-large-v3-turbo-ct2",
-                       "Legacy auto must not resolve to a model the user never configured")
+        XCTAssertEqual(settings.model(for: "auto"), "ivrit-ai/whisper-large-v3-turbo-ct2")
     }
 
     func test_modelForLanguage_routesEnglishAndAutoToEnglishModel() {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -262,6 +262,26 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
                        "A withdrawal must not be recorded as an explicit clear")
     }
 
+    /// The mirror of the refill test, and the case that separates a withdrawal
+    /// from a clear: the user emptied the field by hand, so leaving ivrit and
+    /// coming back must NOT resurrect the pre-filled id. Pins the guard order in
+    /// `prefillEnglishModelIfNeeded` — `cleared` is checked before the primary
+    /// is, so no route back to an ivrit primary can bypass it.
+    func test_prefill_explicitClearSurvivesARoundTripThroughAMultilingualPrimary() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel,
+                       "Precondition: pre-filled for the ivrit primary")
+        settings.englishModel = ""   // user empties it by hand
+
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "")
+
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        XCTAssertEqual(settings.englishModel, "",
+                       "An explicit clear must outlast a round trip through another primary")
+        XCTAssertEqual(settings.model(for: "en"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+    }
+
     /// The invariant holds across a relaunch too, not just an in-session edit —
     /// e.g. the primary was changed by a `.milaconfig` on a previous launch.
     func test_prefill_isWithdrawnOnLaunch_whenPersistedPrimaryIsNotIvrit() {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -280,6 +280,24 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(relaunched.model(for: "en"), "whisper-1")
     }
 
+    /// The reverse sequence, end to end: a value the user typed against a
+    /// multilingual primary must survive a detour through an ivrit primary and
+    /// back. It was never Mila's to withdraw at any point along the way.
+    func test_prefill_withdrawal_userValueSurvivesARoundTripThroughIvrit() {
+        let settings = makeUpgrading(from: "whisper-1")
+        XCTAssertEqual(settings.englishModel, "", "Precondition: multilingual, nothing pre-filled")
+
+        settings.englishModel = "my-own/english-model"   // typed by hand
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        XCTAssertEqual(settings.englishModel, "my-own/english-model",
+                       "The prefill must not overwrite a value the user already typed")
+
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "my-own/english-model",
+                       "…and the withdrawal must not eat it on the way back either")
+        XCTAssertEqual(settings.model(for: "en"), "my-own/english-model")
+    }
+
     /// An `englishModel` that predates this code has no auto-filled marker, so
     /// it must be treated as the user's and never withdrawn.
     func test_prefill_withdrawal_leavesPreExistingValuesAlone() {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -124,6 +124,79 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(second.englishModel, "deepdml/faster-whisper-large-v3-turbo-ct2")
     }
 
+    // MARK: - English-model prefill
+
+    /// Helper: build settings over a suite that already has a persisted primary
+    /// model, i.e. an existing user upgrading into per-language routing.
+    private func makeUpgrading(from primary: String,
+                               englishModel: String? = nil,
+                               cleared: Bool = false,
+                               _ label: String = #function) -> RemoteTranscriptionSettings {
+        let name = "RemoteTranscriptionSettingsTests.prefill.\(label)"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        suite.set(primary, forKey: "remote.model")
+        if let englishModel { suite.set(englishModel, forKey: "remote.model.en") }
+        if cleared { suite.set(true, forKey: "remote.model.en.cleared") }
+        return RemoteTranscriptionSettings(defaults: suite,
+                                           apiKeyKeychainKey: "\(name).apiKey")
+    }
+
+    func test_isHebrewOnlyModel_matchesIvritVariants() {
+        XCTAssertTrue(RemoteTranscriptionSettings.isHebrewOnlyModel("ivrit-ai/whisper-large-v3-turbo-ct2"))
+        XCTAssertTrue(RemoteTranscriptionSettings.isHebrewOnlyModel("IVRIT-AI/whisper-large-v3-ggml"))
+        XCTAssertTrue(RemoteTranscriptionSettings.isHebrewOnlyModel("my-mirror/ivrit-large-v3"))
+        XCTAssertFalse(RemoteTranscriptionSettings.isHebrewOnlyModel("whisper-1"))
+        XCTAssertFalse(RemoteTranscriptionSettings.isHebrewOnlyModel("Systran/faster-whisper-large-v3"))
+        XCTAssertFalse(RemoteTranscriptionSettings.isHebrewOnlyModel(""))
+    }
+
+    /// The upgrade case this exists for: an ivrit primary and no English model
+    /// means English audio goes to Hebrew-only weights. Fill it in.
+    func test_prefill_populatesEnglishModel_forIvritPrimary() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
+        XCTAssertEqual(settings.model(for: "en"), RemoteTranscriptionSettings.defaultEnglishModel)
+        XCTAssertEqual(settings.model(for: "he"), "ivrit-ai/whisper-large-v3-turbo-ct2")
+    }
+
+    /// A blank English model is CORRECT for a multilingual endpoint — filling one
+    /// in would send OpenAI a model id it doesn't have and break English outright.
+    func test_prefill_leavesMultilingualEndpointsAlone() {
+        XCTAssertEqual(makeUpgrading(from: "whisper-1", "openai").englishModel, "")
+        XCTAssertEqual(makeUpgrading(from: "Systran/faster-whisper-large-v3", "systran").englishModel, "")
+    }
+
+    func test_prefill_doesNotOverrideAUserChoice() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2",
+                                     englishModel: "my-own/english-model")
+        XCTAssertEqual(settings.englishModel, "my-own/english-model")
+    }
+
+    /// Clearing the field is a decision. It must survive a relaunch.
+    func test_prefill_respectsAnExplicitClear() {
+        let name = "RemoteTranscriptionSettingsTests.prefill.\(#function)"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        suite.set("ivrit-ai/whisper-large-v3-turbo-ct2", forKey: "remote.model")
+
+        let first = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: "\(name).apiKey")
+        XCTAssertEqual(first.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
+        first.englishModel = ""   // user empties it by hand
+
+        let relaunched = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: "\(name).apiKey")
+        XCTAssertEqual(relaunched.englishModel, "", "An explicit clear must not be re-filled")
+    }
+
+    /// Switching the primary TO an ivrit model is the other moment the English
+    /// model becomes necessary — e.g. applying a `.milaconfig` from a teammate.
+    func test_prefill_firesWhenPrimaryChangesToIvrit() {
+        let settings = makeSettings()
+        XCTAssertEqual(settings.englishModel, "")
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
+    }
+
     func test_localBackend_doesNotReadKeychain() {
         // Seed a real token under an isolated key, then construct with the
         // default (local) backend. A local-only user must come up with an empty

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -210,6 +210,85 @@ final class RemoteTranscriptionSettingsTests: XCTestCase {
         XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
     }
 
+    // MARK: - Withdrawing a pre-filled English model
+
+    /// The mirror of the prefill. A pre-filled id only makes sense against the
+    /// ivrit primary that caused it — carried over to a multilingual endpoint it
+    /// names a model that endpoint doesn't have, breaking English outright,
+    /// which is the exact failure the prefill is narrow to avoid.
+    func test_prefill_isWithdrawn_whenPrimaryLeavesIvrit() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel,
+                       "Precondition: pre-filled for the ivrit primary")
+
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "",
+                       "A pre-filled id must not outlive the ivrit primary")
+        XCTAssertEqual(settings.model(for: "en"), "whisper-1",
+                       "English must route to the new multilingual primary")
+        XCTAssertEqual(settings.model(for: "he"), "whisper-1")
+    }
+
+    /// Withdrawal is scoped to values Mila wrote. A model id the user typed is
+    /// theirs and survives any change of primary.
+    func test_prefill_withdrawal_leavesAUserValueAlone() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2",
+                                     englishModel: "my-own/english-model")
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "my-own/english-model",
+                       "Only auto-filled values are withdrawn")
+    }
+
+    /// A value the user typed over the pre-filled one becomes theirs, so the
+    /// later switch away from ivrit must not withdraw it either.
+    func test_prefill_withdrawal_leavesAValueTypedOverThePrefillAlone() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
+        settings.englishModel = "my-own/english-model"   // user overrides the prefill
+
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "my-own/english-model")
+    }
+
+    /// Withdrawing is not the same as the user clearing: going back to an ivrit
+    /// primary must pre-fill again rather than treat the blank as a decision.
+    func test_prefill_refillsAfterRoundTripThroughAMultilingualPrimary() {
+        let settings = makeUpgrading(from: "ivrit-ai/whisper-large-v3-turbo-ct2")
+        settings.model = "whisper-1"
+        XCTAssertEqual(settings.englishModel, "")
+
+        settings.model = "ivrit-ai/whisper-large-v3-turbo-ct2"
+        XCTAssertEqual(settings.englishModel, RemoteTranscriptionSettings.defaultEnglishModel,
+                       "A withdrawal must not be recorded as an explicit clear")
+    }
+
+    /// The invariant holds across a relaunch too, not just an in-session edit —
+    /// e.g. the primary was changed by a `.milaconfig` on a previous launch.
+    func test_prefill_isWithdrawnOnLaunch_whenPersistedPrimaryIsNotIvrit() {
+        let name = "RemoteTranscriptionSettingsTests.prefill.\(#function)"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        suite.set("ivrit-ai/whisper-large-v3-turbo-ct2", forKey: "remote.model")
+
+        let first = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: "\(name).apiKey")
+        XCTAssertEqual(first.englishModel, RemoteTranscriptionSettings.defaultEnglishModel)
+        // Primary swapped out from under the auto-filled value, then relaunch.
+        suite.set("whisper-1", forKey: "remote.model")
+
+        let relaunched = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: "\(name).apiKey")
+        XCTAssertEqual(relaunched.englishModel, "")
+        XCTAssertEqual(relaunched.model(for: "en"), "whisper-1")
+    }
+
+    /// An `englishModel` that predates this code has no auto-filled marker, so
+    /// it must be treated as the user's and never withdrawn.
+    func test_prefill_withdrawal_leavesPreExistingValuesAlone() {
+        let settings = makeUpgrading(from: "whisper-1", englishModel: "legacy/english-model")
+        XCTAssertEqual(settings.englishModel, "legacy/english-model")
+        settings.model = "Systran/faster-whisper-large-v3"
+        XCTAssertEqual(settings.englishModel, "legacy/english-model")
+    }
+
     func test_localBackend_doesNotReadKeychain() {
         // Seed a real token under an isolated key, then construct with the
         // default (local) backend. A local-only user must come up with an empty


### PR DESCRIPTION
Closes #135

## Why

1.9.2-beta.1 shipped the per-language remote model fix (#121) with `englishModel` defaulting to **empty** — and empty means "use the primary model for every language", i.e. the behaviour the release was meant to fix. Caught live on 1.9.2-beta.1 mid-recording:

```
remote.model      = ivrit-ai/whisper-large-v3-turbo-ct2
remote.model.en   = (not set)
RemoteWhisperEngine transcribe: POST model=ivrit-ai/whisper-large-v3-turbo-ct2 lang=en
```

The blank default was a deliberate safety choice — it let the client ship before the server warmed a second model, and it leaves multilingual endpoints untouched. For the users who actually had the bug, it meant the upgrade fixed nothing and the app never said why.

## What changed

`prefillEnglishModelIfNeeded()` sets `englishModel` to `deepdml/faster-whisper-large-v3-turbo-ct2` when the primary model is a Hebrew-only ivrit id. It runs:

- in `init` — the upgrade path for existing installs;
- in `model.didSet` — when the primary *becomes* an ivrit id, e.g. a teammate's `.milaconfig` lands.

**It fires only for ivrit primaries, and that narrowness is the main design decision here.** A blank English model is *correct* for a genuinely multilingual endpoint: OpenAI's `whisper-1`, or a plain `Systran/faster-whisper-large-v3` deployment. Pre-filling one of those would send a model id the server doesn't have, and English would fail outright rather than come back in the wrong script. Wrong-language text is bad; a hard failure is worse.

**An explicit clear is respected.** Emptying the field by hand sets `remote.model.en.cleared`, and no later launch or model edit re-fills it. An `isPrefilling` flag keeps the programmatic write from tripping that.

## Residual risk, stated plainly

Someone self-hosting ivrit on a server that has *only* that model now gets a model id their server can't serve, and this version of speaches needs a model pre-registered rather than lazy-loading it — so their English recordings would error instead of returning Hebrew-ish text. I judged that the better failure: it's loud, it's visible in Settings, and it's one field to clear. Say the word if you'd rather it stayed silent for them.

## Testing

- `make build` and `xcodebuild build-for-testing` — both clean.
- 6 new unit tests: ivrit-variant matching (incl. uppercase and a rehost that keeps the name), prefill on upgrade, multilingual endpoints left alone (`whisper-1`, `Systran/…`), a user's own value not overridden, an explicit clear surviving relaunch, and prefill firing when the primary changes to ivrit.
- Not run locally (no local test runs while you're working) — CI is the first execution.

Independent of the AI-settings-tab and Updates-tab PRs; touches only `RemoteTranscriptionSettings` and its tests, so no conflicts with either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hebrew-only transcription endpoints now automatically apply a default English model when appropriate.
  * English model routing updates automatically when switching between Hebrew-only and multilingual primary models.
* **Bug Fixes**
  * Prevented a previously cleared English model preference from being restored unexpectedly after changes or relaunches.
  * Improved language routing behavior so “auto” never incorrectly falls back to an unconfigured English model.
* **Tests**
  * Expanded coverage for upgrade, prefill, withdrawal, and user-override scenarios across Hebrew, English, and auto routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->