### PR TITLE
feat(settings): split AI config into "AI Provider" + "AI Features" tabs

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -16,16 +16,16 @@ enum LLMRunnerError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .toolDisabled:
-            return "No LLM is configured in Settings → AI."
+            return "No LLM is configured in Settings → AI Provider."
         case .executableNotFound(let name):
-            return "Could not find \(name) on PATH. Install it or set the full path in Settings → AI."
+            return "Could not find \(name) on PATH. Install it or set the full path in Settings → AI Provider."
         case .launchFailed(let err):
             return "Could not launch the LLM CLI: \(err.localizedDescription)"
         case .nonZeroExit(let code, let stderr):
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             return "LLM CLI exited with status \(code). \(trimmed)"
         case .timedOut(let seconds):
-            return "LLM CLI did not respond within \(seconds)s. If it's running an agentic task (e.g. calendar lookup), raise the timeout in Settings → AI."
+            return "LLM CLI did not respond within \(seconds)s. If it's running an agentic task (e.g. calendar lookup), raise the timeout in Settings → AI Provider."
         case .emptyOutput:
             return "LLM CLI returned no output. Check the prompt or your CLI's auth."
         case .cancelled:
@@ -34,7 +34,7 @@ enum LLMRunnerError: LocalizedError {
     }
 }
 
-/// Everything the Settings → AI test panel needs to explain a run to the
+/// Everything the Settings → AI Provider test panel needs to explain a run to
 /// user. Produced by `LLMRunner.diagnose`. Unlike `LLMRunner.run`, nothing is
 /// thrown away on failure: the user sees the exact command, the exit code, and
 /// both streams so they can self-diagnose (or re-run `command` in a terminal).
