### PR TITLE
ci: require every PR to be linked to a GitHub issue

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,21 +1,56 @@
 # Pull Requests
 
-## Every fix PR must be linked to a GitHub issue
+## Every PR must be linked to a GitHub issue
 
-When opening a PR that fixes a bug or changes reported behavior, it MUST be
-connected to a GitHub issue:
+**This is enforced by CI** — the `Require linked issue` workflow
+(`.github/workflows/require-linked-issue.yml`, check name **"Linked issue"**)
+fails any PR that has no linked issue.
 
 1. **Create the issue first** if one doesn't already exist. Describe the
    problem, the root cause, and the intended fix — a repro helps.
-2. **Link the PR to the issue** in the PR description with a closing keyword —
-   `Closes #<n>` (or `Fixes #<n>`) — so merging the PR auto-closes the issue and
-   the two stay permanently cross-referenced.
+2. **Link the PR to the issue.** Either mechanism satisfies the check:
+   - a closing keyword in the PR description — `Closes #<n>` (`Fixes` and
+     `Resolves` work too, any case; so do the `owner/repo#<n>` and full-URL
+     forms). `.github/pull_request_template.md` puts a `Closes #` line at the
+     top so this is the default path;
+   - GitHub's own linkage, via the sidebar **Development → Link an issue**.
+
+A closing keyword is preferred — it also auto-closes the issue on merge, so the
+two stay permanently cross-referenced.
 
 **Why:** the issue is the durable, searchable record of *what was wrong and
 why*; the PR is *how it was fixed*. Linking them keeps that history navigable
 (release notes, regression hunts, "why did we change this?" archaeology)
 instead of scattering the context across commit messages that are easy to lose.
 
-This applies to bug fixes and behavior changes. Trivial chores (typo fix,
-comment tweak, dependency bump) don't need an issue, but anything a user could
-file a bug about does.
+### Scope and escape hatches
+
+The requirement applies to **every** PR, not just bug fixes. This replaces the
+older "trivial chores don't need an issue" carve-out, which in practice was
+self-applied to almost everything. Two exemptions exist instead, both narrow
+and both visible:
+
+- **Dependabot PRs are exempt automatically.** They can never have an issue,
+  and the repo receives them regularly; without this every dependency bump
+  would be permanently red. Detected by the PR author (or triggering actor)
+  being `dependabot[bot]`.
+- **The `no-issue-needed` label bypasses the check.** For genuine trivia — a
+  typo, a comment tweak. It is a deliberate, attributable maintainer action
+  that shows up in the PR timeline, which is the point: skipping the rule
+  should leave a trace rather than being the silent default. Adding or removing
+  the label re-runs the check immediately.
+
+Anything a user could file a bug about does not qualify for the label.
+
+### Notes for maintainers
+
+- The check runs on `pull_request`, not `pull_request_target`, so it never runs
+  privileged against untrusted fork code and it checks nothing out. Fork PRs
+  are still checked; the only degradation is that the read-only fork token
+  cannot post the explanatory comment, so the guidance goes to the failure
+  annotation and the run summary instead.
+- The workflow posts a single comment and updates it in place — pushes do not
+  spam new comments, and the comment flips to a resolved note once the link is
+  added.
+- Placeholder text inside HTML comments does not count: the check strips HTML
+  comments before matching, so an unfilled `Closes #` template still fails.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
+Closes #
+
+<!-- Required: every PR must link an issue (CI check "Linked issue"). `Closes`,
+     `Fixes` or `Resolves` all work, as does the sidebar Development link.
+     No issue yet? Open one first. Genuine trivia: ask for `no-issue-needed`. -->
+
 ## What & why
 
