### PR TITLE
fix(obsidian): stop same-day, same-title notes overwriting each other

### DIFF
--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -6,7 +6,9 @@ import Foundation
 /// Content is **summary + action items** when a summary exists; when it
 /// doesn't (summaries off, LLM unconfigured, or generation failed) it falls
 /// back to **transcript + action items** so export stays independent of the
-/// LLM. One `.md` per recording, `<date> <title>.md`, into `vault/subfolder`.
+/// LLM. One `.md` per recording, `<date> <title>.md`, into `vault/subfolder`
+/// — suffixed with a slice of the recording ID when a different recording has
+/// already taken that name (see `noteTarget`).
 ///
 /// Idempotency: a per-recording seen-index (Drive-importer discipline) maps the
 /// recording ID to its last-written relative path, so a re-transcription (or a
@@ -129,7 +131,18 @@ final class ObsidianExporter: ObservableObject {
             return nil
         }
 
-        let target = destDir.appendingPathComponent(Self.fileName(for: recording))
+        // The key is scoped to the vault. The stored value is a path *relative
+        // to the vault it was written into*, so resolving it against whatever
+        // vault happens to be configured now would, after the user switches
+        // vaults, delete `<newVault>/<oldRelativePath>` — an unrelated file, or
+        // nothing — and orphan the real note in the previous vault.
+        //
+        // Resolved before the filename, because the name this recording gets
+        // depends on what it was called last time — see `noteTarget`.
+        let key = Self.indexKey(vault: vault, id: recording.id)
+        migrateLegacyIndexEntry(&index, key: key, vault: vault, id: recording.id)
+
+        let target = noteTarget(for: recording, in: destDir, vault: vault, index: index, key: key)
         // Re-checked for the file itself, not just its directory: the note name
         // could already exist as a symlink pointing out of the vault.
         guard ObsidianPathSanitizer.isContained(target, in: vault, fileManager: fileManager) else {
@@ -141,14 +154,6 @@ final class ObsidianExporter: ObservableObject {
 
         // Overwrite discipline: if we wrote a differently-named file for this
         // recording before (title changed / moved to another folder), remove it.
-        //
-        // The key is scoped to the vault. The stored value is a path *relative
-        // to the vault it was written into*, so resolving it against whatever
-        // vault happens to be configured now would, after the user switches
-        // vaults, delete `<newVault>/<oldRelativePath>` — an unrelated file, or
-        // nothing — and orphan the real note in the previous vault.
-        let key = Self.indexKey(vault: vault, id: recording.id)
-        migrateLegacyIndexEntry(&index, key: key, vault: vault, id: recording.id)
         if let prevRelative = index[key], prevRelative != newRelative {
             let old = vault.appendingPathComponent(prevRelative)
             // Never follow a stored path back out of the vault.
@@ -166,6 +171,107 @@ final class ObsidianExporter: ObservableObject {
         }
         index[key] = newRelative
         return (target, changedPaths)
+    }
+
+    // MARK: - Note naming
+
+    /// Where this recording's note goes: `<date> <title>.md`, disambiguated
+    /// when that name is already spoken for by a *different* recording.
+    ///
+    /// The plain name is not unique. Titles default to the capture source
+    /// rather than to anything per-recording — two system-audio captures on the
+    /// same day are both "System Audio" — so without this, the second export
+    /// silently overwrote the first and one note was simply lost. The index is
+    /// keyed by recording ID, so it never noticed: both recordings held their
+    /// own entry pointing at the same file, and the rename cleanup saw nothing
+    /// to delete.
+    ///
+    /// **Stickiness is the whole point.** A re-export (re-transcription, a
+    /// summary landing, a backfill sweep) must resolve to the file it wrote
+    /// last time, not to a fresh name — otherwise every pass would leave
+    /// another copy behind. Two things provide it:
+    ///
+    ///  * the candidate names are *derived from the recording ID*, not from a
+    ///    counter over the directory, so they don't shift when neighbouring
+    ///    notes come and go; and
+    ///  * whichever candidate the index already records for this recording wins
+    ///    outright, before any availability check — so a note that had to be
+    ///    disambiguated keeps its suffix even once the plain name frees up.
+    private func noteTarget(for recording: Recording,
+                            in destDir: URL,
+                            vault: URL,
+                            index: [String: String],
+                            key: String) -> URL {
+        let candidates = Self.nameCandidates(for: recording)
+        let previous = index[key]
+
+        // Sticky: the name we wrote for this recording last time, as long as
+        // it's still one of the names this recording would pick today. (After
+        // a retitle none of them match, and the rename path takes over.)
+        for name in candidates {
+            let url = destDir.appendingPathComponent(name)
+            if previous == Self.relativePath(of: url, vault: vault) { return url }
+        }
+
+        // Both signals matter. The index catches the same-day/same-title clash
+        // even when the other note has been synced away or not yet written;
+        // the disk catches what the index can't know about — a note from a
+        // build before this index existed, a copy arriving over git sync, or
+        // a file the user wrote by hand and would not thank us for clobbering.
+        let claimed = Self.pathsClaimedByOtherRecordings(index, vault: vault, id: recording.id)
+        for name in candidates {
+            let url = destDir.appendingPathComponent(name)
+            let relative = Self.relativePath(of: url, vault: vault)
+            if !claimed.contains(relative) && !fileManager.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+        // Unreachable in practice: the last candidate carries the full
+        // recording UUID, which no other recording can produce. Falling back
+        // to it (rather than to the plain name) keeps the worst case a
+        // collision we lose to, never an overwrite.
+        return destDir.appendingPathComponent(candidates[candidates.count - 1])
+    }
+
+    /// The note names this recording will accept, in order of preference:
+    /// the plain `<date> <title>.md`, then the same stem suffixed with a short
+    /// prefix of the recording UUID, then with the whole thing.
+    ///
+    /// Deterministic by construction — the same recording yields the same list
+    /// on every run, which is what lets `noteTarget` be idempotent. The short
+    /// form is what a user will normally see; the full form exists only so the
+    /// list cannot run out, since two distinct recordings can never share it.
+    ///
+    /// Length stays inside the 255-byte component limit: the stem is capped at
+    /// 180 bytes by `ObsidianPathSanitizer.nameFragment` plus an 11-byte date
+    /// prefix, and the longest suffix here adds 37 more.
+    static func nameCandidates(for recording: Recording) -> [String] {
+        let base = fileName(for: recording)
+        let stem = base.hasSuffix(".md") ? String(base.dropLast(3)) : base
+        let uuid = recording.id.uuidString.lowercased()
+        return [base, "\(stem) \(uuid.prefix(8)).md", "\(stem) \(uuid).md"]
+    }
+
+    /// Relative paths inside `vault` that the index records for some recording
+    /// other than `id`.
+    ///
+    /// Legacy bare-UUID keys are skipped on purpose: they carry no vault, so
+    /// attributing their path to *this* vault could suppress the plain name on
+    /// the strength of a note that lives somewhere else entirely.
+    private static func pathsClaimedByOtherRecordings(_ index: [String: String],
+                                                      vault: URL,
+                                                      id: UUID) -> Set<String> {
+        let prefix = "\(vault.standardized.path)#"
+        var claimed: Set<String> = []
+        for (key, relative) in index where key.hasPrefix(prefix) {
+            let suffix = String(key.dropFirst(prefix.count))
+            // A vault path may itself contain "#", so a prefix match alone
+            // doesn't prove the key belongs to this vault — the remainder has
+            // to be exactly a UUID.
+            guard let other = UUID(uuidString: suffix), other != id else { continue }
+            claimed.insert(relative)
+        }
+        return claimed
     }
 
     /// Index keys written before the index was vault-scoped are bare UUIDs.
@@ -293,6 +399,10 @@ final class ObsidianExporter: ObservableObject {
     }
 
     /// `<yyyy-MM-dd> <title>.md`, sanitized for the filesystem.
+    ///
+    /// The *preferred* name, not necessarily the one on disk: it is not unique
+    /// per recording, so `noteTarget` may pick a suffixed variant instead. Use
+    /// `nameCandidates(for:)` for the full set.
     static func fileName(for recording: Recording) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/MilaTests/ObsidianExporterTests.swift
+++ b/MilaTests/ObsidianExporterTests.swift
@@ -344,6 +344,144 @@ final class ObsidianExporterTests: XCTestCase {
             atPath: vault.appendingPathComponent("\(Self.expectedDatePrefix) After.md").path))
     }
 
+    // MARK: - Filename collisions
+
+    /// Titles are not unique. They default to the capture source — see
+    /// `QuickActionsController`, which titles a system-audio capture with the
+    /// foreground app's name or "System Audio" — so two captures on the same
+    /// day routinely want the same `<date> <title>.md`. Before this was
+    /// handled, the second export silently overwrote the first and one note
+    /// was lost: the index is keyed by recording ID, so both recordings held
+    /// an entry pointing at the same file and the rename cleanup saw nothing
+    /// wrong.
+    func test_two_same_day_same_title_recordings_get_distinct_notes() throws {
+        let first = makeRecording(title: "System Audio", summary: "First meeting")
+        let second = makeRecording(title: "System Audio", summary: "Second meeting")
+        XCTAssertNotEqual(first.id, second.id)
+
+        let firstURL = try XCTUnwrap(exporter.export(first))
+        let secondURL = try XCTUnwrap(exporter.export(second))
+
+        XCTAssertNotEqual(firstURL.path, secondURL.path,
+                          "the second recording must not land on the first one's note")
+        XCTAssertEqual(try String(contentsOf: firstURL, encoding: .utf8).contains("First meeting"),
+                       true, "the first note was overwritten")
+        XCTAssertTrue(try String(contentsOf: secondURL, encoding: .utf8).contains("Second meeting"))
+
+        // The first one keeps the clean name; only the loser of the race is
+        // suffixed, and it is suffixed from its own ID.
+        XCTAssertEqual(firstURL.lastPathComponent, "\(Self.expectedDatePrefix) System Audio.md")
+        XCTAssertTrue(secondURL.lastPathComponent.hasPrefix("\(Self.expectedDatePrefix) System Audio "))
+        XCTAssertTrue(secondURL.lastPathComponent
+            .contains(second.id.uuidString.lowercased().prefix(8)))
+
+        XCTAssertEqual(try Self.notes(in: vault).count, 2)
+    }
+
+    /// The idempotency half: re-exporting either recording (a re-transcription,
+    /// a late summary, a backfill sweep) must overwrite *its own* note rather
+    /// than mint a third. The disambiguated name has to be remembered and
+    /// reused, not recomputed against whatever is on disk at the time.
+    func test_reexport_after_a_collision_overwrites_each_recordings_own_note() throws {
+        var first = makeRecording(title: "System Audio", summary: "First v1")
+        var second = makeRecording(title: "System Audio", summary: "Second v1")
+        let firstURL = try XCTUnwrap(exporter.export(first))
+        let secondURL = try XCTUnwrap(exporter.export(second))
+
+        // Re-export in the opposite order, to prove the choice doesn't depend
+        // on who happens to run first.
+        second.summary = "Second v2"
+        first.summary = "First v2"
+        XCTAssertEqual(try XCTUnwrap(exporter.export(second)).path, secondURL.path)
+        XCTAssertEqual(try XCTUnwrap(exporter.export(first)).path, firstURL.path)
+
+        XCTAssertEqual(try Self.notes(in: vault).count, 2, "a re-export must not create a third note")
+        XCTAssertTrue(try String(contentsOf: firstURL, encoding: .utf8).contains("First v2"))
+        XCTAssertTrue(try String(contentsOf: secondURL, encoding: .utf8).contains("Second v2"))
+    }
+
+    /// Same collision, arriving through the backfill path in a single batch —
+    /// where the index is threaded in memory and only persisted at the end, so
+    /// the in-batch claim is the only thing standing between the two notes.
+    func test_exportAll_disambiguates_same_day_same_title_recordings() throws {
+        let a = makeRecording(title: "System Audio", summary: "A")
+        let b = makeRecording(title: "System Audio", summary: "B")
+        let c = makeRecording(title: "System Audio", summary: "C")
+
+        XCTAssertEqual(exporter.exportAll([a, b, c]), 3)
+        XCTAssertEqual(try Self.notes(in: vault).count, 3)
+
+        // And running the same sweep again is a no-op on the file count.
+        XCTAssertEqual(exporter.exportAll([a, b, c]), 3)
+        XCTAssertEqual(try Self.notes(in: vault).count, 3)
+    }
+
+    /// The suffix sticks even once the plain name frees up. Recomputing
+    /// availability on every run would move the note back, renaming a file in
+    /// the user's vault (and breaking their links to it) because an unrelated
+    /// note was deleted.
+    func test_disambiguated_note_keeps_its_name_after_the_plain_one_frees_up() throws {
+        var first = makeRecording(title: "System Audio", summary: "First")
+        let second = makeRecording(title: "System Audio", summary: "Second")
+        let firstURL = try XCTUnwrap(exporter.export(first))
+        let secondURL = try XCTUnwrap(exporter.export(second))
+
+        // The plain name is released — the first recording is retitled.
+        first.title = "Renamed"
+        XCTAssertNotNil(exporter.export(first))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstURL.path))
+
+        XCTAssertEqual(try XCTUnwrap(exporter.export(second)).path, secondURL.path,
+                       "the disambiguated note must not migrate back to the plain name")
+    }
+
+    /// A file the exporter has no record of — a note from a build before the
+    /// index existed, a copy landing over git sync, or something the user wrote
+    /// by hand — is not ours to clobber either. The index can't know about it,
+    /// so the on-disk check is what catches this one.
+    func test_export_does_not_clobber_an_unknown_file_with_the_same_name() throws {
+        let vaultRoot = try XCTUnwrap(settings.vaultURL)
+        let squatter = vaultRoot.appendingPathComponent("\(Self.expectedDatePrefix) System Audio.md")
+        try "hand-written".write(to: squatter, atomically: true, encoding: .utf8)
+
+        let rec = makeRecording(title: "System Audio", summary: "Mine")
+        let url = try XCTUnwrap(exporter.export(rec))
+        XCTAssertNotEqual(url.path, squatter.path)
+        XCTAssertEqual(try String(contentsOf: squatter, encoding: .utf8), "hand-written")
+
+        // Still idempotent against it.
+        XCTAssertEqual(try XCTUnwrap(exporter.export(rec)).path, url.path)
+        XCTAssertEqual(try Self.notes(in: vaultRoot).count, 2)
+    }
+
+    /// Candidate names are derived from the recording, so they're stable across
+    /// runs, and every one of them stays a legal path component.
+    func test_nameCandidates_are_distinct_stable_and_writable() {
+        let rec = makeRecording(title: String(repeating: "עברית ", count: 200))
+        let candidates = ObsidianExporter.nameCandidates(for: rec)
+        XCTAssertEqual(candidates, ObsidianExporter.nameCandidates(for: rec), "must be deterministic")
+        XCTAssertEqual(Set(candidates).count, candidates.count, "candidates must be distinct")
+        XCTAssertEqual(candidates.first, ObsidianExporter.fileName(for: rec))
+        for name in candidates {
+            XCTAssertTrue(name.hasSuffix(".md"))
+            XCTAssertFalse(name.contains("/"))
+            XCTAssertFalse(name.hasPrefix("."))
+            XCTAssertLessThanOrEqual(name.utf8.count, 255, name)
+        }
+        // Distinct recordings never share the last-resort candidate.
+        let other = makeRecording(title: "Same")
+        let another = makeRecording(title: "Same")
+        XCTAssertNotEqual(ObsidianExporter.nameCandidates(for: other).last,
+                          ObsidianExporter.nameCandidates(for: another).last)
+    }
+
+    /// Every `.md` under `dir`, recursively.
+    private static func notes(in dir: URL) throws -> [URL] {
+        let fm = FileManager.default
+        guard let walker = fm.enumerator(at: dir, includingPropertiesForKeys: nil) else { return [] }
+        return walker.compactMap { $0 as? URL }.filter { $0.pathExtension == "md" }
+    }
+
     // MARK: - Written index
 
     /// The index stores a path *relative to the vault it was written into*. If