@@ -136,7 +136,7 @@ enum LLMRunner {
     /// shape in that case.
     ///
     /// `extraArgs` are appended verbatim after the tool's standard arguments
-    /// — the user's persisted "Extra CLI args" from Settings → AI (e.g.
+    /// — the user's persisted "Extra args" from Settings → AI Provider (e.g.
     /// `--model …`, a permission flag). Empty for callers that manage their
     /// own args (Live AI pins its own model).
     ///
@@ -334,7 +334,7 @@ enum LLMRunner {
 
     /// Run the configured CLI like `run` does, but never throw — capture the
     /// exact command line, exit code, stdout, and stderr and hand them all
-    /// back so the Settings → AI test panel can show the user precisely what
+    /// back so the Settings → AI Provider test panel can show precisely what
     /// happened. This is the "why isn't my LLM working?" debugging path: the
     /// returned `command` is copy-pasteable into a terminal so the user can
     /// reproduce the run themselves.
@@ -426,7 +426,7 @@ enum LLMRunner {
     }
 
     /// Non-throwing HTTP diagnostic for `tool == .openaiCompatible` — the
-    /// "test" path the Settings → AI panel uses to explain an OpenAI endpoint
+    /// "test" path the Settings → AI Provider panel uses to explain an endpoint
     /// to the user. Mirrors `runOpenAICompatible`'s request building but,
     /// because `diagnose` never throws, captures every outcome into the
     /// `LLMTestResult` fields: `url`/`requestBody`/`httpStatus` for the request
@@ -447,7 +447,7 @@ enum LLMRunner {
         guard !trimmedBase.isEmpty else {
             return LLMTestResult(
                 setupError: LLMRunnerError.toolDisabled.errorDescription
-                    ?? "No OpenAI endpoint is configured in Settings → AI.")
+                    ?? "No OpenAI endpoint is configured in Settings → AI Provider.")
         }
         // `makeRequest` throws `invalidEndpoint` for a malformed base URL
         // (issue celarent7/mila#1). `diagnose` never throws, so surface it as

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -16,16 +16,16 @@ enum LLMRunnerError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .toolDisabled:
-            return "No LLM is configured in Settings → LLM."
+            return "No LLM is configured in Settings → AI."
         case .executableNotFound(let name):
-            return "Could not find \(name) on PATH. Install it or set the full path in Settings → LLM."
+            return "Could not find \(name) on PATH. Install it or set the full path in Settings → AI."
         case .launchFailed(let err):
             return "Could not launch the LLM CLI: \(err.localizedDescription)"
         case .nonZeroExit(let code, let stderr):
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             return "LLM CLI exited with status \(code). \(trimmed)"
         case .timedOut(let seconds):
-            return "LLM CLI did not respond within \(seconds)s. If it's running an agentic task (e.g. calendar lookup), raise the timeout in Settings → LLM."
+            return "LLM CLI did not respond within \(seconds)s. If it's running an agentic task (e.g. calendar lookup), raise the timeout in Settings → AI."
         case .emptyOutput:
             return "LLM CLI returned no output. Check the prompt or your CLI's auth."
         case .cancelled:
@@ -34,7 +34,7 @@ enum LLMRunnerError: LocalizedError {
     }
 }
 
-/// Everything the Settings → LLM test panel needs to explain a run to the
+/// Everything the Settings → AI test panel needs to explain a run to the
 /// user. Produced by `LLMRunner.diagnose`. Unlike `LLMRunner.run`, nothing is
 /// thrown away on failure: the user sees the exact command, the exit code, and
 /// both streams so they can self-diagnose (or re-run `command` in a terminal).
@@ -136,7 +136,7 @@ enum LLMRunner {
     /// shape in that case.
     ///
     /// `extraArgs` are appended verbatim after the tool's standard arguments
-    /// — the user's persisted "Extra CLI args" from Settings → LLM (e.g.
+    /// — the user's persisted "Extra CLI args" from Settings → AI (e.g.
     /// `--model …`, a permission flag). Empty for callers that manage their
     /// own args (Live AI pins its own model).
     ///
@@ -334,7 +334,7 @@ enum LLMRunner {
 
     /// Run the configured CLI like `run` does, but never throw — capture the
     /// exact command line, exit code, stdout, and stderr and hand them all
-    /// back so the Settings → LLM test panel can show the user precisely what
+    /// back so the Settings → AI test panel can show the user precisely what
     /// happened. This is the "why isn't my LLM working?" debugging path: the
     /// returned `command` is copy-pasteable into a terminal so the user can
     /// reproduce the run themselves.
@@ -426,7 +426,7 @@ enum LLMRunner {
     }
 
     /// Non-throwing HTTP diagnostic for `tool == .openaiCompatible` — the
-    /// "test" path the Settings → LLM panel uses to explain an OpenAI endpoint
+    /// "test" path the Settings → AI panel uses to explain an OpenAI endpoint
     /// to the user. Mirrors `runOpenAICompatible`'s request building but,
     /// because `diagnose` never throws, captures every outcome into the
     /// `LLMTestResult` fields: `url`/`requestBody`/`httpStatus` for the request
@@ -447,7 +447,7 @@ enum LLMRunner {
         guard !trimmedBase.isEmpty else {
             return LLMTestResult(
                 setupError: LLMRunnerError.toolDisabled.errorDescription
-                    ?? "No OpenAI endpoint is configured in Settings → LLM.")
+                    ?? "No OpenAI endpoint is configured in Settings → AI.")
         }
         // `makeRequest` throws `invalidEndpoint` for a malformed base URL
         // (issue celarent7/mila#1). `diagnose` never throws, so surface it as

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -210,6 +210,11 @@ final class LLMSettings: ObservableObject {
         didSet { defaults.set(postActionPrompt, forKey: Keys.actionPrompt) }
     }
 
+    /// Value `cliTimeout` falls back to when nothing is persisted, and the
+    /// value Settings → AI Provider's "Reset" restores. Named rather than
+    /// repeated as a literal so the two can't drift apart.
+    static let defaultTimeout: TimeInterval = 300
+
     /// Maximum wall-clock seconds Mila allows a post-recording LLM call to
     /// run before killing the subprocess. Applies to title generation, the
     /// auto-summary, and the Send-action button. Live AI's per-tick timeouts
@@ -230,7 +235,7 @@ final class LLMSettings: ObservableObject {
     ///
     /// Defaults to ON (see init) so existing users keep their summaries
     /// unless they opt out. Surfaced in the "Automatic summary" section of
-    /// Settings → AI, alongside the summary prompt it governs.
+    /// Settings → AI Features, alongside the summary prompt it governs.
     @Published var summaryEnabled: Bool {
         didSet { defaults.set(summaryEnabled, forKey: Keys.summaryEnabled) }
     }
@@ -383,7 +388,7 @@ final class LLMSettings: ObservableObject {
 
     // MARK: - Test / diagnostics
     //
-    // Backing state for the Settings → AI "Test" panel. The transcript /
+    // Backing state for the Settings → AI Provider "Test" panel. The transcript /
     // result here are an ephemeral scratch area for answering "why isn't my
     // LLM working?" — they're not persisted (the extra-args the test uses ARE
     // persisted; see `extraArgs` above). Kept on the app-lifetime settings
@@ -487,7 +492,7 @@ final class LLMSettings: ObservableObject {
         // have never seen this key, silently disabling summaries for
         // everyone on upgrade. Treat "key absent" as true.
         self.summaryEnabled = (defaults.object(forKey: Keys.summaryEnabled) as? Bool) ?? true
-        self.cliTimeout = (defaults.object(forKey: Keys.cliTimeout) as? Double) ?? 300
+        self.cliTimeout = (defaults.object(forKey: Keys.cliTimeout) as? Double) ?? Self.defaultTimeout
         self.extraArgs = defaults.string(forKey: Keys.extraArgs) ?? ""
 
         self.openAIProvider = OpenAIProvider(rawValue:

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -229,8 +229,8 @@ final class LLMSettings: ObservableObject {
     /// governs the automatic path.
     ///
     /// Defaults to ON (see init) so existing users keep their summaries
-    /// unless they opt out. Surfaced in Settings → LLM next to the name /
-    /// action toggles, which is where users expect to find it.
+    /// unless they opt out. Surfaced in the "Automatic summary" section of
+    /// Settings → AI, alongside the summary prompt it governs.
     @Published var summaryEnabled: Bool {
         didSet { defaults.set(summaryEnabled, forKey: Keys.summaryEnabled) }
     }
@@ -383,7 +383,7 @@ final class LLMSettings: ObservableObject {
 
     // MARK: - Test / diagnostics
     //
-    // Backing state for the Settings → LLM "Test" panel. The transcript /
+    // Backing state for the Settings → AI "Test" panel. The transcript /
     // result here are an ephemeral scratch area for answering "why isn't my
     // LLM working?" — they're not persisted (the extra-args the test uses ARE
     // persisted; see `extraArgs` above). Kept on the app-lifetime settings

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -28,7 +28,7 @@ enum OpenAIRequestError: LocalizedError, Equatable {
         case .emptyOutput:
             return "The model returned no content."
         case .invalidEndpoint(let baseURL):
-            return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → LLM (it must look like https://api.openai.com/v1)."
+            return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → AI (it must look like https://api.openai.com/v1)."
         }
     }
 }

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -28,7 +28,7 @@ enum OpenAIRequestError: LocalizedError, Equatable {
         case .emptyOutput:
             return "The model returned no content."
         case .invalidEndpoint(let baseURL):
-            return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → AI (it must look like https://api.openai.com/v1)."
+            return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → AI Provider (it must look like https://api.openai.com/v1)."
         }
     }
 }

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -90,7 +90,7 @@ final class RecordingSummarizer: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     /// Timeout for the one-shot summary call. Reads from `LLMSettings.cliTimeout`
-    /// so it follows the user's preference set in Settings → AI Features.
+    /// so it follows the user's preference set in Settings → AI Provider.
     var timeoutSeconds: TimeInterval { llmSettings.cliTimeout }
 
     /// `runLLM` defaults to the real CLI invocation (`LLMRunner.run`).

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -90,7 +90,7 @@ final class RecordingSummarizer: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     /// Timeout for the one-shot summary call. Reads from `LLMSettings.cliTimeout`
-    /// so it follows the user's preference set in Settings → LLM.
+    /// so it follows the user's preference set in Settings → AI.
     var timeoutSeconds: TimeInterval { llmSettings.cliTimeout }
 
     /// `runLLM` defaults to the real CLI invocation (`LLMRunner.run`).

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -90,7 +90,7 @@ final class RecordingSummarizer: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     /// Timeout for the one-shot summary call. Reads from `LLMSettings.cliTimeout`
-    /// so it follows the user's preference set in Settings → AI.
+    /// so it follows the user's preference set in Settings → AI Features.
     var timeoutSeconds: TimeInterval { llmSettings.cliTimeout }
 
     /// `runLLM` defaults to the real CLI invocation (`LLMRunner.run`).

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1237,7 +1237,7 @@ struct MilaApp: App {
                 // the recording UI shows the live transcript pane even
                 // when AI mode is off. Apply the user's tick-interval
                 // setting before start() so the running loop picks it
-                // up (default 5s, settable in Settings → Live AI).
+                // up (default 5s, settable in Settings → AI).
                 transcriber.chunkSeconds = aiSettings.chunkSeconds
                 transcriber.useVAD = aiSettings.useVAD
                 // Attach the neural-VAD speech gate (drops noise-only

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1237,7 +1237,7 @@ struct MilaApp: App {
                 // the recording UI shows the live transcript pane even
                 // when AI mode is off. Apply the user's tick-interval
                 // setting before start() so the running loop picks it
-                // up (default 5s, settable in Settings → AI).
+                // up (default 5s, settable in Settings → AI Features).
                 transcriber.chunkSeconds = aiSettings.chunkSeconds
                 transcriber.useVAD = aiSettings.useVAD
                 // Attach the neural-VAD speech gate (drops noise-only

--- a/Mila/Views/HomeView.swift
+++ b/Mila/Views/HomeView.swift
@@ -185,7 +185,7 @@ struct HomeView: View {
         }
         .font(.caption)
         .foregroundStyle(.secondary)
-        .help("Press these shortcuts anywhere in macOS to dictate. Configure in Settings → Hotkeys.")
+        .help("Press these shortcuts anywhere in macOS to dictate. Configure in Settings → General.")
         .accessibilityIdentifier("home.dictation.hint")
     }
 

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -321,7 +321,7 @@ struct RenameRecordingSheet: View {
                                     text: llm.postActionPrompt)
                     }
                     if !llm.nameGenerationEnabled && !llm.postActionEnabled {
-                        Text("No prompts enabled. Turn on Suggest a name or Run an action in Settings → LLM.")
+                        Text("No prompts enabled. Turn on Suggest a name or Run an action in Settings → AI.")
                             .font(.callout)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -321,7 +321,7 @@ struct RenameRecordingSheet: View {
                                     text: llm.postActionPrompt)
                     }
                     if !llm.nameGenerationEnabled && !llm.postActionEnabled {
-                        Text("No prompts enabled. Turn on Suggest a name or Run an action in Settings → AI.")
+                        Text("No prompts enabled. Turn on Recording names or Send-to-LLM action in Settings → AI Features.")
                             .font(.callout)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1353,20 +1353,20 @@ private struct AIFeaturesSettingsTab: View {
                 Divider()
 
                 AIFeatureRow(title: "Live AI mode",
-                             caption: liveAI.isLiveAIAvailable
-                                 ? "Show action items while the recording runs."
-                                 : "Not available on this Mac — expand for the override.",
+                             caption: liveAICaption,
                              help: "During a recording Mila streams the transcript to your provider every few seconds and surfaces action items in real time. The home screen swaps to a split-pane recording view as soon as you press Record.",
                              isOn: $liveAI.enabled,
-                             // Hardware gate: the switch stays visible (so the
-                             // user knows the feature exists) but is inert on
-                             // Macs where Live AI can't keep up. The persisted
-                             // value still round-trips.
-                             toggleDisabled: !liveAI.isLiveAIAvailable,
+                             // Both gates grey the switch out rather than
+                             // hiding it, so the user can still see the
+                             // feature exists. The persisted value keeps
+                             // round-tripping either way.
+                             toggleDisabled: !liveAI.isLiveAIAvailable
+                                 || settings.liveAIDisabledByRemoteOpenAI,
                              toggleIdentifier: "liveAI.enabled.toggle",
                              identifier: "ai.section.liveAI",
                              isExpanded: $showLiveAI) {
-                    LiveAISection(settings: liveAI)
+                    LiveAISection(settings: liveAI,
+                                  disabledByRemoteEndpoint: settings.liveAIDisabledByRemoteOpenAI)
                 }
 
                 Spacer(minLength: 0)
@@ -1374,6 +1374,23 @@ private struct AIFeaturesSettingsTab: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)
         }
+    }
+
+    /// Live AI has two independent gates on top of the user's own switch, and
+    /// a switch that reads "on" while the feature is inert is exactly the
+    /// legibility problem this redesign is fixing. Say which gate is closed.
+    ///
+    /// Hardware comes first: its override lives one click away in the expanded
+    /// body, whereas the remote-endpoint gate is only cleared by changing the
+    /// provider on the other tab.
+    private var liveAICaption: String {
+        if !liveAI.isLiveAIAvailable {
+            return "Not available on this Mac — expand for the override."
+        }
+        if settings.liveAIDisabledByRemoteOpenAI {
+            return "Off while the provider is a remote endpoint."
+        }
+        return "Show action items while the recording runs."
     }
 
     /// Shown once, at the top, instead of repeating "no provider" inside every
@@ -1443,6 +1460,10 @@ private struct AIFeaturesSettingsTab: View {
 /// per tick rather than inheriting the CLI default.
 private struct LiveAISection: View {
     @ObservedObject var settings: LiveAISettings
+    /// `LLMSettings.liveAIDisabledByRemoteOpenAI`, passed as a plain `Bool`
+    /// rather than the whole settings object so this view doesn't re-render on
+    /// every unrelated provider edit.
+    let disabledByRemoteEndpoint: Bool
     @State private var showAdvanced: Bool = false
 
     var body: some View {
@@ -1450,10 +1471,34 @@ private struct LiveAISection: View {
             if !settings.isLiveAIAvailable {
                 hardwareDisabledNotice
             }
+            if disabledByRemoteEndpoint {
+                remoteEndpointDisabledNotice
+            }
             promptEditor
             advancedDisclosure
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Live AI is gated to local endpoints (`liveAIDisabledByRemoteOpenAI`),
+    /// and `LiveAISession` enforces that silently — so without this the switch
+    /// could be on, the recording could run, and no action items would ever
+    /// appear with nothing on screen explaining why.
+    private var remoteEndpointDisabledNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .foregroundStyle(.orange)
+            Text("Your provider is a remote endpoint, so Live AI won't run. Switch to a CLI tool or a local endpoint.")
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 6))
+        .help("Every Live AI tick re-sends the whole transcript. A hosted OpenAI-compatible endpoint bills that in full each time with no prompt-cache discount, so Mila restricts the live loop to CLI tools and local endpoints (localhost, loopback, .local).")
+        .accessibilityIdentifier("liveAI.remoteEndpointDisabled")
     }
 
     /// Banner shown when this Mac is below the hardware bar for Live

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1023,7 +1023,7 @@ private struct AIProviderSettingsTab: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 toolRow
-                AICaption("Shared by every AI feature. Only transcript text is ever sent — never audio.")
+                AICaption("Used by every AI feature. Only transcript text is sent, never audio.")
 
                 if settings.tool != .none {
                     Divider()
@@ -1155,7 +1155,7 @@ private struct AIProviderSettingsTab: View {
 
     private var remoteEndpointWarning: some View {
         Label {
-            Text("Remote endpoint — transcript text leaves your Mac. Pick a provider you trust.")
+            Text("Remote endpoint — transcript text leaves your Mac.")
                 .font(.caption)
                 .fixedSize(horizontal: false, vertical: true)
         } icon: {
@@ -1164,6 +1164,7 @@ private struct AIProviderSettingsTab: View {
         }
         .frame(maxWidth: aiCaptionWidth, alignment: .leading)
         .padding(.leading, aiLabelWidth + aiLabelGap)
+        .help("This base URL is not localhost, loopback or .local, so transcript text is sent off your machine for processing. Choose a provider you trust.")
     }
 
     // MARK: Timeout
@@ -1399,7 +1400,7 @@ private struct AIFeaturesSettingsTab: View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-            Text("No AI provider is set up yet — these features stay idle until you pick one in Settings → AI Provider.")
+            Text("No AI provider yet — set one up in Settings → AI Provider.")
                 .font(.caption)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: aiCaptionWidth, alignment: .leading)
@@ -1488,7 +1489,7 @@ private struct LiveAISection: View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.circle.fill")
                 .foregroundStyle(.orange)
-            Text("Your provider is a remote endpoint, so Live AI won't run. Switch to a CLI tool or a local endpoint.")
+            Text("Won't run on a remote endpoint. Use a CLI tool or a local one.")
                 .font(.caption)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: aiCaptionWidth, alignment: .leading)
@@ -1511,10 +1512,11 @@ private struct LiveAISection: View {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "exclamationmark.circle.fill")
                     .foregroundStyle(.orange)
-                Text("Live AI is gated off on Air-class chips, where it couldn't keep up. Recordings still transcribe in the background.")
+                Text("Gated off on Air-class chips. Recordings still transcribe.")
                     .font(.caption)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                    .help("Live AI was too slow on Air-class chips when this gate was added. With Apple Neural Engine encoder offload it may now keep up — hence the override below. Recordings transcribe in the background either way.")
             }
             Toggle("Try Live AI anyway", isOn: $settings.forceLiveAIOnLowEndHardware)
                 .font(.callout)
@@ -1540,11 +1542,12 @@ private struct LiveAISection: View {
             // recording — which produced blended "previous meeting + this
             // meeting" summaries and action items lifted from a stale
             // agenda. Point users at the per-meeting Context box instead.
-            Text("Reused for every recording — put one meeting's agenda in the recording pane's **Context** box.")
+            Text("Reused for every recording. One meeting's agenda goes in **Context**.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                .help("Anything meeting-specific pasted here silently applies to every LATER recording, which produced blended \u{201C}previous meeting + this meeting\u{201D} summaries. The Context box in the recording pane is cleared when that recording stops — put per-meeting notes there instead.")
         }
     }
 

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -3,10 +3,16 @@ import AppKit
 import Carbon.HIToolbox
 
 enum SettingsTab: Int, Hashable {
-    /// `ai` replaces the former separate `llm` and `liveAI` tabs: the AI
-    /// provider is now configured once and each AI feature gets its own
-    /// collapsible section inside that single tab.
-    case general, audio, models, ai, speakers, meetings, voiceMemos, storage
+    /// `aiProvider` + `aiFeatures` replace the former separate `llm` and
+    /// `liveAI` tabs. The split is by *how often you touch it*: the provider
+    /// is technical and set once (often via a `.milaconfig` import), while the
+    /// feature switches are what people come back for. Keeping them on one
+    /// screen forced every feature below the fold behind a disclosure arrow.
+    ///
+    /// Net tab count is unchanged from before the AI work (two AI tabs
+    /// replacing two AI tabs), which matters: the strip has to stay inside
+    /// the run measured in `SettingsView.body` below.
+    case general, audio, models, aiProvider, aiFeatures, speakers, meetings, voiceMemos, storage
 }
 
 @Observable
@@ -30,9 +36,12 @@ struct SettingsView: View {
             ModelsSettingsTab()
                 .tabItem { Label("Models", systemImage: "cube.box") }
                 .tag(SettingsTab.models)
-            AISettingsTab()
-                .tabItem { Label("AI", systemImage: "sparkles") }
-                .tag(SettingsTab.ai)
+            AIProviderSettingsTab()
+                .tabItem { Label("AI Provider", systemImage: "sparkles") }
+                .tag(SettingsTab.aiProvider)
+            AIFeaturesSettingsTab()
+                .tabItem { Label("AI Features", systemImage: "wand.and.stars") }
+                .tag(SettingsTab.aiFeatures)
             DiarizationSettingsTab()
                 .tabItem { Label("Speakers", systemImage: "person.2") }
                 .tag(SettingsTab.speakers)
@@ -807,195 +816,306 @@ private struct ModelRow: View {
 
 // MARK: - AI
 
-/// Settings → AI. One tab for everything LLM-powered.
+/// Longest line the AI tabs let help text run before it wraps.
 ///
-/// Layout, top to bottom:
-///   1. **Provider** — configured ONCE and shared by every AI feature: which
-///      tool (Off / Claude CLI / Cursor CLI / OpenAI-compatible endpoint), the
-///      executable path + extra CLI args (CLI tools) or provider / base URL /
-///      model / API key (HTTP), the request timeout, and the output language.
-///   2. **One `DisclosureGroup` per feature** — automatic summary, recording
-///      names, the Send-to-LLM action, Live AI mode, and the test panel. Each
-///      expands independently so the tab stays short.
-///
-/// This replaces the old separate "LLM" and "Live AI" tabs. It is purely a
-/// UI reorganisation: every `UserDefaults` key (`llm.*`, `liveAI.*`) and the
-/// Keychain item behind the API key are unchanged, so an upgrading user keeps
-/// their provider, prompts and toggles exactly as they were.
-private struct AISettingsTab: View {
-    @EnvironmentObject private var settings: LLMSettings
-    @EnvironmentObject private var liveAI: LiveAISettings
+/// The Settings window is a fixed width, but capping the measure keeps
+/// captions at a readable ~90 characters instead of stretching edge to edge,
+/// and it keeps holding if the window ever grows.
+private let aiCaptionWidth: CGFloat = 520
 
-    // Section expansion state. Only the summary section starts open: it holds
-    // the switch most users come here for, and everything else is opt-in
-    // detail. Not persisted — a fresh Settings window starts from this state.
-    @State private var showSummary = true
-    @State private var showName = false
-    @State private var showAction = false
-    @State private var showLiveAI = false
+/// Label column for the AI Provider field rows. Deliberately the same width
+/// the Models tab uses for the remote transcription backend
+/// (`RemoteBackendSection.fieldRow`), so Mila's two "point this at a backend"
+/// screens read as the same kind of screen rather than two dialects.
+private let aiLabelWidth: CGFloat = 80
+
+/// Gap between the label column and the control column. Captions are indented
+/// by `aiLabelWidth + aiLabelGap` so help text lines up under the control it
+/// describes instead of starting a second left edge under the label.
+private let aiLabelGap: CGFloat = 8
+
+extension View {
+    /// `.help(_:)` that no-ops when there is no extra detail to show.
+    ///
+    /// The AI tabs push every second and third sentence of explanation into a
+    /// tooltip; rows with nothing extra to say pass `nil` rather than an empty
+    /// string, which would still arm a hover target.
+    @ViewBuilder
+    fileprivate func aiHelp(_ text: String?) -> some View {
+        if let text, !text.isEmpty { self.help(text) } else { self }
+    }
+}
+
+/// One short line of help under a field, indented to the control column.
+private struct AICaption: View {
+    let text: String
+
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        // `LocalizedStringKey`, not `String`, so inline markdown — `code`
+        // spans, **bold** — renders instead of showing literal backticks.
+        Text(LocalizedStringKey(text))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+            .padding(.leading, aiLabelWidth + aiLabelGap)
+    }
+}
+
+/// A settings row whose whole label area expands/collapses the row, with an
+/// optional switch on the right that works *without* expanding anything.
+///
+/// The switch is a **sibling** of the tap target, never a child of it:
+///
+/// ```swift
+/// HStack {
+///     Button { isExpanded.toggle() } label: {
+///         HStack { chevron; title + caption; Spacer(minLength: 0) }
+///             .contentShape(Rectangle())      // the whole strip is clickable
+///     }
+///     .buttonStyle(.plain)
+///
+///     Toggle("", isOn: isOn)                  // laid out outside the Button
+/// }
+/// ```
+///
+/// `Spacer(minLength: 0)` inside the button label is what makes "click
+/// anywhere on the row" work — the button stretches across the free space
+/// instead of hugging its text — and `.contentShape(Rectangle())` makes that
+/// empty space hit-testable. Because the `Toggle` is a later child of the
+/// enclosing `HStack`, a click on the switch is never inside the button's
+/// shape, so flipping the switch cannot also expand the row. Wrapping the
+/// whole `HStack` in `.contentShape(Rectangle()).onTapGesture { … }` instead —
+/// the obvious first attempt — leaves every switch click ambiguous.
+private struct AIFeatureRow<Content: View>: View {
+    let title: String
+    /// Exactly one short line. Anything longer belongs in `help`.
+    let caption: String
+    /// The detail that used to be inline prose, as a tooltip.
+    var help: String?
+    /// `nil` for rows that aren't a feature you switch on (the Test panel).
+    var isOn: Binding<Bool>?
+    var toggleDisabled = false
+    var toggleIdentifier: String?
+    /// Carried over from the single-tab design (`ai.section.*`) so existing
+    /// automation keeps resolving these rows.
+    let identifier: String
+    @Binding var isExpanded: Bool
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "chevron.right")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(.secondary)
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                            .frame(width: 10)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(title)
+                                .font(.callout.weight(.semibold))
+                                .foregroundStyle(.primary)
+                            Text(caption)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(identifier)
+                .accessibilityLabel(Text(title))
+                .accessibilityHint(Text(isExpanded ? "Collapse" : "Expand"))
+                .aiHelp(help)
+
+                if let isOn {
+                    Toggle("", isOn: isOn)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .disabled(toggleDisabled)
+                        .accessibilityLabel(Text(title))
+                        .accessibilityIdentifier(toggleIdentifier ?? "\(identifier).toggle")
+                }
+            }
+            .padding(.vertical, 4)
+
+            if isExpanded {
+                content
+                    .padding(.leading, 18)
+                    .padding(.top, 8)
+                    .padding(.bottom, 6)
+            }
+        }
+    }
+}
+
+/// A prompt editor with a "Reset to default" affordance. Used by three of the
+/// four feature rows and by Live AI.
+private struct AIPromptEditor: View {
+    let title: String
+    @Binding var text: String
+    let defaultText: String
+    var minHeight: CGFloat = 90
+    /// One line, under the editor.
+    var caption: String?
+    var isEnabled = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Reset to default") { text = defaultText }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .disabled(!isEnabled)
+            }
+            TextEditor(text: $text)
+                .font(.system(.callout, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: minHeight, maxHeight: minHeight + 60)
+                .padding(4)
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
+                .disabled(!isEnabled)
+            if let caption {
+                Text(LocalizedStringKey(caption))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+            }
+        }
+    }
+}
+
+// MARK: - AI Provider
+
+/// Settings → AI Provider. The technical, set-once half of Mila's AI config:
+/// which tool to talk to, how to reach it, how long to wait for it, and a test
+/// panel to prove it works. Most users touch this once — or never, because a
+/// `.milaconfig` import filled it in for them.
+///
+/// Everything a user *revisits* lives on **AI Features** instead. This screen
+/// deliberately mirrors Settings → Models (`ModelsSettingsTab` /
+/// `RemoteBackendSection`): the same label column, the same "control, then one
+/// line of help underneath" rhythm, the same privacy-warning treatment.
+///
+/// Purely presentational. Every `UserDefaults` key (`llm.*`, `liveAI.*`) and
+/// the `llm.openai.apiKey` Keychain item are unchanged, so an upgrading user
+/// keeps their provider, prompts and toggles exactly as they were.
+private struct AIProviderSettingsTab: View {
+    @EnvironmentObject private var settings: LLMSettings
     @State private var showTest = false
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                header
-                toolPicker
-                timeoutSection
-                outputLanguageSection
-                Divider()
+            VStack(alignment: .leading, spacing: 12) {
+                toolRow
+                AICaption("Shared by every AI feature. Only transcript text is ever sent — never audio.")
 
-                section("Automatic summary",
-                        subtitle: "Summarize every recording when it finishes",
-                        isOn: settings.summaryEnabled,
-                        isExpanded: $showSummary,
-                        identifier: "ai.section.summary") {
-                    summarySection
-                }
-
-                section("Recording names",
-                        subtitle: "Suggest a title from the transcript",
-                        isOn: settings.nameGenerationEnabled,
-                        isExpanded: $showName,
-                        identifier: "ai.section.name") {
-                    namePromptSection
-                }
-
-                section("Send-to-LLM action",
-                        subtitle: "Run your own prompt against a transcript",
-                        isOn: settings.postActionEnabled,
-                        isExpanded: $showAction,
-                        identifier: "ai.section.action") {
-                    actionPromptSection
-                }
-
-                section("Live AI mode",
-                        subtitle: "Action items while the recording runs",
-                        isOn: liveAI.enabled && liveAI.isLiveAIAvailable,
-                        isExpanded: $showLiveAI,
-                        identifier: "ai.section.liveAI") {
-                    LiveAISection(settings: liveAI, llm: settings)
-                }
-
-                section("Test",
-                        subtitle: "Run a prompt against a sample transcript",
-                        isOn: nil,
-                        isExpanded: $showTest,
-                        identifier: "ai.section.test") {
-                    testSection
+                if settings.tool != .none {
+                    Divider()
+                    if settings.isOpenAICompatible { endpointFields } else { cliFields }
+                    timeoutRow
+                    Divider()
+                    testRow
                 }
 
                 Spacer(minLength: 0)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)
         }
     }
 
-    // MARK: Section chrome
+    // MARK: Field chrome
 
-    /// A collapsible feature section: bold title, one-line subtitle, and an
-    /// On/Off pill so the user can see what's configured without expanding
-    /// anything. `isOn: nil` renders no pill (used by the Test section, which
-    /// isn't a feature you turn on).
-    private func section<Content: View>(_ title: String,
-                                        subtitle: String,
-                                        isOn: Bool?,
-                                        isExpanded: Binding<Bool>,
-                                        identifier: String,
-                                        @ViewBuilder content: () -> Content) -> some View {
-        // Materialise the body eagerly: `DisclosureGroup`'s content closure
-        // escapes, and a non-escaping `content` parameter can't be captured
-        // by it. Capturing the built view instead keeps the call sites
-        // trailing-closure shaped without an `@escaping` annotation.
-        let inner = content()
-        return DisclosureGroup(isExpanded: isExpanded) {
-            inner
-                .padding(.top, 8)
-        } label: {
-            HStack(spacing: 8) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.callout.weight(.semibold))
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if let isOn {
-                    Text(isOn ? "On" : "Off")
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(isOn ? .green : .secondary)
-                }
-            }
-            .contentShape(Rectangle())
+    /// `label — control` line. Same geometry as the Models tab's field rows.
+    private func fieldRow<Content: View>(_ label: String,
+                                         help: String? = nil,
+                                         @ViewBuilder content: () -> Content) -> some View {
+        HStack(spacing: aiLabelGap) {
+            Text(label).frame(width: aiLabelWidth, alignment: .leading)
+            content()
         }
-        .accessibilityIdentifier(identifier)
+        .font(.callout)
+        .aiHelp(help)
     }
 
-    // MARK: Shared provider configuration
+    // MARK: Tool
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("AI provider")
-                .font(.title3.weight(.semibold))
-            Text("Pick your AI once here — every AI feature below uses it. Mila can shell out to a local CLI (Claude or Cursor) that runs on your machine with the auth you already configured, or talk to any OpenAI-compatible endpoint. Only transcript text is ever forwarded.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var toolPicker: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private var toolRow: some View {
+        // A pop-up menu, not a full-width segmented control: four options of
+        // very uneven length stretched across the pane gave "Off" a segment
+        // the size of a button.
+        fieldRow("Tool",
+                 help: "Claude and Cursor shell out to a CLI on this Mac, using the login you already set up. OpenAI Compatible calls any /chat/completions endpoint over HTTP, including a local Ollama.") {
             Picker("Tool", selection: $settings.tool) {
                 ForEach(LLMTool.allCases) { tool in
                     Text(tool.displayName).tag(tool)
                 }
             }
-            .pickerStyle(.segmented)
-
-            if settings.isOpenAICompatible {
-                openAISection
-            } else {
-                HStack {
-                    Text("Executable path").frame(width: 130, alignment: .leading)
-                    TextField("(use $PATH)", text: $settings.executablePath)
-                        .textFieldStyle(.roundedBorder)
-                }
-                .font(.callout)
-                Text("Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see by default (e.g. ~/.local/bin, an asdf shim).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                HStack {
-                    Text("Extra CLI args").frame(width: 130, alignment: .leading)
-                    TextField("(none) e.g. --model claude-sonnet-4-6", text: $settings.extraArgs)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.callout, design: .monospaced))
-                }
-                .font(.callout)
-                Text("Appended to every run (name suggestion, auto-summary, Send action, and the test below). Shell-style quoting is supported; for most CLIs a flag here overrides an earlier one. Live AI manages its own model and is unaffected.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .fixedSize()
+            .accessibilityIdentifier("ai.provider.tool")
+            Spacer(minLength: 0)
         }
     }
 
-    /// OpenAI-compatible endpoint configuration, shown only when the tool
-    /// picker is on "OpenAI Compatible": a provider preset (which fills the
-    /// base URL + default model), editable base URL / model name, a
-    /// Keychain-backed API key, and a remote-host privacy disclaimer.
-    private var openAISection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Provider").frame(width: 130, alignment: .leading)
+    // MARK: CLI tools
+
+    private var cliFields: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldRow("Executable",
+                     help: "Set this when `claude` / `cursor-agent` lives somewhere a GUI app won't see by default — ~/.local/bin, an asdf shim, a Homebrew prefix that isn't on the system PATH.") {
+                TextField("(use $PATH)", text: $settings.executablePath)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .accessibilityIdentifier("ai.provider.executablePath")
+            }
+            AICaption("Leave blank to look the binary up on $PATH.")
+
+            fieldRow("Extra args",
+                     help: "Appended to every run — name suggestion, auto-summary, the Send action and the test below. Shell-style quoting is supported; for most CLIs a flag here overrides an earlier one.") {
+                TextField("(none) e.g. --model claude-sonnet-4-6", text: $settings.extraArgs)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.callout, design: .monospaced))
+                    .accessibilityIdentifier("ai.provider.extraArgs")
+            }
+            AICaption("Added to every run. Live AI keeps its own model.")
+        }
+    }
+
+    // MARK: OpenAI-compatible endpoint
+
+    private var endpointFields: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldRow("Provider",
+                     help: "Presets fill in the base URL and a sensible default model. Pick Custom to type your own.") {
                 Picker("Provider", selection: $settings.openAIProvider) {
                     ForEach(OpenAIProvider.allCases) { preset in
                         Text(preset.displayName).tag(preset)
                     }
                 }
+                // Without this the menu picker draws its own "Provider"
+                // label beside the label column's, showing the word twice.
+                .labelsHidden()
                 .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityIdentifier("ai.provider.preset")
                 .onChange(of: settings.openAIProvider) { oldPreset, newPreset in
                     // Pass the PREVIOUS provider explicitly: the Picker
                     // binding has already set `openAIProvider` to
@@ -1004,220 +1124,124 @@ private struct AISettingsTab: View {
                     // (issue celarent7/mila#2).
                     settings.applyPreset(newPreset, previous: oldPreset)
                 }
+                Spacer(minLength: 0)
             }
-            .font(.callout)
 
-            HStack {
-                Text("Base URL").frame(width: 130, alignment: .leading)
+            fieldRow("Base URL") {
                 TextField("https://api.openai.com/v1", text: $settings.openAIBaseURL)
                     .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("ai.provider.baseURL")
             }
-            .font(.callout)
-            Text("The OpenAI-compatible /chat/completions endpoint. A trailing slash is ignored.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            AICaption("Mila appends `/chat/completions`. A trailing slash is ignored.")
 
-            HStack {
-                Text("Model name").frame(width: 130, alignment: .leading)
+            fieldRow("Model") {
                 TextField("gpt-4o-mini", text: $settings.openAIModelName)
                     .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("ai.provider.model")
             }
-            .font(.callout)
 
-            HStack {
-                Text("API key").frame(width: 130, alignment: .leading)
+            fieldRow("API key") {
                 SecureField("Required for most providers", text: $settings.openAIAPIKey)
                     .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("ai.provider.apiKey")
             }
-            .font(.callout)
-            Text("Stored in your Keychain. Leave blank only for a local server without auth (e.g. Ollama Local).")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            AICaption("Stored in your Keychain. Blank only for a local server without auth.")
 
             if !OpenAILocality.isLocal(baseURL: settings.openAIBaseURL) {
-                Label {
-                    Text("This endpoint is on a remote server, so your transcript text is sent off your machine for processing. Choose a provider you trust.")
-                        .font(.caption)
-                } icon: {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                }
-                .fixedSize(horizontal: false, vertical: true)
+                remoteEndpointWarning
             }
         }
     }
 
-    /// Help text under the timeout stepper. Worded for an HTTP request when
-    /// the OpenAI endpoint is active, for a CLI process otherwise.
+    private var remoteEndpointWarning: some View {
+        Label {
+            Text("Remote endpoint — transcript text leaves your Mac. Pick a provider you trust.")
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+        }
+        .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+        .padding(.leading, aiLabelWidth + aiLabelGap)
+    }
+
+    // MARK: Timeout
+
+    /// Whole seconds, clamped to the stepper's range. The row used to be a
+    /// bare `Stepper` with no text field, which made getting from 300 to 900
+    /// an exercise in clicking.
+    private var timeoutSeconds: Binding<Int> {
+        Binding(
+            get: { Int(settings.cliTimeout) },
+            set: { settings.cliTimeout = TimeInterval(min(max($0, 30), 900)) }
+        )
+    }
+
     private var timeoutHelp: String {
-        if settings.isOpenAICompatible {
-            return "Maximum time Mila waits for the endpoint to respond before giving up. Applies to title generation, auto-summary, and the Send-action button."
-        }
-        return "Maximum time Mila waits for a CLI response before giving up. Applies to title generation, auto-summary, and the Send-action button. Raise this if your prompt uses agentic tools (e.g. calendar lookup) that need extra time to complete."
+        settings.isOpenAICompatible
+            ? "How long Mila waits for the endpoint to respond before giving up. Applies to title generation, auto-summary and the Send action."
+            : "How long Mila waits for the CLI before giving up. Applies to title generation, auto-summary and the Send action. Raise it if your prompt uses agentic tools — a calendar lookup, say — that need extra time to finish."
     }
 
-    private var timeoutSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Text(settings.timeoutLabel).frame(width: 130, alignment: .leading)
-                Stepper(value: $settings.cliTimeout, in: 30...900, step: 30) {
-                    EmptyView()
-                }
-                Text("\(Int(settings.cliTimeout))s")
-                    .monospacedDigit()
-                    .frame(width: 44, alignment: .trailing)
-                Button("Reset") { settings.cliTimeout = 300 }
-                    .buttonStyle(.borderless)
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
-            }
-            .font(.callout)
-            Text(timeoutHelp)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    /// Output language is genuinely one knob shared by two features: it fills
-    /// the `{{LANGUAGE}}` slot in BOTH the post-recording summary prompt and
-    /// the Live AI tick prompt (`RecordingSummarizer` and `LiveAISession` read
-    /// the same `LiveAISettings.outputLanguage`). It used to be buried in the
-    /// Live AI tab, which hid it from the many users who only ever get the
-    /// automatic summary — so it lives up here with the provider now. The
-    /// persisted key (`liveAI.outputLanguage`) is unchanged.
-    private var outputLanguageSection: some View {
+    private var timeoutRow: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("Output language").frame(width: 130, alignment: .leading)
-                Picker("Output language", selection: $liveAI.outputLanguage) {
-                    ForEach(LiveAISettings.OutputLanguage.allCases) { lang in
-                        Text(lang.displayName).tag(lang)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(maxWidth: 240)
-                Spacer()
+            fieldRow(settings.timeoutLabel, help: timeoutHelp) {
+                TextField("300", value: timeoutSeconds, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+                    .frame(width: 60)
+                    .accessibilityIdentifier("ai.provider.timeout")
+                Stepper("", value: timeoutSeconds, in: 30...900, step: 30)
+                    .labelsHidden()
+                Text("seconds")
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button("Reset") { settings.cliTimeout = LLMSettings.defaultTimeout }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .disabled(Int(settings.cliTimeout) == Int(LLMSettings.defaultTimeout))
             }
-            .font(.callout)
-            Text("Language the AI writes its summaries and action items in. Auto matches whatever language was spoken. Your recordings can be in any language either way.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            AICaption("30–900 s. Covers titles, summaries and the Send action.")
         }
     }
 
-    // MARK: Automatic summary
+    // MARK: Test
 
-    private var summarySection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle("Automatically summarize recordings", isOn: $settings.summaryEnabled)
-                .toggleStyle(.switch)
-                .accessibilityIdentifier("llm.summary.enabled.toggle")
-            Text("When on, Mila runs a one-shot LLM pass after every recording finishes and stores the result as the recording's AI Overview. Turn this off to keep Mila transcript-only. Existing summaries are kept, and any recording that still has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack {
-                Text("Summary prompt")
-                    .font(.callout.weight(.semibold))
-                Spacer()
-                Button("Reset to default") {
-                    liveAI.summaryPrompt = LiveAISettings.defaultSummaryPrompt
-                }
-                .controlSize(.small)
-                .disabled(!settings.summaryEnabled)
-            }
-            TextEditor(text: $liveAI.summaryPrompt)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 90, maxHeight: 150)
-                .padding(4)
-                .overlay(RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
-                .disabled(!settings.summaryEnabled)
-            Text("Sent once with the full transcript after a recording finishes. `{{LANGUAGE}}` is replaced with the output language you picked above.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+    private var testRow: some View {
+        AIFeatureRow(title: "Test this provider",
+                     caption: "See exactly what Mila sends and what comes back.",
+                     help: "Runs the configured prompt against a sample transcript using your real settings, and shows the literal command or request body so you can reproduce it in a terminal.",
+                     isOn: nil,
+                     identifier: "ai.section.test",
+                     isExpanded: $showTest) {
+            testPanel
         }
     }
 
-    // MARK: Recording names
-
-    private var namePromptSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle("Suggest a name from the LLM", isOn: $settings.nameGenerationEnabled)
-                .toggleStyle(.switch)
-            Text("Prompt sent alongside the transcript when you click Suggest in the rename sheet:")
-                .font(.callout).foregroundStyle(.secondary)
-            TextEditor(text: $settings.namePrompt)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 70, maxHeight: 110)
-                .overlay(RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
-                .disabled(!settings.nameGenerationEnabled)
-            ExamplesView(title: "Examples", items: LLMSettings.nameExamples) {
-                settings.namePrompt = $0
-            }
-        }
-    }
-
-    // MARK: Send-to-LLM action
-
-    private var actionPromptSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle("Run an action with the transcript", isOn: $settings.postActionEnabled)
-                .toggleStyle(.switch)
-            Text("Prompt the rename sheet's Run-action button sends together with the transcript:")
-                .font(.callout).foregroundStyle(.secondary)
-            TextEditor(text: $settings.postActionPrompt)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 70, maxHeight: 110)
-                .overlay(RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
-                .disabled(!settings.postActionEnabled)
-            ExamplesView(title: "Examples", items: LLMSettings.actionExamples) {
-                settings.postActionPrompt = $0
-            }
-        }
-    }
-
-    // MARK: Test panel
-
-    private var testSection: some View {
+    private var testPanel: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Run the configured prompt against a sample transcript to see exactly what Mila sends and what your \(settings.isOpenAICompatible ? "endpoint" : "CLI") returns. Use this to debug a tool that isn't working — the \(settings.isOpenAICompatible ? "request shown below is the literal one Mila sends" : "command shown below is the literal one Mila runs"), so you can copy it into a terminal yourself.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
             Picker("Prompt to test", selection: $settings.testPromptKind) {
                 ForEach(LLMSettings.TestPromptKind.allCases) { kind in
                     Text(kind.label).tag(kind)
                 }
             }
             .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: 320)
 
-            Text("Sample transcript")
-                .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            TextEditor(text: $settings.testTranscript)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 90, maxHeight: 150)
-                .overlay(RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
-
-            if !settings.isOpenAICompatible {
-                Text("The test uses your configured Extra CLI args (above), so it reproduces exactly what a real run does.")
-                    .font(.caption).foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else {
-                Text("The test uses your configured Base URL, Model name, and API key (above), so it reproduces exactly what a real run does.")
-                    .font(.caption).foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Sample transcript")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $settings.testTranscript)
+                    .font(.system(.callout, design: .monospaced))
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 80, maxHeight: 130)
+                    .padding(4)
+                    .overlay(RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
             }
 
             HStack(spacing: 10) {
@@ -1234,11 +1258,8 @@ private struct AISettingsTab: View {
                     }
                 }
                 .disabled(settings.tool == .none || settings.isTesting)
-
-                if settings.tool == .none {
-                    Text("Select a tool above first.")
-                        .font(.caption).foregroundStyle(.secondary)
-                }
+                .accessibilityIdentifier("ai.provider.runTest")
+                Spacer()
             }
 
             if let result = settings.lastTestResult {
@@ -1248,29 +1269,186 @@ private struct AISettingsTab: View {
     }
 }
 
-/// The "Live AI mode" section of Settings → AI: the master toggle, the
-/// per-tick system prompt editor (with reset-to-default), and an Advanced
+// MARK: - AI Features
+
+/// Settings → AI Features. What the AI does for you, one row per feature.
+///
+/// Each row carries a title, a single line of description and a real switch,
+/// so the state of all four features is legible — and changeable — without
+/// opening anything. Clicking anywhere else on the row expands that feature's
+/// prompt editor and its own options. See `AIFeatureRow` for why the switch
+/// and the expand target cannot be the same view.
+private struct AIFeaturesSettingsTab: View {
+    @EnvironmentObject private var settings: LLMSettings
+    @EnvironmentObject private var liveAI: LiveAISettings
+
+    // Nothing starts expanded: the point of this screen is that you can read
+    // and flip every feature without expanding a thing.
+    @State private var showSummary = false
+    @State private var showName = false
+    @State private var showAction = false
+    @State private var showLiveAI = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                if !settings.isConfigured { notConfiguredBanner }
+
+                outputLanguageRow
+                Divider()
+
+                AIFeatureRow(title: "Automatic summary",
+                             caption: "Summarize every recording when it finishes.",
+                             help: "Mila runs a one-shot LLM pass after each recording and stores the result as that recording's AI Overview. Turning this off keeps the summaries you already have; any recording that has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.",
+                             isOn: $settings.summaryEnabled,
+                             toggleIdentifier: "llm.summary.enabled.toggle",
+                             identifier: "ai.section.summary",
+                             isExpanded: $showSummary) {
+                    AIPromptEditor(title: "Summary prompt",
+                                   text: $liveAI.summaryPrompt,
+                                   defaultText: LiveAISettings.defaultSummaryPrompt,
+                                   caption: "Sent with the full transcript. `{{LANGUAGE}}` becomes the output language above.",
+                                   isEnabled: settings.summaryEnabled)
+                }
+                Divider()
+
+                AIFeatureRow(title: "Recording names",
+                             caption: "Suggest a title from the transcript.",
+                             help: "Adds a Suggest button to the rename sheet. The prompt below is sent together with the transcript when you click it.",
+                             isOn: $settings.nameGenerationEnabled,
+                             toggleIdentifier: "llm.name.enabled.toggle",
+                             identifier: "ai.section.name",
+                             isExpanded: $showName) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        AIPromptEditor(title: "Name prompt",
+                                       text: $settings.namePrompt,
+                                       defaultText: LLMSettings.defaultNamePrompt,
+                                       minHeight: 70,
+                                       isEnabled: settings.nameGenerationEnabled)
+                        ExamplesView(title: "Examples", items: LLMSettings.nameExamples) {
+                            settings.namePrompt = $0
+                        }
+                    }
+                }
+                Divider()
+
+                AIFeatureRow(title: "Send-to-LLM action",
+                             caption: "Run your own prompt against a transcript.",
+                             help: "Adds a Run-action button to the rename sheet. The prompt below is sent together with the transcript when you click it.",
+                             isOn: $settings.postActionEnabled,
+                             toggleIdentifier: "llm.action.enabled.toggle",
+                             identifier: "ai.section.action",
+                             isExpanded: $showAction) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        AIPromptEditor(title: "Action prompt",
+                                       text: $settings.postActionPrompt,
+                                       defaultText: LLMSettings.defaultActionPrompt,
+                                       minHeight: 70,
+                                       isEnabled: settings.postActionEnabled)
+                        ExamplesView(title: "Examples", items: LLMSettings.actionExamples) {
+                            settings.postActionPrompt = $0
+                        }
+                    }
+                }
+                Divider()
+
+                AIFeatureRow(title: "Live AI mode",
+                             caption: liveAI.isLiveAIAvailable
+                                 ? "Show action items while the recording runs."
+                                 : "Not available on this Mac — expand for the override.",
+                             help: "During a recording Mila streams the transcript to your provider every few seconds and surfaces action items in real time. The home screen swaps to a split-pane recording view as soon as you press Record.",
+                             isOn: $liveAI.enabled,
+                             // Hardware gate: the switch stays visible (so the
+                             // user knows the feature exists) but is inert on
+                             // Macs where Live AI can't keep up. The persisted
+                             // value still round-trips.
+                             toggleDisabled: !liveAI.isLiveAIAvailable,
+                             toggleIdentifier: "liveAI.enabled.toggle",
+                             identifier: "ai.section.liveAI",
+                             isExpanded: $showLiveAI) {
+                    LiveAISection(settings: liveAI)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+
+    /// Shown once, at the top, instead of repeating "no provider" inside every
+    /// feature that needs one.
+    private var notConfiguredBanner: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("No AI provider is set up yet — these features stay idle until you pick one in Settings → AI Provider.")
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 6))
+        .accessibilityIdentifier("ai.features.notConfigured")
+    }
+
+    /// Output language governs *generated content*, not the connection, so it
+    /// sits with the features rather than with the endpoint. It is one knob
+    /// shared by two of them: it fills the `{{LANGUAGE}}` slot in BOTH the
+    /// post-recording summary prompt and the Live AI tick prompt
+    /// (`RecordingSummarizer` and `LiveAISession` read the same
+    /// `LiveAISettings.outputLanguage`). The persisted key
+    /// (`liveAI.outputLanguage`) is unchanged.
+    private var outputLanguageRow: some View {
+        // Wider than `aiLabelWidth`: this label has no field rows to line up
+        // with on this tab, and "Output language" would truncate at 80.
+        let labelWidth: CGFloat = 110
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: aiLabelGap) {
+                Text("Output language")
+                    .frame(width: labelWidth, alignment: .leading)
+                Picker("Output language", selection: $liveAI.outputLanguage) {
+                    ForEach(LiveAISettings.OutputLanguage.allCases) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(maxWidth: 220)
+                .accessibilityIdentifier("ai.features.outputLanguage")
+                Spacer(minLength: 0)
+            }
+            .font(.callout)
+            Text("Language the AI writes in, for every feature below. Auto follows what was spoken.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                .padding(.leading, labelWidth + aiLabelGap)
+        }
+    }
+}
+
+/// The expanded body of the "Live AI mode" row on Settings → AI Features: the
+/// per-tick system prompt editor (with reset-to-default) and an Advanced
 /// disclosure holding the Live-AI-only model override plus the cost /
 /// segmentation dials most users never touch.
 ///