-<!-- What does this change do, and why? Link the issue it addresses (e.g. "Closes #123"). -->
+<!-- What does this change do, and why? -->
 
 ## How it was tested
 

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,214 @@
+name: Require linked issue
+
+# Enforces the rule in .claude/rules/pull-requests.md: every PR must be linked
+# to a GitHub issue, so the "what was wrong and why" stays a durable, searchable
+# record separate from the "how it was fixed".
+#
+# Why `pull_request` and NOT `pull_request_target`:
+#   * `pull_request_target` runs with a privileged, writable token even for PRs
+#     from forks. That is only safe if the job never checks out or executes PR
+#     code — a footgun we would rather not leave lying around in a repo that
+#     accepts fork contributions.
+#   * `pull_request_target` also always runs the workflow definition from the
+#     BASE branch, so changes to this file could never be tested in the PR that
+#     makes them.
+#   * Fork PRs ARE still checked here: the job runs and passes/fails correctly.
+#     The only degradation is that `GITHUB_TOKEN` is read-only for fork PRs, so
+#     the explanatory comment cannot be posted. The script treats commenting as
+#     best-effort and always writes the same guidance to the failure annotation
+#     and the run summary, which are visible on every run.
+on:
+  pull_request:
+    # `labeled`/`unlabeled` are included beyond the usual set so that applying
+    # or removing the `no-issue-needed` bypass label re-evaluates immediately
+    # instead of leaving a stale red (or green) check.
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: require-linked-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-linked-issue:
+    name: Linked issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write # post/update the single explanatory comment
+    steps:
+      # No checkout: this job only reads PR metadata through the API. Nothing
+      # from the PR is ever executed.
+      - name: Check for a linked issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const BYPASS_LABEL = 'no-issue-needed';
+            const MARKER = '<!-- require-linked-issue -->';
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const author = pr.user?.login ?? '';
+            const labels = (pr.labels ?? []).map((l) => l.name);
+
+            // ---- comment upsert (best-effort; fork PRs get a read-only token)
+            async function upsertComment(body) {
+              try {
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: pr.number, per_page: 100 },
+                );
+                const mine = comments.find((c) => (c.body ?? '').includes(MARKER));
+                const payload = `${MARKER}\n${body}`;
+                if (mine) {
+                  if ((mine.body ?? '') !== payload) {
+                    await github.rest.issues.updateComment({
+                      owner, repo, comment_id: mine.id, body: payload,
+                    });
+                  }
+                } else {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number, body: payload,
+                  });
+                }
+              } catch (err) {
+                // Read-only token (fork PR) or comments disabled. The verdict
+                // still lands via setFailed + the run summary.
+                core.warning(`Could not post the explanatory comment: ${err.message}`);
+              }
+            }
+
+            // Only edits an existing complaint; never opens a new comment just
+            // to say "all good" — that would be pure noise on passing PRs.
+            async function clearComment(reason) {
+              try {
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: pr.number, per_page: 100 },
+                );
+                const mine = comments.find((c) => (c.body ?? '').includes(MARKER));
+                if (mine) {
+                  await github.rest.issues.updateComment({
+                    owner, repo, comment_id: mine.id,
+                    body: `${MARKER}\n:white_check_mark: Linked-issue check passed — ${reason}.`,
+                  });
+                }
+              } catch (err) {
+                core.warning(`Could not update the existing comment: ${err.message}`);
+              }
+            }
+
+            async function pass(reason) {
+              core.info(`PASS: ${reason}`);
+              await core.summary
+                .addHeading('Linked issue: passed', 3)
+                .addRaw(reason)
+                .write();
+              await clearComment(reason);
+            }
+
+            // ---- exemption 1: dependabot. Checked in-script rather than with a
+            // job-level `if:` so the check always reports a real "success"
+            // conclusion — a *skipped* job is a murkier signal for branch
+            // protection than an explicit green one.
+            if (author === 'dependabot[bot]' || context.actor === 'dependabot[bot]') {
+              await pass('dependabot PRs are exempt (they can never have an issue)');
+              return;
+            }
+
+            // ---- exemption 2: maintainer-applied bypass label
+            if (labels.includes(BYPASS_LABEL)) {
+              await pass(`the \`${BYPASS_LABEL}\` label is applied`);
+              return;
+            }
+
+            // ---- primary signal: GitHub's own linkage. This covers both the
+            // sidebar "Development" link and closing keywords GitHub itself
+            // parsed out of the body — it is the authoritative source.
+            let linked = [];
+            try {
+              const res = await github.graphql(
+                `query($owner: String!, $repo: String!, $number: Int!) {
+                   repository(owner: $owner, name: $repo) {
+                     pullRequest(number: $number) {
+                       closingIssuesReferences(first: 20) {
+                         nodes { number url }
+                       }
+                     }
+                   }
+                 }`,
+                { owner, repo, number: pr.number },
+              );
+              linked =
+                res.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
+            } catch (err) {
+              core.warning(`closingIssuesReferences query failed: ${err.message}`);
+            }
+
+            if (linked.length > 0) {
+              const list = linked.map((n) => `#${n.number}`).join(', ');
+              await pass(`linked via GitHub's issue linkage to ${list}`);
+              return;
+            }
+
+            // ---- fallback: closing keyword in the PR body. Catches forms the
+            // GraphQL field does not populate (cross-repo `owner/repo#123`) and
+            // any eventual-consistency lag right after an edit.
+            //
+            // HTML comments are stripped first so the placeholder text in
+            // .github/pull_request_template.md cannot satisfy the check.
+            const body = (pr.body ?? '').replace(/<!--[\s\S]*?-->/g, ' ');
+            const CLOSING_RE = new RegExp(
+              String.raw`(?:^|[\s(\[{,;])` +
+                String.raw`(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed))` +
+                String.raw`\s*:?\s+` +
+                String.raw`(?:https?://github\.com/[\w.-]+/[\w.-]+/issues/\d+` +
+                String.raw`|(?:[\w.-]+/[\w.-]+)?#\d+)`,
+              'gi',
+            );
+            const matches = body.match(CLOSING_RE);
+            if (matches) {
+              await pass(
+                `the PR body contains a closing keyword (\`${matches[0].trim()}\`)`,
+              );
+              return;
+            }
+
+            // ---- no link found
+            const guidance = [
+              '### :link: This PR is not linked to an issue',
+              '',
+              'Every PR in this repo must be connected to a GitHub issue, so the',
+              '*what was wrong and why* survives as a searchable record independent',
+              'of the *how it was fixed*. See `.claude/rules/pull-requests.md`.',
+              '',
+              '**Pick either fix — this check re-runs automatically:**',
+              '',
+              '1. Add a closing keyword to the PR description, near the top:',
+              '',
+              '   ```',
+              '   Closes #123',
+              '   ```',
+              '',
+              '   `Closes`, `Fixes` and `Resolves` all work, in any case.',
+              '2. Or link it from the sidebar: **Development → Link an issue**.',
+              '',
+              "No issue yet? Open one first (`gh issue create`) describing the problem,",
+              'then reference it here.',
+              '',
+              '<sub>Genuinely trivial change (typo, comment tweak)? A maintainer can',
+              `apply the \`${BYPASS_LABEL}\` label to bypass this check. Dependabot PRs`,
+              'are exempt automatically.</sub>',
+            ].join('\n');
+
+            await core.summary.addRaw(guidance).write();
+            await upsertComment(guidance);
+            core.setFailed(
+              'No linked issue found. Add "Closes #<n>" to the PR description, ' +
+                'or link an issue via the sidebar (Development → Link an issue), ' +
+                `or apply the \`${BYPASS_LABEL}\` label for genuine trivia.`,
+            );

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -27,9 +27,13 @@ on:
 permissions:
   contents: read
 