### PR DESCRIPTION
Closes #170

## The bug

The vault note name was `<date> <title>.md` and nothing else. Titles are not user-chosen by default — `QuickActionsController` titles a system-audio capture with the foreground app's name, or `"System Audio"` when there isn't one — so two captures on the same day routinely wanted the same file. The second export overwrote the first and one note was lost, with no error.

Nothing caught it. The written-index is keyed by `<vaultPath>#<recordingID>`, so both recordings held their *own* entry pointing at the *same* relative path; the rename cleanup only fires when **this** recording's stored path differs from the one it is about to write, and two different recordings agreeing on a path is invisible to it. No delete, no conflict — a plain overwrite.

Not a regression from #164 — the naming scheme is the same in #129, the original. It was left out of that review's scope deliberately.

## The fix

A recording now has three candidate names, in preference order:

```
2026-08-02 System Audio.md            ← plain
2026-08-02 System Audio a1b2c3d4.md   ← + short recording UUID
2026-08-02 System Audio a1b2c3d4-….md ← + full recording UUID
```

The first one that isn't taken by a different recording wins. The last exists only so the list cannot run out — two distinct recordings can never produce it — so the worst case is a collision we lose to, never an overwrite.

**Idempotency** is the part that needed care, and it comes from two places:

- The candidates are derived from the recording, not from a counter over the directory, so they are identical on every run and don't shift as neighbouring notes come and go.
- Whichever candidate the index already records for this recording wins **outright, before any availability check**. So a disambiguated note keeps its suffix even once the plain name frees up — recomputing availability every time would rename a file in the user's vault (breaking their `[[wikilinks]]` to it) because an unrelated note happened to be deleted.