-/// Provider setup deliberately does NOT live here — Live AI uses whichever
-/// tool is configured at the top of the tab. The one thing it keeps for
-/// itself is `LiveAISettings.model`, because the live loop pins its own
-/// (cheaper) model per tick rather than inheriting the CLI default.
+/// The master switch is NOT here — it lives in the row header
+/// (`AIFeatureRow`), so Live AI can be turned on or off without expanding
+/// anything. Provider setup isn't here either: Live AI uses whatever is
+/// configured on Settings → AI Provider. The one thing it keeps for itself is
+/// `LiveAISettings.model`, because the live loop pins its own (cheaper) model
+/// per tick rather than inheriting the CLI default.
 private struct LiveAISection: View {
     @ObservedObject var settings: LiveAISettings
-    @ObservedObject var llm: LLMSettings
     @State private var showAdvanced: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            intro
+        VStack(alignment: .leading, spacing: 12) {
             if !settings.isLiveAIAvailable {
                 hardwareDisabledNotice
-            }
-            masterToggle
-            if !llm.isConfigured && settings.isLiveAIAvailable {
-                notConfiguredHint
             }
             promptEditor
             advancedDisclosure
@@ -1278,43 +1456,26 @@ private struct LiveAISection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var intro: some View {
-        Text("During a recording, Mila streams the transcript to the AI provider above every few seconds and surfaces action items in real time.")
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
     /// Banner shown when this Mac is below the hardware bar for Live
-    /// AI (currently: any MacBook Air). The toggle stays visible but
+    /// AI (currently: any MacBook Air). The row's switch stays visible but
     /// is greyed out — the persisted preference still round-trips,
     /// so taking the user's settings back to a fast Mac restores the
     /// previous state without surprises.
     private var hardwareDisabledNotice: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "exclamationmark.circle.fill")
                     .foregroundStyle(.orange)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Disabled on this Mac")
-                        .font(.callout.weight(.semibold))
-                    Text("MacBook Air — Live AI was too slow on Air-class chips when this gate was added. With Apple Neural Engine encoder offload it may now keep up. Recordings still transcribe in the background regardless.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                Text("Live AI is gated off on Air-class chips, where it couldn't keep up. Recordings still transcribe in the background.")
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: aiCaptionWidth, alignment: .leading)
             }
-            Toggle(isOn: $settings.forceLiveAIOnLowEndHardware) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Try Live AI anyway")
-                        .font(.callout)
-                    Text("Override the hardware gate. If transcription lags behind, disable this and use background mode instead.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .toggleStyle(.switch)
+            Toggle("Try Live AI anyway", isOn: $settings.forceLiveAIOnLowEndHardware)
+                .font(.callout)
+                .toggleStyle(.switch)
+                .accessibilityIdentifier("liveAI.forceOnLowEndHardware.toggle")
+                .help("Overrides the hardware gate. Apple Neural Engine encoder offload may have closed the gap. If transcription lags behind, turn this off and use background mode instead.")
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1322,166 +1483,134 @@ private struct LiveAISection: View {
                     in: RoundedRectangle(cornerRadius: 6))
     }
 
-    private var masterToggle: some View {
-        Toggle(isOn: $settings.enabled) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Enable Live AI mode")
-                Text("When on, the home screen swaps to a split-pane recording view as soon as you press Record.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .toggleStyle(.switch)
-        // Hardware gate: keep the toggle visible (so the user
-        // knows the feature exists) but block interaction on Macs
-        // where Live AI is too slow to be useful. The persisted
-        // value still round-trips.
-        .disabled(!settings.isLiveAIAvailable)
-    }
-
-    private var notConfiguredHint: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            Text("No AI provider is configured at the top of this tab. The toggle above is a no-op until you pick one there.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(8)
-        .background(Color.orange.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: 6))
-    }
-
     private var promptEditor: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("System prompt")
-                    .font(.callout.weight(.semibold))
-                Spacer()
-                Button("Reset to default") {
-                    settings.prompt = LiveAISettings.defaultPrompt
-                }
-                .controlSize(.small)
-            }
-            TextEditor(text: $settings.prompt)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 160)
-                .padding(4)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(Color.secondary.opacity(0.25))
-                )
-            Text("Tip: the default prompt asks for a strict JSON array so Mila can parse the response. Free-form prose will be ignored.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            AIPromptEditor(title: "System prompt",
+                           text: $settings.prompt,
+                           defaultText: LiveAISettings.defaultPrompt,
+                           minHeight: 140,
+                           caption: "Ask for a strict JSON array — free-form prose is ignored.")
             // This prompt is a permanent template, so anything meeting-
             // specific pasted here silently applies to every LATER
             // recording — which produced blended "previous meeting + this
             // meeting" summaries and action items lifted from a stale
             // agenda. Point users at the per-meeting Context box instead.
