### PR TITLE
fix(audio): recover capture when the input device changes mid-recording

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -567,9 +567,12 @@ final class QuickActionsController: ObservableObject {
         // the wall clock is a claim the user can't act on — the diagnostic
         // report that prompted this showed a 26:24 row whose audio was 24
         // seconds long, because `max()` always let the timer win. Fall back to
-        // the wall clock only when the file can't be read at all.
-        let capturedDuration = audioDuration(at: outputURL)
-        let duration = capturedDuration > 0 ? capturedDuration : durationBeforeStop
+        // the wall clock only when the file can't be decoded at all — a
+        // readable file reporting zero frames is a real answer, not a failure
+        // to measure, and must not be re-inflated to the full wall clock.
+        let decodedDuration = audioDuration(at: outputURL)
+        let capturedDuration = decodedDuration ?? 0
+        let duration = decodedDuration ?? durationBeforeStop
         let (title, source, appName): (String, RecordingSource, String?) = {
             switch captured {
             case .recordingMic:
@@ -1203,8 +1206,16 @@ final class QuickActionsController: ObservableObject {
         return "\(prefix) · \(f.string(from: Date()))"
     }
 
-    private func audioDuration(at url: URL) -> Double {
-        guard let file = try? AVAudioFile(forReading: url) else { return 0 }
+    /// Length of the audio actually on disk, or `nil` if the file can't be
+    /// decoded at all.
+    ///
+    /// The optional matters: a readable WAV containing zero frames is a real
+    /// answer ("we captured nothing"), and must not be confused with "we
+    /// couldn't tell". Returning 0 for both let a completely empty recording
+    /// fall back to the wall clock and be saved at full length — the exact
+    /// lie this change set out to remove.
+    private func audioDuration(at url: URL) -> Double? {
+        guard let file = try? AVAudioFile(forReading: url) else { return nil }
         return Double(file.length) / file.processingFormat.sampleRate
     }
 }

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -562,7 +562,14 @@ final class QuickActionsController: ObservableObject {
             activeJob = .none
             return
         }
-        let duration = max(durationBeforeStop, audioDuration(at: outputURL))
+        // Prefer what's actually on disk over the wall clock. For a healthy
+        // recording the two agree; when they don't, the file is the truth and
+        // the wall clock is a claim the user can't act on — the diagnostic
+        // report that prompted this showed a 26:24 row whose audio was 24
+        // seconds long, because `max()` always let the timer win. Fall back to
+        // the wall clock only when the file can't be read at all.
+        let capturedDuration = audioDuration(at: outputURL)
+        let duration = capturedDuration > 0 ? capturedDuration : durationBeforeStop
         let (title, source, appName): (String, RecordingSource, String?) = {
             switch captured {
             case .recordingMic:
@@ -594,6 +601,21 @@ final class QuickActionsController: ObservableObject {
         if source == .microphone, session.lastMicFrameCount == 0 {
             transcription.lastError = "Microphone captured no audio. Check System Settings ▸ Privacy & Security ▸ Microphone, and that the input selected in Settings ▸ Audio Input isn't muted, disconnected, or in use by another app."
             quickActionsLog.error("mic-only recording captured 0 frames — surfaced audio-input guidance to the user")
+        }
+
+        // Capture that died PART way through used to be completely silent: the
+        // row showed the full wall-clock length and the transcript just stopped
+        // early, so a lost meeting looked like a bad transcription. Say it out
+        // loud instead. `transcription.lastError` is only set when nothing more
+        // specific claimed it (the 0-frame case above is strictly better
+        // guidance for its own situation).
+        if Self.capturedAudioFellShort(source: source,
+                                       wallClock: durationBeforeStop,
+                                       captured: capturedDuration) {
+            quickActionsLog.error("captured only \(capturedDuration, privacy: .public)s of audio for a \(durationBeforeStop, privacy: .public)s recording (source=\(source.rawValue, privacy: .public), micRebuilds=\(self.session.mic.restartCount, privacy: .public)) — capture died mid-session")
+            if transcription.lastError == nil {
+                transcription.lastError = "Only \(formatDuration(capturedDuration)) of audio was captured for a \(formatDuration(durationBeforeStop)) recording — capture stopped early. This usually means the input device changed or went away mid-recording (headphones unplugged, a USB mic removed, or another app taking over the device). Pinning a specific input in Settings ▸ Audio Input makes it less likely."
+            }
         }
 
         // ---- IMMEDIATE: build a tentative Recording from whatever
@@ -1127,6 +1149,36 @@ final class QuickActionsController: ObservableObject {
             try? await Task.sleep(nanoseconds: pollNs)
         }
         return !Task.isCancelled
+    }
+
+    /// Wall-clock length a recording must reach before a short-capture warning
+    /// is worth showing. Below this, the gap between "time the engine was up"
+    /// and "audio on disk" is dominated by bring-up and teardown latency, and
+    /// warning would just be noise on every quick voice memo.
+    nonisolated static let shortCaptureMinimumWallClock: TimeInterval = 30
+    /// Fraction of the wall clock that must make it to disk. 0.8 tolerates
+    /// normal bring-up/teardown loss and a rebuild or two, while still
+    /// catching the real failure (24s of a 1584s recording = 1.5%).
+    nonisolated static let shortCaptureRatio: Double = 0.8
+
+    /// Whether a finished recording captured far less audio than the user
+    /// spent recording — i.e. capture died part way through.
+    ///
+    /// `.systemAudio` is exempt: ScreenCaptureKit only delivers buffers while
+    /// something is actually playing, so a short file there is expected rather
+    /// than a fault. Mic and meeting sources both have the mic as a continuous
+    /// clock, so their file length should track the wall clock closely.
+    ///
+    /// Pure, static and `nonisolated` so the policy can be unit tested without
+    /// a recording, an audio device, or a hop to the main actor.
+    nonisolated static func capturedAudioFellShort(source: RecordingSource,
+                                                   wallClock: TimeInterval,
+                                                   captured: TimeInterval) -> Bool {
+        guard source == .microphone || source == .meeting else { return false }
+        // captured == 0 is a different failure with its own, better message
+        // (and its own log line) — don't double up on it here.
+        guard captured > 0, wallClock >= shortCaptureMinimumWallClock else { return false }
+        return captured < wallClock * shortCaptureRatio
     }
 
     // MARK: - Helpers

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -167,6 +167,14 @@ final class MicrophoneRecorder: ObservableObject {
     /// both deciding to rebuild at the same moment.
     private var isRebuilding = false
 
+    /// Bumped by every `start()` and `stop()`. A rebuild captures the value it
+    /// began with, because `isRunning` alone cannot tell "my session is still
+    /// live" from "a *later* session is". A stop → start cycle inside a
+    /// rebuild's bring-up (up to `bringUpTimeout`) would otherwise let the
+    /// stale rebuild install its engine over the new session's — leaking a
+    /// running engine, and with it a permanently hot microphone.
+    private var captureEpoch = 0
+
     /// Smoothed digital gain applied to every captured float frame before
     /// it's yielded to consumers. Built fresh on each `start()` so a low-
     /// volume mic doesn't inherit a stale gain from a previous session.
@@ -216,6 +224,7 @@ final class MicrophoneRecorder: ObservableObject {
 
         restartCount = 0
         isRebuilding = false
+        captureEpoch += 1
 
         if let override = bringUpOverride {
             try await Self.withTimeout(seconds: bringUpTimeout) {
@@ -394,7 +403,12 @@ final class MicrophoneRecorder: ObservableObject {
         isRebuilding = true
         restartCount += 1
         let attempt = restartCount
-        defer { isRebuilding = false }
+        let epoch = captureEpoch
+        // Only clear the flag if this rebuild still belongs to the live
+        // session: a stale one finishing late must not clear a *new* session's
+        // in-flight rebuild. `start()` resets the flag itself, so nothing is
+        // left stuck.
+        defer { if captureEpoch == epoch { isRebuilding = false } }
 
         let old = engine
         engine = nil
@@ -429,8 +443,11 @@ final class MicrophoneRecorder: ObservableObject {
             // headphones just died. Adopting the engine now would hand it to a
             // session that no longer exists: nothing would ever tear it down,
             // and the microphone would stay hot for the rest of the process.
-            guard isRunning else {
-                micLog.error("mic rebuild #\(attempt, privacy: .public) finished after the recording ended — tearing down the orphaned engine")
+            // The epoch check covers the nastier variant — a whole stop/start
+            // cycle during the bring-up, where `isRunning` is true again but
+            // belongs to a different recording with its own live engine.
+            guard isRunning, captureEpoch == epoch else {
+                micLog.error("mic rebuild #\(attempt, privacy: .public) finished after its session ended — tearing down the orphaned engine")
                 let orphan = result.engine
                 await Task.detached(priority: .userInitiated) {
                     orphan.inputNode.removeTap(onBus: 0)
@@ -455,7 +472,10 @@ final class MicrophoneRecorder: ObservableObject {
     func stop() async {
         guard isRunning else { return }
         // Kill the watchdog and the notification hook FIRST: a rebuild racing
-        // the teardown below would leave a hot engine nobody owns.
+        // the teardown below would leave a hot engine nobody owns. Bump the
+        // epoch too, so a rebuild already inside its bring-up abandons itself
+        // even if a new recording starts before it returns.
+        captureEpoch += 1
         watchdogTask?.cancel()
         watchdogTask = nil
         if let observer = configChangeObserver {

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -23,6 +23,53 @@ struct MicFrameStats: Sendable {
     var conversionFailures = 0
 }
 
+/// Pure, clock-injected detector for "the input tap has flatlined".
+///
+/// The audio tap is the only thing that grows `MicFrameStats.frames`, and a
+/// live input device delivers buffers *continuously* — a silent room still
+/// arrives as buffers of near-zero samples. So a frame count that stops
+/// growing means capture is dead, not that nobody is talking. That's what
+/// makes this a safe trigger for rebuilding the engine.
+///
+/// Kept as a value type with an injected `now` so the policy can be unit
+/// tested exactly, without sleeping or touching CoreAudio.
+struct CaptureStallDetector {
+    /// How long the frame count may sit still before we call it a stall.
+    let timeout: TimeInterval
+    private var lastFrames: Int?
+    private var armedAt: Date?
+
+    init(timeout: TimeInterval) {
+        self.timeout = timeout
+    }
+
+    /// Feed the current *cumulative* frame count. Returns `true` once the
+    /// count has not moved for `timeout`.
+    ///
+    /// The first call arms the clock rather than reporting a stall, so a
+    /// device that comes up but never delivers its first buffer also trips
+    /// the detector once `timeout` has passed.
+    mutating func observe(frames: Int, now: Date) -> Bool {
+        defer { lastFrames = frames }
+        guard let last = lastFrames, let armedAt else {
+            self.armedAt = now
+            return false
+        }
+        if frames > last {
+            self.armedAt = now
+            return false
+        }
+        return now.timeIntervalSince(armedAt) >= timeout
+    }
+
+    /// Re-arm after a recovery attempt so the next stall is timed from the
+    /// rebuild, not from the last buffer the dead engine happened to deliver.
+    mutating func reset() {
+        lastFrames = nil
+        armedAt = nil
+    }
+}
+
 /// Pulls samples from the user's preferred input device using `AVAudioEngine`.
 /// Emits whisper-format buffers (16kHz mono Float32) on `audioStream`.
 ///
@@ -40,6 +87,25 @@ struct MicFrameStats: Sendable {
 /// (Bluetooth headset moving between A2DP and HFP, AirPods waking up, etc.);
 /// before this fix, a stalled CoreAudio call froze the entire main thread
 /// and made the app unresponsive — including the global hotkeys.
+///
+/// **Mid-session recovery:** bringing the engine up successfully is only half
+/// the job — the input device can also be pulled out from under a *running*
+/// engine. Per Apple's own docs, when the I/O unit sees the input or output
+/// hardware change its sample rate or channel count, "the engine stops
+/// itself" and posts `AVAudioEngineConfigurationChange`. The nodes stay
+/// attached, so nothing looks broken: the tap simply never fires again.
+/// Nobody was listening for that notification, which is how a user's
+/// 26-minute Zoom meeting came back as 24 seconds of audio — their USB
+/// EarPods died 25s in (`AUHAL: Device 860 died!`), CoreAudio re-pointed the
+/// input at the 48kHz built-in mic, and the 44.1kHz tap went quiet for the
+/// remaining 26 minutes while the UI happily showed a growing timer.
+///
+/// Two independent safety nets now cover that:
+///   1. `AVAudioEngineConfigurationChange` → rebuild engine + tap immediately.
+///   2. A `CaptureStallDetector` watchdog → rebuild when frames stop growing
+///      for `captureStallTimeout`, catching stalls that post no notification.
+/// Both keep the session's `AsyncStream`, gain controller and frame counters
+/// intact, so recording continues into the same WAV instead of ending.
 @MainActor
 final class MicrophoneRecorder: ObservableObject {
     @Published private(set) var isRunning = false
@@ -70,7 +136,36 @@ final class MicrophoneRecorder: ObservableObject {
     /// Test seam: when set, replaces the real `AVAudioEngine` bring-up so
     /// `MicrophoneRecorderTests` can simulate slow / stalled / failing
     /// CoreAudio without needing a real microphone or fragile timing in CI.
+    /// Also used for mid-session rebuilds, so a test can count how many times
+    /// the watchdog tried to repair capture.
     var bringUpOverride: (@Sendable () async throws -> Void)?
+
+    /// How long the tap may deliver nothing before the watchdog rebuilds the
+    /// engine. Generous next to a normal buffer interval (4096 frames at
+    /// 44.1kHz ≈ 93ms) so ordinary scheduling jitter can't trip it, and short
+    /// enough that a yanked device costs a few seconds of a meeting instead
+    /// of the rest of it.
+    var captureStallTimeout: TimeInterval = 4.0
+
+    /// Watchdog poll cadence.
+    var watchdogInterval: TimeInterval = 1.0
+
+    /// Hard cap on rebuild attempts within one recording. A permanently dead
+    /// input would otherwise have us rebuilding in a loop for the length of a
+    /// meeting. 60 attempts at ≥1s apart still rides out a device that's
+    /// unplugged for a minute; past that we stop trying and say so in the log.
+    var maxMidSessionRestarts = 60
+
+    /// Rebuild attempts made during the current session — surfaced in the
+    /// stop log so a diagnostic report shows "capture was repaired 3 times"
+    /// rather than leaving an unexplained gap in the audio.
+    private(set) var restartCount = 0
+
+    private var watchdogTask: Task<Void, Never>?
+    private var configChangeObserver: NSObjectProtocol?
+    /// Guards against a configuration-change notification and a watchdog tick
+    /// both deciding to rebuild at the same moment.
+    private var isRebuilding = false
 
     /// Smoothed digital gain applied to every captured float frame before
     /// it's yielded to consumers. Built fresh on each `start()` so a low-
@@ -101,6 +196,12 @@ final class MicrophoneRecorder: ObservableObject {
         // (defensive — `stop()` should have done this, but a partially-started
         // session that threw mid-way could leak engine/tap state). All cheap,
         // can stay on the main actor.
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
         if let existing = engine {
             existing.inputNode.removeTap(onBus: 0)
             existing.stop()
@@ -113,19 +214,19 @@ final class MicrophoneRecorder: ObservableObject {
         self.audioContinuation = newContinuation
         let continuationForTap = newContinuation!
 
+        restartCount = 0
+        isRebuilding = false
+
         if let override = bringUpOverride {
             try await Self.withTimeout(seconds: bringUpTimeout) {
                 try await override()
             }
             isRunning = true
+            // Start the watchdog on the test path too: with no real tap the
+            // frame count never grows, so a test can drive the full
+            // stall → rebuild loop by counting override invocations.
+            startCaptureWatchdog()
             return
-        }
-
-        // The level callback hops back to the main actor for the @Published
-        // mutation. Captured weakly so a deinit'd recorder doesn't keep the
-        // tap closure alive.
-        let onLevel: @Sendable (Float) -> Void = { [weak self] lvl in
-            Task { @MainActor in self?.level = lvl }
         }
 
         // Build a fresh AGC for this session. Pulls the persisted toggle
@@ -144,7 +245,31 @@ final class MicrophoneRecorder: ObservableObject {
         let sessionStats = OSAllocatedUnfairLock(initialState: MicFrameStats())
         self.stats = sessionStats
 
-        let result = try await Self.withTimeout(
+        let result = try await bringUpRealEngine(continuation: continuationForTap,
+                                                 gain: agc,
+                                                 stats: sessionStats)
+        self.engine = result.engine
+        isRunning = true
+        micLog.log("mic started: \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch agc=\(agcEnabled ? "on" : "off", privacy: .public)")
+        observeConfigurationChanges(on: result.engine)
+        startCaptureWatchdog()
+    }
+
+    /// Bring up a fresh engine + tap against the given session state. Shared
+    /// by `start()` and by mid-session rebuilds, so a repaired engine gets the
+    /// same timeout protection and abandoned-engine teardown as the first one.
+    private func bringUpRealEngine(
+        continuation: AsyncStream<AVAudioPCMBuffer>.Continuation,
+        gain: AdaptiveGainController,
+        stats: OSAllocatedUnfairLock<MicFrameStats>
+    ) async throws -> EngineBox {
+        // The level callback hops back to the main actor for the @Published
+        // mutation. Captured weakly so a deinit'd recorder doesn't keep the
+        // tap closure alive.
+        let onLevel: @Sendable (Float) -> Void = { [weak self] lvl in
+            Task { @MainActor in self?.level = lvl }
+        }
+        return try await Self.withTimeout(
             seconds: bringUpTimeout,
             onAbandoned: { box in
                 // The bring-up finished after the timeout already threw.
@@ -155,22 +280,158 @@ final class MicrophoneRecorder: ObservableObject {
                 box.engine.stop()
             }
         ) {
-            try await Self.realBringUp(continuation: continuationForTap,
+            try await Self.realBringUp(continuation: continuation,
                                        onLevel: onLevel,
-                                       gain: agc,
-                                       stats: sessionStats)
+                                       gain: gain,
+                                       stats: stats)
         }
-        self.engine = result.engine
-        isRunning = true
-        micLog.log("mic started: \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch agc=\(agcEnabled ? "on" : "off", privacy: .public)")
+    }
+
+    // MARK: - Mid-session recovery
+
+    /// Watch one engine for the configuration change that silently kills the
+    /// tap. Re-registered after every rebuild, since the notification is
+    /// scoped to a specific engine instance.
+    private func observeConfigurationChanges(on engine: AVAudioEngine) {
+        if let existing = configChangeObserver {
+            NotificationCenter.default.removeObserver(existing)
+        }
+        configChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] _ in
+            // The callback arrives on an AVFoundation-internal dispatch queue,
+            // and its docs warn that tearing the engine down *inside* the
+            // handler can deadlock. Hop to the main actor first; the actual
+            // teardown then happens on a detached task from there.
+            Task { @MainActor [weak self] in
+                await self?.handleConfigurationChange()
+            }
+        }
+    }
+
+    private func handleConfigurationChange() async {
+        guard isRunning else { return }
+        // No "is it really broken?" probe here on purpose: the documented
+        // behaviour is that the engine has ALREADY stopped itself by the time
+        // this notification is posted, so capture is dead either way and
+        // there's nothing to preserve by waiting.
+        micLog.error("AVAudioEngine configuration changed mid-session (input hardware format changed or the device died) — capture is dead until rebuilt")
+        await rebuildEngine(reason: "configuration change")
+    }
+
+    /// Poll the session frame count and rebuild if capture flatlines.
+    ///
+    /// Backstop for the notification above: a device can also stop delivering
+    /// without any format change to report (HAL wedge, a device that
+    /// disappears and is replaced by an aggregate at the same rate), and those
+    /// post nothing at all.
+    private func startCaptureWatchdog() {
+        watchdogTask?.cancel()
+        let interval = max(0.01, watchdogInterval)
+        watchdogTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var detector = CaptureStallDetector(timeout: self.captureStallTimeout)
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                guard !Task.isCancelled, self.isRunning else { return }
+                // A rebuild is already in flight (or the notification handler
+                // beat us to it) — don't stack a second one on top.
+                if self.isRebuilding { continue }
+                guard detector.observe(frames: self.capturedFrameCount, now: Date()) else { continue }
+                // Budget spent: stop watching instead of re-logging the same
+                // stall every `captureStallTimeout` for the rest of the
+                // recording. A stall in a 40-minute meeting would otherwise
+                // bury the diagnostic bundle in hundreds of identical lines —
+                // the same trap `consumeSystem`'s overflow log had to throttle.
+                if self.restartCount >= self.maxMidSessionRestarts {
+                    micLog.error("mic capture is still stalled after \(self.restartCount, privacy: .public) rebuild attempts — giving up and stopping the watchdog; the rest of this recording has no microphone audio")
+                    return
+                }
+                micLog.error("no mic buffers for \(self.captureStallTimeout, privacy: .public)s while recording — treating capture as stalled")
+                await self.rebuildEngine(reason: "capture stalled")
+                detector.reset()
+            }
+        }
+    }
+
+    /// Rebuild the engine + tap in place, keeping the session's `AsyncStream`,
+    /// gain controller and frame counters.
+    ///
+    /// The stream MUST survive: `RecordingSession.micTask` is iterating it, so
+    /// finishing the continuation would *end* the recording rather than repair
+    /// it. A brand-new `AVAudioEngine` is equally mandatory — see the class
+    /// note about reusing one leaving the input node permanently silent.
+    private func rebuildEngine(reason: String) async {
+        guard isRunning, !isRebuilding else { return }
+        guard restartCount < maxMidSessionRestarts else {
+            micLog.error("declining to rebuild capture (reason: \(reason, privacy: .public)): already used all \(self.maxMidSessionRestarts, privacy: .public) rebuild attempts this session")
+            return
+        }
+        isRebuilding = true
+        restartCount += 1
+        let attempt = restartCount
+        defer { isRebuilding = false }
+
+        let old = engine
+        engine = nil
+        if let old {
+            // Off-main, and never from inside the notification handler: both
+            // `removeTap` and `stop()` can block on the CoreAudio HAL queue.
+            await Task.detached(priority: .userInitiated) {
+                old.inputNode.removeTap(onBus: 0)
+                old.stop()
+            }.value
+        }
+
+        if let override = bringUpOverride {
+            // Test path: no CoreAudio, but still exercise the full decision
+            // and the timeout wrapper.
+            try? await Self.withTimeout(seconds: bringUpTimeout) { try await override() }
+            return
+        }
+
+        guard let sessionStats = stats, let agc = gain else {
+            micLog.error("mic rebuild #\(attempt, privacy: .public) skipped: session state was already torn down")
+            return
+        }
+
+        do {
+            let result = try await bringUpRealEngine(continuation: audioContinuation,
+                                                     gain: agc,
+                                                     stats: sessionStats)
+            engine = result.engine
+            observeConfigurationChanges(on: result.engine)
+            micLog.log("mic capture rebuilt (attempt #\(attempt, privacy: .public), reason: \(reason, privacy: .public)) at \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch — recording continues")
+        } catch {
+            // Leave `isRunning` true: the watchdog keeps ticking and will
+            // retry, which is what rides out a device that's briefly absent
+            // (unplug → replug) rather than mid-switch.
+            micLog.error("mic rebuild #\(attempt, privacy: .public) (reason: \(reason, privacy: .public)) failed: \(error.localizedDescription, privacy: .public) — the watchdog will retry")
+            if attempt == maxMidSessionRestarts {
+                micLog.error("giving up on mic recovery after \(attempt, privacy: .public) attempts — the rest of this recording will have no microphone audio")
+            }
+        }
     }
 
     func stop() async {
         guard isRunning else { return }
+        // Kill the watchdog and the notification hook FIRST: a rebuild racing
+        // the teardown below would leave a hot engine nobody owns.
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
         if let s = stats?.withLock({ $0 }) {
-            micLog.log("mic stopping: buffers=\(s.buffers, privacy: .public) frames=\(s.frames, privacy: .public) conversionFailures=\(s.conversionFailures, privacy: .public)")
+            micLog.log("mic stopping: buffers=\(s.buffers, privacy: .public) frames=\(s.frames, privacy: .public) conversionFailures=\(s.conversionFailures, privacy: .public) rebuilds=\(self.restartCount, privacy: .public)")
             if s.frames == 0 {
                 micLog.error("microphone delivered NO audio this session (buffers=\(s.buffers, privacy: .public), conversionFailures=\(s.conversionFailures, privacy: .public)) — the recording will be empty")
+            }
+            if self.restartCount > 0 {
+                micLog.error("capture was rebuilt \(self.restartCount, privacy: .public)x mid-session (input device changed or stalled) — expect a short gap in the audio at each rebuild")
             }
         }
         let toTeardown = engine
@@ -191,6 +452,12 @@ final class MicrophoneRecorder: ObservableObject {
     }
 
     deinit {
+        // Block-based observers are not auto-removed when the observer object
+        // dies, so a recorder torn down mid-session would leave a registration
+        // behind for the lifetime of the process.
+        if let configChangeObserver {
+            NotificationCenter.default.removeObserver(configChangeObserver)
+        }
         audioContinuation.finish()
     }
 

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -330,15 +330,36 @@ final class MicrophoneRecorder: ObservableObject {
     private func startCaptureWatchdog() {
         watchdogTask?.cancel()
         let interval = max(0.01, watchdogInterval)
+        let stallTimeout = captureStallTimeout
         watchdogTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            var detector = CaptureStallDetector(timeout: self.captureStallTimeout)
+            var detector = CaptureStallDetector(timeout: stallTimeout)
+            var seenRebuilds = 0
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-                guard !Task.isCancelled, self.isRunning else { return }
+                // Re-bind `self` weakly on EVERY iteration rather than once
+                // before the loop. `watchdogTask` is stored on `self`, so a
+                // strong binding held for the loop's lifetime would make the
+                // recorder keep itself alive: the loop only ends on cancel or
+                // `isRunning == false`, both of which come from `stop()`. An
+                // owner that dropped a running recorder without calling
+                // `stop()` would then never see `deinit`, and the engine (and
+                // the hot microphone) would outlive it for the whole process.
+                guard !Task.isCancelled, let self, self.isRunning else { return }
                 // A rebuild is already in flight (or the notification handler
                 // beat us to it) — don't stack a second one on top.
                 if self.isRebuilding { continue }
+                // ANY rebuild invalidates the stall clock, including one driven
+                // by the configuration-change notification, which can't reach
+                // this task-local detector. Frames can't grow while a rebuild
+                // runs, so without this a slow rebuild could be followed
+                // straight away by a second "stall" measured from an `armedAt`
+                // that predates it — costing another audio gap and another
+                // slot of the rebuild budget right after a successful repair.
+                if self.restartCount != seenRebuilds {
+                    seenRebuilds = self.restartCount
+                    detector.reset()
+                    continue
+                }
                 guard detector.observe(frames: self.capturedFrameCount, now: Date()) else { continue }
                 // Budget spent: stop watching instead of re-logging the same
                 // stall every `captureStallTimeout` for the rest of the
@@ -351,6 +372,7 @@ final class MicrophoneRecorder: ObservableObject {
                 }
                 micLog.error("no mic buffers for \(self.captureStallTimeout, privacy: .public)s while recording — treating capture as stalled")
                 await self.rebuildEngine(reason: "capture stalled")
+                seenRebuilds = self.restartCount
                 detector.reset()
             }
         }
@@ -401,6 +423,21 @@ final class MicrophoneRecorder: ObservableObject {
             let result = try await bringUpRealEngine(continuation: audioContinuation,
                                                      gain: agc,
                                                      stats: sessionStats)
+            // `bringUpRealEngine` suspends for up to `bringUpTimeout`, and
+            // `stop()` is free to run on the main actor while it does — which
+            // is exactly what happens when the user hits Stop because their
+            // headphones just died. Adopting the engine now would hand it to a
+            // session that no longer exists: nothing would ever tear it down,
+            // and the microphone would stay hot for the rest of the process.
+            guard isRunning else {
+                micLog.error("mic rebuild #\(attempt, privacy: .public) finished after the recording ended — tearing down the orphaned engine")
+                let orphan = result.engine
+                await Task.detached(priority: .userInitiated) {
+                    orphan.inputNode.removeTap(onBus: 0)
+                    orphan.stop()
+                }.value
+                return
+            }
             engine = result.engine
             observeConfigurationChanges(on: result.engine)
             micLog.log("mic capture rebuilt (attempt #\(attempt, privacy: .public), reason: \(reason, privacy: .public)) at \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch — recording continues")

--- a/Mila/Audio/SystemAudioRecorder.swift
+++ b/Mila/Audio/SystemAudioRecorder.swift
@@ -3,7 +3,10 @@ import AVFoundation
 @preconcurrency import ScreenCaptureKit
 import CoreMedia
 import Combine
+import OSLog
 import TranscriptionCore
+
+private let sysLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "SystemAudioRecorder")
 
 /// Captures system audio (optionally limited to a single application like Zoom) via ScreenCaptureKit.
 ///
@@ -49,6 +52,19 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
     private var stream: SCStream?
     private let audioOutput = AudioStreamOutput()
 
+    /// True between `start()` and `stop()` — i.e. "the app still wants system
+    /// audio", as opposed to `isRunning` which tracks whether a live SCStream
+    /// exists right now. The two diverge exactly when SCK kills the stream
+    /// from its side, which is the window where a restart is the right move.
+    private var wantsCapture = false
+
+    /// Self-restarts after an SCK-side stream death in the current session.
+    /// Bounded so a permanently broken capture (revoked TCC) logs a handful of
+    /// attempts instead of spinning for the length of a meeting.
+    private var restartAttempts = 0
+    private let maxRestartAttempts = 5
+    private(set) var restartCount = 0
+
     /// Serial delivery queue for the audio sample callbacks. `.global()`
     /// is a CONCURRENT queue: two SCK callbacks can run in parallel, and
     /// the per-buffer Task hop the old code used added a second unordered
@@ -77,7 +93,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
                 .sorted { $0.applicationName.lowercased() < $1.applicationName.lowercased() }
             self.availableApps = unique.filter { !$0.applicationName.isEmpty }
         } catch {
-            print("SCShareableContent error: \(error)")
+            sysLog.error("SCShareableContent failed: \(error.localizedDescription, privacy: .public)")
             self.availableApps = []
         }
     }
@@ -96,7 +112,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
         }
     }
 
-    static func isPermissionError(_ error: Error) -> Bool {
+    nonisolated static func isPermissionError(_ error: Error) -> Bool {
         let nsError = error as NSError
         // SCStreamErrorDomain code -3801 = userDeclined
         if nsError.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain"
@@ -113,6 +129,22 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
 
     func start() async throws {
         guard !isRunning else { return }
+        wantsCapture = true
+        restartAttempts = 0
+        restartCount = 0
+        do {
+            try await bringUpStream()
+        } catch {
+            wantsCapture = false
+            throw error
+        }
+    }
+
+    /// The SCStream bring-up proper. Split out of `start()` so a mid-session
+    /// restart re-runs exactly the same setup (fresh shareable content, fresh
+    /// filter) without resetting the restart budget or the `wantsCapture`
+    /// intent.
+    private func bringUpStream() async throws {
         let content: SCShareableContent
         do {
             content = try await SCShareableContent.excludingDesktopWindows(false,
@@ -167,6 +199,9 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
     }
 
     func stop() async {
+        // Clear the intent first so a `didStopWithError` callback racing this
+        // teardown can't kick off a restart of a capture the user just ended.
+        wantsCapture = false
         // Deliberately NOT gated on `isRunning`: when SCK killed the stream
         // itself (`didStopWithError` flips isRunning to false), the old
         // `guard isRunning` made this a no-op and the dead SCStream stayed
@@ -176,7 +211,14 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
             level = 0
             return
         }
-        do { try await stream.stopCapture() } catch { print("stopCapture: \(error)") }
+        if restartCount > 0 {
+            sysLog.error("system-audio capture was restarted \(self.restartCount, privacy: .public)x this session after SCK killed the stream")
+        }
+        do {
+            try await stream.stopCapture()
+        } catch {
+            sysLog.error("stopCapture failed: \(error.localizedDescription, privacy: .public)")
+        }
         self.stream = nil
         self.isRunning = false
         self.level = 0
@@ -194,7 +236,12 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
 extension SystemAudioRecorder: SCStreamDelegate {
     nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
         let message = error.localizedDescription
-        print("SCStream stopped with error: \(message)")
+        // Logger, not print: `print` output never reaches OSLog, so when a
+        // user's meeting lost its app-audio leg mid-recording the diagnostic
+        // bundle had no trace of it at all — the SCStream teardown was only
+        // visible through ScreenCaptureKit's own internal log lines, which
+        // don't say who asked for it or why.
+        sysLog.error("SCStream stopped with error: \(message, privacy: .public)")
         Task { @MainActor in
             // Only act for the CURRENTLY active stream — a stale callback
             // from a previous session's stream arriving after a restart
@@ -209,6 +256,63 @@ extension SystemAudioRecorder: SCStreamDelegate {
             self.isRunning = false
             self.level = 0
             self.lastStreamError = message
+            await self.restartAfterStreamDeath(error)
+        }
+    }
+
+    /// Whether an SCK-side stream death should be retried.
+    ///
+    /// Pure and `nonisolated` so `SystemAudioRestartPolicyTests` can cover the
+    /// decisions without ScreenCaptureKit, a Screen Recording grant, or a real
+    /// `SCStream` to hand to the delegate.
+    enum RestartDecision: Equatable {
+        /// `stop()` already ran — the user ended the recording, so a dead
+        /// stream is expected rather than something to repair.
+        case sessionOver
+        /// A revoked or stale grant fails identically every time; retrying
+        /// just buries the real reason under repeated failures.
+        case permissionDenied
+        case budgetExhausted
+        case retry
+    }
+
+    nonisolated static func restartDecision(wantsCapture: Bool,
+                                            attemptsSoFar: Int,
+                                            maxAttempts: Int,
+                                            error: Error) -> RestartDecision {
+        guard wantsCapture else { return .sessionOver }
+        if isPermissionError(error) { return .permissionDenied }
+        guard attemptsSoFar < maxAttempts else { return .budgetExhausted }
+        return .retry
+    }
+
+    /// Try to get the app-audio leg back after SCK killed the stream mid-
+    /// recording. Losing it silently costs the whole other side of a meeting,
+    /// so a bounded retry is well worth a brief gap.
+    private func restartAfterStreamDeath(_ error: Error) async {
+        switch Self.restartDecision(wantsCapture: wantsCapture,
+                                    attemptsSoFar: restartAttempts,
+                                    maxAttempts: maxRestartAttempts,
+                                    error: error) {
+        case .sessionOver:
+            return
+        case .permissionDenied:
+            sysLog.error("not restarting system audio: Screen & System Audio Recording permission was denied or revoked mid-capture")
+            return
+        case .budgetExhausted:
+            sysLog.error("giving up on system-audio capture after \(self.maxRestartAttempts, privacy: .public) restart attempts — the rest of this recording is microphone-only")
+            return
+        case .retry:
+            break
+        }
+        restartAttempts += 1
+        let attempt = restartAttempts
+        do {
+            try await bringUpStream()
+            restartCount += 1
+            sysLog.log("system-audio capture restarted (attempt #\(attempt, privacy: .public)) — app audio is being captured again")
+        } catch {
+            sysLog.error("system-audio restart attempt #\(attempt, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Mila/Audio/SystemAudioRecorder.swift
+++ b/Mila/Audio/SystemAudioRecorder.swift
@@ -65,6 +65,22 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
     private let maxRestartAttempts = 5
     private(set) var restartCount = 0
 
+    /// Bumped by every `start()` and `stop()`. A restart loop captures the
+    /// value it began with and abandons itself as soon as it no longer
+    /// matches, because `wantsCapture` alone cannot tell "my session still
+    /// wants capture" from "a *later* session does". Without this, a
+    /// stop → start inside a restart's backoff window (or inside its bring-up)
+    /// would let the stale loop hand `stream` a replacement it built for the
+    /// previous recording — leaking the new session's live stream, which then
+    /// keeps capturing for the rest of the process while both streams feed the
+    /// same continuation. Same epoch guard `LiveTranscriber` uses.
+    private var captureEpoch = 0
+
+    /// Does the session that started this work still own the recorder?
+    private func stillOwns(epoch: Int) -> Bool {
+        wantsCapture && captureEpoch == epoch
+    }
+
     /// Serial delivery queue for the audio sample callbacks. `.global()`
     /// is a CONCURRENT queue: two SCK callbacks can run in parallel, and
     /// the per-buffer Task hop the old code used added a second unordered
@@ -129,11 +145,13 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
 
     func start() async throws {
         guard !isRunning else { return }
+        captureEpoch += 1
+        let epoch = captureEpoch
         wantsCapture = true
         restartAttempts = 0
         restartCount = 0
         do {
-            try await bringUpStream()
+            try await bringUpStream(epoch: epoch)
         } catch {
             wantsCapture = false
             throw error
@@ -144,7 +162,13 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
     /// restart re-runs exactly the same setup (fresh shareable content, fresh
     /// filter) without resetting the restart budget or the `wantsCapture`
     /// intent.
-    private func bringUpStream() async throws {
+    ///
+    /// Returns whether the new stream was actually adopted: this suspends
+    /// twice (shareable content, `startCapture`), and a `stop()` — or a whole
+    /// stop/start cycle — can land in between, in which case the stream is
+    /// released here rather than installed on top of a newer session's.
+    @discardableResult
+    private func bringUpStream(epoch: Int) async throws -> Bool {
         let content: SCShareableContent
         do {
             content = try await SCShareableContent.excludingDesktopWindows(false,
@@ -193,15 +217,29 @@ final class SystemAudioRecorder: NSObject, ObservableObject {
         // it's idle until startCapture below.
         sampleQueue.sync { audioOutput.resetConverter() }
         try await stream.startCapture()
+        // Adopt only if this is still the session that asked. Assigning
+        // `self.stream` unconditionally would drop a newer session's stream on
+        // the floor without stopping it — it would keep capturing screen and
+        // audio for the rest of the process, and both streams would push
+        // samples into the same continuation.
+        guard epoch == captureEpoch else {
+            sysLog.error("system-audio bring-up finished after its session ended (epoch \(epoch, privacy: .public) ≠ \(self.captureEpoch, privacy: .public)) — releasing the stream instead of adopting it")
+            try? await stream.stopCapture()
+            return false
+        }
         self.stream = stream
         self.isRunning = true
         self.lastStreamError = nil
+        return true
     }
 
     func stop() async {
         // Clear the intent first so a `didStopWithError` callback racing this
-        // teardown can't kick off a restart of a capture the user just ended.
+        // teardown can't kick off a restart of a capture the user just ended,
+        // and bump the epoch so any restart already in flight abandons itself
+        // even if a new recording sets `wantsCapture` back to true meanwhile.
         wantsCapture = false
+        captureEpoch += 1
         // Deliberately NOT gated on `isRunning`: when SCK killed the stream
         // itself (`didStopWithError` flips isRunning to false), the old
         // `guard isRunning` made this a no-op and the dead SCStream stayed
@@ -296,9 +334,10 @@ extension SystemAudioRecorder: SCStreamDelegate {
         // therefore be terminal and the retry budget would be decoration, even
         // though the common causes (a display being reconfigured, no display
         // available for a moment) clear on their own within a second or two.
+        let epoch = captureEpoch
         var cause = error
         while true {
-            switch Self.restartDecision(wantsCapture: wantsCapture,
+            switch Self.restartDecision(wantsCapture: stillOwns(epoch: epoch),
                                         attemptsSoFar: restartAttempts,
                                         maxAttempts: maxRestartAttempts,
                                         error: cause) {
@@ -321,19 +360,13 @@ extension SystemAudioRecorder: SCStreamDelegate {
             // single display reconfiguration. `Task.sleep` suspends rather than
             // blocking, so the main actor stays free throughout.
             try? await Task.sleep(nanoseconds: UInt64(Self.restartBackoff(attempt: attempt) * 1_000_000_000))
-            guard wantsCapture else { return }
+            guard stillOwns(epoch: epoch) else { return }
 
             do {
-                try await bringUpStream()
-                // Same hazard as the mic side: `bringUpStream` suspends, and
-                // `stop()` can run while it does. A stream adopted after the
-                // recording ended would keep capturing for the rest of the
-                // process, since nothing is left to stop it.
-                guard wantsCapture else {
-                    sysLog.error("system-audio restart #\(attempt, privacy: .public) finished after the recording ended — releasing the orphaned stream")
-                    await stop()
-                    return
-                }
+                // `bringUpStream` re-checks the epoch at the moment it would
+                // adopt, and releases the stream itself if the session moved
+                // on — so a stale loop can never replace a live stream.
+                guard try await bringUpStream(epoch: epoch) else { return }
                 restartCount += 1
                 sysLog.log("system-audio capture restarted (attempt #\(attempt, privacy: .public)) — app audio is being captured again")
                 return

--- a/Mila/Audio/SystemAudioRecorder.swift
+++ b/Mila/Audio/SystemAudioRecorder.swift
@@ -290,30 +290,64 @@ extension SystemAudioRecorder: SCStreamDelegate {
     /// recording. Losing it silently costs the whole other side of a meeting,
     /// so a bounded retry is well worth a brief gap.
     private func restartAfterStreamDeath(_ error: Error) async {
-        switch Self.restartDecision(wantsCapture: wantsCapture,
-                                    attemptsSoFar: restartAttempts,
-                                    maxAttempts: maxRestartAttempts,
-                                    error: error) {
-        case .sessionOver:
-            return
-        case .permissionDenied:
-            sysLog.error("not restarting system audio: Screen & System Audio Recording permission was denied or revoked mid-capture")
-            return
-        case .budgetExhausted:
-            sysLog.error("giving up on system-audio capture after \(self.maxRestartAttempts, privacy: .public) restart attempts — the rest of this recording is microphone-only")
-            return
-        case .retry:
-            break
+        // Loop rather than attempt once: `didStopWithError` is the only trigger
+        // for this method, and a bring-up that throws never created a stream —
+        // so no further callback can ever arrive. A single failed attempt would
+        // therefore be terminal and the retry budget would be decoration, even
+        // though the common causes (a display being reconfigured, no display
+        // available for a moment) clear on their own within a second or two.
+        var cause = error
+        while true {
+            switch Self.restartDecision(wantsCapture: wantsCapture,
+                                        attemptsSoFar: restartAttempts,
+                                        maxAttempts: maxRestartAttempts,
+                                        error: cause) {
+            case .sessionOver:
+                return
+            case .permissionDenied:
+                sysLog.error("not restarting system audio: Screen & System Audio Recording permission was denied or revoked mid-capture")
+                return
+            case .budgetExhausted:
+                sysLog.error("giving up on system-audio capture after \(self.maxRestartAttempts, privacy: .public) restart attempts — the rest of this recording is microphone-only")
+                return
+            case .retry:
+                break
+            }
+            restartAttempts += 1
+            let attempt = restartAttempts
+
+            // Back off before attempting, growing with each try, so the budget
+            // spans a real transient window instead of being spent inside a
+            // single display reconfiguration. `Task.sleep` suspends rather than
+            // blocking, so the main actor stays free throughout.
+            try? await Task.sleep(nanoseconds: UInt64(Self.restartBackoff(attempt: attempt) * 1_000_000_000))
+            guard wantsCapture else { return }
+
+            do {
+                try await bringUpStream()
+                // Same hazard as the mic side: `bringUpStream` suspends, and
+                // `stop()` can run while it does. A stream adopted after the
+                // recording ended would keep capturing for the rest of the
+                // process, since nothing is left to stop it.
+                guard wantsCapture else {
+                    sysLog.error("system-audio restart #\(attempt, privacy: .public) finished after the recording ended — releasing the orphaned stream")
+                    await stop()
+                    return
+                }
+                restartCount += 1
+                sysLog.log("system-audio capture restarted (attempt #\(attempt, privacy: .public)) — app audio is being captured again")
+                return
+            } catch {
+                cause = error
+                sysLog.error("system-audio restart attempt #\(attempt, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
-        restartAttempts += 1
-        let attempt = restartAttempts
-        do {
-            try await bringUpStream()
-            restartCount += 1
-            sysLog.log("system-audio capture restarted (attempt #\(attempt, privacy: .public)) — app audio is being captured again")
-        } catch {
-            sysLog.error("system-audio restart attempt #\(attempt, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
-        }
+    }
+
+    /// Delay before restart attempt `attempt` (1-based). Grows linearly so five
+    /// attempts cover ~7.5s of a transient outage without a long first wait.
+    nonisolated static func restartBackoff(attempt: Int) -> TimeInterval {
+        0.5 * Double(max(1, attempt))
     }
 }
 

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import os
 @testable import Mila
 
 /// Regression coverage for the "wireless mic stalls CoreAudio and freezes the
@@ -106,5 +107,161 @@ final class MicrophoneRecorderTests: XCTestCase {
 
         await startTask.value
         await mic.stop()
+    }
+}
+
+/// Coverage for the mid-session recovery added after a user's 26-minute Zoom
+/// meeting came back as 24 seconds of audio: their USB EarPods died 25s in,
+/// CoreAudio re-pointed the engine's input at the built-in mic at a different
+/// sample rate, and — per AVAudioEngine's documented behaviour — the engine
+/// stopped itself. The tap never fired again and nothing noticed for 26
+/// minutes.
+final class CaptureStallDetectorTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    /// A live device delivers buffers continuously, so a growing frame count
+    /// is proof capture is alive no matter how quiet the room is.
+    func test_growing_frame_count_is_never_a_stall() {
+        var detector = CaptureStallDetector(timeout: 4)
+        XCTAssertFalse(detector.observe(frames: 0, now: t0))
+        for step in 1...20 {
+            let now = t0.addingTimeInterval(Double(step))
+            XCTAssertFalse(detector.observe(frames: step * 1600, now: now),
+                           "frames grew at step \(step) — capture is alive")
+        }
+    }
+
+    func test_flatlined_frame_count_trips_after_timeout() {
+        var detector = CaptureStallDetector(timeout: 4)
+        XCTAssertFalse(detector.observe(frames: 16_000, now: t0))
+        // Same count, but not yet long enough to call it.
+        XCTAssertFalse(detector.observe(frames: 16_000, now: t0.addingTimeInterval(1)))
+        XCTAssertFalse(detector.observe(frames: 16_000, now: t0.addingTimeInterval(3.9)))
+        // Crossing the timeout with no growth: stalled.
+        XCTAssertTrue(detector.observe(frames: 16_000, now: t0.addingTimeInterval(4.0)))
+    }
+
+    /// The stall clock must be re-armed by growth, not just by the first
+    /// sample — otherwise a recording longer than `timeout` would report a
+    /// stall the moment any single poll saw no new frames.
+    func test_growth_rearms_the_stall_clock() {
+        var detector = CaptureStallDetector(timeout: 4)
+        _ = detector.observe(frames: 0, now: t0)
+        XCTAssertFalse(detector.observe(frames: 100, now: t0.addingTimeInterval(3.5)))
+        // 5s of total elapsed time, but only 1.5s since the last new frames.
+        XCTAssertFalse(detector.observe(frames: 100, now: t0.addingTimeInterval(5.0)))
+        XCTAssertTrue(detector.observe(frames: 100, now: t0.addingTimeInterval(7.5)))
+    }
+
+    /// A device that comes up but never delivers a single buffer is just as
+    /// broken as one that dies mid-session, so the first observation arms the
+    /// clock rather than being treated as a baseline forever.
+    func test_device_that_never_delivers_a_buffer_trips() {
+        var detector = CaptureStallDetector(timeout: 2)
+        XCTAssertFalse(detector.observe(frames: 0, now: t0))
+        XCTAssertFalse(detector.observe(frames: 0, now: t0.addingTimeInterval(1)))
+        XCTAssertTrue(detector.observe(frames: 0, now: t0.addingTimeInterval(2)))
+    }
+
+    func test_reset_rearms_from_the_rebuild_not_the_last_buffer() {
+        var detector = CaptureStallDetector(timeout: 2)
+        _ = detector.observe(frames: 500, now: t0)
+        XCTAssertTrue(detector.observe(frames: 500, now: t0.addingTimeInterval(2)))
+        detector.reset()
+        // Fresh baseline: the same flat count must get a full timeout again
+        // before it counts as a second stall.
+        XCTAssertFalse(detector.observe(frames: 500, now: t0.addingTimeInterval(2)))
+        XCTAssertFalse(detector.observe(frames: 500, now: t0.addingTimeInterval(3.5)))
+        XCTAssertTrue(detector.observe(frames: 500, now: t0.addingTimeInterval(4)))
+    }
+}
+
+/// End-to-end wiring of the watchdog, driven through the `bringUpOverride`
+/// seam: with no real tap the frame count never grows, so a stalled session is
+/// exactly what the recorder sees when a device dies. Counting bring-ups tells
+/// us whether it actually tried to repair capture.
+@MainActor
+final class MicrophoneWatchdogTests: XCTestCase {
+
+    /// Small helper: a recorder whose bring-ups are counted, tuned to a fast
+    /// watchdog so the test doesn't wait 4 real seconds per rebuild.
+    private func makeRecorder(maxRestarts: Int = 60) -> (MicrophoneRecorder, @Sendable () -> Int) {
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let mic = MicrophoneRecorder()
+        mic.bringUpTimeout = 1.0
+        mic.captureStallTimeout = 0.2
+        mic.watchdogInterval = 0.05
+        mic.maxMidSessionRestarts = maxRestarts
+        mic.bringUpOverride = { counter.withLock { $0 += 1 } }
+        return (mic, { counter.withLock { $0 } })
+    }
+
+    func test_watchdog_rebuilds_capture_when_no_buffers_arrive() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        XCTAssertEqual(bringUps(), 1, "start() should bring the engine up exactly once")
+
+        // Give the watchdog room for at least a couple of stall→rebuild cycles
+        // (0.2s stall timeout + 0.05s poll each).
+        try await Task.sleep(nanoseconds: 1_200_000_000)
+        let rebuilds = mic.restartCount
+        await mic.stop()
+
+        XCTAssertGreaterThanOrEqual(rebuilds, 1,
+                                    "a session that never receives a buffer must be rebuilt, not left dead")
+        XCTAssertGreaterThan(bringUps(), 1,
+                             "each rebuild should re-run the bring-up; saw \(bringUps()) total")
+    }
+
+    /// The recording must not be *ended* by a rebuild: `RecordingSession` is
+    /// iterating `audioStream`, so finishing that continuation would stop the
+    /// recording instead of repairing it.
+    func test_rebuild_keeps_the_session_audio_stream_alive() async throws {
+        let (mic, _) = makeRecorder()
+        try await mic.start()
+        // Read the stream AFTER start(): every start() installs a fresh one so
+        // leftover buffers from a previous recording can't leak into this one.
+        let sessionStream = mic.audioStream
+
+        let consumerEnded = OSAllocatedUnfairLock(initialState: false)
+        let consumer = Task {
+            for await _ in sessionStream {}
+            consumerEnded.withLock { $0 = true }
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        XCTAssertGreaterThanOrEqual(mic.restartCount, 1, "expected at least one rebuild to have happened")
+        XCTAssertFalse(consumerEnded.withLock { $0 },
+                       "a mid-session rebuild must not finish the audio stream — that would end the recording")
+
+        await mic.stop()
+        _ = await consumer.value
+        XCTAssertTrue(consumerEnded.withLock { $0 }, "stop() should finish the stream")
+    }
+
+    func test_rebuild_attempts_are_capped() async throws {
+        let (mic, _) = makeRecorder(maxRestarts: 2)
+        try await mic.start()
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        let rebuilds = mic.restartCount
+        await mic.stop()
+        // The cap is the assertion: given ~6 stall windows in 1.5s the
+        // uncapped code would rebuild far more than twice.
+        XCTAssertGreaterThanOrEqual(rebuilds, 1, "expected the watchdog to have fired at all")
+        XCTAssertLessThanOrEqual(rebuilds, 2,
+                                 "a permanently dead input must stop being retried at the cap, not forever")
+    }
+
+    func test_stop_cancels_the_watchdog() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        try await Task.sleep(nanoseconds: 500_000_000)
+        await mic.stop()
+
+        let afterStop = bringUps()
+        try await Task.sleep(nanoseconds: 600_000_000)
+        XCTAssertEqual(bringUps(), afterStop,
+                       "no bring-ups may happen after stop() — the watchdog must be cancelled")
     }
 }

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -421,3 +421,59 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertEqual(storedB.status, .completed)
     }
 }
+
+/// The short-capture policy that turns "capture died 25 seconds into a
+/// 26-minute meeting" from a silent failure into a warning the user can act
+/// on. Pure inputs, so no recording or audio device is needed.
+final class ShortCapturePolicyTests: XCTestCase {
+
+    func test_healthy_recording_does_not_warn() {
+        // A little loss at each end is normal: engine bring-up and teardown.
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: 600, captured: 599.4))
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .microphone, wallClock: 120, captured: 119))
+    }
+
+    /// The exact shape of the reported bug: 1583.9s on the clock, 24.6s of
+    /// audio on disk.
+    func test_capture_that_died_mid_session_warns() {
+        XCTAssertTrue(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: 1583.9, captured: 24.6))
+    }
+
+    func test_short_recordings_never_warn() {
+        // Below the wall-clock floor, bring-up latency dominates and a warning
+        // would fire on ordinary quick memos.
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .microphone, wallClock: 6, captured: 1))
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .microphone,
+            wallClock: QuickActionsController.shortCaptureMinimumWallClock - 0.1,
+            captured: 1))
+    }
+
+    /// ScreenCaptureKit only delivers buffers while something is playing, so a
+    /// system-audio capture of a mostly-silent app is legitimately far shorter
+    /// than the wall clock.
+    func test_system_audio_only_is_exempt() {
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .systemAudio, wallClock: 1800, captured: 12))
+    }
+
+    /// Zero captured audio has its own, more specific message and log line —
+    /// this policy must not double up on it.
+    func test_zero_capture_is_left_to_the_empty_mic_path() {
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .microphone, wallClock: 600, captured: 0))
+    }
+
+    func test_threshold_boundary() {
+        let wall: TimeInterval = 100
+        let ratio = QuickActionsController.shortCaptureRatio
+        XCTAssertFalse(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: wall, captured: wall * ratio))
+        XCTAssertTrue(QuickActionsController.capturedAudioFellShort(
+            source: .meeting, wallClock: wall, captured: wall * ratio - 0.5))
+    }
+}

--- a/MilaTests/SystemAudioRestartPolicyTests.swift
+++ b/MilaTests/SystemAudioRestartPolicyTests.swift
@@ -55,6 +55,20 @@ final class SystemAudioRestartPolicyTests: XCTestCase {
                        .permissionDenied)
     }
 
+    /// The budget only means something if the attempts are spread over time:
+    /// `didStopWithError` fires once, and a bring-up that throws never creates
+    /// a stream, so without a delay the whole budget would be spent inside a
+    /// single display reconfiguration.
+    func test_backoff_grows_and_covers_a_real_transient_window() {
+        let delays = (1...5).map { SystemAudioRecorder.restartBackoff(attempt: $0) }
+        XCTAssertEqual(delays, [0.5, 1.0, 1.5, 2.0, 2.5])
+        XCTAssertEqual(delays.reduce(0, +), 7.5, accuracy: 0.001,
+                       "five attempts should span several seconds of outage")
+        // Never zero, never negative, even for nonsense input.
+        XCTAssertGreaterThan(SystemAudioRecorder.restartBackoff(attempt: 0), 0)
+        XCTAssertGreaterThan(SystemAudioRecorder.restartBackoff(attempt: -3), 0)
+    }
+
     func test_retries_are_bounded() {
         XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
                                                           attemptsSoFar: 4,

--- a/MilaTests/SystemAudioRestartPolicyTests.swift
+++ b/MilaTests/SystemAudioRestartPolicyTests.swift
@@ -37,6 +37,18 @@ final class SystemAudioRestartPolicyTests: XCTestCase {
                        .sessionOver)
     }
 
+    /// A restart loop that wakes up during a *later* recording must also bail:
+    /// `wantsCapture` is true again by then, so the loop passes the epoch check
+    /// (`stillOwns`) in as the intent flag rather than the raw boolean. Adopting
+    /// there would drop the new session's live stream without stopping it.
+    func test_restart_loop_superseded_by_a_new_session_is_not_retried() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: false,
+                                                          attemptsSoFar: 1,
+                                                          maxAttempts: 5,
+                                                          error: genericError),
+                       .sessionOver)
+    }
+
     func test_permission_failures_are_not_retried() {
         XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
                                                           attemptsSoFar: 0,

--- a/MilaTests/SystemAudioRestartPolicyTests.swift
+++ b/MilaTests/SystemAudioRestartPolicyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Mila
+
+/// When ScreenCaptureKit kills the stream from its own side mid-recording, the
+/// meeting silently loses the *other side of the conversation* — the user's own
+/// mic keeps working, so nothing looks wrong until they read the transcript.
+/// Previously the only reaction was setting `lastStreamError` (and a `print`
+/// that never reached OSLog, so diagnostic bundles showed no trace of it).
+/// Now the recorder tries to get the leg back; these cover when it should and
+/// shouldn't.
+final class SystemAudioRestartPolicyTests: XCTestCase {
+
+    private let genericError = NSError(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                                      code: -3808,
+                                      userInfo: [NSLocalizedDescriptionKey: "stream stopped"])
+
+    /// SCK code -3801 is `userDeclined`.
+    private let permissionError = NSError(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                                         code: -3801,
+                                         userInfo: [NSLocalizedDescriptionKey: "user declined"])
+
+    func test_transient_stream_death_mid_recording_is_retried() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
+                                                          attemptsSoFar: 0,
+                                                          maxAttempts: 5,
+                                                          error: genericError),
+                       .retry)
+    }
+
+    /// A stream that dies *because the user pressed stop* must not be revived —
+    /// that would leave a hot SCStream running after the recording ended.
+    func test_stream_death_after_stop_is_not_retried() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: false,
+                                                          attemptsSoFar: 0,
+                                                          maxAttempts: 5,
+                                                          error: genericError),
+                       .sessionOver)
+    }
+
+    func test_permission_failures_are_not_retried() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
+                                                          attemptsSoFar: 0,
+                                                          maxAttempts: 5,
+                                                          error: permissionError),
+                       .permissionDenied)
+    }
+
+    /// Permission is checked before the budget: a revoked grant should say so
+    /// plainly rather than reporting an exhausted retry budget.
+    func test_permission_check_precedes_the_retry_budget() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
+                                                          attemptsSoFar: 99,
+                                                          maxAttempts: 5,
+                                                          error: permissionError),
+                       .permissionDenied)
+    }
+
+    func test_retries_are_bounded() {
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
+                                                          attemptsSoFar: 4,
+                                                          maxAttempts: 5,
+                                                          error: genericError),
+                       .retry)
+        XCTAssertEqual(SystemAudioRecorder.restartDecision(wantsCapture: true,
+                                                          attemptsSoFar: 5,
+                                                          maxAttempts: 5,
+                                                          error: genericError),
+                       .budgetExhausted)
+    }
+}


### PR DESCRIPTION
Closes #142

## The bug

A user's 26-minute Zoom meeting was saved as a recording that plays for **24 seconds**. The row showed the full `26:24`, the transcript just stopped, and nothing said a word about it. Two of their three meetings that day were truncated the same way.

From their diagnostic bundle (Mila 1.9.1 build 54, macOS 15.5):

```
12:02:03  MicrophoneRecorder  input device: EarPods Microphone … 44100.0Hz 1ch
12:02:25  LiveTranscriber     utterance … startSec=18.69         ← last sign of life
12:02:28  AUHAL   DeviceListener: Device 860 died! Looking for usable device...
12:02:28  AUHAL   FindUsableDevice: Found usable input device 87  ← built-in mic, 48kHz
          …26 minutes with not one line from any Mila audio category…
12:28:27  MicrophoneRecorder  mic stopping: buffers=247 frames=394348
```

`394348 / 16000 = 24.6s` captured across 26 minutes. The app was alive the whole time — it just recorded nothing and reported nothing.

This is documented `AVAudioEngine` behaviour (`AVAudioEngine.h`): when the I/O unit sees the input hardware change sample rate, *"the engine stops itself"* and posts `AVAudioEngineConfigurationChange`, while *"the nodes remain attached and connected with previously set formats."* The 44.1kHz EarPods were replaced by the 48kHz built-in mic, so the engine shut itself down. Nothing in the app observed that notification (zero references repo-wide), and nothing checked mid-session that buffers were still arriving — `MicFrameStats` was only read at `stop()`, and only for the `frames == 0` case, so 24s of a 26-minute meeting looked perfectly healthy.

## What changed

**`MicrophoneRecorder` — two independent safety nets**

1. `AVAudioEngineConfigurationChange` → rebuild engine + tap immediately. No "is it really broken?" probe: the engine has already stopped itself by the time the notification lands, so there's nothing to preserve by waiting.
2. A `CaptureStallDetector` watchdog → rebuild when the frame count stops growing. This is the backstop for stalls that post no notification, which is what the user's *other* truncated session looks like (`default output device changed` → new aggregate at the same rate).

Both keep the session's `AsyncStream`, gain controller and frame counters, so recording continues into the same WAV instead of ending — the stream has to survive, since `RecordingSession.micTask` is iterating it. Each rebuild builds a brand-new `AVAudioEngine`, which is mandatory for the reason already documented on the class (reusing one leaves the input node permanently silent).

Rebuilds are capped per session, and the watchdog stops watching once the budget is spent — otherwise a permanently dead input would re-log the same stall every 4s for the length of a meeting, the same trap `consumeSystem`'s overflow log already had to throttle.

**`SystemAudioRecorder`**

- Restarts its `SCStream` after an SCK-side death (bounded; never for permission failures, since a revoked grant fails identically every time and just buries the real reason).
- `Logger` instead of `print`. `print` never reaches OSLog, which is why this user's bundle contains no trace of the app-audio leg dying — only ScreenCaptureKit's own internal lines, which don't say who asked or why. Worth calling out: **the system-leg root cause is not fully confirmed** by this bundle. The mic side is proven; this logging change is what will settle the SCK side next time.

**`QuickActionsController`**

- Duration now comes from the audio file rather than `max(wallClock, fileDuration)`. The timer always won, which is why the row claimed 26:24 for a 24-second file.
- Capture that dies part way through now warns the user instead of looking like a bad transcription. Exempt for `.systemAudio`, where SCK legitimately delivers nothing while no audio is playing.

## Testing

19 new tests. The stall detector, the short-capture policy and the SCK restart policy are all pure functions with injected clocks/inputs, so they cover the decisions exactly — no audio device, no permission grants, no sleeping. Watchdog wiring (rebuild happens, stream survives it, cap is respected, `stop()` cancels it) is driven through the existing `bringUpOverride` seam.

```
Executed 39 tests, with 0 failures     # new + the two suites this touches
```

Local `make build` and `build-for-testing` are clean; the only warnings left in the touched files are pre-existing.

Not verifiable in CI: the real device-yank path. Worth a manual check on the beta — start a meeting recording on a USB mic or wired headset, unplug it ~20s in, and confirm the recording keeps going (the log should show `mic capture rebuilt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording duration accuracy by prioritizing the captured audio file’s length.
  * Added detection and user-facing alerts for substantial microphone or meeting capture loss.
  * Improved microphone recovery when audio capture stalls or system configuration changes.
  * Added automatic, limited recovery for temporary system-audio stream failures.
  * Prevented misleading warnings for short recordings, system-audio-only captures, and empty files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->