### PR TITLE
fix(audio): stop the config-change recovery loop from re-triggering itself

### DIFF
--- a/Mila/Audio/AudioDeviceManager.swift
+++ b/Mila/Audio/AudioDeviceManager.swift
@@ -63,13 +63,40 @@ enum AudioDeviceManager {
         return inputs.first(where: { !$0.isVirtual })
     }
 
+    /// The device an engine's input unit is currently bound to, or nil if it
+    /// can't be read. A fresh `AVAudioEngine` comes up on the system default
+    /// input, so this is usually already the device we're about to select.
+    static func currentInputDeviceID(on engine: AVAudioEngine) -> AudioDeviceID? {
+        guard let unit = engine.inputNode.audioUnit else { return nil }
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioUnitGetProperty(
+            unit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            &size
+        )
+        return status == noErr ? deviceID : nil
+    }
+
     /// Force an existing `AVAudioEngine`'s input node to read from the given device.
     /// Must be called before `engine.start()` and *after* touching `engine.inputNode`.
+    ///
+    /// Setting `kAudioOutputUnitProperty_CurrentDevice` reconfigures the I/O
+    /// unit, and a reconfiguration can make the engine post
+    /// `AVAudioEngineConfigurationChange` — which the recorder's mid-session
+    /// recovery listens for. When the unit is *already* on the device we want
+    /// (the common case: the user's pinned input is also the system default),
+    /// that notification buys nothing and costs a rebuild, so skip the write
+    /// entirely. See issue #147.
     static func setInputDevice(_ device: Device, on engine: AVAudioEngine) throws {
         guard let unit = engine.inputNode.audioUnit else {
             throw NSError(domain: "AudioDeviceManager", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Engine has no input audio unit."])
         }
+        if currentInputDeviceID(on: engine) == device.id { return }
         var deviceID = device.id
         let status = AudioUnitSetProperty(
             unit,

--- a/Mila/Audio/AudioUtilities.swift
+++ b/Mila/Audio/AudioUtilities.swift
@@ -172,6 +172,26 @@ final class StreamingWhisperConverter {
     }
 }
 
+/// Predicates about a raw sample buffer, shared by every path that has to
+/// decide "is there anything here at all?".
+enum AudioSignal {
+    /// True when a buffer carries no signal whatsoever: no samples, or nothing
+    /// but exact digital silence.
+    ///
+    /// Deliberately the strictest possible test. It is NOT the "too quiet to
+    /// be speech" gate — that's `TranscriptionService.minimumAudioPeak`, which
+    /// only the batch path applies, because a quiet-but-real utterance is
+    /// still worth transcribing. This one answers the narrower question "did
+    /// capture produce anything?", which is safe to apply even to a 300ms live
+    /// utterance: a live microphone, in a silent room, still delivers dither
+    /// and noise, never a run of exact zeros.
+    ///
+    /// O(1) for real audio — `contains` returns at the first non-zero sample.
+    static func isSilent(_ samples: [Float]) -> Bool {
+        !samples.contains { $0 != 0 }
+    }
+}
+
 /// Computes a 0...1 RMS level from an audio buffer for VU meters.
 enum AudioMeter {
     static func level(from buffer: AVAudioPCMBuffer) -> Float {

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -585,7 +585,19 @@ final class MicrophoneRecorder: ObservableObject {
         if let override = bringUpOverride {
             // Test path: no CoreAudio, but still exercise the full decision
             // and the timeout wrapper.
-            try? await Self.withTimeout(seconds: bringUpTimeout) { try await override() }
+            //
+            // Success and failure are kept as distinct as they are on the real
+            // path below: a bring-up that threw installed no engine, so it must
+            // not re-arm the grace window or register a new notification
+            // source. Otherwise the seam would quietly misreport a *failed*
+            // mid-session rebuild as a successful one — and the grace window is
+            // exactly what a test of this area is measuring.
+            do {
+                try await Self.withTimeout(seconds: bringUpTimeout) { try await override() }
+            } catch {
+                micLog.error("mic rebuild #\(attempt, privacy: .public) (reason: \(reason, privacy: .public)) failed: \(error.localizedDescription, privacy: .public) — the watchdog will retry")
+                return
+            }
             guard captureEpoch == epoch else { return }
             lastBringUpAt = Date()
             // Mirror the real path: a rebuild installs a new engine, so the

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -99,9 +99,16 @@ struct RebuildThrottle {
 
     private var lastAllowedAt: Date?
     /// Rebuilds allowed in the current burst. Reset once things go quiet for
-    /// `maximumInterval`, so an unrelated device change an hour into a meeting
+    /// `quietPeriod`, so an unrelated device change an hour into a meeting
     /// isn't punished for a storm at the start of it.
     private(set) var streak = 0
+
+    /// Idle time that ends a burst. Twice the ceiling rather than the ceiling
+    /// itself: a burst that has saturated the backoff arrives *exactly* one
+    /// `maximumInterval` apart, and treating that as "quiet" would reset the
+    /// ladder on every tick and cap the backoff at `minimumInterval` forever —
+    /// which is the bug this type exists to prevent, reintroduced one level up.
+    var quietPeriod: TimeInterval { maximumInterval * 2 }
 
     init(minimumInterval: TimeInterval, maximumInterval: TimeInterval) {
         self.minimumInterval = minimumInterval
@@ -123,8 +130,8 @@ struct RebuildThrottle {
         if let last = lastAllowedAt {
             let elapsed = now.timeIntervalSince(last)
             if elapsed < currentInterval { return false }
-            // Quiet for a full backoff ceiling: the previous burst is over.
-            if elapsed >= maximumInterval { streak = 0 }
+            // Quiet for long enough that the previous burst is over.
+            if elapsed >= quietPeriod { streak = 0 }
         }
         lastAllowedAt = now
         streak += 1

--- a/Mila/Audio/MicrophoneRecorder.swift
+++ b/Mila/Audio/MicrophoneRecorder.swift
@@ -70,6 +70,68 @@ struct CaptureStallDetector {
     }
 }
 
+/// Pure, clock-injected minimum-interval + exponential-backoff gate for
+/// *notification-driven* engine rebuilds.
+///
+/// `AVAudioEngineConfigurationChange` does not mean "something broke" — it
+/// means "the I/O unit was reconfigured", and binding the input device during
+/// our own bring-up is itself a reconfiguration. On at least one Mac that made
+/// the recovery path self-sustaining: bind → notification → rebuild → bind →
+/// notification, measured at ~150ms per cycle, which never let the tap live
+/// long enough to deliver a single buffer (issue #147). The whole
+/// `maxMidSessionRestarts` budget — documented as "60 attempts at ≥1s apart" —
+/// was spent in about nine seconds, and the macOS microphone indicator
+/// flickered for the entire recording.
+///
+/// The watchdog path is naturally spaced by `captureStallTimeout`; this gate
+/// gives the notification path the same property, so the budget spans minutes
+/// the way its comment always claimed. Throttled notifications are not lost
+/// work: capture that is genuinely dead stops growing the frame count, so
+/// `CaptureStallDetector` picks it up within `captureStallTimeout`.
+///
+/// A value type with an injected `now`, like `CaptureStallDetector`, so the
+/// policy is unit-testable exactly and without sleeping.
+struct RebuildThrottle {
+    /// Floor between the first rebuild and the second one.
+    let minimumInterval: TimeInterval
+    /// Ceiling the doubling backoff saturates at.
+    let maximumInterval: TimeInterval
+
+    private var lastAllowedAt: Date?
+    /// Rebuilds allowed in the current burst. Reset once things go quiet for
+    /// `maximumInterval`, so an unrelated device change an hour into a meeting
+    /// isn't punished for a storm at the start of it.
+    private(set) var streak = 0
+
+    init(minimumInterval: TimeInterval, maximumInterval: TimeInterval) {
+        self.minimumInterval = minimumInterval
+        self.maximumInterval = max(minimumInterval, maximumInterval)
+    }
+
+    /// How long after the last allowed rebuild the next one may happen.
+    /// Zero before the first rebuild — the first configuration change of a
+    /// session is always acted on immediately.
+    var currentInterval: TimeInterval {
+        guard streak > 0 else { return 0 }
+        let scaled = minimumInterval * pow(2, Double(streak - 1))
+        return min(scaled, maximumInterval)
+    }
+
+    /// Whether a rebuild may proceed at `now`. Mutating: an allowed rebuild
+    /// starts the clock for the next one and lengthens the backoff.
+    mutating func allow(now: Date) -> Bool {
+        if let last = lastAllowedAt {
+            let elapsed = now.timeIntervalSince(last)
+            if elapsed < currentInterval { return false }
+            // Quiet for a full backoff ceiling: the previous burst is over.
+            if elapsed >= maximumInterval { streak = 0 }
+        }
+        lastAllowedAt = now
+        streak += 1
+        return true
+    }
+}
+
 /// Pulls samples from the user's preferred input device using `AVAudioEngine`.
 /// Emits whisper-format buffers (16kHz mono Float32) on `audioStream`.
 ///
@@ -152,9 +214,34 @@ final class MicrophoneRecorder: ObservableObject {
 
     /// Hard cap on rebuild attempts within one recording. A permanently dead
     /// input would otherwise have us rebuilding in a loop for the length of a
-    /// meeting. 60 attempts at ≥1s apart still rides out a device that's
-    /// unplugged for a minute; past that we stop trying and say so in the log.
+    /// meeting. Combined with the pacing below (the watchdog fires at most
+    /// once per `captureStallTimeout`, the notification path is gated by
+    /// `RebuildThrottle`), 60 attempts span minutes rather than seconds; past
+    /// that we stop trying and say so in the log.
     var maxMidSessionRestarts = 60
+
+    /// Configuration changes arriving this soon after a bring-up are treated
+    /// as OUR OWN doing and ignored.
+    ///
+    /// `bringUp` binds the chosen input with
+    /// `kAudioOutputUnitProperty_CurrentDevice`, and on some machines that
+    /// bind is itself enough to make the engine post
+    /// `AVAudioEngineConfigurationChange` — indistinguishable, at the
+    /// notification, from a device being yanked. Reacting to it rebuilt the
+    /// engine, which bound the device again, which posted again (issue #147).
+    ///
+    /// The cost of the window is that a device genuinely lost in the first
+    /// fraction of a second of a recording is not repaired by the *fast*
+    /// path — the stall watchdog still catches it `captureStallTimeout` later,
+    /// so the failure mode is a few seconds of delay, not a lost recording.
+    var configurationChangeGracePeriod: TimeInterval = 0.75
+
+    /// Floor between two notification-driven rebuilds (doubling up to
+    /// `maximumRebuildInterval`). See `RebuildThrottle`.
+    var minimumRebuildInterval: TimeInterval = 1.0
+
+    /// Ceiling for the notification-path backoff.
+    var maximumRebuildInterval: TimeInterval = 30.0
 
     /// Rebuild attempts made during the current session — surfaced in the
     /// stop log so a diagnostic report shows "capture was repaired 3 times"
@@ -163,6 +250,27 @@ final class MicrophoneRecorder: ObservableObject {
 
     private var watchdogTask: Task<Void, Never>?
     private var configChangeObserver: NSObjectProtocol?
+
+    /// The object whose `AVAudioEngineConfigurationChange` notifications we're
+    /// currently observing — the live `AVAudioEngine` in production.
+    ///
+    /// Held (rather than just registered for) for two reasons: `NotificationCenter`
+    /// does not retain the object an observer is scoped to, and it gives the
+    /// `bringUpOverride` test path — which has no real engine — a stand-in to
+    /// post to. Tests exercise the REAL observer, the real notification name
+    /// and the real handler policy; only the poster of the notification is
+    /// simulated. Re-read it after every rebuild: production installs a fresh
+    /// engine (and so a fresh source) each time, and a faithful test does the
+    /// same.
+    private(set) var configurationChangeSource: AnyObject?
+
+    /// When the most recent successful bring-up finished — the start of the
+    /// `configurationChangeGracePeriod` window.
+    private var lastBringUpAt: Date?
+
+    /// Paces notification-driven rebuilds. Rebuilt per session in `start()`.
+    private var rebuildThrottle = RebuildThrottle(minimumInterval: 1.0, maximumInterval: 30.0)
+
     /// Guards against a configuration-change notification and a watchdog tick
     /// both deciding to rebuild at the same moment.
     private var isRebuilding = false
@@ -210,6 +318,7 @@ final class MicrophoneRecorder: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil
         }
+        configurationChangeSource = nil
         if let existing = engine {
             existing.inputNode.removeTap(onBus: 0)
             existing.stop()
@@ -225,12 +334,21 @@ final class MicrophoneRecorder: ObservableObject {
         restartCount = 0
         isRebuilding = false
         captureEpoch += 1
+        lastBringUpAt = nil
+        rebuildThrottle = RebuildThrottle(minimumInterval: minimumRebuildInterval,
+                                          maximumInterval: maximumRebuildInterval)
 
         if let override = bringUpOverride {
             try await Self.withTimeout(seconds: bringUpTimeout) {
                 try await override()
             }
             isRunning = true
+            lastBringUpAt = Date()
+            // Observe on the test path too, against a stand-in source: the
+            // configuration-change handling and its pacing are the part of
+            // this class most in need of coverage, and the real path can't be
+            // driven in CI (no microphone, no CoreAudio device to reconfigure).
+            observeConfigurationChanges(on: ConfigurationChangeSource())
             // Start the watchdog on the test path too: with no real tap the
             // frame count never grows, so a test can drive the full
             // stall → rebuild loop by counting override invocations.
@@ -259,7 +377,13 @@ final class MicrophoneRecorder: ObservableObject {
                                                  stats: sessionStats)
         self.engine = result.engine
         isRunning = true
+        lastBringUpAt = Date()
         micLog.log("mic started: \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch agc=\(agcEnabled ? "on" : "off", privacy: .public)")
+        // Registered only now, i.e. after the device bind inside the bring-up
+        // has returned. That ordering alone is NOT enough (the notification is
+        // posted asynchronously and can land after we register, which is why
+        // `configurationChangeGracePeriod` exists), but it does drop the
+        // changes that are already in flight by this point.
         observeConfigurationChanges(on: result.engine)
         startCaptureWatchdog()
     }
@@ -298,16 +422,26 @@ final class MicrophoneRecorder: ObservableObject {
 
     // MARK: - Mid-session recovery
 
+    /// Stand-in notification source used on the `bringUpOverride` path, where
+    /// there is no `AVAudioEngine` to scope the observer to. Its only job is to
+    /// be an identity a test can post to.
+    final class ConfigurationChangeSource: NSObject {}
+
     /// Watch one engine for the configuration change that silently kills the
     /// tap. Re-registered after every rebuild, since the notification is
     /// scoped to a specific engine instance.
-    private func observeConfigurationChanges(on engine: AVAudioEngine) {
+    ///
+    /// Takes `AnyObject` rather than `AVAudioEngine` so the override path can
+    /// register the same observer against a `ConfigurationChangeSource` — see
+    /// `configurationChangeSource`.
+    private func observeConfigurationChanges(on source: AnyObject) {
         if let existing = configChangeObserver {
             NotificationCenter.default.removeObserver(existing)
         }
+        configurationChangeSource = source
         configChangeObserver = NotificationCenter.default.addObserver(
             forName: NSNotification.Name.AVAudioEngineConfigurationChange,
-            object: engine,
+            object: source,
             queue: nil
         ) { [weak self] _ in
             // The callback arrives on an AVFoundation-internal dispatch queue,
@@ -322,6 +456,26 @@ final class MicrophoneRecorder: ObservableObject {
 
     private func handleConfigurationChange() async {
         guard isRunning else { return }
+        let now = Date()
+
+        // 1. Did we cause this ourselves? Our own bring-up binds the input
+        //    device, and on some machines that bind posts a configuration
+        //    change. Acting on it re-binds, which posts again — the ~150ms
+        //    self-sustaining loop of issue #147, during which the tap never
+        //    lives long enough to deliver one buffer.
+        if let lastBringUpAt, now.timeIntervalSince(lastBringUpAt) < configurationChangeGracePeriod {
+            micLog.log("ignoring AVAudioEngineConfigurationChange \(now.timeIntervalSince(lastBringUpAt), privacy: .public)s after bring-up — inside the \(self.configurationChangeGracePeriod, privacy: .public)s grace window, so this is our own device selection echoing back; the stall watchdog still covers a device that really did go away")
+            return
+        }
+
+        // 2. Pace what's left. The watchdog is spaced by `captureStallTimeout`;
+        //    without this the notification path had no spacing at all, so the
+        //    rebuild budget could be spent in seconds.
+        guard rebuildThrottle.allow(now: now) else {
+            micLog.error("AVAudioEngine configuration changed again within \(self.rebuildThrottle.currentInterval, privacy: .public)s of the last rebuild — throttling this one (streak=\(self.rebuildThrottle.streak, privacy: .public)); if capture really is dead the stall watchdog will rebuild it")
+            return
+        }
+
         // No "is it really broken?" probe here on purpose: the documented
         // behaviour is that the engine has ALREADY stopped itself by the time
         // this notification is posted, so capture is dead either way and
@@ -425,6 +579,11 @@ final class MicrophoneRecorder: ObservableObject {
             // Test path: no CoreAudio, but still exercise the full decision
             // and the timeout wrapper.
             try? await Self.withTimeout(seconds: bringUpTimeout) { try await override() }
+            guard captureEpoch == epoch else { return }
+            lastBringUpAt = Date()
+            // Mirror the real path: a rebuild installs a new engine, so the
+            // notification source is new too.
+            observeConfigurationChanges(on: ConfigurationChangeSource())
             return
         }
 
@@ -456,6 +615,7 @@ final class MicrophoneRecorder: ObservableObject {
                 return
             }
             engine = result.engine
+            lastBringUpAt = Date()
             observeConfigurationChanges(on: result.engine)
             micLog.log("mic capture rebuilt (attempt #\(attempt, privacy: .public), reason: \(reason, privacy: .public)) at \(result.format.sampleRate, privacy: .public)Hz \(result.format.channelCount, privacy: .public)ch — recording continues")
         } catch {
@@ -482,6 +642,8 @@ final class MicrophoneRecorder: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil
         }
+        configurationChangeSource = nil
+        lastBringUpAt = nil
         if let s = stats?.withLock({ $0 }) {
             micLog.log("mic stopping: buffers=\(s.buffers, privacy: .public) frames=\(s.frames, privacy: .public) conversionFailures=\(s.conversionFailures, privacy: .public) rebuilds=\(self.restartCount, privacy: .public)")
             if s.frames == 0 {
@@ -554,8 +716,14 @@ final class MicrophoneRecorder: ObservableObject {
             }
             let nativeFormat = input.inputFormat(forBus: 0)
             micLog.log("native input format: \(nativeFormat.sampleRate, privacy: .public)Hz \(nativeFormat.channelCount, privacy: .public)ch")
-            guard nativeFormat.sampleRate > 0 else {
-                micLog.error("input format reports sampleRate=0 — no usable input device; throwing noInputDevice")
+            // Both halves matter. A rebuild that lands on the wrong AUHAL —
+            // issue #147 saw the *output* device selected, leaving an
+            // "Input render format: 0 ch, 0 Hz" node — must be reported as a
+            // failed bring-up rather than adopted as a working engine that
+            // will never deliver a buffer. The caller logs the failure and the
+            // watchdog retries, instead of the session silently going quiet.
+            guard nativeFormat.sampleRate > 0, nativeFormat.channelCount > 0 else {
+                micLog.error("input format reports \(nativeFormat.sampleRate, privacy: .public)Hz \(nativeFormat.channelCount, privacy: .public)ch — no usable input device; throwing noInputDevice")
                 throw MicrophoneError.noInputDevice
             }
             // One converter for the whole session: resampling is stateful,

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -32,6 +32,7 @@ protocol RemoteTranscribing: TranscribingEngine {
 actor RemoteWhisperEngine: RemoteTranscribing {
     enum RemoteError: LocalizedError {
         case notConfigured
+        case noAudioCaptured
         case http(status: Int, body: String)
         case badResponse
         case emptyResult
@@ -40,6 +41,8 @@ actor RemoteWhisperEngine: RemoteTranscribing {
             switch self {
             case .notConfigured:
                 return "Remote transcription endpoint is not configured."
+            case .noAudioCaptured:
+                return "No audio was captured, so there was nothing to transcribe. Check that the input in Settings ▸ Audio Input is connected and not muted."
             case .http(let status, let body):
                 let detail = Self.shortMessage(from: body)
                 return "Remote server returned HTTP \(status)\(detail.map { ": \($0)" } ?? "")."
@@ -102,6 +105,17 @@ actor RemoteWhisperEngine: RemoteTranscribing {
                     isCancelled: (@Sendable () -> Bool)?) async throws -> [TranscriptSegment] {
         guard let config else { throw RemoteError.notConfigured }
         if isCancelled?() == true { throw CancellationError() }
+
+        // Never POST audio with nothing in it. A capture session that
+        // delivered zero frames encodes to a header-only file, and the server
+        // answers — correctly — `HTTP 500: {"detail":"Failed to decode
+        // audio."}`, which reads to the user as a server outage and is
+        // completely unactionable. The failure belongs to the microphone, so
+        // say so here rather than letting the network report it. (issue #147)
+        guard !AudioSignal.isSilent(samples) else {
+            remoteLog.error("transcribe: REFUSING to upload \(samples.count, privacy: .public) samples with no signal — nothing was captured")
+            throw RemoteError.noAudioCaptured
+        }
 
         progress?(0.05)
         let audioData = try await Self.encodeM4A(samples: samples)

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -49,6 +49,11 @@ final class TranscriptionService: ObservableObject {
     /// to clipping levels and produce ghost transcripts.
     static let minimumAudioPeak: Float = 0.005
 
+    /// Shown when capture produced no samples at all — the microphone's
+    /// problem, surfaced as the microphone's problem. See the guard in
+    /// `transcribeOnceSegments`.
+    static let noAudioCapturedMessage = "No audio was captured, so there was nothing to transcribe. Check System Settings ▸ Privacy & Security ▸ Microphone, and that the input selected in Settings ▸ Audio Input isn't muted, disconnected, or in use by another app."
+
     private let engine: any TranscribingEngine
     private let store: RecordingStore
     private let modelManager: ModelManager
@@ -321,6 +326,19 @@ final class TranscriptionService: ObservableObject {
     }
 
     func transcribeOnceSegments(samples: [Float], language: String, audioCtx: Int32?) async -> [TranscriptSegment] {
+        // Nothing was captured: don't hand it to any backend. The remote one
+        // uploads a header-only file and gets back `HTTP 500: Failed to decode
+        // audio.`, which the user reads as "the transcription server is down"
+        // — a diagnosis they can neither confirm nor act on, when the real
+        // problem is on this machine. Say what actually happened instead.
+        // The local backend fails the same way, just more quietly. (issue #147)
+        if AudioSignal.isSilent(samples) {
+            serviceLog.error("transcribeOnceSegments: REFUSING to transcribe \(samples.count, privacy: .public) samples with no signal — capture produced nothing")
+            if lastError == nil {
+                lastError = Self.noAudioCapturedMessage
+            }
+            return []
+        }
         // Remote backend: route dictation/live utterances to the configured
         // endpoint too, so the user's "global backend" choice holds for every
         // path. Misconfiguration degrades to an empty result (same contract as

--- a/MilaTests/AudioConvertTests.swift
+++ b/MilaTests/AudioConvertTests.swift
@@ -157,3 +157,29 @@ final class AudioConvertTests: XCTestCase {
         return buffer
     }
 }
+
+/// `AudioSignal.isSilent` is the "did capture produce anything at all?"
+/// predicate that keeps a zero-frame session off the network (issue #147). It
+/// deliberately is NOT a loudness gate — see the quiet-audio case.
+final class AudioSignalTests: XCTestCase {
+
+    func test_emptyBufferIsSilent() {
+        XCTAssertTrue(AudioSignal.isSilent([]))
+    }
+
+    func test_allZerosIsSilent() {
+        XCTAssertTrue(AudioSignal.isSilent([Float](repeating: 0, count: 48_000)))
+    }
+
+    func test_oneNonZeroSampleIsNotSilent() {
+        var samples = [Float](repeating: 0, count: 48_000)
+        samples[47_999] = -0.000_01
+        XCTAssertFalse(AudioSignal.isSilent(samples),
+                       "the predicate must not discard real, quiet audio — that's a separate, louder threshold")
+    }
+
+    func test_normalAudioIsNotSilent() {
+        let samples = (0..<1_600).map { Float(sin(Double($0) * 0.1)) * 0.3 }
+        XCTAssertFalse(AudioSignal.isSilent(samples))
+    }
+}

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -177,6 +177,93 @@ final class CaptureStallDetectorTests: XCTestCase {
     }
 }
 
+/// Policy coverage for the rebuild pacing added after issue #147: binding the
+/// input device during bring-up made the engine post
+/// `AVAudioEngineConfigurationChange` on the reporter's Mac, the handler
+/// rebuilt immediately, the rebuild re-bound the device, and the whole thing
+/// went round at ~150ms — ~7 microphone start/stop cycles per second, with the
+/// tap never alive long enough to deliver one buffer.
+///
+/// `maxMidSessionRestarts = 60` did not save it: its "60 attempts at ≥1s
+/// apart" comment described the watchdog's cadence, and the notification path
+/// had no cadence at all, so the whole budget burned in about nine seconds.
+final class RebuildThrottleTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 2_000_000)
+
+    /// The first configuration change of a session is always acted on
+    /// immediately — pacing must not make a genuine device swap feel broken.
+    func test_first_rebuild_is_immediate() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 30)
+        XCTAssertEqual(throttle.currentInterval, 0)
+        XCTAssertTrue(throttle.allow(now: t0))
+    }
+
+    /// The regression, stated as policy: a burst of notifications at the
+    /// observed ~150ms cadence must collapse to a single rebuild.
+    func test_a_storm_of_changes_collapses_to_one_rebuild() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 30)
+        var allowed = 0
+        for step in 0..<60 {                       // 9 seconds at 150ms
+            if throttle.allow(now: t0.addingTimeInterval(Double(step) * 0.15)) { allowed += 1 }
+        }
+        // 9 seconds spans the 1s floor and then the 2s and 4s backoff steps.
+        XCTAssertLessThanOrEqual(allowed, 4,
+                                 "60 changes in 9s must not mean 60 rebuilds; allowed \(allowed)")
+        XCTAssertGreaterThanOrEqual(allowed, 1, "the first change must still be acted on")
+    }
+
+    /// Documents the behaviour being replaced: with no minimum interval, every
+    /// single notification is a rebuild. This is what shipped in 1.9.2-beta.2.
+    func test_without_a_minimum_interval_every_change_rebuilds() {
+        var throttle = RebuildThrottle(minimumInterval: 0, maximumInterval: 0)
+        var allowed = 0
+        for step in 0..<60 {
+            if throttle.allow(now: t0.addingTimeInterval(Double(step) * 0.15)) { allowed += 1 }
+        }
+        XCTAssertEqual(allowed, 60)
+    }
+
+    func test_backoff_doubles_and_saturates_at_the_ceiling() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 8)
+        var now = t0
+        var intervals: [TimeInterval] = []
+        for _ in 0..<6 {
+            XCTAssertTrue(throttle.allow(now: now))
+            intervals.append(throttle.currentInterval)
+            // Advance exactly to the next permitted moment.
+            now = now.addingTimeInterval(throttle.currentInterval)
+        }
+        XCTAssertEqual(intervals, [1, 2, 4, 8, 8, 8])
+    }
+
+    /// The budget has to span minutes, which was the whole claim of the
+    /// `maxMidSessionRestarts` comment. Walk the ladder for the real defaults.
+    func test_the_rebuild_budget_spans_minutes_not_seconds() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 30)
+        var now = t0
+        for _ in 0..<60 {
+            XCTAssertTrue(throttle.allow(now: now))
+            now = now.addingTimeInterval(throttle.currentInterval)
+        }
+        let spanned = now.timeIntervalSince(t0)
+        XCTAssertGreaterThan(spanned, 20 * 60,
+                             "60 notification-driven rebuilds should span many minutes, not the ~9s of the bug; spanned \(spanned)s")
+    }
+
+    /// Backoff must not punish an unrelated event much later in a long
+    /// meeting: a quiet spell means the burst is over.
+    func test_a_quiet_spell_resets_the_backoff() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 10)
+        XCTAssertTrue(throttle.allow(now: t0))
+        XCTAssertTrue(throttle.allow(now: t0.addingTimeInterval(1)))
+        XCTAssertEqual(throttle.currentInterval, 2)
+        // 10 minutes later, the user unplugs their headphones.
+        XCTAssertTrue(throttle.allow(now: t0.addingTimeInterval(600)))
+        XCTAssertEqual(throttle.currentInterval, 1, "the ladder should start over after a quiet spell")
+    }
+}
+
 /// End-to-end wiring of the watchdog, driven through the `bringUpOverride`
 /// seam: with no real tap the frame count never grows, so a stalled session is
 /// exactly what the recorder sees when a device dies. Counting bring-ups tells
@@ -263,5 +350,146 @@ final class MicrophoneWatchdogTests: XCTestCase {
         try await Task.sleep(nanoseconds: 600_000_000)
         XCTAssertEqual(bringUps(), afterStop,
                        "no bring-ups may happen after stop() — the watchdog must be cancelled")
+    }
+}
+
+/// The configuration-change path, driven through the REAL observer.
+///
+/// Issue #147: on the reporter's Mac, `bringUp()`'s own
+/// `kAudioOutputUnitProperty_CurrentDevice` bind made AVAudioEngine post
+/// `AVAudioEngineConfigurationChange`; the handler rebuilt at once, the
+/// rebuild re-bound the device, and the loop sustained itself at ~150ms until
+/// the user hit Stop — `buffers=0 frames=0 rebuilds=13`, a header-only WAV,
+/// and an `HTTP 500: Failed to decode audio.` that looked like a server
+/// outage.
+///
+/// Why these tests can run on a headless CI runner with no microphone: the
+/// recorder registers its observer against `configurationChangeSource` — the
+/// live `AVAudioEngine` in production, a stand-in object on the
+/// `bringUpOverride` path. Everything under test is real (the observer, the
+/// notification name, the handler, the grace window, the throttle, the rebuild
+/// budget); only the *poster* of the notification is simulated, which is
+/// exactly the part CoreAudio would otherwise have to provide.
+///
+/// The watchdog is parked (`captureStallTimeout` far beyond the test's
+/// lifetime) in every test here so the only thing that can rebuild capture is
+/// the notification path being measured.
+@MainActor
+final class MicrophoneConfigurationChangeTests: XCTestCase {
+
+    private func makeRecorder() -> (MicrophoneRecorder, @Sendable () -> Int) {
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let mic = MicrophoneRecorder()
+        mic.bringUpTimeout = 1.0
+        // Park the stall watchdog: it has its own tests, and here it would be
+        // a second source of rebuilds.
+        mic.captureStallTimeout = 3600
+        mic.watchdogInterval = 3600
+        mic.configurationChangeGracePeriod = 0.2
+        mic.minimumRebuildInterval = 1.0
+        mic.maximumRebuildInterval = 4.0
+        mic.bringUpOverride = { counter.withLock { $0 += 1 } }
+        return (mic, { counter.withLock { $0 } })
+    }
+
+    private func postConfigurationChange(to mic: MicrophoneRecorder) {
+        // Re-read the source every time: production installs a brand-new
+        // engine on each rebuild, and it is the new engine that posts the next
+        // change. Posting to a stale source would make the loop untestable —
+        // the second notification would simply go nowhere.
+        guard let source = mic.configurationChangeSource else {
+            return XCTFail("recorder registered no configuration-change source")
+        }
+        NotificationCenter.default.post(
+            name: NSNotification.Name.AVAudioEngineConfigurationChange,
+            object: source)
+    }
+
+    /// Fix (1): the notification our own device bind provokes must not be
+    /// mistaken for the world changing.
+    func test_self_inflicted_change_during_bring_up_does_not_rebuild() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        XCTAssertEqual(bringUps(), 1)
+
+        // Same instant as the bring-up — this is what the bind itself posts.
+        postConfigurationChange(to: mic)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(mic.restartCount, 0,
+                       "a configuration change inside the bring-up grace window is our own doing — rebuilding it is what started the loop")
+        XCTAssertEqual(bringUps(), 1, "the engine must not have been torn down and rebuilt")
+        await mic.stop()
+    }
+
+    /// The counterweight to the test above, and the risk the grace window
+    /// carries: suppressing self-inflicted changes must NOT blind the recorder
+    /// to a device that genuinely went away.
+    func test_change_after_the_grace_window_still_rebuilds() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        try await Task.sleep(nanoseconds: 300_000_000)   // past the 0.2s window
+
+        postConfigurationChange(to: mic)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertEqual(mic.restartCount, 1,
+                       "a real device change must still be repaired promptly")
+        XCTAssertEqual(bringUps(), 2)
+        await mic.stop()
+    }
+
+    /// Fix (2), and the shape of the actual bug: a *storm* of changes — each
+    /// one provoked by the rebuild that answered the last — must be bounded.
+    ///
+    /// Before the fix this produced one rebuild per notification: the
+    /// reporter's log shows 13 rebuilds in the ~2s before they hit Stop, and
+    /// the 60-rebuild budget would have been gone in nine seconds.
+    func test_a_storm_of_configuration_changes_is_bounded() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        try await Task.sleep(nanoseconds: 300_000_000)   // past the grace window
+
+        // Post continuously for a fixed WALL-CLOCK window at roughly the
+        // cadence observed in the bug (~150ms, compressed to 15ms here).
+        // Wall-clock rather than a fixed iteration count so a slow CI runner
+        // stretches the number of posts, not the window the policy is judged
+        // over.
+        var posts = 0
+        let deadline = Date().addingTimeInterval(0.6)
+        while Date() < deadline {
+            postConfigurationChange(to: mic)
+            posts += 1
+            try await Task.sleep(nanoseconds: 15_000_000)
+        }
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertGreaterThan(posts, 10, "the burst should have delivered plenty of notifications")
+        // Floor is 1s and the burst is 0.6s, so one rebuild is the expected
+        // answer; the bound is 2 purely for CI clock jitter. The point is that
+        // the count tracks the POLICY, not the number of notifications.
+        XCTAssertLessThanOrEqual(mic.restartCount, 2,
+                                 "\(posts) configuration changes in 0.6s produced \(mic.restartCount) rebuilds — the notification path is not paced")
+        XCTAssertLessThanOrEqual(bringUps(), 3)
+        await mic.stop()
+    }
+
+    /// A rebuild storm must not be able to outlive the recording either.
+    func test_configuration_change_after_stop_is_ignored() async throws {
+        let (mic, bringUps) = makeRecorder()
+        try await mic.start()
+        let source = mic.configurationChangeSource
+        try await Task.sleep(nanoseconds: 300_000_000)
+        await mic.stop()
+
+        if let source {
+            NotificationCenter.default.post(
+                name: NSNotification.Name.AVAudioEngineConfigurationChange,
+                object: source)
+        }
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(mic.restartCount, 0)
+        XCTAssertEqual(bringUps(), 1, "no bring-up may happen after stop()")
     }
 }

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -262,6 +262,22 @@ final class RebuildThrottleTests: XCTestCase {
         XCTAssertTrue(throttle.allow(now: t0.addingTimeInterval(600)))
         XCTAssertEqual(throttle.currentInterval, 1, "the ladder should start over after a quiet spell")
     }
+
+    /// The subtle one, and a real bug caught by CI on the first push: a burst
+    /// that has saturated the backoff arrives *exactly* `maximumInterval`
+    /// apart. If that counted as a quiet spell, the ladder would reset on
+    /// every tick and the effective floor would collapse back to
+    /// `minimumInterval` — the unpaced behaviour, reintroduced one level up.
+    func test_pacing_exactly_at_the_ceiling_is_not_a_quiet_spell() {
+        var throttle = RebuildThrottle(minimumInterval: 1, maximumInterval: 8)
+        var now = t0
+        for _ in 0..<8 {
+            XCTAssertTrue(throttle.allow(now: now))
+            now = now.addingTimeInterval(throttle.currentInterval)
+        }
+        XCTAssertEqual(throttle.currentInterval, 8,
+                       "a burst pacing itself at the ceiling must stay at the ceiling")
+    }
 }
 
 /// End-to-end wiring of the watchdog, driven through the `bringUpOverride`

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -509,6 +509,39 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
         await mic.stop()
     }
 
+    /// A rebuild that FAILS installed no engine, so it must not re-arm the
+    /// grace window or swap in a new notification source. Without this the
+    /// seam would report a failed mid-session rebuild as a successful one —
+    /// and the grace window is precisely what the tests above measure through
+    /// it. (CodeRabbit caught the asymmetry against the real-engine path.)
+    func test_a_failed_rebuild_does_not_rearm_the_grace_window() async throws {
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let mic = MicrophoneRecorder()
+        mic.bringUpTimeout = 1.0
+        mic.captureStallTimeout = 3600
+        mic.watchdogInterval = 3600
+        mic.configurationChangeGracePeriod = 0.1
+        mic.minimumRebuildInterval = 1.0
+        mic.maximumRebuildInterval = 4.0
+        // First bring-up succeeds (start); every rebuild after it fails.
+        mic.bringUpOverride = {
+            let n = counter.withLock { c -> Int in c += 1; return c }
+            if n > 1 { throw MicrophoneError.noInputDevice }
+        }
+
+        try await mic.start()
+        let sourceAfterStart = mic.configurationChangeSource
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        postConfigurationChange(to: mic)
+        await waitUntil { mic.restartCount >= 1 }
+
+        XCTAssertEqual(mic.restartCount, 1, "the failed attempt still spends a rebuild slot")
+        XCTAssertTrue(mic.configurationChangeSource === sourceAfterStart,
+                      "a rebuild that threw installed no engine — there is no new source to observe")
+        await mic.stop()
+    }
+
     /// A rebuild storm must not be able to outlive the recording either.
     func test_configuration_change_after_stop_is_ignored() async throws {
         let (mic, bringUps) = makeRecorder(grace: 0.1)

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -377,7 +377,13 @@ final class MicrophoneWatchdogTests: XCTestCase {
 @MainActor
 final class MicrophoneConfigurationChangeTests: XCTestCase {
 
-    private func makeRecorder() -> (MicrophoneRecorder, @Sendable () -> Int) {
+    /// `grace` is per-test on purpose. The handler timestamps a notification
+    /// when it RUNS, not when it was posted, so a test that wants a change
+    /// treated as self-inflicted needs a window comfortably longer than any
+    /// plausible main-actor hop on a loaded runner, while a test that wants it
+    /// treated as real needs a short one it can wait out. Neither number is a
+    /// production value; the shipped default is 0.75s.
+    private func makeRecorder(grace: TimeInterval) -> (MicrophoneRecorder, @Sendable () -> Int) {
         let counter = OSAllocatedUnfairLock(initialState: 0)
         let mic = MicrophoneRecorder()
         mic.bringUpTimeout = 1.0
@@ -385,11 +391,22 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
         // a second source of rebuilds.
         mic.captureStallTimeout = 3600
         mic.watchdogInterval = 3600
-        mic.configurationChangeGracePeriod = 0.2
+        mic.configurationChangeGracePeriod = grace
         mic.minimumRebuildInterval = 1.0
         mic.maximumRebuildInterval = 4.0
         mic.bringUpOverride = { counter.withLock { $0 += 1 } }
         return (mic, { counter.withLock { $0 } })
+    }
+
+    /// Poll until `condition` holds or `timeout` elapses. Lets a slow runner
+    /// take longer without letting it change the verdict — the assertions that
+    /// follow still have to hold exactly.
+    private func waitUntil(_ timeout: TimeInterval = 3.0,
+                           _ condition: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline && !condition() {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
     }
 
     private func postConfigurationChange(to mic: MicrophoneRecorder) {
@@ -408,13 +425,13 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
     /// Fix (1): the notification our own device bind provokes must not be
     /// mistaken for the world changing.
     func test_self_inflicted_change_during_bring_up_does_not_rebuild() async throws {
-        let (mic, bringUps) = makeRecorder()
+        let (mic, bringUps) = makeRecorder(grace: 1.0)
         try await mic.start()
         XCTAssertEqual(bringUps(), 1)
 
         // Same instant as the bring-up — this is what the bind itself posts.
         postConfigurationChange(to: mic)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 300_000_000)
 
         XCTAssertEqual(mic.restartCount, 0,
                        "a configuration change inside the bring-up grace window is our own doing — rebuilding it is what started the loop")
@@ -426,15 +443,15 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
     /// carries: suppressing self-inflicted changes must NOT blind the recorder
     /// to a device that genuinely went away.
     func test_change_after_the_grace_window_still_rebuilds() async throws {
-        let (mic, bringUps) = makeRecorder()
+        let (mic, bringUps) = makeRecorder(grace: 0.1)
         try await mic.start()
-        try await Task.sleep(nanoseconds: 300_000_000)   // past the 0.2s window
+        try await Task.sleep(nanoseconds: 400_000_000)   // past the 0.1s window
 
         postConfigurationChange(to: mic)
-        try await Task.sleep(nanoseconds: 500_000_000)
+        await waitUntil { mic.restartCount >= 1 }
 
         XCTAssertEqual(mic.restartCount, 1,
-                       "a real device change must still be repaired promptly")
+                       "a real device change must still be repaired promptly, and exactly once")
         XCTAssertEqual(bringUps(), 2)
         await mic.stop()
     }
@@ -446,9 +463,11 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
     /// reporter's log shows 13 rebuilds in the ~2s before they hit Stop, and
     /// the 60-rebuild budget would have been gone in nine seconds.
     func test_a_storm_of_configuration_changes_is_bounded() async throws {
-        let (mic, bringUps) = makeRecorder()
+        // Short grace window on purpose: what's under test here is the
+        // throttle, not the self-inflicted-change suppression.
+        let (mic, bringUps) = makeRecorder(grace: 0.1)
         try await mic.start()
-        try await Task.sleep(nanoseconds: 300_000_000)   // past the grace window
+        try await Task.sleep(nanoseconds: 400_000_000)   // past the grace window
 
         // Post continuously for a fixed WALL-CLOCK window at roughly the
         // cadence observed in the bug (~150ms, compressed to 15ms here).
@@ -476,10 +495,10 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
 
     /// A rebuild storm must not be able to outlive the recording either.
     func test_configuration_change_after_stop_is_ignored() async throws {
-        let (mic, bringUps) = makeRecorder()
+        let (mic, bringUps) = makeRecorder(grace: 0.1)
         try await mic.start()
         let source = mic.configurationChangeSource
-        try await Task.sleep(nanoseconds: 300_000_000)
+        try await Task.sleep(nanoseconds: 400_000_000)
         await mic.stop()
 
         if let source {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -592,6 +592,32 @@ final class RemoteWhisperEngineParsingTests: XCTestCase {
         XCTAssertTrue(text.contains("--B--"), "Must be terminated with the closing boundary")
     }
 
+    /// Issue #147, at the transport layer: whatever else went wrong upstream,
+    /// audio with nothing in it must never be POSTed. The endpoint here points
+    /// at a port nothing listens on, so a network error would prove the guard
+    /// leaked; `.noAudioCaptured` proves it refused before the request.
+    func test_refusesToUploadEmptyAudio() async {
+        let engine = RemoteWhisperEngine()
+        await engine.configure(RemoteTranscriptionConfig(
+            endpoint: URL(string: "http://127.0.0.1:1/v1")!,
+            apiKey: "",
+            model: "whisper-1"))
+
+        do {
+            _ = try await engine.transcribe(samples: [], language: "en",
+                                            audioCtx: 0, progress: nil, isCancelled: nil)
+            XCTFail("Expected .noAudioCaptured; the engine uploaded empty audio")
+        } catch let error as RemoteWhisperEngine.RemoteError {
+            guard case .noAudioCaptured = error else {
+                return XCTFail("Expected .noAudioCaptured, got \(error)")
+            }
+            XCTAssertTrue(error.localizedDescription.contains("No audio was captured"),
+                          "the message has to name the real problem, not the server's decode failure")
+        } catch {
+            XCTFail("Expected .noAudioCaptured, got \(error) — the request reached the network")
+        }
+    }
+
     func test_multipartBodyOmitsLanguageWhenAuto() {
         let body = RemoteWhisperEngine.multipartBody(boundary: "B",
                                                      audio: Data(),

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -113,6 +113,90 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertNotNil(svc.lastError, "A live remote failure must surface, not silently empty the pane")
     }
 
+    // MARK: - Empty capture never reaches the network (issue #147)
+
+    /// A recording session that delivered zero frames used to be encoded to a
+    /// header-only file and POSTed anyway; the server answered
+    /// `HTTP 500: {"detail":"Failed to decode audio."}` and the user read that
+    /// as "the transcription server is down". The microphone's failure has to
+    /// be reported as the microphone's failure, and the upload must not happen.
+    func test_zeroFrameCapture_neverReachesTheUploadPath() async {
+        let suite = UserDefaults(suiteName: "TranscriptionServiceTests.emptyAudio")!
+        suite.removePersistentDomain(forName: "TranscriptionServiceTests.emptyAudio")
+        let keychainKey = "TranscriptionServiceTests.emptyAudio.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let remote = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: keychainKey)
+        remote.backend = .remote
+        remote.endpoint = "http://localhost:8080/v1"
+        let counting = CountingRemoteEngine()
+        let svc = TranscriptionService(
+            store: store, modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "TranscriptionServiceTests.emptyAudio.diar")!),
+            remoteSettings: remote, engine: StubWhisperEngine(),
+            remoteEngine: counting)
+
+        let segs = await svc.transcribeOnceSegments(samples: [], language: "en", audioCtx: nil)
+
+        XCTAssertTrue(segs.isEmpty)
+        let calls = await counting.transcribeCalls
+        XCTAssertEqual(calls, 0, "empty audio must never be handed to the remote backend")
+        XCTAssertEqual(svc.lastError, TranscriptionService.noAudioCapturedMessage,
+                       "the user must be told nothing was captured, not shown the server's decode error")
+    }
+
+    /// Same for a buffer that has samples but no signal — a muted or dead
+    /// input device. There is nothing to transcribe and nothing to upload.
+    func test_digitalSilence_neverReachesTheUploadPath() async {
+        let suite = UserDefaults(suiteName: "TranscriptionServiceTests.silentAudio")!
+        suite.removePersistentDomain(forName: "TranscriptionServiceTests.silentAudio")
+        let keychainKey = "TranscriptionServiceTests.silentAudio.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let remote = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: keychainKey)
+        remote.backend = .remote
+        remote.endpoint = "http://localhost:8080/v1"
+        let counting = CountingRemoteEngine()
+        let svc = TranscriptionService(
+            store: store, modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "TranscriptionServiceTests.silentAudio.diar")!),
+            remoteSettings: remote, engine: StubWhisperEngine(),
+            remoteEngine: counting)
+
+        let segs = await svc.transcribeOnceSegments(samples: [Float](repeating: 0, count: 16_000),
+                                                    language: "en", audioCtx: nil)
+
+        XCTAssertTrue(segs.isEmpty)
+        let calls = await counting.transcribeCalls
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(svc.lastError, TranscriptionService.noAudioCapturedMessage)
+    }
+
+    /// The guard is the strictest possible one, so ordinary quiet speech is
+    /// still transcribed — a 0.2s utterance at -60 dBFS must go through.
+    func test_quietButRealAudio_isStillTranscribed() async {
+        let suite = UserDefaults(suiteName: "TranscriptionServiceTests.quietAudio")!
+        suite.removePersistentDomain(forName: "TranscriptionServiceTests.quietAudio")
+        let keychainKey = "TranscriptionServiceTests.quietAudio.apiKey"
+        defer { KeychainHelper.delete(key: keychainKey) }
+        let remote = RemoteTranscriptionSettings(defaults: suite, apiKeyKeychainKey: keychainKey)
+        remote.backend = .remote
+        remote.endpoint = "http://localhost:8080/v1"
+        let counting = CountingRemoteEngine()
+        let svc = TranscriptionService(
+            store: store, modelManager: manager,
+            diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "TranscriptionServiceTests.quietAudio.diar")!),
+            remoteSettings: remote, engine: StubWhisperEngine(),
+            remoteEngine: counting)
+
+        var samples = [Float](repeating: 0, count: 3_200)   // 0.2s @ 16kHz
+        samples[1_000] = 0.001
+        let segs = await svc.transcribeOnceSegments(samples: samples, language: "en", audioCtx: nil)
+
+        XCTAssertEqual(segs.count, 1, "quiet is not the same as empty")
+        let calls = await counting.transcribeCalls
+        XCTAssertEqual(calls, 1)
+        XCTAssertNil(svc.lastError)
+    }
+
     // MARK: - Single recording happy path
 
     func test_enqueue_single_recording_marks_running_then_completed() async throws {
@@ -876,6 +960,24 @@ private final class Probe401URLProtocol: URLProtocol {
         client?.urlProtocolDidFinishLoading(self)
     }
     override func stopLoading() {}
+}
+
+/// Counts how many times the service actually handed audio to the remote
+/// backend. Used to prove that a session which captured nothing never reaches
+/// the upload path at all.
+private actor CountingRemoteEngine: RemoteTranscribing {
+    private(set) var transcribeCalls = 0
+    func configure(_ config: RemoteTranscriptionConfig) async {}
+    func loadIfNeeded(modelURL: URL, displayName: String) async throws {}
+    func shutdown() async {}
+    func transcribe(samples: [Float],
+                    language: String,
+                    audioCtx: Int32?,
+                    progress: (@Sendable (Float) -> Void)?,
+                    isCancelled: (@Sendable () -> Bool)?) async throws -> [TranscriptSegment] {
+        transcribeCalls += 1
+        return [TranscriptSegment(start: 0, end: 1, text: "uploaded")]
+    }
 }
 
 /// A remote engine that always throws an HTTP 401 — stands in for a


### PR DESCRIPTION
Closes #147

> **Release-blocking.** This needs to ship as build 57 / 1.9.2-beta.3: Sparkle
> won't downgrade, so anyone already on build 56 stays broken until a higher
> build number is published. 1.9.2-beta.2 is held in the appcast meanwhile.

## The mechanism

Confirmed by bisect on the reporter's machine — same Mac, same audio devices,
same macOS 27.0 (26A5388g), only the build changed:

* build 56 (has #143): `buffers=0 frames=0 rebuilds=13`, upload `bytes=1138`, HTTP 500.
* build 55 (predates #143): `buffers=14 frames=21626`, upload `bytes=31572`, transcription succeeds.

Build 55 runs the *same* `setInputDevice` path against the same devices and is
fine. So the configuration change was in all likelihood being posted before
#143 too — what #143 added is an observer that now **reacts** to it, and the
reaction re-triggers it. The fix is therefore built around not reacting to a
change we caused, not around preventing the change.

## Why it loops

`MicrophoneRecorder.bringUp()` binds the chosen input with
`AudioDeviceManager.setInputDevice` → `kAudioOutputUnitProperty_CurrentDevice`.
On the reporter's Mac that write is itself a reconfiguration of the I/O unit,
and AVAudioEngine answers it with `AVAudioEngineConfigurationChange`
(`iounit configuration changed > posting notification` in their log).

`handleConfigurationChange()` could not tell that notification apart from a
yanked device, so it rebuilt the engine immediately — and the rebuild bound the
device again, which posted again. Measured cadence ≈ 150 ms, i.e. ~7 microphone
start/stop cycles per second: the flickering indicator the user saw. A 4096-frame
buffer at 48 kHz needs ~85 ms to fill, against a ~150 ms teardown cycle, so the
tap never survived long enough to deliver one — `buffers=0 frames=0 rebuilds=13`.

`maxMidSessionRestarts = 60` didn't bound it in any useful way. Its comment
("60 attempts at ≥1s apart") describes the *watchdog's* cadence; the
notification path had no spacing at all, so the whole budget could burn in ~9 s.

Everything after that is downstream: zero frames → a header-only ~1.1 KB WAV →
POSTed → `HTTP 500: {"detail":"Failed to decode audio."}`, which reads to the
user as a transcription-server outage. The server was right; the audio was empty.

Regression window: this recovery path is new in #143 (`a982547`), so beta.2 has
it and beta.1 does not.

## What changed

**1. Don't react to our own bind** (the primary fix) — configuration changes
arriving within `configurationChangeGracePeriod` (0.75 s) of a bring-up are
logged and ignored. Build 55 proves the bind is survivable; reacting to it is
what isn't.

**2. Don't provoke the reconfiguration where it's free not to** —
`AudioDeviceManager.setInputDevice` now reads
`kAudioOutputUnitProperty_CurrentDevice` first and skips the write when the unit
is already on the device we want. Secondary and opportunistic, not the fix: it
removes one redundant reconfiguration in the common case (pinned input == system
default) and does nothing otherwise.

**3. Pace what's left** — `RebuildThrottle`, a pure clock-injected policy in the
shape of the existing `CaptureStallDetector`: 1 s floor, doubling to a 30 s
ceiling, with the ladder resetting after a quiet spell so an unrelated device
change 40 minutes into a meeting isn't punished for a storm at the start. The
60-rebuild budget now spans ~28 minutes on the notification path instead of ~9
seconds. The watchdog path is left alone — it is already spaced by
`captureStallTimeout` (4 s), which gives it a 4-minute floor for the same budget,
and throttling it too would only cost recovery latency.

**4. Never adopt a rebuild that didn't work** — the bring-up now requires
`channelCount > 0` as well as `sampleRate > 0`. In the reporter's log the
rebuilt engines selected the *output* device (126, `Input:No | Output:Yes`) and
reported `Input render format: 0 ch, 0 Hz`; those were adopted as working
engines. Now they throw `noInputDevice`, get logged as a failed rebuild, and the
watchdog retries.

**5. Never upload empty audio** — independent of the loop, and the change that
converts an unactionable HTTP 500 into a real diagnosis. `AudioSignal.isSilent`
(no samples, or nothing but exact zeros) gates two places:

* `TranscriptionService.transcribeOnceSegments` — the live/dictation path the
  reporter actually hit — sets `lastError` to "No audio was captured, so there
  was nothing to transcribe. Check System Settings ▸ Privacy & Security ▸
  Microphone…" and returns no segments.
* `RemoteWhisperEngine.transcribe` throws `.noAudioCaptured` before encoding
  anything, so the transport layer can't be made to POST an empty file by some
  future caller.

This guard stands on its own merits and would be worth landing even if the
recovery-loop fix were narrowed to nothing: it is what turns
`HTTP 500: Failed to decode audio.` into a sentence the next person can act on.

The predicate is deliberately the strictest one possible, *not* a loudness gate:
`minimumAudioPeak` already handles "too quiet to be speech" on the batch path,
and a 300 ms live utterance must not be discarded for being quiet. A live
microphone in a silent room delivers dither, never a run of exact zeros.

## Why this escaped CI, and what the new tests assert

`MicrophoneRecorderTests` drove only the `bringUpOverride` seam — and that seam
replaces precisely the real-engine code that self-triggers. The
configuration-change path had no coverage at all, and CI runners have no
microphone.

**The seam.** The recorder now registers its observer against
`configurationChangeSource`: the live `AVAudioEngine` in production, a stand-in
`ConfigurationChangeSource` object on the override path. Everything under test is
real — the observer, the notification name, the handler, the grace window, the
throttle, the budget, the epoch guards. Only the *poster* of the notification is
simulated, which is exactly the part CoreAudio would otherwise have to supply.
Tests re-read the source before each post, because production installs a new
engine per rebuild and it is the new engine that posts the next change; a test
that held the first source would silently stop exercising the loop.

| Test | Asserts |
| --- | --- |
| `RebuildThrottleTests.test_a_storm_of_changes_collapses_to_one_rebuild` | 60 changes at 150 ms → ≤4 rebuilds |
| `…test_without_a_minimum_interval_every_change_rebuilds` | documents the shipped behaviour: 60 changes → 60 rebuilds |
| `…test_backoff_doubles_and_saturates_at_the_ceiling` | 1, 2, 4, 8, 8, 8 |
| `…test_the_rebuild_budget_spans_minutes_not_seconds` | 60 rebuilds span >20 min, not ~9 s |
| `…test_a_quiet_spell_resets_the_backoff` | a device change 10 min later isn't stuck at the ceiling |
| `…test_pacing_exactly_at_the_ceiling_is_not_a_quiet_spell` | CI caught a real flaw here on the first push: a saturated burst arrives exactly `maximumInterval` apart, and the original reset rule read that as "quiet", collapsing the floor back to 1 s. A burst now ends only after `quietPeriod` (2× the ceiling). |
| `MicrophoneConfigurationChangeTests.test_self_inflicted_change_during_bring_up_does_not_rebuild` | a change at bring-up time produces **0** rebuilds |
| `…test_change_after_the_grace_window_still_rebuilds` | the counterweight — a genuine change is still repaired, exactly once |
| `…test_a_storm_of_configuration_changes_is_bounded` | dozens of notifications over a 0.6 s wall-clock window → ≤2 rebuilds (this is the bug's own shape) |
| `…test_configuration_change_after_stop_is_ignored` | no bring-up may happen after `stop()` |
| `TranscriptionServiceTests.test_zeroFrameCapture_neverReachesTheUploadPath` | zero samples → remote engine called **0** times, `lastError` is the "no audio was captured" message |
| `…test_digitalSilence_neverReachesTheUploadPath` | same for a muted/dead device |
| `…test_quietButRealAudio_isStillTranscribed` | one −60 dBFS sample in 0.2 s still goes through — the guard is not a loudness gate |
| `RemoteWhisperEngineParsingTests.test_refusesToUploadEmptyAudio` | endpoint points at a dead port; `.noAudioCaptured` (not a network error) proves it refused *before* the request |
| `AudioSignalTests` (4) | the predicate itself |

All of these run headless: no microphone, no CoreAudio device, no network, and no
real-timer sleeping except the deliberately wall-clock-bounded storm test.
The existing `MicrophoneRecorderTests` / `CaptureStallDetectorTests` /
`MicrophoneWatchdogTests` are untouched.

## Verified vs. inferred

**Verified by test:** the pacing policy and its arithmetic; that a self-inflicted
change inside the grace window produces no rebuild; that a real change outside it
still does; that a storm is bounded; that empty and all-zero audio never reach
the remote engine while quiet audio does.

**Inferred from the issue's logs, not reproduced here:** that the `setInputDevice`
write is what posts the configuration change on that Mac (the log ordering is
strong evidence — the bind is the only thing between "input device: …" and
"iounit configuration changed"); that the redundant-bind skip actually fires
there (it depends on the AUHAL already being on device 121, which the log's
`fetched default input device, ID = 121` supports but does not prove); and that
`channelCount > 0` is the right discriminator for the degenerate rebuilt engines.
None of that is testable without that machine's audio stack — I could not
reproduce the bug.

**The AUHAL-picks-the-output-device case, explicitly.** On that Mac the AUHAL
constructor selects device 126 (`Input:No | Output:Yes`) before Mila binds the
real mic (121). This PR tolerates that but does not cure it:

* the redundant-bind skip compares `current (126)` against `target (121)`, sees a
  mismatch, and binds exactly as before — no behaviour change, no regression;
* if the unit is *still* effectively on the output device afterwards, the
  bring-up now reads `0 ch, 0 Hz` and throws `noInputDevice` instead of adopting
  a mute engine. At session start that surfaces as a real error the user can
  see; mid-session it's logged as a failed rebuild and the watchdog retries.

So the failure mode becomes loud and bounded rather than silent, but Mila still
cannot stop the constructor from picking 126, and does not currently fall back to
a different input device when the bound one comes up unusable.

**Not addressed:** whether BlackHole 2ch / Microsoft Teams Audio / the `ddagg`
dynamic-aggregate activity are aggravators. If the bind still provokes a change
on that Mac despite fix (1) — e.g. because the user pins an input that is *not*
the system default — the residual behaviour is a rebuild every ~4 s from the
watchdog, capped at 60 and then logged as given up, instead of ~7 per second for
the whole recording. Bounded and diagnosable, but still not capturing; that case
needs the reporter's machine to settle.

## Risk

**Fix (2) can mask a real device change.** A device genuinely lost within 0.75 s
of a bring-up no longer takes the fast notification path. The stall watchdog
still catches it, so the cost is up to `captureStallTimeout` (4 s) of silence at
the very start of a recording rather than a lost recording — and
`test_change_after_the_grace_window_still_rebuilds` exists to keep the window
from quietly widening into "never react". Fix (3) has the same shape one level
up: a second genuine change within the backoff interval is deferred to the
watchdog rather than handled immediately.

**Fix (1)** changes device-binding behaviour for everyone, not just the reporter.
If reading `kAudioOutputUnitProperty_CurrentDevice` ever returned a stale or
misleading value we would skip a bind we needed; a failed read returns `nil` and
falls through to the write, so that failure mode is "behaves exactly as before".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for empty and silent audio recordings.
  * Added clear user-facing messaging when no audio is captured.
  * Improved microphone device tracking and configuration recovery.

* **Bug Fixes**
  * Prevented unnecessary audio device updates.
  * Reduced repeated microphone rebuilds during configuration changes.
  * Prevented silent recordings from being uploaded for transcription.
  * Preserved transcription for very quiet but valid audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->