-            Text("This prompt is reused for every recording. For notes about one specific meeting (agenda, attendees, acronyms), use the **Context** box in the recording pane — it's cleared when that recording stops.")
+            Text("Reused for every recording — put one meeting's agenda in the recording pane's **Context** box.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
         }
     }
 
+    /// The dials most users never touch. Same text discipline as the rest of
+    /// the AI tabs: one line of caption per control, the paragraph that used
+    /// to sit under it moved into the control's tooltip.
     private var advancedDisclosure: some View {
         DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
             VStack(alignment: .leading, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Model").font(.callout.weight(.semibold))
+                    Text("Model").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                     TextField(LiveAISettings.defaultModel, text: $settings.model)
                         .textFieldStyle(.roundedBorder)
-                    Text("Passed to the CLI as `--model` for the live loop only. Default is the cheapest current Claude. Leave blank to let your CLI pick.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("liveAI.model")
+                    advancedCaption("Live loop only. Blank lets your CLI pick.")
                 }
+                .help("Passed to the CLI as `--model` for the live loop only, so the cheap per-tick model doesn't have to be your default. Leave blank to let the CLI choose.")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Auto-segment by silence (beta)", isOn: $settings.useVAD)
-                        .font(.callout.weight(.semibold))
-                    Text("Detect natural pauses (≥400ms silence) and run whisper once per utterance instead of on a fixed timer. Lower latency, cleaner word boundaries. Force-cut at 25s for monologue speakers.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedToggle("Auto-segment by silence (beta)",
+                               isOn: $settings.useVAD,
+                               caption: "Transcribe per utterance instead of on a timer.",
+                               help: "Detects natural pauses (≥400 ms of silence) and runs whisper once per utterance rather than on a fixed timer: lower latency and cleaner word boundaries. Force-cuts at 25s for monologue speakers.")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Filter non-speech (neural VAD)", isOn: $settings.useNeuralVAD)
-                        .font(.callout.weight(.semibold))
-                        .disabled(!settings.useVAD)
-                    Text("Run a lightweight neural voice detector on each segment and skip ones with no actual speech. Stops whisper from inventing filler text on background noise or silence. Recommended on. Needs auto-segment.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedToggle("Filter non-speech (neural VAD)",
+                               isOn: $settings.useNeuralVAD,
+                               caption: "Skip segments with no speech. Needs auto-segment.",
+                               help: "Runs a lightweight neural voice detector on each segment and drops the ones with no actual speech, so whisper stops inventing filler text over background noise. Recommended on.",
+                               disabled: !settings.useVAD)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Background mode (hide live pane)", isOn: $settings.backgroundMode)
-                        .font(.callout.weight(.semibold))
-                    Text("Stay on the Home screen during recording. Transcription, speaker labels, and Live AI summary still run in the background and are saved when you stop. Useful on lower-power Macs where rendering the live pane competes with whisper for CPU.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedToggle("Background mode (hide live pane)",
+                               isOn: $settings.backgroundMode,
+                               caption: "Stay on Home while recording.",
+                               help: "Transcription, speaker labels and the Live AI summary still run in the background and are saved when you stop. Useful on lower-power Macs, where rendering the live pane competes with whisper for CPU.")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Update every").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text("\(Int(settings.chunkSeconds))s")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.chunkSeconds, in: 15...60, step: 5)
-                        .disabled(settings.useVAD)
-                    Text("How often Mila re-transcribes and re-prompts when auto-segment is off. 30s is the default — matches the whisper window so words don't get cut mid-utterance.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedSlider("Update every",
+                               value: $settings.chunkSeconds,
+                               range: 15...60,
+                               step: 5,
+                               readout: "\(Int(settings.chunkSeconds))s",
+                               caption: "Used only when auto-segment is off.",
+                               help: "How often Mila re-transcribes and re-prompts when auto-segment is off. 30s is the default — it matches the whisper window, so words don't get cut mid-utterance.",
+                               disabled: settings.useVAD)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("AI update interval").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text("\(Int(settings.llmMinIntervalSeconds))s")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.llmMinIntervalSeconds, in: 5...60, step: 5)
-                    Text("Minimum time between AI summary updates. The transcript is sent to the LLM at most once per interval, so longer values use less CPU and fewer API calls on long recordings. 20s is the default; the final update when you stop always runs regardless.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedSlider("AI update interval",
+                               value: $settings.llmMinIntervalSeconds,
+                               range: 5...60,
+                               step: 5,
+                               readout: "\(Int(settings.llmMinIntervalSeconds))s",
+                               caption: "Longer means fewer API calls.",
+                               help: "Minimum time between AI summary updates: the transcript is sent to the LLM at most once per interval, so longer values use less CPU and fewer API calls on long recordings. The final update when you stop always runs regardless.")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Speaker similarity threshold").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text(String(format: "%.2f", settings.speakerSimilarityThreshold))
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.speakerSimilarityThreshold, in: 0.5...0.95, step: 0.01)
-                    Text("Higher values make the live diarizer more conservative about merging similar voices into one speaker.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                advancedSlider("Speaker similarity",
+                               value: $settings.speakerSimilarityThreshold,
+                               range: 0.5...0.95,
+                               step: 0.01,
+                               readout: String(format: "%.2f", settings.speakerSimilarityThreshold),
+                               caption: "Higher merges fewer similar voices.",
+                               help: "How confident the live diarizer must be before it treats two segments as the same speaker. Higher values make it more conservative about merging similar voices.")
             }
             .padding(.top, 6)
         }
     }
