### PR TITLE
fix(ci): match the rate-limit notice to the head before blaming quota

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -65,18 +65,30 @@ review.
 ### Triaging a red "CodeRabbit reviewed head"
 
 Read the job log line `signals — review@head:… inline@head:… verdict:…
-walkthrough@head:… rateLimitNotices:…`, then:
+walkthrough@head:… rateLimitNotices:… rateLimit@head:…`, then:
 
-- `review@head:no`, `inline@head:0`, `verdict:no`, `walkthrough@head:no`, **and
-  a rate-limit notice that names the current head** → **quota stall**, not a
-  gap. The count alone is not enough: `rateLimitNotices` tallies every notice on
-  the PR, including ones left on older heads, so a stale notice can dress a real
-  review gap up as a quota problem. Check that a notice names *this* head. See
-  *The quota is per PR author* below.
-- same signals, but no rate-limit notice naming the head, and CodeRabbit has
-  plainly commented on the head → likely a **detector gap**; check the comment
-  against the four signals below before assuming the bot misbehaved.
+- all four review signals negative (`review@head:no`, `inline@head:0`,
+  `verdict:no`, `walkthrough@head:no`) **and `rateLimit@head:yes`** → **quota
+  stall**, not a gap: a "Review limit reached" notice whose commit line names
+  *this* head. The check's own comment links that notice and quotes its
+  countdown. See *The quota is per PR author* below.
+- all four negative, `rateLimit@head:no`, but `rateLimitNotices` non-zero →
+  **not** a quota stall, however much it looks like one. Those notices sit on
+  earlier revisions — CodeRabbit edits its summary comment in place, so they
+  linger on the PR forever — and their countdowns have almost certainly
+  elapsed. The check says as much in its comment; do not read an old countdown
+  as the live state.
+- all four negative, `rateLimit@head:no`, and CodeRabbit has plainly commented
+  on the head → likely a **detector gap**; check the comment against the four
+  signals below before assuming the bot misbehaved.
 - otherwise → **a real gap**: the head genuinely has no review.
+
+Only `rateLimit@head` is head-matched. `rateLimitNotices` is a raw count of
+every notice on the PR, and reading the count as the live state is what produced
+two wrong diagnoses before #172: once a stale notice was believed over a
+genuinely unreviewed head, once a real stall on a short-SHA notice looked like a
+detector gap. The head match now uses the same second-SHA, full-or-abbreviated
+rule as signal 4 below, via one shared helper so the two cannot drift.
 
 ### Do not trust the `CodeRabbit` status check
 

--- a/.github/workflows/require-coderabbit-review.yml
+++ b/.github/workflows/require-coderabbit-review.yml
@@ -350,34 +350,60 @@ jobs:
             // prefix of the head (as enforced by the pattern) is the head.
             const namesHead = (sha) => head.startsWith(sha.toLowerCase());
 
+            // Does this body carry a commit line whose SECOND sha — the revision
+            // that was read, not the diff base — is the current head?
+            //
+            // Deliberately shared with the rate-limit diagnostics below, because
+            // the notice embeds this line VERBATIM (17 of the 35 commit lines in
+            // the last 70 PRs belong to a notice, not a walkthrough). Two copies
+            // of "does this name the head" would drift, and the copy that drifted
+            // is what #172 fixed.
+            //
+            // `lastIndex` is reset because the pattern is /g: `matchAll` seeds
+            // its iterator from wherever a previous call left the index.
+            function commentNamesHead(body) {
+              REVIEWED_BETWEEN_RE.lastIndex = 0;
+              for (const m of (body ?? '').matchAll(REVIEWED_BETWEEN_RE)) {
+                if (namesHead(m[2])) return true;
+              }
+              return false;
+            }
+
             const walkthroughComment = comments.filter(byBot).find((c) => {
               const body = c.body ?? '';
               if (RATE_LIMIT_RE.test(body) || NOT_A_VERDICT_RE.test(body)) return false;
               if (!VERDICT_RE.test(body)) return false;
-              REVIEWED_BETWEEN_RE.lastIndex = 0;
-              for (const m of body.matchAll(REVIEWED_BETWEEN_RE)) {
-                if (namesHead(m[2])) return true;
-              }
-              return false;
+              return commentNamesHead(body);
             });
 
-            // ---- rate-limit notice: the OPPOSITE of a review. Surfaced so a
-            // human reading the red check knows the bot was blocked by quota
-            // rather than broken. CodeRabbit edits its summary comment in place,
-            // so prefer a notice that names the current head.
+            // ---- rate-limit notice: the OPPOSITE of a review. DIAGNOSTICS ONLY
+            // — surfaced so a human reading the red check knows the bot was
+            // blocked by quota rather than broken. Nothing below section 5 reads
+            // it; the pass/fail decision is made by the four signals above and
+            // this cannot move it either way.
+            //
+            // A notice describes the LIVE state only if its commit line names the
+            // current head, matched by exactly the rule signal (d) uses: the
+            // second sha of the range, full or abbreviated.
+            //
+            // There is deliberately NO fallback to "the newest notice on the PR".
+            // CodeRabbit edits its summary comment in place and old notices linger
+            // forever, so the fallback reported a genuinely unreviewed new head as
+            // quota-blocked and sent the reader off to wait out a countdown that
+            // had already expired (#172). A notice that names only an older
+            // revision is reported as exactly that, further down.
             const rateLimited = comments.filter(byBot).filter((c) =>
               RATE_LIMIT_RE.test(c.body ?? ''),
             );
-            const activeLimit =
-              rateLimited.find((c) => (c.body ?? '').includes(head)) ??
-              rateLimited[rateLimited.length - 1];
+            const activeLimit = rateLimited.find((c) => commentNamesHead(c.body));
 
             core.info(
               `signals — review@head:${reviewAtHead ? 'yes' : 'no'} ` +
                 `inline@head:${inlineAtHead.length} ` +
                 `verdict:${verdictComment ? 'yes' : 'no'} ` +
                 `walkthrough@head:${walkthroughComment ? 'yes' : 'no'} ` +
-                `rateLimitNotices:${rateLimited.length}`,
+                `rateLimitNotices:${rateLimited.length} ` +
+                `rateLimit@head:${activeLimit ? 'yes' : 'no'}`,
             );
 
             // ---- 5. verdict -------------------------------------------------
@@ -422,21 +448,32 @@ jobs:
 
             if (activeLimit) {
               const countdown = countdownFrom(activeLimit.body);
-              const stale = !(activeLimit.body ?? '').includes(head);
               lines.push(
                 '> [!WARNING]',
                 "> **CodeRabbit was rate-limited, not silent.** It posted a",
-                `> [\"Review limit reached\" notice](${activeLimit.html_url}): the`,
-                "> account hit its per-user PR review quota, so the review never",
-                '> started.',
+                `> [\"Review limit reached\" notice](${activeLimit.html_url}) naming`,
+                `> this very commit (\`${shortHead}\`): the account hit its per-user`,
+                '> PR review quota, so the review never started.',
                 countdown
-                  ? `> **Next review available in:** ${countdown}${
-                      stale ? ' _(from an earlier revision — may have elapsed)_' : ''
-                    }`
+                  ? `> **Next review available in:** ${countdown} _(counted from ` +
+                      'when that notice was posted)_'
                   : '> No countdown was given in the notice.',
                 '>',
                 '> Note that the separate `CodeRabbit` status check goes **green**',
                 '> in this situation. It is not a review.',
+                '',
+              );
+            } else if (rateLimited.length > 0) {
+              // Stale notices are worth naming explicitly: left unexplained, the
+              // reader finds them on the PR and concludes "rate-limited" anyway,
+              // which is the misdiagnosis this whole change exists to stop.
+              lines.push(
+                '> [!NOTE]',
+                `> This PR carries ${rateLimited.length} CodeRabbit rate-limit`,
+                `> notice(s), but none of them names \`${shortHead}\` — they were`,
+                '> left on earlier revisions, and their countdowns have very likely',
+                '> elapsed. Do not read them as the current state: as far as this',
+                '> check can tell, nothing is blocking a review of this head.',
                 '',
               );
             }