+# Serialise runs per PR, but deliberately do NOT cancel in-progress ones: a
+# cancelled run reports a `cancelled` conclusion, which counts as blocking once
+# this is a required check, and rapid edits could leave that as the last word.
+# The job takes ~5s, so there is nothing worth saving by cancelling.
 concurrency:
   group: require-linked-issue-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   require-linked-issue:


### PR DESCRIPTION
Closes #149

## What & why

`.claude/rules/pull-requests.md` already said every fix PR must link an issue,
and explained why. Nothing enforced it, so it was routinely skipped. This makes
it a CI check.

New workflow `.github/workflows/require-linked-issue.yml` (check name
**"Linked issue"**) runs on `pull_request`
(`opened`, `edited`, `reopened`, `synchronize`, plus `labeled`/`unlabeled`) and
fails a PR with no linked issue. It accepts both mechanisms:

- **`closingIssuesReferences` via GraphQL** — the primary, authoritative signal.
  This is what the sidebar **Development → Link an issue** sets, and it also
  reflects closing keywords GitHub itself parsed out of the body.
- **A closing-keyword regex over the PR body** as fallback — covers
  `Closes`/`Fixes`/`Resolves` (any case, all tenses), the `owner/repo#123` and
  full-URL forms, and any eventual-consistency lag right after an edit.

HTML comments are stripped before matching, so template placeholder text — and
an unfilled `Closes #` line — cannot satisfy the check. On failure it posts one
comment and **updates it in place** on later runs, so pushes don't spam; once
the link is added the comment flips to a resolved note.