+
+    private func advancedCaption(_ text: String) -> some View {
+        Text(LocalizedStringKey(text))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+    }
+
+    private func advancedToggle(_ title: String,
+                                isOn: Binding<Bool>,
+                                caption: String,
+                                help: String,
+                                disabled: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Toggle(title, isOn: isOn)
+                .font(.callout)
+                .toggleStyle(.switch)
+                .disabled(disabled)
+            advancedCaption(caption)
+        }
+        .help(help)
+    }
+
+    private func advancedSlider(_ title: String,
+                                value: Binding<Double>,
+                                range: ClosedRange<Double>,
+                                step: Double,
+                                readout: String,
+                                caption: String,
+                                help: String,
+                                disabled: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title).font(.callout)
+                Spacer()
+                Text(readout)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Slider(value: value, in: range, step: step)
+                .disabled(disabled)
+            advancedCaption(caption)
+        }
+        .help(help)
+    }
 }
 
-/// Renders the outcome of a Settings → AI test run: the exact command (with a
+/// Renders the outcome of a Settings → AI Provider test run: the exact command
 /// Copy button), a status line, and the captured stdout/stderr. Designed so a
 /// user who can't get their CLI working can read or copy everything they need
 /// to self-diagnose.

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -932,10 +932,13 @@ private struct AIFeatureRow<Content: View>: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                // `.help` sets the accessibility hint as well as the tooltip,
+                // so it goes on FIRST and the explicit expand/collapse hint
+                // below wins for VoiceOver.
+                .aiHelp(help)
                 .accessibilityIdentifier(identifier)
                 .accessibilityLabel(Text(title))
                 .accessibilityHint(Text(isExpanded ? "Collapse" : "Expand"))