### PR DESCRIPTION
Closes #172

## What & why

The review gate's quota-recovery guidance fired whenever *any* rate-limit notice
existed on the PR. Two bugs, pulling in opposite directions:

1. `activeLimit` fell back to the newest notice **even when that notice named an
   older revision**. CodeRabbit edits its summary comment in place, so old
   notices linger on a PR forever — a genuinely unreviewed new head got reported
   as quota-blocked, and the reader was sent off to wait out a countdown that had
   already expired.
2. The head test was `body.includes(head)` — a full-40-char match — so a real
   stall whose notice used an **abbreviated SHA** was missed. With more than one
   notice on the PR, bug 1's fallback then cited the *wrong* notice's link and
   countdown.

The notice embeds the same `Reviewing files that changed … between <base> and
<head>` line as the walkthrough (17 of the 35 commit lines across the last 70 PRs
belong to a notice, not a walkthrough), so both paths need the identical head
test. This extracts it as `commentNamesHead()` — second SHA of the range, full or
abbreviated, exactly what signal (d) already required — uses it for both, and
drops the fallback. Sharing one helper is the point: the two copies are what
drifted.

Also:

- A PR carrying only stale notices now gets an explicit note saying none of them
  names this head and their countdowns have very likely elapsed, instead of a
  confident "rate-limited" warning quoting an expired countdown.
