### PR TITLE
chore(gitignore): match the PythonRuntime worktree symlink, not just the directory

### DIFF
--- a/.claude/skills/build-mila-locally/SKILL.md
+++ b/.claude/skills/build-mila-locally/SKILL.md
@@ -47,6 +47,11 @@ make dmg VERSION="$VERSION"
 ## Other known build gotchas
 
 - **PythonRuntime placeholder:** `Mila/Resources/PythonRuntime/` is a `.gitignored` folder reference. If missing, `xcodebuild` fails on the copy-resources phase. The `make project` target auto-creates an empty placeholder (the app falls back to system Python for diarization). For a *real* bundled diarization runtime, run `make bundle-diarization` first (~150-200 MB, slow, cached).
+- **PythonRuntime in a git worktree:** a fresh worktree has no runtime and rebuilding it costs ~150-200 MB. Reuse the main checkout's instead of running `make bundle-diarization` again:
+  ```bash
+  ln -s /path/to/main-checkout/Mila/Resources/PythonRuntime <worktree>/Mila/Resources/PythonRuntime
+  ```
+  The `.gitignore` entry has no trailing slash so it matches the symlink too — never commit it (it points at an absolute path on one machine).
 - **Models are NOT bundled.** Whisper weights download at first launch into `~/Library/Application Support/Mila/Models/` (or pre-fetch with `make models`, ~4.6 GB). A fresh build with no models will prompt/download on first transcription.
 - **`xcodegen` must be installed.** `make bootstrap` installs it via Homebrew if missing.
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,10 @@ default.profraw
 Mila-*.dmg
 
 # Generated diarization Python runtime bundle (built by scripts/build-diarization-bundle.sh,
-# distributed via GitHub release asset; do NOT commit ~150 MB into git)
-Mila/Resources/PythonRuntime/
+# distributed via GitHub release asset; do NOT commit ~150 MB into git).
+# No trailing slash on purpose: in a git worktree this path is often a *symlink*
+# back to the main checkout, and a trailing-slash pattern matches directories only.
+Mila/Resources/PythonRuntime
 
 # macOS
 .DS_Store


### PR DESCRIPTION
## Problem

`.gitignore` line 23 was:

```
Mila/Resources/PythonRuntime/
```

A **trailing slash makes a gitignore pattern match directories only**. In the main checkout `Mila/Resources/PythonRuntime` is a real directory, so it looked fine. But every git worktree needs that path as a **symlink** back to the main checkout, to reuse the ~150-200 MB bundled Python runtime instead of rebuilding it:

```bash
ln -s /path/to/main-checkout/Mila/Resources/PythonRuntime <worktree>/Mila/Resources/PythonRuntime
```

A symlink is not a directory, so the pattern did not match it. Result: `git status` showed it as untracked and `git add -A` would cheerfully stage a symlink pointing at an absolute path on one developer's machine. This nearly got committed.

## Fix

Drop the trailing slash (plus a comment explaining why it must stay off). The slash-less pattern matches both the real directory and the symlink.

## Evidence

**Before** — symlink present, nothing ignores it:

```
$ ls -ld Mila/Resources/PythonRuntime
lrwxr-xr-x  ... Mila/Resources/PythonRuntime -> /Users/…/Mila/Mila/Resources/PythonRuntime

$ git status --porcelain
?? Mila/Resources/PythonRuntime

$ git check-ignore -v Mila/Resources/PythonRuntime
$ echo $?
1                      # no pattern matched
```

**After** — same symlink, now ignored:

```
$ git check-ignore -v Mila/Resources/PythonRuntime
.gitignore:25:Mila/Resources/PythonRuntime	Mila/Resources/PythonRuntime

$ git status --porcelain
 M .gitignore          # symlink no longer listed

$ git add -A && git status --porcelain
M  .gitignore          # symlink not staged
```

**Real-directory case still ignored** (recreated `Mila/Resources/PythonRuntime/bin/python3` as an actual dir+file):

```
$ git check-ignore -v Mila/Resources/PythonRuntime Mila/Resources/PythonRuntime/bin/python3
.gitignore:25:Mila/Resources/PythonRuntime	Mila/Resources/PythonRuntime
.gitignore:25:Mila/Resources/PythonRuntime	Mila/Resources/PythonRuntime/bin/python3

$ git status --porcelain
 M .gitignore
```

Both the symlink and the scratch directory were removed afterwards; the worktree is clean apart from the two tracked edits.

## Audit of the rest of `.gitignore`

Every other trailing-slash pattern (`*.xcodeproj/`, `build/`, `build-release/`, `DerivedData/`, `.build/`, `Packages/*/.build/`, `Packages/*/.swiftpm/`, `.vscode/`, `.idea/`, `__pycache__/`, `llm-artifacts/`) has the same directory-only semantics, but none of them is a plausible symlink here:

- `build/` is `DERIVED` in the Makefile and `*.xcodeproj` is regenerated per-worktree by `xcodegen` — sharing either across worktrees would cause concurrent-build contention, so nobody symlinks them.
- Whisper model weights live outside the repo (`~/Library/Application Support/Mila/Models/`), so no ignore pattern is involved.
- A sweep of the main checkout and all live worktrees found exactly one symlink anywhere: `Mila/Resources/PythonRuntime`, in three worktrees.

Left unchanged deliberately — no sweeping rewrite.

## Docs

`.claude/skills/build-mila-locally/SKILL.md` documented the PythonRuntime placeholder but not the worktree symlink workaround. Added a short bullet next to it (`make project` already `mkdir -p`s an empty placeholder; the symlink is what gets you a *real* runtime in a worktree without a 150 MB rebuild), noting the symlink must never be committed.

## Issue link

Skipped per `.claude/rules/pull-requests.md`, which exempts trivial chores — this is a one-character gitignore semantics fix plus a doc bullet, with no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for setting up fresh worktrees using an existing local Python runtime.
  * Clarified that the shared runtime link should not be committed.

* **Chores**
  * Updated ignore rules to cover both generated runtime directories and linked worktree paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->