-                .aiHelp(help)
 
                 if let isOn {
                     Toggle("", isOn: isOn)
@@ -1223,14 +1226,22 @@ private struct AIProviderSettingsTab: View {
 
     private var testPanel: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Picker("Prompt to test", selection: $settings.testPromptKind) {
-                ForEach(LLMSettings.TestPromptKind.allCases) { kind in
-                    Text(kind.label).tag(kind)
+            // Labelled above rather than inline, to match the "Sample
+            // transcript" block below it — `.labelsHidden()` alone left a
+            // bare segmented control with nothing saying what it selects.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Prompt to test")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Picker("Prompt to test", selection: $settings.testPromptKind) {
+                    ForEach(LLMSettings.TestPromptKind.allCases) { kind in
+                        Text(kind.label).tag(kind)
+                    }
                 }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(maxWidth: 320)
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(maxWidth: 320)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Sample transcript")

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -3,7 +3,10 @@ import AppKit
 import Carbon.HIToolbox
 
 enum SettingsTab: Int, Hashable {
-    case general, audio, models, llm, speakers, meetings, liveAI, voiceMemos, storage
+    /// `ai` replaces the former separate `llm` and `liveAI` tabs: the AI
+    /// provider is now configured once and each AI feature gets its own
+    /// collapsible section inside that single tab.
+    case general, audio, models, ai, speakers, meetings, voiceMemos, storage
 }
 
 @Observable
@@ -27,18 +30,15 @@ struct SettingsView: View {
             ModelsSettingsTab()
                 .tabItem { Label("Models", systemImage: "cube.box") }
                 .tag(SettingsTab.models)
-            LLMSettingsTab()
-                .tabItem { Label("LLM", systemImage: "sparkles") }
-                .tag(SettingsTab.llm)
+            AISettingsTab()
+                .tabItem { Label("AI", systemImage: "sparkles") }
+                .tag(SettingsTab.ai)
             DiarizationSettingsTab()
                 .tabItem { Label("Speakers", systemImage: "person.2") }
                 .tag(SettingsTab.speakers)
             MeetingsSettingsTab()
                 .tabItem { Label("Meetings", systemImage: "video.fill") }
                 .tag(SettingsTab.meetings)
-            LiveAISettingsTab()
-                .tabItem { Label("Live AI", systemImage: "sparkles.tv") }
-                .tag(SettingsTab.liveAI)
             VoiceMemosSettingsTab()
                 .tabItem { Label("Voice Memos", systemImage: "waveform") }
                 .tag(SettingsTab.voiceMemos)
@@ -805,36 +805,139 @@ private struct ModelRow: View {
     }
 }
 
-// MARK: - LLM
+// MARK: - AI
 
-private struct LLMSettingsTab: View {
+/// Settings → AI. One tab for everything LLM-powered.
+///
+/// Layout, top to bottom:
+///   1. **Provider** — configured ONCE and shared by every AI feature: which
+///      tool (Off / Claude CLI / Cursor CLI / OpenAI-compatible endpoint), the
+///      executable path + extra CLI args (CLI tools) or provider / base URL /
+///      model / API key (HTTP), the request timeout, and the output language.
+///   2. **One `DisclosureGroup` per feature** — automatic summary, recording
+///      names, the Send-to-LLM action, Live AI mode, and the test panel. Each
+///      expands independently so the tab stays short.
+///
+/// This replaces the old separate "LLM" and "Live AI" tabs. It is purely a
+/// UI reorganisation: every `UserDefaults` key (`llm.*`, `liveAI.*`) and the
+/// Keychain item behind the API key are unchanged, so an upgrading user keeps
+/// their provider, prompts and toggles exactly as they were.
+private struct AISettingsTab: View {
     @EnvironmentObject private var settings: LLMSettings
+    @EnvironmentObject private var liveAI: LiveAISettings
+
+    // Section expansion state. Only the summary section starts open: it holds
+    // the switch most users come here for, and everything else is opt-in
+    // detail. Not persisted — a fresh Settings window starts from this state.
+    @State private var showSummary = true
+    @State private var showName = false
+    @State private var showAction = false
+    @State private var showLiveAI = false
+    @State private var showTest = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 header
                 toolPicker
-                Divider()
-                summarySection
-                Divider()
                 timeoutSection
+                outputLanguageSection
                 Divider()
-                namePromptSection
-                Divider()
-                actionPromptSection
-                Divider()
-                testSection
+
+                section("Automatic summary",
+                        subtitle: "Summarize every recording when it finishes",
+                        isOn: settings.summaryEnabled,
+                        isExpanded: $showSummary,
+                        identifier: "ai.section.summary") {
+                    summarySection
+                }
+
+                section("Recording names",
+                        subtitle: "Suggest a title from the transcript",
+                        isOn: settings.nameGenerationEnabled,
+                        isExpanded: $showName,
+                        identifier: "ai.section.name") {
+                    namePromptSection
+                }
+
+                section("Send-to-LLM action",
+                        subtitle: "Run your own prompt against a transcript",
+                        isOn: settings.postActionEnabled,
+                        isExpanded: $showAction,
+                        identifier: "ai.section.action") {
+                    actionPromptSection
+                }
+
+                section("Live AI mode",
+                        subtitle: "Action items while the recording runs",
+                        isOn: liveAI.enabled && liveAI.isLiveAIAvailable,
+                        isExpanded: $showLiveAI,
+                        identifier: "ai.section.liveAI") {
+                    LiveAISection(settings: liveAI, llm: settings)
+                }
+
+                section("Test",
+                        subtitle: "Run a prompt against a sample transcript",
+                        isOn: nil,
+                        isExpanded: $showTest,
+                        identifier: "ai.section.test") {
+                    testSection
+                }
+
+                Spacer(minLength: 0)
             }
             .padding(.vertical, 4)
         }
     }
 
+    // MARK: Section chrome
+
+    /// A collapsible feature section: bold title, one-line subtitle, and an
+    /// On/Off pill so the user can see what's configured without expanding
+    /// anything. `isOn: nil` renders no pill (used by the Test section, which
+    /// isn't a feature you turn on).
+    private func section<Content: View>(_ title: String,
+                                        subtitle: String,
+                                        isOn: Bool?,
+                                        isExpanded: Binding<Bool>,
+                                        identifier: String,
+                                        @ViewBuilder content: () -> Content) -> some View {
+        // Materialise the body eagerly: `DisclosureGroup`'s content closure
+        // escapes, and a non-escaping `content` parameter can't be captured
+        // by it. Capturing the built view instead keeps the call sites
+        // trailing-closure shaped without an `@escaping` annotation.
+        let inner = content()
+        return DisclosureGroup(isExpanded: isExpanded) {
+            inner
+                .padding(.top, 8)
+        } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if let isOn {
+                    Text(isOn ? "On" : "Off")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(isOn ? .green : .secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier(identifier)
+    }
+
+    // MARK: Shared provider configuration
+
     private var header: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("LLM integration")
+            Text("AI provider")
                 .font(.title3.weight(.semibold))
-            Text("After a recording finishes transcribing, Mila can shell out to a local LLM CLI (Claude or Cursor) to suggest a name and/or run a custom action with the transcript. Both CLIs run on your machine with whatever auth you already configured for them; we only forward the transcript text — nothing else.")
+            Text("Pick your AI once here — every AI feature below uses it. Mila can shell out to a local CLI (Claude or Cursor) that runs on your machine with the auth you already configured, or talk to any OpenAI-compatible endpoint. Only transcript text is ever forwarded.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -946,18 +1049,6 @@ private struct LLMSettingsTab: View {
         }
     }
 
-    private var summarySection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle("Automatically summarize recordings", isOn: $settings.summaryEnabled)
-                .toggleStyle(.switch)
-                .accessibilityIdentifier("llm.summary.enabled.toggle")
-            Text("When on, Mila runs a one-shot LLM pass after every recording finishes and stores the result as the recording's AI Overview. Turn this off to keep Mila transcript-only. Existing summaries are kept, and any recording that still has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
     /// Help text under the timeout stepper. Worded for an HTTP request when
     /// the OpenAI endpoint is active, for a CLI process otherwise.
     private var timeoutHelp: String {
@@ -970,7 +1061,7 @@ private struct LLMSettingsTab: View {
     private var timeoutSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text(settings.timeoutLabel).frame(width: 100, alignment: .leading)
+                Text(settings.timeoutLabel).frame(width: 130, alignment: .leading)
                 Stepper(value: $settings.cliTimeout, in: 30...900, step: 30) {
                     EmptyView()
                 }
@@ -990,6 +1081,73 @@ private struct LLMSettingsTab: View {
         }
     }
 
+    /// Output language is genuinely one knob shared by two features: it fills
+    /// the `{{LANGUAGE}}` slot in BOTH the post-recording summary prompt and
+    /// the Live AI tick prompt (`RecordingSummarizer` and `LiveAISession` read
+    /// the same `LiveAISettings.outputLanguage`). It used to be buried in the
+    /// Live AI tab, which hid it from the many users who only ever get the
+    /// automatic summary — so it lives up here with the provider now. The
+    /// persisted key (`liveAI.outputLanguage`) is unchanged.
+    private var outputLanguageSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Output language").frame(width: 130, alignment: .leading)
+                Picker("Output language", selection: $liveAI.outputLanguage) {
+                    ForEach(LiveAISettings.OutputLanguage.allCases) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(maxWidth: 240)
+                Spacer()
+            }
+            .font(.callout)
+            Text("Language the AI writes its summaries and action items in. Auto matches whatever language was spoken. Your recordings can be in any language either way.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: Automatic summary
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("Automatically summarize recordings", isOn: $settings.summaryEnabled)
+                .toggleStyle(.switch)
+                .accessibilityIdentifier("llm.summary.enabled.toggle")
+            Text("When on, Mila runs a one-shot LLM pass after every recording finishes and stores the result as the recording's AI Overview. Turn this off to keep Mila transcript-only. Existing summaries are kept, and any recording that still has one can be refreshed from its right-click \u{201C}Regenerate summary\u{201D} action.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Text("Summary prompt")
+                    .font(.callout.weight(.semibold))
+                Spacer()
+                Button("Reset to default") {
+                    liveAI.summaryPrompt = LiveAISettings.defaultSummaryPrompt
+                }
+                .controlSize(.small)
+                .disabled(!settings.summaryEnabled)
+            }
+            TextEditor(text: $liveAI.summaryPrompt)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minHeight: 90, maxHeight: 150)
+                .padding(4)
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1))
+                .disabled(!settings.summaryEnabled)
+            Text("Sent once with the full transcript after a recording finishes. `{{LANGUAGE}}` is replaced with the output language you picked above.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: Recording names
+
     private var namePromptSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Toggle("Suggest a name from the LLM", isOn: $settings.nameGenerationEnabled)
@@ -1007,6 +1165,8 @@ private struct LLMSettingsTab: View {
             }
         }
     }
+
+    // MARK: Send-to-LLM action
 
     private var actionPromptSection: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1030,8 +1190,6 @@ private struct LLMSettingsTab: View {
 
     private var testSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Test")
-                .font(.title3.weight(.semibold))
             Text("Run the configured prompt against a sample transcript to see exactly what Mila sends and what your \(settings.isOpenAICompatible ? "endpoint" : "CLI") returns. Use this to debug a tool that isn't working — the \(settings.isOpenAICompatible ? "request shown below is the literal one Mila sends" : "command shown below is the literal one Mila runs"), so you can copy it into a terminal yourself.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -1090,7 +1248,240 @@ private struct LLMSettingsTab: View {
     }
 }
 
-/// Renders the outcome of a Settings → LLM test run: the exact command (with a
+/// The "Live AI mode" section of Settings → AI: the master toggle, the
+/// per-tick system prompt editor (with reset-to-default), and an Advanced
+/// disclosure holding the Live-AI-only model override plus the cost /
+/// segmentation dials most users never touch.
+///
+/// Provider setup deliberately does NOT live here — Live AI uses whichever
+/// tool is configured at the top of the tab. The one thing it keeps for
+/// itself is `LiveAISettings.model`, because the live loop pins its own
+/// (cheaper) model per tick rather than inheriting the CLI default.
+private struct LiveAISection: View {
+    @ObservedObject var settings: LiveAISettings
+    @ObservedObject var llm: LLMSettings
+    @State private var showAdvanced: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            intro
+            if !settings.isLiveAIAvailable {
+                hardwareDisabledNotice
+            }
+            masterToggle
+            if !llm.isConfigured && settings.isLiveAIAvailable {
+                notConfiguredHint
+            }
+            promptEditor
+            advancedDisclosure
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var intro: some View {
+        Text("During a recording, Mila streams the transcript to the AI provider above every few seconds and surfaces action items in real time.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// Banner shown when this Mac is below the hardware bar for Live
+    /// AI (currently: any MacBook Air). The toggle stays visible but
+    /// is greyed out — the persisted preference still round-trips,
+    /// so taking the user's settings back to a fast Mac restores the
+    /// previous state without surprises.
+    private var hardwareDisabledNotice: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Disabled on this Mac")
+                        .font(.callout.weight(.semibold))
+                    Text("MacBook Air — Live AI was too slow on Air-class chips when this gate was added. With Apple Neural Engine encoder offload it may now keep up. Recordings still transcribe in the background regardless.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Toggle(isOn: $settings.forceLiveAIOnLowEndHardware) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Try Live AI anyway")
+                        .font(.callout)
+                    Text("Override the hardware gate. If transcription lags behind, disable this and use background mode instead.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toggleStyle(.switch)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var masterToggle: some View {
+        Toggle(isOn: $settings.enabled) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Enable Live AI mode")
+                Text("When on, the home screen swaps to a split-pane recording view as soon as you press Record.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.switch)
+        // Hardware gate: keep the toggle visible (so the user
+        // knows the feature exists) but block interaction on Macs
+        // where Live AI is too slow to be useful. The persisted
+        // value still round-trips.
+        .disabled(!settings.isLiveAIAvailable)
+    }
+
+    private var notConfiguredHint: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("No AI provider is configured at the top of this tab. The toggle above is a no-op until you pick one there.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(8)
+        .background(Color.orange.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var promptEditor: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("System prompt")
+                    .font(.callout.weight(.semibold))
+                Spacer()
+                Button("Reset to default") {
+                    settings.prompt = LiveAISettings.defaultPrompt
+                }
+                .controlSize(.small)
+            }
+            TextEditor(text: $settings.prompt)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minHeight: 160)
+                .padding(4)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.secondary.opacity(0.25))
+                )
+            Text("Tip: the default prompt asks for a strict JSON array so Mila can parse the response. Free-form prose will be ignored.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            // This prompt is a permanent template, so anything meeting-
+            // specific pasted here silently applies to every LATER
+            // recording — which produced blended "previous meeting + this
+            // meeting" summaries and action items lifted from a stale
+            // agenda. Point users at the per-meeting Context box instead.
+            Text("This prompt is reused for every recording. For notes about one specific meeting (agenda, attendees, acronyms), use the **Context** box in the recording pane — it's cleared when that recording stops.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var advancedDisclosure: some View {
+        DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Model").font(.callout.weight(.semibold))
+                    TextField(LiveAISettings.defaultModel, text: $settings.model)
+                        .textFieldStyle(.roundedBorder)
+                    Text("Passed to the CLI as `--model` for the live loop only. Default is the cheapest current Claude. Leave blank to let your CLI pick.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Auto-segment by silence (beta)", isOn: $settings.useVAD)
+                        .font(.callout.weight(.semibold))
+                    Text("Detect natural pauses (≥400ms silence) and run whisper once per utterance instead of on a fixed timer. Lower latency, cleaner word boundaries. Force-cut at 25s for monologue speakers.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Filter non-speech (neural VAD)", isOn: $settings.useNeuralVAD)
+                        .font(.callout.weight(.semibold))
+                        .disabled(!settings.useVAD)
+                    Text("Run a lightweight neural voice detector on each segment and skip ones with no actual speech. Stops whisper from inventing filler text on background noise or silence. Recommended on. Needs auto-segment.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Background mode (hide live pane)", isOn: $settings.backgroundMode)
+                        .font(.callout.weight(.semibold))
+                    Text("Stay on the Home screen during recording. Transcription, speaker labels, and Live AI summary still run in the background and are saved when you stop. Useful on lower-power Macs where rendering the live pane competes with whisper for CPU.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Update every").font(.callout.weight(.semibold))
+                        Spacer()
+                        Text("\(Int(settings.chunkSeconds))s")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $settings.chunkSeconds, in: 15...60, step: 5)
+                        .disabled(settings.useVAD)
+                    Text("How often Mila re-transcribes and re-prompts when auto-segment is off. 30s is the default — matches the whisper window so words don't get cut mid-utterance.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("AI update interval").font(.callout.weight(.semibold))
+                        Spacer()
+                        Text("\(Int(settings.llmMinIntervalSeconds))s")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $settings.llmMinIntervalSeconds, in: 5...60, step: 5)
+                    Text("Minimum time between AI summary updates. The transcript is sent to the LLM at most once per interval, so longer values use less CPU and fewer API calls on long recordings. 20s is the default; the final update when you stop always runs regardless.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Speaker similarity threshold").font(.callout.weight(.semibold))
+                        Spacer()
+                        Text(String(format: "%.2f", settings.speakerSimilarityThreshold))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $settings.speakerSimilarityThreshold, in: 0.5...0.95, step: 0.01)
+                    Text("Higher values make the live diarizer more conservative about merging similar voices into one speaker.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.top, 6)
+        }
+    }
+}
+
+/// Renders the outcome of a Settings → AI test run: the exact command (with a
 /// Copy button), a status line, and the captured stdout/stderr. Designed so a
 /// user who can't get their CLI working can read or copy everything they need
 /// to self-diagnose.
@@ -1610,261 +2001,6 @@ private struct MeetingsSettingsTab: View {
                     .padding(.vertical, 4)
                 }
             }
-        }
-    }
-}
-
-// MARK: - Live AI
-
-/// Settings → Live AI. Hosts the master toggle, the cheap-model override,
-/// the system prompt editor (with reset-to-default), and the two cost
-/// dials that most users will never touch.
-private struct LiveAISettingsTab: View {
-    @EnvironmentObject private var settings: LiveAISettings
-    @EnvironmentObject private var llm: LLMSettings
-    @State private var showAdvanced: Bool = false
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                header
-                if !settings.isLiveAIAvailable {
-                    hardwareDisabledNotice
-                }
-                masterToggle
-                if !llm.isConfigured && settings.isLiveAIAvailable {
-                    notConfiguredHint
-                }
-                Divider()
-                promptEditor
-                advancedDisclosure
-                Spacer(minLength: 0)
-            }
-            .padding(.vertical, 4)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    /// Banner shown when this Mac is below the hardware bar for Live
-    /// AI (currently: any MacBook Air). The toggle stays visible but
-    /// is greyed out — the persisted preference still round-trips,
-    /// so taking the user's settings back to a fast Mac restores the
-    /// previous state without surprises.
-    private var hardwareDisabledNotice: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: "exclamationmark.circle.fill")
-                    .foregroundStyle(.orange)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Disabled on this Mac")
-                        .font(.callout.weight(.semibold))
-                    Text("MacBook Air — Live AI was too slow on Air-class chips when this gate was added. With Apple Neural Engine encoder offload it may now keep up. Recordings still transcribe in the background regardless.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            Toggle(isOn: $settings.forceLiveAIOnLowEndHardware) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Try Live AI anyway")
-                        .font(.callout)
-                    Text("Override the hardware gate. If transcription lags behind, disable this and use background mode instead.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .toggleStyle(.switch)
-        }
-        .padding(10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.orange.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: 6))
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Live AI mode")
-                .font(.title3.weight(.semibold))
-            Text("During a recording, Mila streams the transcript to your LLM every few seconds and surfaces action items in real time. Requires Claude or Cursor CLI set up under LLM.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var masterToggle: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Toggle(isOn: $settings.enabled) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Enable Live AI mode")
-                    Text("Off by default. When on, the home screen swaps to a split-pane recording view as soon as you press Record.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .toggleStyle(.switch)
-            // Hardware gate: keep the toggle visible (so the user
-            // knows the feature exists) but block interaction on Macs
-            // where Live AI is too slow to be useful. The persisted
-            // value still round-trips.
-            .disabled(!settings.isLiveAIAvailable)
-
-            HStack {
-                Text("Output language")
-                    .font(.callout)
-                Spacer()
-                Picker("Output language", selection: $settings.outputLanguage) {
-                    ForEach(LiveAISettings.OutputLanguage.allCases) { lang in
-                        Text(lang.displayName).tag(lang)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(maxWidth: 220)
-            }
-            .disabled(!settings.isLiveAIAvailable)
-        }
-    }
-
-    private var notConfiguredHint: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            Text("No LLM CLI is configured under Settings → LLM. The toggle above is a no-op until you pick Claude or Cursor there.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(8)
-        .background(Color.orange.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: 6))
-    }
-
-    private var promptEditor: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("System prompt")
-                    .font(.callout.weight(.semibold))
-                Spacer()
-                Button("Reset to default") {
-                    settings.prompt = LiveAISettings.defaultPrompt
-                }
-                .controlSize(.small)
-            }
-            TextEditor(text: $settings.prompt)
-                .font(.system(.callout, design: .monospaced))
-                .frame(minHeight: 160)
-                .padding(4)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(Color.secondary.opacity(0.25))
-                )
-            Text("Tip: the default prompt asks for a strict JSON array so Mila can parse the response. Free-form prose will be ignored.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            // This prompt is a permanent template, so anything meeting-
-            // specific pasted here silently applies to every LATER
-            // recording — which produced blended "previous meeting + this
-            // meeting" summaries and action items lifted from a stale
-            // agenda. Point users at the per-meeting Context box instead.
-            Text("This prompt is reused for every recording. For notes about one specific meeting (agenda, attendees, acronyms), use the **Context** box in the recording pane — it's cleared when that recording stops.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var advancedDisclosure: some View {
-        DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
-            VStack(alignment: .leading, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Model").font(.callout.weight(.semibold))
-                    TextField(LiveAISettings.defaultModel, text: $settings.model)
-                        .textFieldStyle(.roundedBorder)
-                    Text("Passed to the CLI as `--model`. Default is the cheapest current Claude. Leave blank to let your CLI pick.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Auto-segment by silence (beta)", isOn: $settings.useVAD)
-                        .font(.callout.weight(.semibold))
-                    Text("Detect natural pauses (≥400ms silence) and run whisper once per utterance instead of on a fixed timer. Lower latency, cleaner word boundaries. Force-cut at 25s for monologue speakers.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Filter non-speech (neural VAD)", isOn: $settings.useNeuralVAD)
-                        .font(.callout.weight(.semibold))
-                        .disabled(!settings.useVAD)
-                    Text("Run a lightweight neural voice detector on each segment and skip ones with no actual speech. Stops whisper from inventing filler text on background noise or silence. Recommended on. Needs auto-segment.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Background mode (hide live pane)", isOn: $settings.backgroundMode)
-                        .font(.callout.weight(.semibold))
-                    Text("Stay on the Home screen during recording. Transcription, speaker labels, and Live AI summary still run in the background and are saved when you stop. Useful on lower-power Macs where rendering the live pane competes with whisper for CPU.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Update every").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text("\(Int(settings.chunkSeconds))s")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.chunkSeconds, in: 15...60, step: 5)
-                        .disabled(settings.useVAD)
-                    Text("How often Mila re-transcribes and re-prompts when auto-segment is off. 30s is the default — matches the whisper window so words don't get cut mid-utterance.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("AI update interval").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text("\(Int(settings.llmMinIntervalSeconds))s")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.llmMinIntervalSeconds, in: 5...60, step: 5)
-                    Text("Minimum time between AI summary updates. The transcript is sent to the LLM at most once per interval, so longer values use less CPU and fewer API calls on long recordings. 20s is the default; the final update when you stop always runs regardless.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Speaker similarity threshold").font(.callout.weight(.semibold))
-                        Spacer()
-                        Text(String(format: "%.2f", settings.speakerSimilarityThreshold))
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    Slider(value: $settings.speakerSimilarityThreshold, in: 0.5...0.95, step: 0.01)
-                    Text("Higher values make the live diarizer more conservative about merging similar voices into one speaker.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .padding(.top, 6)
         }
     }
 }

--- a/MilaTests/AISettingsKeyCompatibilityTests.swift
+++ b/MilaTests/AISettingsKeyCompatibilityTests.swift
@@ -1,16 +1,16 @@
 import XCTest
 @testable import Mila
 
-/// Guards the upgrade path for the unified **Settings → AI** tab.
+/// Guards the upgrade path for **Settings → AI Provider** and
+/// **Settings → AI Features**.
 ///
-/// The tab merged what used to be two separate tabs ("LLM" and "Live AI")
-/// into one screen: the provider is configured once at the top and each
-/// feature gets its own collapsible section. That was a pure UI
-/// reorganisation — but the two settings models it drives (`LLMSettings`,
-/// `LiveAISettings`) persist to `UserDefaults` under namespaced string keys,
-/// and renaming or re-scoping any of them would silently reset an upgrading
-/// user's provider, prompts and toggles back to defaults with no error and
-/// nothing to roll back.
+/// Those two tabs replace what used to be two *different* tabs ("LLM" and
+/// "Live AI"): connection config on one screen, the feature switches people
+/// actually revisit on the other. That is a pure UI reorganisation — but the
+/// two settings models it drives (`LLMSettings`, `LiveAISettings`) persist to
+/// `UserDefaults` under namespaced string keys, and renaming or re-scoping any
+/// of them would silently reset an upgrading user's provider, prompts and
+/// toggles back to defaults with no error and nothing to roll back.
 ///
 /// These tests pin the wire format: every key the AI tab writes is asserted
 /// by its literal string, in both directions (a value already on disk is
@@ -19,11 +19,10 @@ import XCTest
 /// their configuration.
 ///
 /// Note the deliberate cross-model sharing: the output-language picker and
-/// the automatic-summary prompt live in the *provider* / *summary* sections
-/// of the AI tab but are backed by `liveAI.outputLanguage` and
-/// `liveAI.summaryPrompt`, because `RecordingSummarizer` and `LiveAISession`
-/// have always read them from `LiveAISettings`. Moving the control did not
-/// move the key.
+/// the automatic-summary prompt both sit on **AI Features** but are backed by
+/// `liveAI.outputLanguage` and `liveAI.summaryPrompt`, because
+/// `RecordingSummarizer` and `LiveAISession` have always read them from
+/// `LiveAISettings`. Moving the control did not move the key.
 @MainActor
 final class AISettingsKeyCompatibilityTests: XCTestCase {
 
@@ -128,8 +127,9 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
     // MARK: - Controls the merge moved between sections
 
     func test_outputLanguage_still_uses_the_liveAI_key() {
-        // Surfaced next to the provider now (it drives BOTH the automatic
-        // summary and the Live AI loop), still persisted where it always was.
+        // Sits at the top of AI Features now — it governs generated content,
+        // not the connection, and drives BOTH the automatic summary and the
+        // Live AI loop. Still persisted where it always was.
         defaults.set("he", forKey: "liveAI.outputLanguage")
         XCTAssertEqual(LiveAISettings(defaults: defaults).outputLanguage, .hebrew)
 
@@ -170,10 +170,52 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
 
     // MARK: - Tab identity
 
-    func test_ai_tab_replaces_both_former_tabs() {
-        // One AI destination, distinct from its neighbours — deep links
+    func test_ai_tabs_replace_both_former_tabs() {
+        // Two AI destinations — provider config and feature switches — each
+        // distinct from the other and from their neighbours. Deep links
         // (`SettingsNavigation.pendingTab`) must resolve to exactly one tag.
-        XCTAssertNotEqual(SettingsTab.ai, SettingsTab.models)
-        XCTAssertNotEqual(SettingsTab.ai, SettingsTab.speakers)
+        XCTAssertNotEqual(SettingsTab.aiProvider, SettingsTab.aiFeatures)
+        XCTAssertNotEqual(SettingsTab.aiProvider, SettingsTab.models)
+        XCTAssertNotEqual(SettingsTab.aiFeatures, SettingsTab.speakers)
+
+        // Every tab tag is unique. The enum is `Int`-raw-valued and the split
+        // inserted a case mid-list, so a hand-written raw value colliding with
+        // a neighbour would silently make two tabs share a tag.
+        let all: [SettingsTab] = [.general, .audio, .models, .aiProvider, .aiFeatures,
+                                  .speakers, .meetings, .voiceMemos, .storage]
+        XCTAssertEqual(Set(all).count, all.count, "Two Settings tabs share a tag")
+    }
+
+    // MARK: - Controls the two-tab split moved between screens
+
+    func test_timeout_default_matches_the_reset_button() {
+        // Settings → AI Provider's "Reset" writes `LLMSettings.defaultTimeout`.
+        // If that drifted from the value used when nothing is persisted, Reset
+        // would quietly move users to a different timeout than a fresh install.
+        XCTAssertEqual(makeLLM().cliTimeout, LLMSettings.defaultTimeout)
+        XCTAssertEqual(LLMSettings.defaultTimeout, 300)
+
+        // And it still round-trips through the documented key.
+        let llm = makeLLM()
+        llm.cliTimeout = 450
+        XCTAssertEqual(defaults.double(forKey: "llm.cli.timeout"), 450)
+    }
+
+    func test_feature_switches_moved_to_row_headers_keep_their_keys() {
+        // The four AI Features rows each expose a real `Toggle` in the row
+        // header instead of an On/Off label plus a switch hidden one
+        // disclosure down. Same four keys behind them.
+        let llm = makeLLM()
+        llm.summaryEnabled = true
+        llm.nameGenerationEnabled = true
+        llm.postActionEnabled = true
+
+        XCTAssertTrue(defaults.bool(forKey: "llm.summary.enabled"))
+        XCTAssertTrue(defaults.bool(forKey: "llm.name.enabled"))
+        XCTAssertTrue(defaults.bool(forKey: "llm.action.enabled"))
+
+        let live = LiveAISettings(defaults: defaults)
+        live.enabled = true
+        XCTAssertTrue(defaults.bool(forKey: "liveAI.enabled"))
     }
 }

--- a/MilaTests/AISettingsKeyCompatibilityTests.swift
+++ b/MilaTests/AISettingsKeyCompatibilityTests.swift
@@ -178,12 +178,27 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
         XCTAssertNotEqual(SettingsTab.aiProvider, SettingsTab.models)
         XCTAssertNotEqual(SettingsTab.aiFeatures, SettingsTab.speakers)
 
-        // Every tab tag is unique. The enum is `Int`-raw-valued and the split
-        // inserted a case mid-list, so a hand-written raw value colliding with
-        // a neighbour would silently make two tabs share a tag.
-        let all: [SettingsTab] = [.general, .audio, .models, .aiProvider, .aiFeatures,
-                                  .speakers, .meetings, .voiceMemos, .storage]
-        XCTAssertEqual(Set(all).count, all.count, "Two Settings tabs share a tag")
+        // Pin the raw values. Asserting the cases are merely *distinct* would
+        // be vacuous — `Hashable` is synthesized over the cases, so they never
+        // collide whatever their raw values, and Swift rejects duplicate
+        // explicit raw values at compile time. What the split actually risks
+        // is SHIFTING the implicit raw value of every case after the insertion
+        // point. Nothing persists them today (`SettingsNavigation.pendingTab`
+        // is in-memory only, which is why this PR could renumber freely), so
+        // this is a tripwire for whoever first writes one to disk or a URL.
+        //
+        // The list is also the authoritative tab inventory: nine tabs, which
+        // is what the measured tab-strip run in `SettingsView` assumes. Adding
+        // a tenth needs that measurement redone, not just a line here.
+        XCTAssertEqual(SettingsTab.general.rawValue, 0)
+        XCTAssertEqual(SettingsTab.audio.rawValue, 1)
+        XCTAssertEqual(SettingsTab.models.rawValue, 2)
+        XCTAssertEqual(SettingsTab.aiProvider.rawValue, 3)
+        XCTAssertEqual(SettingsTab.aiFeatures.rawValue, 4)
+        XCTAssertEqual(SettingsTab.speakers.rawValue, 5)
+        XCTAssertEqual(SettingsTab.meetings.rawValue, 6)
+        XCTAssertEqual(SettingsTab.voiceMemos.rawValue, 7)
+        XCTAssertEqual(SettingsTab.storage.rawValue, 8)
     }
 
     // MARK: - Controls the two-tab split moved between screens

--- a/MilaTests/AISettingsKeyCompatibilityTests.swift
+++ b/MilaTests/AISettingsKeyCompatibilityTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import Mila
+
+/// Guards the upgrade path for the unified **Settings → AI** tab.
+///
+/// The tab merged what used to be two separate tabs ("LLM" and "Live AI")
+/// into one screen: the provider is configured once at the top and each
+/// feature gets its own collapsible section. That was a pure UI
+/// reorganisation — but the two settings models it drives (`LLMSettings`,
+/// `LiveAISettings`) persist to `UserDefaults` under namespaced string keys,
+/// and renaming or re-scoping any of them would silently reset an upgrading
+/// user's provider, prompts and toggles back to defaults with no error and
+/// nothing to roll back.
+///
+/// These tests pin the wire format: every key the AI tab writes is asserted
+/// by its literal string, in both directions (a value already on disk is
+/// adopted at init; an edit in the UI writes that same key). A rename shows
+/// up here as a failure rather than as a bug report from a user who lost
+/// their configuration.
+///
+/// Note the deliberate cross-model sharing: the output-language picker and
+/// the automatic-summary prompt live in the *provider* / *summary* sections
+/// of the AI tab but are backed by `liveAI.outputLanguage` and
+/// `liveAI.summaryPrompt`, because `RecordingSummarizer` and `LiveAISession`
+/// have always read them from `LiveAISettings`. Moving the control did not
+/// move the key.
+@MainActor
+final class AISettingsKeyCompatibilityTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    /// Isolated Keychain item so constructing an OpenAI-configured
+    /// `LLMSettings` never reads or writes the real app's stored token.
+    private var keychainKey: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "AISettingsKeyCompatibilityTests.\(UUID())"
+        defaults = UserDefaults(suiteName: suiteName)
+        keychainKey = "AISettingsKeyCompatibilityTests.\(UUID())"
+    }
+
+    override func tearDown() async throws {
+        if let suiteName { defaults.removePersistentDomain(forName: suiteName) }
+        try await super.tearDown()
+    }
+
+    private func makeLLM() -> LLMSettings {
+        LLMSettings(defaults: defaults, apiKeyKeychainKey: keychainKey)
+    }
+
+    // MARK: - Provider section (shared by every AI feature)
+
+    func test_provider_keys_are_adopted_from_existing_defaults() {
+        // Simulate a user who configured the old, separate "LLM" tab.
+        defaults.set("cursor", forKey: "llm.tool")
+        defaults.set("/opt/homebrew/bin/cursor-agent", forKey: "llm.executablePath")
+        defaults.set("--model sonnet", forKey: "llm.extraArgs")
+        defaults.set(600.0, forKey: "llm.cli.timeout")
+
+        let llm = makeLLM()
+
+        XCTAssertEqual(llm.tool, .cursor)
+        XCTAssertEqual(llm.executablePath, "/opt/homebrew/bin/cursor-agent")
+        XCTAssertEqual(llm.extraArgs, "--model sonnet")
+        XCTAssertEqual(llm.cliTimeout, 600.0)
+    }
+
+    func test_provider_edits_write_the_documented_keys() {
+        let llm = makeLLM()
+
+        llm.tool = .claude
+        llm.executablePath = "/usr/local/bin/claude"
+        llm.extraArgs = "--verbose"
+        llm.cliTimeout = 120
+
+        XCTAssertEqual(defaults.string(forKey: "llm.tool"), "claude")
+        XCTAssertEqual(defaults.string(forKey: "llm.executablePath"), "/usr/local/bin/claude")
+        XCTAssertEqual(defaults.string(forKey: "llm.extraArgs"), "--verbose")
+        XCTAssertEqual(defaults.double(forKey: "llm.cli.timeout"), 120)
+    }
+
+    func test_openAI_endpoint_keys_round_trip() {
+        defaults.set("groq", forKey: "llm.openai.provider")
+        defaults.set("https://api.groq.com/openai/v1", forKey: "llm.openai.baseURL")
+        defaults.set("llama-3.3-70b-versatile", forKey: "llm.openai.modelName")
+
+        let llm = makeLLM()
+        XCTAssertEqual(llm.openAIProvider, .groq)
+        XCTAssertEqual(llm.openAIBaseURL, "https://api.groq.com/openai/v1")
+        XCTAssertEqual(llm.openAIModelName, "llama-3.3-70b-versatile")
+
+        llm.openAIProvider = .deepseek
+        llm.openAIBaseURL = "https://api.deepseek.com/v1"
+        llm.openAIModelName = "deepseek-chat"
+
+        XCTAssertEqual(defaults.string(forKey: "llm.openai.provider"), "deepseek")
+        XCTAssertEqual(defaults.string(forKey: "llm.openai.baseURL"), "https://api.deepseek.com/v1")
+        XCTAssertEqual(defaults.string(forKey: "llm.openai.modelName"), "deepseek-chat")
+    }
+
+    // MARK: - Per-feature sections
+
+    func test_feature_toggles_and_prompts_round_trip() {
+        defaults.set(true, forKey: "llm.name.enabled")
+        defaults.set("Give me a title", forKey: "llm.name.prompt")
+        defaults.set(true, forKey: "llm.action.enabled")
+        defaults.set("Email this to the team", forKey: "llm.action.prompt")
+        defaults.set(false, forKey: "llm.summary.enabled")
+
+        let llm = makeLLM()
+        XCTAssertTrue(llm.nameGenerationEnabled)
+        XCTAssertEqual(llm.namePrompt, "Give me a title")
+        XCTAssertTrue(llm.postActionEnabled)
+        XCTAssertEqual(llm.postActionPrompt, "Email this to the team")
+        XCTAssertFalse(llm.summaryEnabled,
+                       "An explicit opt-out of automatic summaries must survive the tab merge")
+
+        llm.namePrompt = "Three words only"
+        llm.postActionPrompt = "Translate to English"
+        llm.summaryEnabled = true
+
+        XCTAssertEqual(defaults.string(forKey: "llm.name.prompt"), "Three words only")
+        XCTAssertEqual(defaults.string(forKey: "llm.action.prompt"), "Translate to English")
+        XCTAssertTrue(defaults.bool(forKey: "llm.summary.enabled"))
+    }
+
+    // MARK: - Controls the merge moved between sections
+
+    func test_outputLanguage_still_uses_the_liveAI_key() {
+        // Surfaced next to the provider now (it drives BOTH the automatic
+        // summary and the Live AI loop), still persisted where it always was.
+        defaults.set("he", forKey: "liveAI.outputLanguage")
+        XCTAssertEqual(LiveAISettings(defaults: defaults).outputLanguage, .hebrew)
+
+        let live = LiveAISettings(defaults: defaults)
+        live.outputLanguage = .english
+        XCTAssertEqual(defaults.string(forKey: "liveAI.outputLanguage"), "en")
+    }
+
+    func test_summaryPrompt_still_uses_the_liveAI_key() {
+        // Newly editable from the "Automatic summary" section; the key is the
+        // one `RecordingSummarizer` has always read.
+        defaults.set("Summarize in one line", forKey: "liveAI.summaryPrompt")
+        XCTAssertEqual(LiveAISettings(defaults: defaults).summaryPrompt,
+                       "Summarize in one line")
+
+        let live = LiveAISettings(defaults: defaults)
+        live.summaryPrompt = "Bullet points only"
+        XCTAssertEqual(defaults.string(forKey: "liveAI.summaryPrompt"), "Bullet points only")
+    }
+
+    func test_liveAI_section_keys_round_trip() {
+        defaults.set(false, forKey: "liveAI.enabled")
+        defaults.set("claude-haiku-4-5", forKey: "liveAI.model")
+        defaults.set("Custom live prompt", forKey: "liveAI.prompt")
+        defaults.set(true, forKey: "liveAI.backgroundMode")
+
+        let live = LiveAISettings(defaults: defaults)
+        XCTAssertFalse(live.enabled)
+        XCTAssertEqual(live.model, "claude-haiku-4-5")
+        XCTAssertEqual(live.prompt, "Custom live prompt")
+        XCTAssertTrue(live.backgroundMode)
+
+        live.enabled = true
+        live.prompt = "Another prompt"
+        XCTAssertTrue(defaults.bool(forKey: "liveAI.enabled"))
+        XCTAssertEqual(defaults.string(forKey: "liveAI.prompt"), "Another prompt")
+    }
+
+    // MARK: - Tab identity
+
+    func test_ai_tab_replaces_both_former_tabs() {
+        // One AI destination, distinct from its neighbours — deep links
+        // (`SettingsNavigation.pendingTab`) must resolve to exactly one tag.
+        XCTAssertNotEqual(SettingsTab.ai, SettingsTab.models)
+        XCTAssertNotEqual(SettingsTab.ai, SettingsTab.speakers)
+    }
+}