- The signals log line gains `rateLimit@head:` so the distinction the triage
  notes ask the reader to make by hand is visible in the log.
- `.claude/rules/pull-requests.md` triage block updated to read the new signal,
  and to record why the raw `rateLimitNotices` count is not the live state.

**This is diagnostics-only.** Pass/fail is decided by the four review signals in
section 5; none of them is touched, and nothing in the rate-limit path feeds
them. A mislabelled reason could never admit unreviewed code, and still cannot.

## How it was tested

YAML + embedded JS, so there is nothing to `make build`. Instead the real script
was extracted from the workflow with a YAML parser and executed under the
`actions/github-script` contract (an async function body given `github`,
`context`, `core`) with stubbed API responses, against fixtures captured from
this repo — every `coderabbitai[bot]` issue comment, review object and inline
review comment of the last 70 PRs, all reads `--paginate`d.

Scenario matrix (real notice body from #163, whose commit line ends at that PR's
head `9c6e70a`; "head advanced" replays the same body against a later real
commit; the abbreviated variants are that same body with its SHAs trimmed to 7
chars, since every notice on record here happens to use full SHAs):

| # | scenario | before | after |
|---|---|---|---|
| A | notice names current head, full SHA | quota warning ✔ | quota warning ✔ |
| B | same notice, head has since advanced | quota warning ✘ (wrong) | stale-notice note ✔ |
| C | notice names current head, abbreviated SHA | quota warning, but only via the fallback | quota warning, matched properly ✔ |
| D | abbreviated notice naming an older head | quota warning ✘ (wrong) | stale-notice note ✔ |
| H | abbreviated notice at head **+** an unrelated stale notice | cites the *stale* notice (`#167`, "30 minutes") ✘ | cites the head notice (`#163`, "18 minutes") ✔ |
| E | clean walkthrough at head (signal d) | PASS | PASS |
| F | that walkthrough after a push | FAIL, no quota claim | FAIL, no quota claim |
| G | abbreviated clean walkthrough at head | PASS | PASS |

Verdicts unchanged, checked rather than argued: replaying all 70 PRs through both
versions of the script and diffing the pass/fail + signals output is
byte-identical once the new `rateLimit@head` field is stripped (39 pass, 31 fail).
All 17 historical rate-limit notices still match at head under the stricter rule,
so no real quota stall stops being reported.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — n/a, CI YAML
      only; validated by parsing the workflow and executing the script against
      fixtures as above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a,
      CI-internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-status diagnostics by matching rate-limit notices to the current commit.
  * Prevented outdated notices from being incorrectly treated as active limits.
  * Added clearer failure messages distinguishing current review limits from historical notices.
* **Documentation**
  * Expanded triage guidance for identifying quota stalls, detector gaps, and stale rate-limit notices.
  * Clarified how review signals and commit matching determine the appropriate diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->