### PR TITLE
ci: bump the actions group across 1 directory with 6 updates (relay of #141)

### DIFF
--- a/.github/workflows/build-speaches-image.yml
+++ b/.github/workflows/build-speaches-image.yml
@@ -62,7 +62,7 @@ jobs:
       # don't push — PRs from forks can't get a write token anyway.
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
       # Initialize BEFORE the build so CodeQL's tracer observes Swift
       # compilation (manual build mode — autobuild can't drive XcodeGen).
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: swift
           build-mode: manual
@@ -74,6 +74,6 @@ jobs:
             | cat
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:swift"

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -41,7 +41,7 @@ jobs:
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
@@ -71,7 +71,7 @@ jobs:
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
@@ -151,7 +151,7 @@ jobs:
           name: ui-screenshots
           path: /tmp/mila-ui-screenshots/
           if-no-files-found: warn
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,13 +28,13 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Closes #166
Supersedes #141 — dependabot's commit is cherry-picked unchanged, so the diff is byte-identical.

## Why this exists instead of #141

The `CodeRabbit reviewed head` gate has **no dependabot exemption** — a deliberate choice, since the ask was that nothing skips review. But CodeRabbit bills each review to the **PR author's** per-user quota, and a bot has none, so #141 could never satisfy the gate it is subject to. Re-opening under a human account is the way out that keeps the gate intact rather than punching a hole in it.

## The diff

Six SHA-pinned action bumps across 4 workflow files, +8/-8:

| Action | From | To |
|---|---|---|
| `docker/login-action` | 4.4.0 | 4.5.1 |
| `github/codeql-action/{init,analyze,upload-sarif}` | 4.37.1 | 4.37.3 |
| `actions/setup-python` | 6.3.0 | **7.0.0** (major) |
| `ossf/scorecard-action` | 2.4.3 | 2.4.4 |

Every entry stays a full 40-char SHA with a `# vX.Y.Z` comment, matching the house convention across all 16 third-party `uses:` in this repo.

## What I checked

- The diff is exactly dependabot's, cherry-picked — no hand edits.
- `setup-python` v6 → v7 is the only major bump. It is used by the Live AI E2E mock jobs and the speaches image build; those jobs passed on #141 before it went stale, and they run again here.
- Whether the org wants dependabot exempted from the CodeRabbit gate going forward is a separate decision worth making deliberately — otherwise every future bump needs this same manual relay. Flagging rather than deciding it here.