--- a/MilaTests/LiveAIMeetingContextTests.swift
+++ b/MilaTests/LiveAIMeetingContextTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 /// Per-meeting background notes (`LiveAISettings.meetingContext`).
 ///
-/// Origin: a user pasted a meeting agenda into Settings → Live AI →
-/// System prompt, which is a PERMANENT template. Every later recording was
+/// Origin: a user pasted a meeting agenda into the Live AI system prompt
+/// (Settings → AI → Live AI mode), which is a PERMANENT template. Every later recording was
 /// therefore handed the previous meeting's agenda as context, and the model
 /// returned a blended "previous call + this call" summary plus action items
 /// lifted straight from the stale agenda (all stamped

--- a/MilaTests/LiveAIMeetingContextTests.swift
+++ b/MilaTests/LiveAIMeetingContextTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Per-meeting background notes (`LiveAISettings.meetingContext`).
 ///
 /// Origin: a user pasted a meeting agenda into the Live AI system prompt
-/// (Settings → AI → Live AI mode), which is a PERMANENT template. Every later recording was
+/// (Settings → AI Features → Live AI mode), which is a PERMANENT template. Every later recording was
 /// therefore handed the previous meeting's agenda as context, and the model
 /// returned a blended "previous call + this call" summary plus action items
 /// lifted straight from the stale agenda (all stamped

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ running through `whisper.cpp` (GPU via Metal).
 - **AI summaries and titles** — after each recording, Mila shells out to a
   local Claude/Cursor/OpenAI-compatible CLI to auto-name the recording and
   generate an AI overview. Pick your provider once and edit the per-feature
