### PR TITLE
docs(audio): explain WAVHeaderRepair's 44-byte floor and pin the crash signature in its tests

### DIFF
--- a/Mila/Audio/WAVHeaderRepair.swift
+++ b/Mila/Audio/WAVHeaderRepair.swift
@@ -44,7 +44,10 @@ enum WAVHeaderRepair {
     ///     live in the first few KB; pass a generous prefix, e.g. 64 KB).
     ///   - fileSize: the physical file size in bytes.
     static func plan(header: [UInt8], fileSize: Int) -> Plan? {
-        // Minimum: RIFF(8) + WAVE(4) + fmt(24) + data header(8) = 44.
+        // A canonical WAV header is RIFF(8) + WAVE(4) + fmt(24) + data
+        // header(8) = 44 bytes, so 44 is the smallest a WAV can be — and such
+        // a file is *all* header, with zero audio bytes after it. There is
+        // nothing to recover at or below 44, hence the strict `>`.
         guard fileSize > 44, header.count >= 12 else { return nil }
         guard header[0] == 0x52, header[1] == 0x49, header[2] == 0x46, header[3] == 0x46, // "RIFF"
               header[8] == 0x57, header[9] == 0x41, header[10] == 0x56, header[11] == 0x45 // "WAVE"
@@ -140,6 +143,9 @@ enum WAVHeaderRepair {
     @discardableResult
     static func repairIfNeeded(at url: URL) -> Bool {
         let fileSize = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        // Same floor as `plan`: 44 bytes is a header with no audio behind it,
+        // so there is nothing to repair. Checked here too, to skip opening a
+        // FileHandle for a file that can't possibly need one.
         guard fileSize > 44 else { return false }
         guard let handle = try? FileHandle(forUpdating: url) else { return false }
         defer { try? handle.close() }

--- a/MilaTests/WAVHeaderRepairTests.swift
+++ b/MilaTests/WAVHeaderRepairTests.swift
@@ -65,6 +65,24 @@ final class WAVHeaderRepairTests: XCTestCase {
             | (UInt32(bytes[offset + 2]) << 16) | (UInt32(bytes[offset + 3]) << 24)
     }
 
+    /// Offset of the `data` chunk header in a real WAV, found by walking the
+    /// chunk table. AVAudioFile emits JUNK + fmt + FLLR before `data`, and the
+    /// FLLR padding is sized to align the audio to a block boundary — so
+    /// `data` sits at no fixed offset and must be located, not assumed.
+    private func dataChunkOffset(in bytes: [UInt8]) -> Int? {
+        guard bytes.count >= 12,
+              Array(bytes[0..<4]) == ascii("RIFF"),
+              Array(bytes[8..<12]) == ascii("WAVE") else { return nil }
+        var offset = 12
+        while offset + 8 <= bytes.count {
+            let size = u32(bytes, offset + 4)
+            if Array(bytes[offset..<offset + 4]) == ascii("data") { return offset }
+            // Chunks are word-aligned: an odd size carries a trailing pad byte.
+            offset += 8 + Int(size) + (Int(size) & 1)
+        }
+        return nil
+    }
+
     private func writeTemp(_ bytes: [UInt8]) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("wavrepair-\(UUID().uuidString).wav")
@@ -177,6 +195,25 @@ final class WAVHeaderRepairTests: XCTestCase {
             .appendingPathComponent("wavrepair-live-\(UUID().uuidString).wav")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
 
+        // `AVLinearPCMIsNonInterleaved: false` next to `interleaved: false` is
+        // not the contradiction it looks like — the two configure *different*
+        // formats and AVFoundation honours them independently:
+        //
+        //   * `settings` describes the **file format**. A WAV is interleaved by
+        //     definition; passing `AVLinearPCMIsNonInterleaved: true` only makes
+        //     CoreAudio log "Audio files cannot be non-interleaved. Ignoring
+        //     setting AVLinearPCMIsNonInterleaved YES" and write an interleaved
+        //     file anyway. `false` is the only value with any meaning here.
+        //   * `interleaved:` describes the **processing format** — the layout of
+        //     the in-memory buffers handed to `write(from:)`. That one *is*
+        //     honoured, and `false` is what gives the planar
+        //     `floatChannelData[channel][frame]` addressing used below.
+        //
+        // Making them "agree" would break the point of this test: the pairing is
+        // copied verbatim from `RecordingSession` — the recorder that produces
+        // the crashed files being simulated (and from `FileTranscriber`,
+        // `DictationController` and `TestSupport`). Change either value and the
+        // test stops reproducing the real recorder's output.
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: 16000.0,
@@ -201,6 +238,20 @@ final class WAVHeaderRepairTests: XCTestCase {
 
         XCTAssertEqual(unclosed.count, finalized.count, "close() must not change the file length.")
         XCTAssertNotEqual(unclosed, finalized, "close() is expected to backfill the size fields.")
+
+        // Pin the exact crash signature `plan()` keys off, rather than settling
+        // for "the bytes differ somewhere": a still-open AVAudioFile must leave
+        // `data` size at the placeholder 0. If a future AVFoundation started
+        // publishing a running size mid-write, the assertions above would still
+        // pass while the repair quietly stopped firing in production.
+        let liveDataOffset = try XCTUnwrap(dataChunkOffset(in: unclosed),
+                                           "AVAudioFile must emit a `data` chunk.")
+        XCTAssertEqual(u32(unclosed, liveDataOffset + 4), 0,
+                       "A still-open AVAudioFile must leave `data` size at 0.")
+        XCTAssertEqual(u32(finalized, liveDataOffset + 4), UInt32(4 * 16_000 * 4),
+                       "close() backfills the real byte count (4 writes x 16k frames x 4 bytes).")
+        XCTAssertEqual(u32(unclosed, 4), u32(finalized, 4) - UInt32(4 * 16_000 * 4),
+                       "The unclosed RIFF size must be short by exactly the audio payload.")
 
         // Put the unfinalized bytes back and let the repair redo close()'s work.
         try Data(unclosed).write(to: url)


### PR DESCRIPTION
Closes #161

## What & why

Comments and tests only — **no runtime behaviour changes**. Both findings come from Copilot's review of #115, deliberately deferred there rather than invalidating that PR's hard-won CodeRabbit review with a cosmetic commit.

### 1. `WAVHeaderRepair.plan` — the comment now matches the guard

`// Minimum: … = 44.` sat above `guard fileSize > 44`, so the comment implied 44 was allowed while the code rejected it. The guard is right: a 44-byte file is *all* header with zero audio behind it, so there is nothing to recover. The comment now says that, and explains the strict `>`.

`repairIfNeeded` repeats the same bare `guard fileSize > 44` with no comment at all, so the confusion had two places to happen — it now carries a matching note, plus why the check is duplicated there (it skips opening a `FileHandle` for a file that can't possibly need one).

### 2. `WAVHeaderRepairTests` — the `interleaved` pairing is correct, and now says so

`AVLinearPCMIsNonInterleaved: false` next to `interleaved: false` reads as a contradiction, and Copilot suggested making them agree. **They must not be made to agree** — they configure two different formats, which AVFoundation honours independently:

- `settings` describes the **file format**. A WAV is interleaved by definition; passing `AVLinearPCMIsNonInterleaved: true` only makes CoreAudio log `Audio files cannot be non-interleaved. Ignoring setting AVLinearPCMIsNonInterleaved YES` and write an interleaved file anyway. `false` is the only value with any meaning there.
- `interleaved:` describes the **processing format** — the layout of the in-memory buffers handed to `write(from:)`. That one *is* honoured, and `false` is what gives the planar `floatChannelData[channel][frame]` addressing the test uses.

The pairing is copied verbatim from `RecordingSession` — the recorder that produces the crashed files this test simulates (the same pairing also appears in `FileTranscriber`, `DictationController` and `TestSupport`). Changing either value would make the test stop reproducing the real recorder's output, which is the entire point of `test_repair_matches_a_real_AVAudioFile_close`. So the fix is a comment, not a code change.

### 3. Hardening: pin the actual crash signature

`test_repair_matches_a_real_AVAudioFile_close` only asserted `XCTAssertNotEqual(unclosed, finalized)` — that the bytes differ *somewhere*. It never asserted the specific signature `plan()` keys off: a `data` size of exactly `0`. If a future AVFoundation started publishing a running size mid-write, the test would keep passing while the repair silently stopped firing in production.

Added a `dataChunkOffset(in:)` helper that walks the chunk table — AVAudioFile's JUNK + fmt + FLLR layout puts `data` at no fixed offset (measured at **4088**, not 44) — and three assertions: `data` size is `0` while the file is open, `256000` after `close()`, and the unclosed `RIFF` size is short by exactly the audio payload.

## How it was tested

`make build` — **BUILD SUCCEEDED**.

```
$ xcodebuild test -scheme Mila -destination 'platform=macOS' -derivedDataPath build \
      -only-testing:MilaTests/WAVHeaderRepairTests
     Executed 15 tests, with 0 failures (0 unexpected) in 0.027 (0.030) seconds
** TEST SUCCEEDED **
```

The three new constants are measured, not guessed. A standalone AVFoundation probe using the exact same `settings` / `interleaved:` pairing reports:

```
file length: unclosed=260096 finalized=260096
data chunk offset (unclosed) = 4088, (finalized) = 4088
chunk table (unclosed):   @12 'JUNK' size=28  @48 'fmt ' size=16  @72 'FLLR' size=4008  @4088 'data' size=0
chunk table (finalized):  @12 'JUNK' size=28  @48 'fmt ' size=16  @72 'FLLR' size=4008  @4088 'data' size=256000
data size:  unclosed=0  finalized=256000  expected payload=256000
RIFF size:  unclosed=4088  finalized=260088  finalized-payload=4088
finalized RIFF == fileSize-8 ? true
```

Note `data` at offset **4088** — a hard-coded 44 would have been wrong, which is exactly why the chunk-table walk is needed.

**Negative control** — the new assertion is not vacuous. Temporarily changing the expected `0` to `999` and re-running just that test:

```
WAVHeaderRepairTests.swift:249: error: -[MilaTests.WAVHeaderRepairTests
  test_repair_matches_a_real_AVAudioFile_close] : XCTAssertEqual failed:
  ("0") is not equal to ("999") - A still-open AVAudioFile must leave `data` size at 0.
     Executed 1 test, with 1 failure (0 unexpected) in 0.388 seconds
** TEST FAILED **
```

It reads the real on-disk value and fails when that value disagrees. Reverted afterwards.

UI tests were deliberately not run locally (they steal focus and flake on this machine); CI covers them.

## Checklist

- [x] Builds locally (`make build`) and the affected test class passes
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] No user-facing change (comments + tests only), so no changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WAV header repair now skips header-only files and files that are too small to contain audio data.
  * Improved handling of RIFF chunks with word-alignment padding.
  * Added validation for WAV and data chunk sizes before and after repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->