Also: `Closes #` moved to the top of the PR template (it was previously only
mentioned inside an HTML comment, which by design no longer counts), and the
rule doc rewritten to match what CI actually enforces.

## :warning: Two deliberate softenings of "every PR" — veto either if you disagree

The rule as literally stated would wedge the repo, so I added two exemptions.
Both are documented in the rule doc; both are easy to remove.

1. **Dependabot PRs are exempt automatically.** They can never have an issue and
   we get them regularly — without this, every dependency bump is permanently
   red. Matched on the PR author *or* triggering actor being `dependabot[bot]`
   (author, not just actor, so a human editing a dependabot PR doesn't
   accidentally un-exempt it).
2. **A new `no-issue-needed` label bypasses the check**, for genuine trivia
   (typo, comment tweak). Already created via `gh label create`, so it exists.
   It's a deliberate, attributable action visible in the PR timeline — the point
   being that skipping the rule leaves a trace instead of being the silent
   default.

If you'd rather have neither, deleting the two guard blocks in the script is a
~10-line change.

## `pull_request` vs `pull_request_target`

I used **`pull_request`**, deliberately:

- The job reads only PR metadata over the API. It performs **no checkout** and
  executes nothing from the PR, so there is no reason to hand it a privileged
  token — `pull_request_target` would be handing out write credentials on a PR
  event for no benefit, and leaves that footgun in the file for whoever edits it
  next.
- `pull_request_target` always runs the workflow definition from the **base**
  branch, so this workflow could never have been tested by the PR that adds it —
  the check below would not exist.
- **Fork PRs are still checked.** The job runs and passes/fails correctly. The
  only degradation is that `GITHUB_TOKEN` is read-only for fork PRs, so the
  explanatory comment can't be posted; the script treats commenting as
  best-effort and always writes the same guidance to the failure annotation and
  the run summary, which are visible on every run.

## Permissions

Minimum needed, set at both workflow and job level:
`contents: read`, `issues: read`, `pull-requests: write` (the comment only).
No blanket write.

Exemptions are evaluated **inside** the script rather than as a job-level `if:`,
so exempt PRs report a real `success` conclusion instead of `skipped` — a
cleaner signal if you later make this a required check.

## How it was tested

CI-and-docs only; no Swift touched, no app build involved.

- `actionlint` clean.
- `actions/github-script` pinned to a full commit SHA with a version comment
  (`3a2844b…` # v9.0.0), matching the house style; SHA verified against the
  upstream repo.
- The embedded script was extracted and run against a mocked
  `github`/`context`/`core` in the same `AsyncFunction` wrapper github-script
  uses — **26 cases, all passing**. Including: a body closing keyword → pass; no reference
  → fail + comment; dependabot → pass; `no-issue-needed` → pass; sidebar linkage
  with empty body → pass; unfilled template → **fail**; filled template → pass;
  `Related to #123` / `See #123` / `prefixes #12` / `closest #12` → correctly
  fail; GraphQL erroring → falls back to the regex; read-only fork token → still
  fails with a warning instead of erroring. Comment upsert verified: 3 failing
  runs produce exactly 1 comment, then it's updated (not duplicated) on fix.
- And this PR is its own live test — it links #149 with a closing keyword at the
  top, so the check should be green below.

  I also ran a **live negative test** on this PR: temporarily removing the
  closing line and re-saving the description fired the `edited` trigger, the
  check went red and posted the explanatory comment; restoring the line fired it
  again and the check went green with the comment updated in place (not
  duplicated). Both transitions are in this PR's checks history.

  > Note, since it nearly bit me while writing this: a *prose example* pairing a
  > closing keyword with an issue number is parsed by GitHub as a **real** link —
  > it would have quietly added a second closing reference to this PR. Every
  > example in this description is therefore worded to avoid that adjacency. It
  > is a pre-existing GitHub behaviour, not something this check introduces.

## :point_right: One manual step for you

I deliberately did **not** make this a required status check — that's a
branch-protection change and yours to make. When you're happy with it:

**Settings → Rules → Rulesets** (or **Branches → branch protection rule** for
`main`) **→ Require status checks to pass → add `Linked issue`.**

Worth letting a few PRs go through first to confirm it behaves before making it
blocking.