-  prompts in **Settings → AI** (which also hosts Live AI mode).
+  prompts in **Settings → AI Features** (which also hosts Live AI mode). Pick the
+  provider once in **Settings → AI Provider**.
 - **iPhone Voice Memos sync** — Mila watches the folders iCloud syncs from your
   iPhone and auto-transcribes new recordings. Set up in **Settings → Voice Memos**.
 - **One-click team setup with `.milaconfig` files** — double-click a config file

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ running through `whisper.cpp` (GPU via Metal).
   a persistent directory that's reused across recordings.
 - **AI summaries and titles** — after each recording, Mila shells out to a
   local Claude/Cursor/OpenAI-compatible CLI to auto-name the recording and
-  generate an AI overview. Pick your provider once and edit the per-feature
-  prompts in **Settings → AI Features** (which also hosts Live AI mode). Pick the
-  provider once in **Settings → AI Provider**.
+  generate an AI overview. Point Mila at a provider once in
+  **Settings → AI Provider**, then turn features on and edit their prompts in
+  **Settings → AI Features** (which also hosts Live AI mode).
 - **iPhone Voice Memos sync** — Mila watches the folders iCloud syncs from your
   iPhone and auto-transcribes new recordings. Set up in **Settings → Voice Memos**.
 - **One-click team setup with `.milaconfig` files** — double-click a config file

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ running through `whisper.cpp` (GPU via Metal).
   a persistent directory that's reused across recordings.
 - **AI summaries and titles** — after each recording, Mila shells out to a
   local Claude/Cursor/OpenAI-compatible CLI to auto-name the recording and
-  generate an AI overview. Configure and test in **Settings → LLM**.
+  generate an AI overview. Pick your provider once and edit the per-feature
+  prompts in **Settings → AI** (which also hosts Live AI mode).
 - **iPhone Voice Memos sync** — Mila watches the folders iCloud syncs from your
   iPhone and auto-transcribes new recordings. Set up in **Settings → Voice Memos**.
 - **One-click team setup with `.milaconfig` files** — double-click a config file


### PR DESCRIPTION
Closes #144

## What this does

Replaces the two AI-related Settings tabs (**LLM** and **Live AI**) with two
*differently drawn* tabs — **AI Provider** (`sparkles`) and **AI Features**
(`wand.and.stars`) — split by how often you touch them rather than by which
feature owns the setting.

> **History:** the first pass on this branch merged everything into a single
> **AI** tab with five `DisclosureGroup`s. Reviewing it running, that was
> rejected: too much prose, no way to tell what was on or off, an `On`/`Off`
> label that looked like a control but wasn't, and a hit target limited to the
> chevron. The functionality was right; the presentation wasn't. This PR keeps
> the former and redoes the latter. The single-tab commit is kept in history.

### Tab A — AI Provider

Technical, set-once, often supplied by a `.milaconfig` import rather than typed.

- **Tool** as a pop-up menu sized to its content, not a full-width segmented
  control. Four options of very uneven length stretched across the pane gave
  "Off" a segment the size of a button.
- Only the fields the selected tool needs: `Executable` + `Extra args` for the
  CLIs; `Provider` / `Base URL` / `Model` / `API key` for OpenAI-compatible.
  Nothing renders at all while the tool is `Off`.
- **Timeout** is now an editable text field **and** a stepper. It used to be a
  bare stepper with a read-only `300s` label — getting to 900 meant clicking.
  `Reset` survives as a secondary link, disabled when already at the default.
- The **Test** panel lives here, collapsed by default.
- The privacy statement is one line — *"Shared by every AI feature. Only
  transcript text is ever sent — never audio."* — instead of the tail of a
  three-line paragraph.
- Field-row geometry (80 pt label column, control, one line of help beneath)
  is copied from `RemoteBackendSection` on the **Models** tab, so Mila's two
  "point this at a backend" screens read as siblings instead of two dialects.

### Tab B — AI Features

What the AI does for you — the tab people actually revisit.

- **Output language** moved here from the provider block. It governs generated
  content, not the connection, and it feeds both the automatic summary and the
  Live AI loop, so it sits at the top as a preamble to all four features.
- One row per feature: **Automatic summary**, **Recording names**,
  **Send-to-LLM action**, **Live AI mode**. Each is a title, **one** line of
  description, and a real `Toggle(.switch)` right-aligned — flippable without
  expanding anything. That replaces the coloured `On`/`Off` text.
- Clicking anywhere else on the row expands that feature's prompt editor and
  its own options (Live AI keeps its Advanced dials and its model override).
- Nothing starts expanded. All four features and their states fit above the
  fold.

**The switch is a sibling of the expand target, never a child of it** — this is
the easy thing to get subtly wrong:

```swift
HStack {
    Button { isExpanded.toggle() } label: {
        HStack { chevron; title + caption; Spacer(minLength: 0) }
            .contentShape(Rectangle())      // the whole strip is clickable
    }
    .buttonStyle(.plain)

    Toggle("", isOn: isOn)                  // laid out outside the Button
}
```

`Spacer(minLength: 0)` inside the button label is what makes "click anywhere on
the row" work — the button stretches across the free space instead of hugging
its text — and `.contentShape(Rectangle())` makes that empty space
hit-testable. Because the `Toggle` is a later child of the enclosing `HStack`,
a click on the switch is never *inside* the button's shape, so it cannot also
expand the row. Wrapping the whole `HStack` in
`.contentShape(Rectangle()).onTapGesture { … }` — the obvious first attempt —
leaves every switch click ambiguous.

## Text discipline

The main complaint was prose volume: 5 controls carried ~14 lines of caption,
all the same size and weight, so nothing was skimmable.

- Every caption is now **one short line**, rendered at `.caption`, capped at
  **520 pt** (`aiCaptionWidth`) so it can't run the full window width.
- Captions are indented to the **control** column (`aiLabelWidth + aiLabelGap`),
  not the label column, so the screen has one left edge for text instead of two.
- The second and third sentences moved into `.help()` tooltips on the row they
  describe — nothing was deleted outright. Examples:

| Was (inline) | Now (inline) | Detail moved to |
|---|---|---|
| "Pick your AI once here — every AI feature below uses it. Mila can shell out to a local CLI… Only transcript text is ever forwarded." (3 lines) | "Shared by every AI feature. Only transcript text is ever sent — never audio." | tooltip on the Tool row |
| "Leave blank to look up the binary on $PATH. Set this if `claude` / `cursor-agent` lives somewhere a GUI app won't see…" | "Leave blank to look the binary up on $PATH." | tooltip on the Executable row |
| "Appended to every run (name suggestion, auto-summary, Send action, and the test below). Shell-style quoting… Live AI manages its own model…" | "Added to every run. Live AI keeps its own model." | tooltip on the Extra args row |
| "Maximum time Mila waits… Raise this if your prompt uses agentic tools (e.g. calendar lookup)…" | "30–900 s. Covers titles, summaries and the Send action." | tooltip on the timeout row |
| "When on, Mila runs a one-shot LLM pass after every recording finishes… Existing summaries are kept, and any recording that still has one can be refreshed from its right-click 'Regenerate summary' action." (4 lines) | "Summarize every recording when it finishes." | tooltip on the Automatic summary row |
| Live AI's 2-paragraph prompt footnote | "Ask for a strict JSON array — free-form prose is ignored." + the (deliberately retained) one-line Context-box warning | tooltip / kept inline |
| Each of the 6 Advanced dials' 2–3 line captions | one line each | tooltip per dial |

The **"put one meeting's agenda in the recording pane's Context box"** warning
was kept inline rather than demoted to a tooltip — it exists because a stale
agenda in `liveAI.prompt` silently poisons every later recording, and that's
worth the line.

The `AI provider` heading is gone: it only repeated the tab name.

## Settings keys

**No persisted key changed, and no stored value changed meaning.** Verified by
diffing every `static let … = "…"` key literal in `LLMSettings` and
`LiveAISettings` against `main` — empty diff. `LiveAISettings.swift` is not
modified by this PR at all.

*Read/written by the new tabs, all unchanged:* `llm.tool`,
`llm.executablePath`, `llm.extraArgs`, `llm.cli.timeout`, `llm.name.enabled`,
`llm.name.prompt`, `llm.action.enabled`, `llm.action.prompt`,
`llm.summary.enabled`, `llm.openai.provider`, `llm.openai.baseURL`,
`llm.openai.modelName`, `liveAI.enabled`, `liveAI.model`, `liveAI.prompt`,
`liveAI.summaryPrompt`, `liveAI.outputLanguage`, `liveAI.chunkSeconds`,
`liveAI.llmMinIntervalSeconds`, `liveAI.useVAD`, `liveAI.useNeuralVAD`,
`liveAI.backgroundMode`, `liveAI.forceOnLowEndHardware`,
`liveAI.speakerSimilarityThreshold`.

*Keychain, unchanged:* `llm.openai.apiKey`.

The only non-presentational line in the whole PR is a named constant:
`LLMSettings.defaultTimeout = 300`, now backing **both** the init fallback and
the `Reset` button so the two can't drift. Same value as the literal it
replaced; a new test pins that.

`SettingsTab` replaces `.ai` with `.aiProvider` + `.aiFeatures`. It's an
in-memory enum only — `SettingsNavigation.pendingTab` is never persisted and
has no non-test call sites — so the shifted `Int` raw values are inert. A new
assertion pins that all ten tags stay distinct, since the split inserted a case
mid-list.

## Accessibility identifiers

- **Preserved verbatim:** `llm.summary.enabled.toggle` (now on the summary
  row's switch), and `ai.section.{summary,name,action,liveAI,test}` (now on
  each row's expand button).
- **Added:** `llm.name.enabled.toggle`, `llm.action.enabled.toggle`,
  `liveAI.enabled.toggle`, `liveAI.forceOnLowEndHardware.toggle`,
  `liveAI.model`, `ai.features.outputLanguage`, `ai.features.notConfigured`,
  and `ai.provider.{tool,preset,executablePath,extraArgs,baseURL,model,apiKey,timeout,runTest}`.
- `MilaUITests`' `liveAI.stop` / `liveAI.summary` belong to the recording view,
  not Settings, and are untouched. No `MilaUITests` file references any AI
  Settings identifier today.

## Also updated

- Strings naming the old tab now name the right one of the two:
  `LLMRunnerError` (→ AI Provider), `OpenAIRequestError.invalidEndpoint`
  (→ AI Provider), `RenameRecordingSheet`'s "no prompts enabled" hint
  (→ AI Features, and it now names the rows it means),
  `RecordingSummarizer`, `MilaApp`, `LLMSettings` doc comments.
- Live AI's "no provider configured" warning moved to a single banner at the
  top of **AI Features**, instead of being repeated inside the one feature that
  happened to mention it.
- `README.md`.
- Historical `RELEASE_NOTES/*` deliberately untouched. No new release note:
  this PR doesn't bump `MARKETING_VERSION`, so the note belongs to whichever
  release ships it.

## Incidental fix

The OpenAI **Provider** picker was missing `.labelsHidden()`, so a `.menu`
picker drew its own "Provider" label next to the label column's — the word
appeared twice. Fixed.

## Verified

- ✅ `make build` — clean.
- ✅ `xcodebuild … build-for-testing` — unit and UI test targets compile.
- ✅ Key-literal diff against `main` is empty (see above).

## NOT verified — needs a human or CI

- ❌ **The visual layout is completely unverified.** The app was never
  launched: the user is actively working on this Mac, and local UI-test runs
  steal focus and flake. Someone needs to open both tabs and eyeball them.
- ❌ Unit tests compiled but **not executed** locally. CI runs them.
- ❌ No manual upgrade test (configure on an old build → upgrade → confirm
  settings survive). `AISettingsKeyCompatibilityTests` is the automated
  stand-in.

## Tab-strip budget — resolved by the rebase

Rebased onto `main` at `4fe587a`, which brought in two PRs that settle this:

- **#138** widened the Settings frame to 700 pt (740 pt window), with a measured
  comment about the `>>` overflow. **Not touched here.**
- **#133** renamed Hotkeys → **General** and folded the **Updates** tab into it,
  freeing a slot.

Net effect: two AI tabs replace two AI tabs, so the count is unchanged from
before any of this work. The strip is now:

`General │ Audio │ Models │ AI Provider │ AI Features │ Speakers │ Meetings │ Voice Memos │ Storage`

Nine tabs, ~595 pt against the ~740 pt the strip gets — it fits, with no room
for a tenth. `SettingsTab` is now
`case general, audio, models, aiProvider, aiFeatures, speakers, meetings, voiceMemos, storage`,
and `AISettingsKeyCompatibilityTests` pins all nine raw values so a tenth tab
can't be added without someone re-reading the measurement comment.

## Rebase conflicts resolved

Three, all in the `SettingsTab` enum / its test, all resolved by keeping every
side's intent:

1. `main`'s `general` (was `hotkeys`) and dropped `updates`, plus this PR's
   `aiProvider` / `aiFeatures` replacing `ai`.
2. Same again on the commit that performs the split.
3. The test's raw-value pins, renumbered 0–8 for the nine-tab set.

## Incidental fix (from the rebase)

`HomeView`'s dictation tooltip still said "Configure in Settings → **Hotkeys**"
— #133 renamed that tab to General but missed this one `.help` string, so it
named a tab that no longer exists. One word, and squarely in scope for a PR
about tab names being right.

## Conflicts to expect

`#138 / #117` (window width) and `#133` (General tab) are **merged** and this
branch is rebased on top of them, so those are settled.

Still open and touching the same region:
- **#119** — adds Gemini CLI. Its new `LLMTool` case needs no layout work here
  (the Tool pop-up is a `ForEach` over `allCases`), but any Gemini-specific
  fields belong in `AIProviderSettingsTab.cliFields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



