### PR TITLE
fix(settings): widen the Settings window so every tab stays visible

### DIFF
--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -49,7 +49,26 @@ struct SettingsView: View {
                 .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
                 .tag(SettingsTab.updates)
         }
-        .frame(width: 560, height: 560)
+        // The width is load-bearing: it has to hold the whole tab strip.
+        // AppKit's NSTabView collapses whatever doesn't fit into a `>>`
+        // overflow menu, which reads as a stray "expand button" and makes
+        // the collapsed tabs look disabled (reported in #131, fixed here
+        // per #137).
+        //
+        // Measured on macOS 26 at the default system font: the ten tab
+        // items occupy a 599 pt run (widest single item — "Voice Memos" —
+        // is 82 pt).
+        //
+        // The strip is NOT laid out inside this 700 pt frame. `.padding(20)`
+        // below sizes the Settings window to 740 pt, and AppKit draws the
+        // tab strip edge-to-edge across the whole window, so the run has the
+        // full 740 pt to sit in — measured item origins are 70 pt from the
+        // left window edge and 71 pt from the right. That is why 560 failed:
+        // it gave the strip 600 pt for a 599 pt run.
+        //
+        // If you add a tab, re-check Settings for the `>>` chevron rather
+        // than assuming it still fits.
+        .frame(width: 700, height: 560)
         .padding(20)
         .onChange(of: SettingsNavigation.shared.pendingTab, initial: true) { _, newTab in
             if let tab = newTab {


### PR DESCRIPTION
Closes #137

## What was wrong

`SettingsView` pinned its `TabView` to `.frame(width: 560, height: 560)` while carrying 10 tab items. AppKit's `NSTabView` collapses whatever doesn't fit into a `>>` overflow menu — that chevron is the "odd expand button" from #131, and it's why the collapsed trailing tab reads as disabled.

#131 diagnosed this and #133 folded the Updates tab into General, but deliberately left the width alone pending visual verification. This is that follow-up.

## Measurement (this corrects #131's estimate)

I built the app with a deliberately over-wide frame and read each tab item's frame out of the accessibility tree, on macOS 26 at the default system font:

| tab | width (pt) |
|---|---|
| Hotkeys | 55 |
| Audio | 55 |
| Models | 55 |
| LLM | 55 |
| Speakers | 60 |
| Meetings | 60 |
| Live AI | 55 |
| Voice Memos | 82 |
| Storage | 55 |
| Updates | 56 |

The items lay out contiguously, so the strip needs a **599 pt** run. The strip is given the frame width *plus* the 40 pt from the `.padding(20)` on the same view — so `width: 560` offers ~600 pt for a 599 pt run and the tenth item collapses.

**#131 put this at ~845 pt (10 tabs) / ~758 pt (9 tabs), derived offline from AppKit text metrics; the real figure is 599 pt.** Two consequences worth noting: the fix is a far smaller widening than that issue implied, and — contrary to #131 — removing one tab *would* have cleared the overflow on its own.

## The change

One constant, 560 → **700**, plus a comment recording the measurement and the "re-check if you add a tab" constraint.

700 fits the 599 pt run with ~70 pt of margin per side, i.e. headroom for about one more average-width tab. I did not go to the 780–800 pt that #131's estimate suggested: tab content is left-aligned with inner max widths around 360 pt, so the extra width is pure dead whitespace.

**Relationship to #117**, which proposes `640` for this same bug: by the measurement above 640 also clears the overflow (680 pt available vs. a 599 pt run), just with ~40 pt less headroom. Either value fixes the reported problem — if you'd rather land #117, this PR is redundant apart from the comment and the corrected numbers. Whichever lands, the other should close.

**Pending tab-set changes stay inside 700**, since both *shrink* the strip: #133 renames Hotkeys → General and drops Updates (~544 pt), and `feat/unified-ai-settings-tab` replaces LLM + Live AI with one AI tab. Combined they land near ~480 pt. (That branch currently has no commits on it, so I compared against its description rather than its code.)

## Verification

`make build` clean. No tests were run — this is a layout constant, and local UI-test runs are off-limits on this machine.

Visual verification, debug build launched and Settings driven via the accessibility API, window pinned to a fixed origin and captured per-tab:

- **Before, at 560:** reproduced exactly — 9 tabs visible (Hotkeys…Storage) plus the `>>` chevron, with Updates collapsed into it.
- **After, at 700:** all 10 tabs visible, no chevron.
- **Per-tab content checked at 700, no stretching or clipping:** Hotkeys, Audio, Models, LLM, Speakers, Meetings, Live AI, Voice Memos. Wide controls (text fields on Models/LLM, the Live AI prompt editor) simply follow the window width as they already did; the fixed-width label columns are unaffected. LLM and Live AI still scroll vertically, unchanged by this PR.
- **Not visually checked:** the **Storage** and **Updates** tab *content* at 700 pt — I was asked to stop driving the app locally before I captured those two. Both are visible and clickable in the strip (that's the actual fix, and it is confirmed); only their body layout is unverified, and neither has wide or fixed-width content. Worth a glance by whoever reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Settings tab layout to reduce the likelihood of tabs collapsing into an overflow menu.
  * Increased the available tab-strip width for a more consistent appearance on macOS.
  * Improved the display of Settings tabs within the available window space. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->