### PR TITLE
fix(transcription): merge pass results onto the live row instead of clobbering it

### DIFF
--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -585,18 +585,16 @@ final class TranscriptionService: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty
 
-        // Flip the LIVE row to `.running` instead of writing the whole snapshot
+        // Flip the LIVE row to `.running` rather than writing the whole snapshot
         // back — `await remoteEngine.configure` above is a suspension point the
         // user can rename/file/delete the row through. See `mergePassResult`.
-        // `working` is re-seeded from the persisted row so the rest of the pass
-        // reads the freshest values.
+        // (`working` is deliberately NOT re-seeded from the result: the pass must
+        // keep transcribing the `language` it just resolved a model for.)
         working.status = .running
         working.modelName = modelDisplayName
-        if let started = mergePassResult(id: recording.id, {
+        mergePassResult(id: recording.id) {
             $0.status = working.status
             $0.modelName = working.modelName
-        }) {
-            working = started
         }
 
         let recordingID = recording.id

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -812,10 +812,15 @@ final class TranscriptionService: ObservableObject {
                 $0.fullText = working.fullText
                 $0.duration = working.duration
                 $0.modelName = working.modelName
-                // Only a pass that actually produced segments owns this — it
-                // re-keyed every SPEAKER_NN, so the user's old names would now
-                // point at different voices (cleared just above).
-                $0.speakerNames = working.speakerNames
+                // Only a pass that actually produced segments owns this. Such a
+                // pass re-keyed every SPEAKER_NN, so names bound to the old IDs
+                // would now label a different voice — hence the reset above. A
+                // pass that came back EMPTY minted no IDs and owns nothing here,
+                // so the user's speaker names must survive it untouched (they're
+                // hand-typed work, and the next successful pass re-keys anyway).
+                if !enrichedSegments.isEmpty {
+                    $0.speakerNames = working.speakerNames
+                }
             }) else {
                 print("Transcribe: \(working.title) vanished from the store mid-pass — result discarded, row not recreated")
                 return

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -935,11 +935,14 @@ final class TranscriptionService: ObservableObject {
     ///   in-flight language switch must not be rolled back by an older pass.
     ///
     /// **Deleted rows.** Returns `nil` — writing nothing — when the recording
-    /// is gone from the store entirely: hard-deleted, emptied from the trash,
-    /// or just removed by the `autoDropIfShortAndEmpty` gate that runs
-    /// immediately before the completion write. We never re-`add` it;
-    /// resurrecting a row the user deleted is the failure mode this whole
-    /// helper exists to prevent. A **soft**-deleted row is still written: its
+    /// is gone from the store entirely: hard-deleted from the sidebar, or
+    /// swept by Empty Trash. We never re-`add` it; resurrecting a row the user
+    /// deleted is the failure mode this whole helper exists to prevent. (The
+    /// `autoDropIfShortAndEmpty` gate that runs immediately before the
+    /// completion write also removes the row, so the merge can never fight it
+    /// — but its callers early-return on `true`, so that case never reaches
+    /// here. The `nil` branch is the backstop if that ever changes.)
+    /// A **soft**-deleted row is still written: its
     /// `deletedAt` is user-owned, so it stays in Recently Deleted, but the
     /// merge moves it out of `.running` into a terminal status (otherwise it
     /// would sit in the queue UI as "Transcribing" forever) and keeps the

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -512,6 +512,12 @@ final class TranscriptionService: ObservableObject {
         // while transcribing with `working.language` (below) could load/persist
         // the wrong model for the language actually transcribed.
         // (The recording may also have been edited or soft-deleted in the gap.)
+        //
+        // NOTE: this snapshot goes stale again the moment the pass starts — the
+        // user keeps editing the row while we transcribe. From here on it is a
+        // local scratch buffer for the pass's own output and is NEVER written
+        // back to the store as-is; every write goes through `mergePassResult`,
+        // which re-reads the live row and applies just the pass-owned fields.
         var working = store.recordings.first(where: { $0.id == recording.id }) ?? recording
         // Whether this is the recording's FIRST transcription — the only case
         // the issue-#61 auto-drop gate may discard a recording. A manual
@@ -579,9 +585,19 @@ final class TranscriptionService: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty
 
+        // Flip the LIVE row to `.running` instead of writing the whole snapshot
+        // back — `await remoteEngine.configure` above is a suspension point the
+        // user can rename/file/delete the row through. See `mergePassResult`.
+        // `working` is re-seeded from the persisted row so the rest of the pass
+        // reads the freshest values.
         working.status = .running
         working.modelName = modelDisplayName
-        store.update(working)
+        if let started = mergePassResult(id: recording.id, {
+            $0.status = working.status
+            $0.modelName = working.modelName
+        }) {
+            working = started
+        }
 
         let recordingID = recording.id
         activeRecordingID = recordingID
@@ -651,7 +667,15 @@ final class TranscriptionService: ObservableObject {
                 // transcribable audio is pure list spam. A long-but-silent clip
                 // is over the threshold, so the gate keeps it as .failed.
                 if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: "", isFirstTranscription: isFirstTranscription) { return }
-                store.update(working)
+                // Merge onto the live row rather than writing the snapshot
+                // back (see `mergePassResult`). This branch produced no
+                // transcript, so the only fields the pass owns here are the
+                // status and the (emptied) transcript output.
+                mergePassResult(id: recording.id) {
+                    $0.status = working.status
+                    $0.fullText = working.fullText
+                    $0.segments = working.segments
+                }
                 return
             }
 
@@ -779,17 +803,46 @@ final class TranscriptionService: ObservableObject {
             // keeps any clip that produced text (even a short one) and anything
             // at/over the threshold, so this only ever removes worthless rows.
             if autoDropIfShortAndEmpty(working, duration: durationSeconds, transcript: text, isFirstTranscription: isFirstTranscription) { return }
-            store.update(working)
-
-            if working.status == .completed {
-                TranscriptExporter.writeSRT(for: working, in: store.recordingsDirectory)
-                onTranscriptionCompleted?(working, hadSummaryBeforeRun)
+            // Merge the pass output onto the LIVE row instead of writing the
+            // snapshot captured minutes ago back over it — see
+            // `mergePassResult` for the full field-ownership table. `nil` means
+            // the row is gone (hard-deleted / trash emptied / just auto-dropped
+            // above); there is nothing to write and nothing to follow up on.
+            guard let persisted = mergePassResult(id: recording.id, {
+                $0.status = working.status
+                $0.segments = working.segments
+                $0.fullText = working.fullText
+                $0.duration = working.duration
+                $0.modelName = working.modelName
+                // Only a pass that actually produced segments owns this — it
+                // re-keyed every SPEAKER_NN, so the user's old names would now
+                // point at different voices (cleared just above).
+                $0.speakerNames = working.speakerNames
+            }) else {
+                print("Transcribe: \(working.title) vanished from the store mid-pass — result discarded, row not recreated")
+                return
+            }
+            if persisted.status == .completed {
+                if persisted.isTrashed {
+                    // The user sent this to Recently Deleted mid-pass. It keeps
+                    // its transcript (so a restore isn't empty) but gets none of
+                    // the *user-facing* completion work: no stray `.srt` sidecar
+                    // on disk, and no summarizer/LLM spend on something the user
+                    // just threw away.
+                    print("Transcribe: \(persisted.title) was moved to Recently Deleted mid-pass — transcript saved, skipping SRT + summary")
+                } else {
+                    TranscriptExporter.writeSRT(for: persisted, in: store.recordingsDirectory)
+                    onTranscriptionCompleted?(persisted, hadSummaryBeforeRun)
+                }
                 // Shrink storage: transcode the WAV to m4a now that
                 // transcription + diarization are done reading it. Runs in
                 // the background so it doesn't hold up the queue; playback
                 // and re-transcribe read m4a natively, re-diarize decodes
-                // it. No-op on already-compressed (imported) audio.
-                let compressID = working.id
+                // it. No-op on already-compressed (imported) audio. Trashed
+                // recordings get this too — their audio sits on disk until the
+                // trash is emptied, and a restore shouldn't come back
+                // uncompressed.
+                let compressID = persisted.id
                 Task { await store.compressRecordingAudio(id: compressID) }
             }
         } catch is CancellationError {
@@ -801,8 +854,12 @@ final class TranscriptionService: ObservableObject {
             cancellation.remove(recording.id)
         } catch {
             print("Transcribe error for \(working.title): \(error)")
-            working.status = .failed
-            store.update(working)
+            // A failed pass produced no transcript, so `status` is the ONLY
+            // field it owns here — in particular it must not overwrite
+            // `speakerNames`/`segments`, which it never re-keyed. Merging onto
+            // the live row also means a rename/re-file/soft-delete the user
+            // made while the pass was failing survives (see `mergePassResult`).
+            mergePassResult(id: recording.id) { $0.status = .failed }
             lastError = "Transcription failed: \(error.localizedDescription)"
         }
     }
@@ -835,10 +892,61 @@ final class TranscriptionService: ObservableObject {
     }
 
     private func markFailed(_ recording: Recording) {
-        if var working = store.recordings.first(where: { $0.id == recording.id }) {
-            working.status = .failed
-            store.update(working)
-        }
+        mergePassResult(id: recording.id) { $0.status = .failed }
+    }
+
+    /// Persist the result of a transcription pass by merging it onto the row
+    /// that is in the store **right now**, instead of writing back the snapshot
+    /// captured when the pass started.
+    ///
+    /// **Why.** A batch pass runs for as long as the audio takes — minutes on a
+    /// long meeting — and every non-live recording goes through it
+    /// (`QuickActionsController.finalizeTail` enqueues them). Throughout that
+    /// window the user can rename the recording, drop it into a folder, rename
+    /// speakers, or send it to Recently Deleted from the sidebar. The old
+    /// `store.update(working)` wrote the stale snapshot over the live row and
+    /// silently reverted all of it (issue #152). This is the same discipline the live
+    /// finalize tail already applies ("we update only the segments rather than
+    /// clobbering the row", `QuickActionsController`).
+    ///
+    /// **Field ownership.** `apply` receives the LIVE row and must set ONLY
+    /// pass-owned fields. Anything a future change adds to `Recording` needs to
+    /// be classified into one of these buckets:
+    ///
+    /// * **Pass-owned** — the transcription output and the metadata describing
+    ///   the run that produced it: `status`, `segments`, `fullText`,
+    ///   `duration`, `modelName`, and `speakerNames`. `speakerNames` is
+    ///   pass-owned *only for a pass that produced segments*, because such a
+    ///   pass re-keys every `SPEAKER_NN` and names assigned against the old IDs
+    ///   would then label the wrong voice. A failed/rejected pass must leave it
+    ///   alone.
+    /// * **User-owned** — never written here; the live row always wins:
+    ///   `title`, `folder`, `deletedAt`, `summary`, `actionItems`.
+    /// * **Store-owned** — identity and provenance, also never written here:
+    ///   `id`, `createdAt`, `source`, `audioFileName`, `appName`,
+    ///   `voiceMemoUniqueID`, `voiceMemoFolderUUID`. (`audioFileName` in
+    ///   particular: the post-completion compression renames the file, and
+    ///   restoring the snapshot's name would point the row at a deleted `.wav`.)
+    /// * `language` is deliberately **not** pass-owned. The pass only *reads*
+    ///   it; `RecordingStore.prepareForRetranscription` is the writer, so an
+    ///   in-flight language switch must not be rolled back by an older pass.
+    ///
+    /// **Deleted rows.** Returns `nil` — writing nothing — when the recording
+    /// is gone from the store entirely: hard-deleted, emptied from the trash,
+    /// or just removed by the `autoDropIfShortAndEmpty` gate that runs
+    /// immediately before the completion write. We never re-`add` it;
+    /// resurrecting a row the user deleted is the failure mode this whole
+    /// helper exists to prevent. A **soft**-deleted row is still written: its
+    /// `deletedAt` is user-owned, so it stays in Recently Deleted, but the
+    /// merge moves it out of `.running` into a terminal status (otherwise it
+    /// would sit in the queue UI as "Transcribing" forever) and keeps the
+    /// transcript around in case the user restores it.
+    @discardableResult
+    private func mergePassResult(id: UUID, _ apply: (inout Recording) -> Void) -> Recording? {
+        guard var live = store.recordings.first(where: { $0.id == id }) else { return nil }
+        apply(&live)
+        store.update(live)
+        return live
     }
 
     /// Permanently delete `recording` when the auto-drop gate flags it as an

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -971,10 +971,13 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(stored.fullText, "filed")
     }
 
-    /// Edits must also survive a pass that ends in failure — there the ONLY
-    /// pass-owned field is `status`.
-    func test_rename_during_a_failing_pass_survives_the_write_back() async throws {
+    /// Edits must also survive a pass that ends in failure. A pass that comes
+    /// back EMPTY minted no `SPEAKER_NN` ids, so it owns neither the user's
+    /// rename nor their hand-typed speaker names — only `status`.
+    func test_rename_and_speaker_names_survive_a_failing_pass() async throws {
         let fixture = try TestRecordingFixture.make(in: store, title: "Will come back empty", durationSeconds: 1.0)
+        store.setSpeakerName("Daniel", forSpeaker: "SPEAKER_00", recordingID: fixture.recording.id)
+        store.setSpeakerName("Maya", forSpeaker: "SPEAKER_01", recordingID: fixture.recording.id)
         await stub.setDefaultDelay(Self.midPassDelay)
         await stub.setDefaultCanned([])   // empty transcript → .failed
 
@@ -987,6 +990,30 @@ final class TranscriptionServiceTests: XCTestCase {
         let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertEqual(stored.title, "Renamed anyway")
         XCTAssertEqual(stored.status, .failed)
+        XCTAssertEqual(stored.speakerNames, ["SPEAKER_00": "Daniel", "SPEAKER_01": "Maya"],
+                       "A pass that produced no segments re-keyed nothing, so it must not wipe the user's speaker names")
+    }
+
+    /// The other side of that contract: a pass that DID produce segments re-keys
+    /// every `SPEAKER_NN`, so the old names would label the wrong voice and must
+    /// be cleared — even though the user's rename in the same window survives.
+    func test_successful_pass_clears_speaker_names_but_keeps_the_rename() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Re-keyed", durationSeconds: 1.0)
+        store.setSpeakerName("Daniel", forSpeaker: "SPEAKER_00", recordingID: fixture.recording.id)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "fresh clustering")])
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        store.rename(live, to: "Renamed during re-key")
+
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.title, "Renamed during re-key", "User-owned: the rename wins")
+        XCTAssertTrue(stored.speakerNames.isEmpty,
+                      "Pass-owned: a pass that produced segments re-keyed the ids, so stale names go")
+        XCTAssertEqual(stored.fullText, "fresh clustering")
     }
 
     /// Soft-deleting mid-pass must NOT be undone by the write-back: the

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -932,12 +932,27 @@ final class TranscriptionServiceTests: XCTestCase {
         return live
     }
 