Availability is judged against **both** the index and the disk, and both signals earn their place:

- the index catches the same-day clash when the other note has been synced away, or is only being written later in the same `exportAll` batch (where the index is threaded in memory and persisted once at the end);
- the disk catches what the index cannot know about — a note from a build before the index existed, a copy arriving over git sync, or a file the user wrote by hand. None of those are ours to clobber either, which is a small behaviour improvement that falls out of the same check.

One structural change: the index key and legacy-key migration now resolve *before* the filename, since the name a recording gets depends on what it was called last time.

Names stay inside the 255-byte component limit — the stem is capped at 180 bytes by `nameFragment` plus an 11-byte date prefix, and the longest suffix adds 37.

## Tests

Six new cases in `ObsidianExporterTests`, the first two being exactly what #170 asks for:

- two same-day/same-title recordings produce two distinct notes, and the *first* keeps the clean name;
- re-exporting either one overwrites its own note rather than minting a third — checked in the opposite order from the first export, so the result can't depend on who runs first;
- the same collision through the `exportAll` backfill path, plus a second sweep that must not change the file count;
- a disambiguated note keeps its name after the plain one frees up;
- an unknown same-named file on disk is not clobbered, and export stays idempotent against it;
- candidate names are deterministic, distinct, and legal path components (including a 2200-byte Hebrew title).

**Verified these fail without the fix**, not just pass with it: against the pre-fix exporter the vault holds 1 note where 2 and 3 are expected, and the first note's body has been replaced by the second's.

All 62 Obsidian unit tests pass (`ObsidianExporterTests`, `ObsidianExportSequencingTests`, `ObsidianGitSyncerTests`, `ObsidianVaultSettingsTests`); `make build` is clean.

## Not in scope

Existing vaults are not repaired — a note already lost to this was overwritten on disk and there is nothing left to recover. This stops it happening from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Obsidian exports from overwriting notes when multiple recordings share the same date.
  * Re-exports now consistently reuse each recording’s assigned filename.
  * Improved vault-specific index handling to avoid cleanup affecting notes in other vaults.
  * Existing, unrelated Markdown files are preserved during export.

* **Documentation**
  * Clarified fallback note content and preferred filename behavior for Obsidian exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->