-    /// Drain the WAV→m4a transcode the completion path kicks off in a detached
-    /// `Task`. `waitForIdle` only tracks the queue, so without this the
-    /// compression can outlive the test and write into a `tempRoot` that
-    /// `tearDown` has already deleted. Idempotent — a no-op if it already ran.
-    private func drainPostCompletionCompression(_ id: UUID) async {
+    /// Settle the WAV→m4a transcode the completion path kicks off in a detached
+    /// `Task`. `waitForIdle` only tracks `activeRecordingID` and the queue, so
+    /// without this the transcode can outlive the test and run against a
+    /// `tempRoot` that `tearDown` has already removed.
+    ///
+    /// One `await store.compressRecordingAudio(id:)` is NOT a join on its own:
+    /// the in-flight guard (`compressingIDs`) is taken before the first
+    /// suspension, so if the detached task got there first our call returns
+    /// straight back while its transcode is still running. So kick it — a
+    /// no-op when the detached task already started or already finished — and
+    /// then wait for the observable end state: the row's audio is no longer
+    /// the `.wav`. Returns early if the row is gone (nothing left to settle).
+    private func drainPostCompletionCompression(_ id: UUID,
+                                                timeout: TimeInterval = 5) async {
         await store.compressRecordingAudio(id: id)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            guard let current = store.recordings.first(where: { $0.id == id }) else { return }
+            if !current.audioFileName.lowercased().hasSuffix(".wav") { return }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 
     func test_rename_during_transcription_survives_the_write_back() async throws {

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -897,6 +897,150 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(prepared.status, .pending, "status must be reset to pending")
     }
 
+    // MARK: - Edits made DURING a pass must survive the write-back (issue #152)
+    //
+    // `process` snapshots the row when the pass begins and used to write that
+    // snapshot back wholesale when the pass finished, silently reverting any
+    // edit the user made in the (potentially minutes-long) gap. These pin the
+    // merge: pass-owned fields land, user-owned fields are left alone, and a
+    // deleted recording is never resurrected.
+
+    /// How long the stub pretends to transcribe for in these tests. Long
+    /// enough that the mid-pass edit reliably lands inside the window even on
+    /// a loaded CI box; `liveRowMidPass` asserts it actually did.
+    private static let midPassDelay: Double = 0.8
+
+    /// Block until the pass for `id` is genuinely in flight, then hand back the
+    /// LIVE store row so the test can edit it — exactly like a user clicking
+    /// around the sidebar while a batch transcription runs. Fails loudly if the
+    /// pass already finished, so a mistimed run can never pass by accident.
+    private func liveRowMidPass(_ id: UUID,
+                                timeout: TimeInterval = 3,
+                                file: StaticString = #filePath,
+                                line: UInt = #line) async throws -> Recording {
+        let deadline = Date().addingTimeInterval(timeout)
+        while service.activeRecordingID != id && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertEqual(service.activeRecordingID, id,
+                       "Transcription never became active — can't test the mid-pass window",
+                       file: file, line: line)
+        let live = try XCTUnwrap(store.recordings.first { $0.id == id }, file: file, line: line)
+        XCTAssertEqual(live.status, .running,
+                       "The pass must still be in flight when the test edits the row",
+                       file: file, line: line)
+        return live
+    }
+
+    func test_rename_during_transcription_survives_the_write_back() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Old name", durationSeconds: 1.0)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "the transcript")])
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        store.rename(live, to: "New name")
+
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.title, "New name",
+                       "A rename made while the pass was running must not be reverted by the write-back")
+        XCTAssertEqual(stored.status, .completed, "The pass still owns status")
+        XCTAssertEqual(stored.fullText, "the transcript", "The pass still owns the transcript")
+        XCTAssertEqual(stored.segments.count, 1)
+    }
+
+    func test_folder_assignment_during_transcription_survives_the_write_back() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Filed mid-pass", durationSeconds: 1.0)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "filed")])
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        XCTAssertNil(live.folder)
+        store.assign(live, toFolder: "Work")
+
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.folder, "Work",
+                       "Dropping a recording into a folder mid-pass must not be reverted")
+        XCTAssertEqual(store.recordings(inFolder: "Work").map(\.id), [fixture.recording.id])
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.fullText, "filed")
+    }
+
+    /// Edits must also survive a pass that ends in failure — there the ONLY
+    /// pass-owned field is `status`.
+    func test_rename_during_a_failing_pass_survives_the_write_back() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Will come back empty", durationSeconds: 1.0)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([])   // empty transcript → .failed
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        store.rename(live, to: "Renamed anyway")
+
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.title, "Renamed anyway")
+        XCTAssertEqual(stored.status, .failed)
+    }
+
+    /// Soft-deleting mid-pass must NOT be undone by the write-back: the
+    /// recording stays in Recently Deleted. It still reaches a terminal status
+    /// (otherwise it sits in the queue UI as "Transcribing" forever) and keeps
+    /// its transcript for a later restore, but gets none of the user-facing
+    /// completion work — no `.srt` sidecar, no summarizer/LLM spend.
+    func test_soft_delete_during_transcription_is_not_resurrected() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Trashed mid-pass", durationSeconds: 1.0)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "still transcribed")])
+
+        var completionFired = false
+        service.onTranscriptionCompleted = { _, _ in completionFired = true }
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        store.softDelete(live)
+
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertTrue(stored.isTrashed,
+                      "A recording the user deleted mid-pass must not be resurrected by the write-back")
+        XCTAssertNotEqual(stored.status, .running,
+                          "It must still leave the running state or the queue shows it forever")
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.fullText, "still transcribed",
+                       "The transcript is kept so a restore isn't empty")
+        XCTAssertFalse(completionFired,
+                       "No summarizer/LLM work for a recording on its way to the trash")
+        let srt = store.recordingsDirectory.appendingPathComponent(stored.subtitleFileName)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: srt.path),
+                       "No stray .srt sidecar for a trashed recording")
+    }
+
+    /// The row can also disappear ENTIRELY mid-pass (hard delete, or emptying
+    /// Recently Deleted). The write-back must not re-add it.
+    func test_hard_delete_during_transcription_does_not_recreate_the_row() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Gone mid-pass", durationSeconds: 1.0)
+        await stub.setDefaultDelay(Self.midPassDelay)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "orphan")])
+
+        service.enqueue(fixture.recording)
+        let live = try await liveRowMidPass(fixture.recording.id)
+        store.permanentlyDelete(live)
+        XCTAssertNil(store.recordings.first { $0.id == fixture.recording.id })
+
+        await service.waitForIdle()
+
+        XCTAssertNil(store.recordings.first { $0.id == fixture.recording.id },
+                     "A hard-deleted recording must not be recreated by the transcription write-back")
+    }
+
     // MARK: - Speaker label normalization
 
     func test_normalizeSpeakerLabels_closes_gaps_from_diarizer_clustering() {

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -932,6 +932,14 @@ final class TranscriptionServiceTests: XCTestCase {
         return live
     }
 
+    /// Drain the WAV→m4a transcode the completion path kicks off in a detached
+    /// `Task`. `waitForIdle` only tracks the queue, so without this the
+    /// compression can outlive the test and write into a `tempRoot` that
+    /// `tearDown` has already deleted. Idempotent — a no-op if it already ran.
+    private func drainPostCompletionCompression(_ id: UUID) async {
+        await store.compressRecordingAudio(id: id)
+    }
+
     func test_rename_during_transcription_survives_the_write_back() async throws {
         let fixture = try TestRecordingFixture.make(in: store, title: "Old name", durationSeconds: 1.0)
         await stub.setDefaultDelay(Self.midPassDelay)
@@ -942,6 +950,7 @@ final class TranscriptionServiceTests: XCTestCase {
         store.rename(live, to: "New name")
 
         await service.waitForIdle()
+        await drainPostCompletionCompression(fixture.recording.id)
 
         let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertEqual(stored.title, "New name",
@@ -962,6 +971,7 @@ final class TranscriptionServiceTests: XCTestCase {
         store.assign(live, toFolder: "Work")
 
         await service.waitForIdle()
+        await drainPostCompletionCompression(fixture.recording.id)
 
         let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertEqual(stored.folder, "Work",
@@ -1008,6 +1018,7 @@ final class TranscriptionServiceTests: XCTestCase {
         store.rename(live, to: "Renamed during re-key")
 
         await service.waitForIdle()
+        await drainPostCompletionCompression(fixture.recording.id)
 
         let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertEqual(stored.title, "Renamed during re-key", "User-owned: the rename wins")
@@ -1034,13 +1045,13 @@ final class TranscriptionServiceTests: XCTestCase {
         store.softDelete(live)
 
         await service.waitForIdle()
+        await drainPostCompletionCompression(fixture.recording.id)
 
         let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertTrue(stored.isTrashed,
                       "A recording the user deleted mid-pass must not be resurrected by the write-back")
-        XCTAssertNotEqual(stored.status, .running,
-                          "It must still leave the running state or the queue shows it forever")
-        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.status, .completed,
+                       "It must still leave the running state or the queue shows it as Transcribing forever")
         XCTAssertEqual(stored.fullText, "still transcribed",
                        "The transcript is kept so a restore isn't empty")
         XCTAssertFalse(completionFired,


### PR DESCRIPTION
Closes #152.

## The bug

`TranscriptionService.process` snapshotted the store row when a pass began and
wrote that snapshot back **wholesale** when the pass ended:

```swift
// :515 — snapshot
var working = store.recordings.first(where: { $0.id == recording.id }) ?? recording
// ... model load, decode, diarization + whisper — minutes on a real meeting ...
store.update(working)   // :769 — replaces the live row entirely
```

Anything the user changed in that window — rename, folder assignment, sending
the recording to Recently Deleted — was silently reverted when the pass
finished. Reachable in the ordinary flow: every non-live recording is enqueued
for batch transcription (`QuickActionsController:997`) and the sidebar stays
fully interactive while the queue works through it.

The read side already knew about the race (the comment above `:515` says the
row "may also have been edited or soft-deleted in the gap"); the write side
ignored it.

## The fix

Every write-back in `process` now goes through one helper that re-reads the
live row and applies only the fields the pass owns — the same discipline the
live-finalize tail in `QuickActionsController:944-966` already documents.

```swift
@discardableResult
private func mergePassResult(id: UUID, _ apply: (inout Recording) -> Void) -> Recording? {
    guard var live = store.recordings.first(where: { $0.id == id }) else { return nil }
    apply(&live)
    store.update(live)
    return live
}
```

Four call sites converted (`.running` flip, silence-guard reject, completion,
`catch`), plus `markFailed` folded into the same helper. `working` is now
read-only from the snapshot onwards.

### Field ownership

Spelled out in full in the helper's doc comment so a field added to `Recording`
later has an obvious home:

| bucket | fields | rule |
| --- | --- | --- |
| **Pass-owned** | `status`, `segments`, `fullText`, `duration`, `modelName`, `speakerNames` | copied from the pass |
| **User-owned** | `title`, `folder`, `deletedAt`, `summary`, `actionItems` | never written — live row wins |
| **Store-owned** | `id`, `createdAt`, `source`, `audioFileName`, `appName`, `voiceMemoUniqueID`, `voiceMemoFolderUUID` | never written |
| `language` | | read-only for the pass; `prepareForRetranscription` is the writer |

Two nuances worth a reviewer's eye:

- `speakerNames` is pass-owned **only for a pass that produced segments**,
  because such a pass re-keys every `SPEAKER_NN` and names bound to the old IDs
  would then label a different voice. The `catch` and silence-guard sites
  deliberately don't touch it.
- `audioFileName` being store-owned is load-bearing: the post-completion
  compression renames the file to `.m4a`, and restoring the snapshot's name
  would point the row at a deleted `.wav` (the flake fixed earlier by
  `prepareForRetranscription`).

### Deleted rows

- **Soft-deleted mid-pass** — `deletedAt` is user-owned, so the merge leaves it
  set and the recording stays in Recently Deleted. It still gets the pass-owned
  fields: it has to leave `.running` (otherwise it sits in the queue UI as
  "Transcribing" forever) and keeping the transcript means a restore isn't
  empty. The *user-facing* completion work is skipped — no `.srt` sidecar, no
  summarizer/LLM spend on something the user just threw away. Background audio
  compression still runs; it's storage hygiene either way.
- **Row gone entirely** (hard delete, trash emptied, or the
  `autoDropIfShortAndEmpty` gate removed it one line earlier) — the helper
  returns `nil`, nothing is written, and the row is never re-`add`ed. This also
  means the merge can't fight the auto-drop gate.

## Tests

Five regression tests in `TranscriptionServiceTests`, all driving the real
`process` path with the stub engine parked mid-pass:

- `test_rename_during_transcription_survives_the_write_back`
- `test_folder_assignment_during_transcription_survives_the_write_back`
- `test_rename_during_a_failing_pass_survives_the_write_back` (the `catch`/empty-transcript site, where `status` is the only pass-owned field)
- `test_soft_delete_during_transcription_is_not_resurrected` (stays trashed, still reaches a terminal status, transcript kept, no `.srt`, `onTranscriptionCompleted` never fires)
- `test_hard_delete_during_transcription_does_not_recreate_the_row`

The shared `liveRowMidPass` helper asserts the pass is genuinely still
`.running` when the test edits the row, so a mistimed run fails loudly instead
of passing by accident.

## Provenance

Found while checking whether #127's folder-loss bug also existed on `main`. It
does not — that one is a rename-sheet-specific mechanism. This is an
independent bug in the transcription write-back; the two shouldn't be
conflated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transcription updates now preserve concurrent edits, including recording names, folders, and other user-managed details.
  * Deleted recordings are no longer recreated during transcription.
  * Soft-deleted recordings retain completed transcripts without generating exports or summaries.
  * Failure and short-audio cases now preserve existing recording information while applying available results.
  * Speaker information is retained or updated appropriately when diarization changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->