### PR TITLE
fix(llm): share one Claude Code project across all LLM invocations

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -774,9 +774,25 @@ enum LLMRunner {
     /// fails outright if `currentDirectoryURL` doesn't exist.
     static func sandboxDirectory() -> URL {
         let url = sandboxDirectory(appSupportRoot: applicationSupportRoot())
-        try? FileManager.default.createDirectory(at: url,
-                                                 withIntermediateDirectories: true)
-        return url
+        do {
+            try FileManager.default.createDirectory(at: url,
+                                                    withIntermediateDirectories: true)
+            return url
+        } catch {
+            // `applicationSupportRoot()` only falls back when the *lookup*
+            // fails. If the directory resolves but can't be created -- a
+            // read-only or permission-broken Application Support -- swallowing
+            // the error and returning the path anyway breaks every subsequent
+            // CLI launch, because `Process.run()` fails outright when
+            // `currentDirectoryURL` does not exist. Degrade to a temp directory
+            // instead: the Claude project slug stops being stable, which costs
+            // resumability, but LLM calls keep working.
+            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LLMRunner").error("llm sandbox unavailable at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public) -- falling back to a temp directory")
+            let fallback = sandboxDirectory(appSupportRoot: FileManager.default.temporaryDirectory)
+            try? FileManager.default.createDirectory(at: fallback,
+                                                     withIntermediateDirectories: true)
+            return fallback
+        }
     }
 
     /// Pure path composition, split out so tests can assert the layout

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -210,23 +210,12 @@ enum LLMRunner {
         let handle = ProcessHandle()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                // For Live AI's session continuity to work, every tick
-                // must share a CWD so claude's per-CWD session
-                // storage stays addressable. We key the stable
-                // sandbox off the session UUID.
-                let sandboxKey: String? = {
-                    switch session {
-                    case .none: return nil
-                    case .new(let id), .resume(let id): return id.uuidString
-                    }
-                }()
                 DispatchQueue.global(qos: .userInitiated).async {
                     do {
                         let outcome = try executeProcess(executable: executable,
                                                          arguments: tool.arguments(prompt: fullPrompt, model: model, session: session) + extraArgs,
                                                          timeout: timeout,
-                                                         handle: handle,
-                                                         sandboxKey: sandboxKey)
+                                                         handle: handle)
                         // The Swift Task that drove us was cancelled mid-flight
                         // — `handle` SIGTERM'd the process, so the user-visible
                         // truth is "we cancelled it", not "the CLI crashed".
@@ -400,8 +389,7 @@ enum LLMRunner {
                         let outcome = try executeProcess(executable: executable,
                                                          arguments: args,
                                                          timeout: timeout,
-                                                         handle: handle,
-                                                         sandboxKey: nil)
+                                                         handle: handle)
                         continuation.resume(returning: LLMTestResult(
                             command: command,
                             succeeded: !outcome.timedOut && outcome.exitCode == 0,
@@ -602,8 +590,7 @@ enum LLMRunner {
     private static func executeProcess(executable: URL,
                                        arguments: [String],
                                        timeout: TimeInterval,
-                                       handle: ProcessHandle,
-                                       sandboxKey: String? = nil) throws -> ProcessOutcome {
+                                       handle: ProcessHandle) throws -> ProcessOutcome {
         let process = Process()
         process.executableURL = executable
         process.arguments = arguments
@@ -614,34 +601,20 @@ enum LLMRunner {
         // surprises users whose claude/cursor wrappers source nvm/asdf/etc.
         process.environment = childEnvironment(for: executable)
 
-        // CRITICAL: spawn in a fresh, empty temp directory. macOS attributes
-        // any file access by the child process to *our* bundle ID, so if
-        // claude / cursor-agent walks the cwd looking for project files
-        // (which both do — particularly cursor-agent in `-f` mode), the user
-        // sees scary TCC prompts saying "Mila would like to access
-        // Desktop / Downloads". Launching from an isolated, empty directory
-        // guarantees there's nothing for the LLM CLI to discover and reach
-        // for, so no permission prompts fire.
+        // CRITICAL: spawn in an empty directory Mila owns — never $HOME, `/`,
+        // or a user folder. macOS attributes any file access by the child
+        // process to *our* bundle ID, so if claude / cursor-agent walks the
+        // cwd looking for project files (which both do — particularly
+        // cursor-agent in `-f` mode), the user sees scary TCC prompts saying
+        // "Mila would like to access Desktop / Downloads". Launching from an
+        // isolated, empty directory guarantees there's nothing for the LLM
+        // CLI to discover and reach for, so no permission prompts fire.
         //
-        // When `sandboxKey` is non-nil we use a STABLE per-key sandbox
-        // instead of a fresh one. claude stores its session jsonl
-        // inside a hash of the CWD — if every tick spawns in a
-        // different sandbox, `--resume <uuid>` errors with "No
-        // conversation with ID …" because the storage lives in the
-        // previous (already-deleted) sandbox. Live AI passes the
-        // session UUID as the key so all ticks share one sandbox; the
-        // caller is responsible for cleaning it up via
-        // `cleanupStableSandbox(key:)` when the session ends.
-        let sandbox: URL
-        let ephemeral: Bool
-        if let key = sandboxKey {
-            sandbox = stableSandboxDirectory(key: key)
-            ephemeral = false
-        } else {
-            sandbox = makeSandboxDirectory()
-            ephemeral = true
-        }
-        process.currentDirectoryURL = sandbox
+        // The directory is SHARED and STABLE across every invocation — see
+        // `sandboxDirectory()` for why (issue #181: claude derives its
+        // `~/.claude/projects/<slug-of-cwd>` project directory from the cwd,
+        // so a per-run cwd leaked a per-run project directory forever).
+        process.currentDirectoryURL = sandboxDirectory()
 
         // Close stdin immediately. Some CLIs (claude) read both stdin AND
         // argv; some (cursor-agent) ignore stdin entirely. We standardised
@@ -653,15 +626,6 @@ enum LLMRunner {
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-
-        // Only tear down the sandbox if it was ephemeral. Stable
-        // session sandboxes are cleaned up by the caller when the
-        // Live AI session ends.
-        defer {
-            if ephemeral {
-                try? FileManager.default.removeItem(at: sandbox)
-            }
-        }
 
         do {
             try process.run()
@@ -773,40 +737,66 @@ enum LLMRunner {
                               cancelled: handle.wasTerminated)
     }
 
-    /// Create a brand-new empty directory inside the system temp area. The
-    /// child LLM process is chdir'd here so anything it scans for context
-    /// finds nothing — no popups for Desktop, Downloads, Documents, etc.
-    private static func makeSandboxDirectory() -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("island-mila-llm-\(UUID().uuidString)",
-                                    isDirectory: true)
+    /// The ONE working directory every LLM CLI invocation is chdir'd into.
+    ///
+    /// Two requirements meet here, and a single stable directory is the only
+    /// shape that satisfies both:
+    ///
+    /// 1. **TCC isolation.** The child must start in an empty directory Mila
+    ///    owns, so a CLI that scans its cwd for project context finds nothing
+    ///    and no "Mila would like to access Desktop" prompts fire.
+    /// 2. **One Claude Code project, not one per run** (issue #181). claude
+    ///    stores its conversation transcripts in
+    ///    `~/.claude/projects/<slug-of-cwd>/<session-uuid>.jsonl` — the
+    ///    *project* comes from the cwd, the *session* from the UUID we pass in
+    ///    `--session-id` / `--resume`. The old code handed every invocation
+    ///    its own cwd (`$TMPDIR/island-mila-llm-<UUID>` for one-shots,
+    ///    `$TMPDIR/island-mila-llm-session-<UUID>` for Live AI ticks), so
+    ///    every invocation minted a new project directory under
+    ///    `~/.claude/projects/` — named after a temp path Mila then deleted,
+    ///    never cleaned up, burying the user's real projects in claude's own
+    ///    resume/project pickers. One reporter had 175 of them, 46 MB.
+    ///    A shared cwd collapses all of that into a single project holding
+    ///    one jsonl per run.
+    ///
+    /// Session isolation is unaffected: sessions are keyed by the UUID in
+    /// `--session-id` / `--resume`, not by the cwd, so Live AI's `--resume`
+    /// continuity still works — and the conversations are now actually
+    /// *resumable by hand* (`cd` here, `claude --resume <uuid>`), which the
+    /// old delete-the-cwd design made impossible.
+    ///
+    /// Application Support rather than `$TMPDIR` on purpose: the project slug
+    /// must stay stable across reboots, and macOS both rotates the per-user
+    /// temp directory and periodically purges it — either would fragment the
+    /// project directory again over time.
+    ///
+    /// The directory is created on demand and never removed: `Process.run()`
+    /// fails outright if `currentDirectoryURL` doesn't exist.
+    static func sandboxDirectory() -> URL {
+        let url = sandboxDirectory(appSupportRoot: applicationSupportRoot())
         try? FileManager.default.createDirectory(at: url,
-                                                  withIntermediateDirectories: true)
+                                                 withIntermediateDirectories: true)
         return url
     }
 
-    /// Stable sandbox directory for a Claude session keyed by `key`
-    /// (the session UUID). Reused across every tick of a Live AI
-    /// session so claude's per-CWD session storage stays put and
-    /// `--resume <uuid>` keeps finding the conversation.
-    static func stableSandboxDirectory(key: String) -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("island-mila-llm-session-\(key)",
-                                    isDirectory: true)
-        try? FileManager.default.createDirectory(at: url,
-                                                  withIntermediateDirectories: true)
-        return url
+    /// Pure path composition, split out so tests can assert the layout
+    /// without touching the real Application Support directory.
+    static func sandboxDirectory(appSupportRoot: URL) -> URL {
+        appSupportRoot
+            .appendingPathComponent("Mila", isDirectory: true)
+            .appendingPathComponent("llm-sandbox", isDirectory: true)
     }
 
-    /// Tear down a stable session sandbox. Safe to call when the
-    /// directory doesn't exist. Should be called by the Live AI
-    /// session when it cancels so /tmp doesn't accumulate stale
-    /// session dirs across recordings.
-    static func cleanupStableSandbox(key: String) {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("island-mila-llm-session-\(key)",
-                                    isDirectory: true)
-        try? FileManager.default.removeItem(at: url)
+    /// `~/Library/Application Support`, with a temp-directory fallback so a
+    /// pathological environment degrades to "LLM calls still work" rather than
+    /// "LLM calls throw". Mila is not app-sandboxed, so this is the real
+    /// user-domain path (the same one `RecordingStore` uses).
+    private static func applicationSupportRoot() -> URL {
+        if let url = FileManager.default.urls(for: .applicationSupportDirectory,
+                                              in: .userDomainMask).first {
+            return url
+        }
+        return FileManager.default.temporaryDirectory
     }
 
     private static func resolveExecutable(tool: LLMTool,

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -239,7 +239,6 @@ final class LiveAISession: ObservableObject {
     /// Cancel any in-flight call and clear state. Called when the
     /// recording stops or live AI mode is toggled off mid-recording.
     func cancel() {
-        let inFlightHandle = inFlight
         inFlight?.cancel()
         inFlight = nil
         coalesced = false
@@ -260,19 +259,12 @@ final class LiveAISession: ObservableObject {
         pendingKickTask = nil
         lastKickStartedAt = nil
         isFinalizing = false
-        // Wipe the per-session stable sandbox dir LLMRunner created so
-        // /tmp doesn't accumulate one folder per recording. The child
-        // claude subprocess receives SIGTERM via the cancelled Task,
-        // but exit is async — wait for the Task's continuation to
-        // complete before removing the sandbox so we don't rip the
-        // CWD out from under the still-living process.
-        if let id = sessionID {
-            let key = id.uuidString
-            Task.detached(priority: .utility) {
-                _ = await inFlightHandle?.value
-                LLMRunner.cleanupStableSandbox(key: key)
-            }
-        }
+        // No sandbox teardown to do: every LLM invocation now shares the one
+        // stable CWD `LLMRunner.sandboxDirectory()` owns (issue #181), so
+        // there is no per-session directory to accumulate or to wipe. The
+        // conversation itself lives in claude's own store, keyed by the
+        // session UUID — deliberately left in place so a bad summary can be
+        // re-read later with `claude --resume <uuid>`.
         sessionID = nil
         sessionEstablished = false
         lastTranscriptSent = ""
@@ -390,17 +382,6 @@ final class LiveAISession: ObservableObject {
             sessionID = UUID()
             sessionEstablished = false
             lastTranscriptSent = ""
-            // The abandoned session's stable sandbox is nobody's job
-            // otherwise: `cancel()` only cleans up the CURRENT sessionID.
-            // Safe to remove now — `kick()` only runs with no call in
-            // flight, so no live child process is chdir'd into it. Off the
-            // main actor for the same reason `cancel()` defers it: a
-            // recursive directory removal is a blocking syscall and this is
-            // the tick path.
-            let staleKey = stale.uuidString
-            Task.detached(priority: .utility) {
-                LLMRunner.cleanupStableSandbox(key: staleKey)
-            }
         }
         let prompt = Self.promptWithContext(
             liveAISettings.prompt

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -853,20 +853,19 @@ final class QuickActionsController: ObservableObject {
         // snapshot above, because `cancel()` clears `summary` /
         // `actionItems` and those are what we just saved.
         //
-        // Left running, the session outlives the recording in two ways:
+        // Left running, the session outlives the recording: a
+        // `pendingKickTask` sleeping out the min-interval floor wakes up
+        // after the meeting is over and spawns a full `claude --resume`
+        // subprocess whose result lands on a Recording that was already
+        // written — observed 2026-07-26: stop at 13:33:58, a tick at
+        // 13:34:49. `finalizeTail` regenerates the summary from the complete
+        // transcript anyway, so that call was never anything but waste.
         //
-        //   1. A `pendingKickTask` sleeping out the min-interval floor
-        //      wakes up after the meeting is over and spawns a full
-        //      `claude --resume` subprocess whose result lands on a
-        //      Recording that was already written — observed 2026-07-26:
-        //      stop at 13:33:58, a tick at 13:34:49. `finalizeTail`
-        //      regenerates the summary from the complete transcript
-        //      anyway, so that call was never anything but waste.
-        //   2. The session's stable sandbox
-        //      (`/tmp/island-mila-llm-session-<uuid>`, plus a
-        //      `~/.claude/projects/` dir per recording) is only removed by
-        //      `cancel()` — so it survived until the NEXT recording called
-        //      `start()`, and forever if the app quit first.
+        // (There used to be a second reason: the session's per-recording
+        // stable sandbox, and the `~/.claude/projects/` directory it minted,
+        // were only removed by `cancel()`. Issue #181 replaced both with the
+        // one shared CWD `LLMRunner.sandboxDirectory()` owns, so there is
+        // nothing per-recording left to leak.)
         //
         // Not done in `wireLiveAIPipeline`'s `.idle` handler: that fires
         // during `session.stop()` above, i.e. BEFORE the snapshot, and it

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -43,12 +43,17 @@ final class LLMRunnerTests: XCTestCase {
     /// directory — never the user's $HOME or `/` — because macOS attributes
     /// the child's file access to *our* bundle ID and the user would see
     /// scary prompts for any folder the LLM CLI happens to scan.
-    func test_runner_spawns_child_in_isolated_temp_directory() async throws {
-        // Script prints its cwd and lists the entries it sees there.
+    func test_runner_spawns_child_in_isolated_empty_directory() async throws {
+        // Script prints its cwd and counts the entries it sees there.
+        // Deliberately `ls` and not `ls -A`: since #181 the sandbox is shared
+        // and persistent, so an LLM CLI is free to leave its own dot-files
+        // (`.claude/`) behind. What must stay true is that the child sees no
+        // *user* content — which is what a visible-entry count proves, and it
+        // still fails loudly if the cwd ever became $HOME or a user folder.
         let script = makeScript("""
             #!/bin/sh
             printf 'cwd=%s\\n' "$PWD"
-            printf 'entries=%s\\n' "$(ls -A 2>/dev/null | wc -l | tr -d ' ')"
+            printf 'entries=%s\\n' "$(ls 2>/dev/null | wc -l | tr -d ' ')"
             """)
         defer { try? FileManager.default.removeItem(at: script) }
         let out = try await LLMRunner.run(
@@ -61,14 +66,13 @@ final class LLMRunnerTests: XCTestCase {
                        "Child spawned in $HOME: \(out)")
         XCTAssertFalse(out.contains("cwd=/\n"),
                        "Child spawned in /: \(out)")
-        // It SHOULD be empty — proving there's nothing for the LLM to scan.
+        // It SHOULD hold nothing visible — proving there's nothing for the
+        // LLM to scan and reach for.
         XCTAssertTrue(out.contains("entries=0"),
                       "Sandbox directory is not empty: \(out)")
-        // And it should be under the temp dir.
-        let tempRoot = FileManager.default.temporaryDirectory.path
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        XCTAssertTrue(out.contains(tempRoot),
-                      "Child cwd is not under temporary directory: \(out)")
+        // And it must be the one directory Mila owns for this.
+        XCTAssertTrue(out.contains("cwd=\(LLMRunner.sandboxDirectory().path)\n"),
+                      "Child cwd is not the shared LLM sandbox: \(out)")
     }
 
     /// The transcript travels in argv (via `composedPrompt`), not stdin —

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -23,6 +23,41 @@ import XCTest
 final class LLMSandboxDirectoryTests: XCTestCase {
 
     /// A stand-in for `claude -p` that just prints its working directory.
+    /// Prints the cwd and then its whole argv, on separate marked lines, so a
+    /// test can assert both "where did it run" and "what was it told" from one
+    /// invocation. The cwd assertions can't speak to argv, which is what let
+    /// the session-UUID claim go unchecked.
+    private func makeCWDAndArgvEchoScript() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
+        try? "#!/bin/sh\nprintf 'CWD:%s\\n' \"$PWD\"\nprintf 'ARGV:%s\\n' \"$*\"\n".write(
+            to: url, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: url.path)
+        return url
+    }
+
+    /// Blocks until `barrier` exists, then prints the cwd — so two runs can be
+    /// proven genuinely concurrent (both inside the sandbox at once) rather
+    /// than merely sequential. The barrier lives OUTSIDE the sandbox so the
+    /// synchronisation itself doesn't write into the directory under test.
+    private func makeBarrierCWDScript(barrier: URL) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
+        let body = """
+        #!/bin/sh
+        i=0
+        while [ ! -f "\(barrier.path)" ] && [ $i -lt 300 ]; do
+          i=$((i+1)); sleep 0.05
+        done
+        printf '%s' "$PWD"
+        """
+        try? body.write(to: url, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: url.path)
+        return url
+    }
+
     private func makeCWDEchoScript() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
@@ -120,10 +155,59 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         XCTAssertEqual(other, oneShot,
                        "a second session got its own CWD — one project "
                        + "directory per Live AI session, which is the leak")
-        // The session UUID must still reach the CLI: it is what keeps the
-        // conversations apart inside the shared project.
+        // The cwd must not carry the UUID...
         XCTAssertFalse(newSession.contains(id.uuidString),
                        "session UUID leaked into the CWD: \(newSession)")
+
+        // ...but the UUID does have to reach the CLI, because that is what
+        // keeps the conversations apart inside the one shared project. The
+        // assertion above cannot show it: this script echoes only the cwd, so
+        // "UUID absent" is equally consistent with "never passed at all".
+        // Check argv directly.
+        let argvScript = makeCWDAndArgvEchoScript()
+        defer { try? FileManager.default.removeItem(at: argvScript) }
+        let newOut = try await LLMRunner.run(tool: .claude,
+                                             prompt: "x", transcript: "y",
+                                             executablePathOverride: argvScript.path,
+                                             session: .new(id),
+                                             timeout: 30)
+        let resumedOut = try await LLMRunner.run(tool: .claude,
+                                                 prompt: "x", transcript: "y",
+                                                 executablePathOverride: argvScript.path,
+                                                 session: .resume(id),
+                                                 timeout: 30)
+        XCTAssertTrue(newOut.contains(id.uuidString),
+                      "a new session must pass its UUID to the CLI; argv was: \(newOut)")
+        XCTAssertTrue(resumedOut.contains(id.uuidString),
+                      "a resumed session must pass its UUID to the CLI; argv was: \(resumedOut)")
+    }
+
+    /// The PR claims concurrent invocations can share one cwd. Sequential runs
+    /// cannot show that -- they never overlap. Here both processes are held
+    /// inside the sandbox simultaneously on a barrier that lives outside it,
+    /// then released, so the shared-cwd result is observed under genuine
+    /// concurrency.
+    func test_concurrent_runs_share_one_working_directory() async throws {
+        let barrier = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-mila-barrier-\(UUID().uuidString)")
+        let script = makeBarrierCWDScript(barrier: barrier)
+        defer {
+            try? FileManager.default.removeItem(at: script)
+            try? FileManager.default.removeItem(at: barrier)
+        }
+
+        async let first = LLMRunner.run(tool: .claude, prompt: "x", transcript: "y",
+                                        executablePathOverride: script.path, timeout: 60)
+        async let second = LLMRunner.run(tool: .claude, prompt: "x", transcript: "y",
+                                         executablePathOverride: script.path, timeout: 60)
+
+        // Both children are now spinning on the barrier; release them together.
+        try await Task.sleep(for: .milliseconds(300))
+        try Data().write(to: barrier)
+
+        let (a, b) = try await (first, second)
+        XCTAssertFalse(a.isEmpty)
+        XCTAssertEqual(a, b, "concurrent invocations must share the one sandbox cwd")
     }
 
     /// The runner must not delete the shared directory after a run — a

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import Mila
+
+/// Issue #181 — "every LLM invocation creates a new ~/.claude/projects
+/// directory".
+///
+/// The LLM CLIs Mila drives derive their session store from the process
+/// working directory: `claude` writes
+/// `~/.claude/projects/<slug-of-cwd>/<session-uuid>.jsonl`. Mila used to hand
+/// every invocation its own cwd — `$TMPDIR/island-mila-llm-<UUID>` for
+/// one-shot calls, `$TMPDIR/island-mila-llm-session-<UUID>` for Live AI ticks
+/// — so every invocation minted a project directory that nothing ever
+/// removed (175 of them, 46 MB, in the report) and that was unresumable
+/// because Mila deleted the cwd it was named after.
+///
+/// These tests pin the fix: ONE stable working directory for every path into
+/// `executeProcess`, with session identity still carried by the `--session-id`
+/// / `--resume` UUID rather than by the cwd.
+///
+/// Kept in its own class (not `LLMRunnerTests`) so it can be run on its own —
+/// `LLMRunnerTests` also holds smoke tests that invoke the real `claude` /
+/// `cursor-agent` / `gemini` binaries.
+final class LLMSandboxDirectoryTests: XCTestCase {
+
+    /// A stand-in for `claude -p` that just prints its working directory.
+    private func makeCWDEchoScript() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
+        try? "#!/bin/sh\nprintf '%s' \"$PWD\"\n".write(to: url,
+                                                        atomically: true,
+                                                        encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: url.path)
+        return url
+    }
+
+    /// claude derives its `~/.claude/projects/<slug-of-cwd>` project directory
+    /// from the process CWD. A per-invocation CWD therefore leaked a
+    /// per-invocation project directory that nothing ever cleaned up (175
+    /// orphans / 46 MB in the report). The path must contain nothing
+    /// run-specific — no UUID, no PID, no timestamp.
+    func test_sandbox_path_has_no_per_run_component() {
+        let root = URL(fileURLWithPath: "/tmp/fake-app-support", isDirectory: true)
+        let first = LLMRunner.sandboxDirectory(appSupportRoot: root)
+        let second = LLMRunner.sandboxDirectory(appSupportRoot: root)
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.path, "/tmp/fake-app-support/Mila/llm-sandbox")
+    }
+
+    /// The real resolver must be stable across calls, live under Mila's own
+    /// Application Support directory (so the `~/.claude/projects` slug
+    /// survives reboots and $TMPDIR purges), and actually exist — `Process`
+    /// refuses to launch into a missing `currentDirectoryURL`.
+    func test_sandboxDirectory_is_stable_and_exists() {
+        let first = LLMRunner.sandboxDirectory()
+        let second = LLMRunner.sandboxDirectory()
+        XCTAssertEqual(first, second, "sandbox directory is not stable across calls")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path),
+                      "sandbox directory was not created: \(first.path)")
+        XCTAssertTrue(first.path.contains("/Mila/llm-sandbox"),
+                      "sandbox is not under Mila's own directory: \(first.path)")
+        // Not $TMPDIR: macOS rotates and purges the per-user temp directory,
+        // which would fragment the project directory again over time.
+        XCTAssertFalse(first.path.hasPrefix(FileManager.default.temporaryDirectory.path),
+                       "sandbox is under $TMPDIR: \(first.path)")
+        XCTAssertEqual(first.lastPathComponent, "llm-sandbox",
+                       "sandbox name looks run-specific: \(first.lastPathComponent)")
+    }
+
+    /// The actual leak, end to end: two separate invocations must land in the
+    /// SAME cwd, so claude files them as two sessions of one project instead
+    /// of two projects. Covers the one-shot path (title generation, the
+    /// Settings test button, the post-recording action).
+    func test_two_oneshot_runs_share_one_working_directory() async throws {
+        let script = makeCWDEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        let first = try await LLMRunner.run(tool: .claude,
+                                            prompt: "x", transcript: "y",
+                                            executablePathOverride: script.path,
+                                            timeout: 30)
+        let second = try await LLMRunner.run(tool: .claude,
+                                             prompt: "x", transcript: "y",
+                                             executablePathOverride: script.path,
+                                             timeout: 30)
+        XCTAssertFalse(first.isEmpty)
+        XCTAssertEqual(first, second,
+                       "each invocation got its own CWD — that is one leaked "
+                       + "~/.claude/projects directory per run")
+    }
+
+    /// Session-carrying runs (Live AI ticks, `--session-id` / `--resume`) must
+    /// share that same one directory too. Session identity comes from the UUID
+    /// in argv, never from the cwd, so `--resume` continuity survives — while
+    /// a per-session cwd would mint a project directory per recording.
+    func test_session_runs_share_the_same_directory_as_oneshot_runs() async throws {
+        let script = makeCWDEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        let oneShot = try await LLMRunner.run(tool: .claude,
+                                              prompt: "x", transcript: "y",
+                                              executablePathOverride: script.path,
+                                              timeout: 30)
+        let id = UUID()
+        let newSession = try await LLMRunner.run(tool: .claude,
+                                                 prompt: "x", transcript: "y",
+                                                 executablePathOverride: script.path,
+                                                 session: .new(id),
+                                                 timeout: 30)
+        let resumed = try await LLMRunner.run(tool: .claude,
+                                               prompt: "x", transcript: "y",
+                                               executablePathOverride: script.path,
+                                               session: .resume(id),
+                                               timeout: 30)
+        let other = try await LLMRunner.run(tool: .claude,
+                                             prompt: "x", transcript: "y",
+                                             executablePathOverride: script.path,
+                                             session: .new(UUID()),
+                                             timeout: 30)
+        XCTAssertEqual(newSession, oneShot)
+        XCTAssertEqual(resumed, oneShot)
+        XCTAssertEqual(other, oneShot,
+                       "a second session got its own CWD — one project "
+                       + "directory per Live AI session, which is the leak")
+        // The session UUID must still reach the CLI: it is what keeps the
+        // conversations apart inside the shared project.
+        XCTAssertFalse(newSession.contains(id.uuidString),
+                       "session UUID leaked into the CWD: \(newSession)")
+    }
+
+    /// The runner must not delete the shared directory after a run — a
+    /// subsequent `Process.run()` would fail outright on a missing cwd, and
+    /// the deleted-cwd design is exactly what made past conversations
+    /// unresumable by hand.
+    func test_runner_leaves_the_shared_directory_in_place() async throws {
+        let script = makeCWDEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        _ = try await LLMRunner.run(tool: .claude,
+                                    prompt: "x", transcript: "y",
+                                    executablePathOverride: script.path,
+                                    timeout: 30)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: LLMRunner.sandboxDirectory().path),
+            "shared sandbox was torn down after the run")
+    }
+
+    /// `diagnose` (Settings → AI Provider "Test") is the third code path into
+    /// `executeProcess`; it used to take the ephemeral branch. It must land in
+    /// the shared directory as well.
+    func test_diagnose_runs_in_the_shared_directory() async {
+        let script = makeCWDEchoScript()
+        defer { try? FileManager.default.removeItem(at: script) }
+        let result = await LLMRunner.diagnose(tool: .claude,
+                                              prompt: "x", transcript: "y",
+                                              executablePathOverride: script.path,
+                                              timeout: 30)
+        XCTAssertTrue(result.succeeded, "diagnose failed: \(result)")
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+                       LLMRunner.sandboxDirectory().path)
+    }
+}

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -86,6 +86,28 @@ final class LLMSandboxDirectoryTests: XCTestCase {
     /// Application Support directory (so the `~/.claude/projects` slug
     /// survives reboots and $TMPDIR purges), and actually exist — `Process`
     /// refuses to launch into a missing `currentDirectoryURL`.
+    /// The preferred root is Application Support, not $TMPDIR -- macOS rotates
+    /// and purges the per-user temp directory, which would fragment the Claude
+    /// project directory again over time.
+    ///
+    /// Asserted against the *pure* path builder rather than
+    /// `sandboxDirectory()`, because that one deliberately falls back to a temp
+    /// directory when Application Support cannot be created. Asserting "never
+    /// under $TMPDIR" on the impure call would fail exactly when the documented
+    /// fallback is working.
+    func test_sandbox_layout_is_the_same_under_either_root() {
+        let appSupport = URL(fileURLWithPath: "/Users/someone/Library/Application Support",
+                             isDirectory: true)
+        let temp = URL(fileURLWithPath: "/var/folders/xx/T", isDirectory: true)
+        for root in [appSupport, temp] {
+            let url = LLMRunner.sandboxDirectory(appSupportRoot: root)
+            XCTAssertTrue(url.path.hasPrefix(root.path),
+                          "sandbox escaped its root: \(url.path)")
+            XCTAssertTrue(url.path.hasSuffix("/Mila/llm-sandbox"),
+                          "sandbox layout changed: \(url.path)")
+        }
+    }
+
     func test_sandboxDirectory_is_stable_and_exists() {
         let first = LLMRunner.sandboxDirectory()
         let second = LLMRunner.sandboxDirectory()
@@ -94,10 +116,6 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                       "sandbox directory was not created: \(first.path)")
         XCTAssertTrue(first.path.contains("/Mila/llm-sandbox"),
                       "sandbox is not under Mila's own directory: \(first.path)")
-        // Not $TMPDIR: macOS rotates and purges the per-user temp directory,
-        // which would fragment the project directory again over time.
-        XCTAssertFalse(first.path.hasPrefix(FileManager.default.temporaryDirectory.path),
-                       "sandbox is under $TMPDIR: \(first.path)")
         XCTAssertEqual(first.lastPathComponent, "llm-sandbox",
                        "sandbox name looks run-specific: \(first.lastPathComponent)")
     }


### PR DESCRIPTION
Closes #181

## What & why

Every LLM invocation minted a new `~/.claude/projects/` directory. The reporter had 175 of them / 46 MB; this machine had 91 / 11 MB.

### Confirmed root cause

`claude` derives its session store from the **process working directory** — it writes `~/.claude/projects/<slug-of-cwd>/<session-uuid>.jsonl`, where the slug is the cwd path with `/` and `.` replaced by `-`. `LLMRunner.executeProcess` gave every invocation its own cwd:

- one-shot calls (title generation, post-recording action, Settings → AI Provider test) → `makeSandboxDirectory()` → `$TMPDIR/island-mila-llm-<UUID>`
- Live AI ticks → `stableSandboxDirectory(key:)` → `$TMPDIR/island-mila-llm-session-<UUID>`

So: new cwd per run ⇒ new project directory per run. Evidence on this machine (91 orphans, of which 28 are Live-AI session dirs):

```
$ ls -d ~/.claude/projects/*island-mila-llm-* | wc -l
      91
$ du -shc ~/.claude/projects/*island-mila-llm-*/ | tail -1
  11M	total
$ getconf DARWIN_USER_TEMP_DIR
/var/folders/xh/lmcmd9sd57bf7zzyjb3pp9w40000gn/T/
$ ls ~/.claude/projects/ | grep island-mila-llm | head -1
-private-var-folders-xh-lmcmd9sd57bf7zzyjb3pp9w40000gn-T-island-mila-llm-03E62ADD-…
```

The directory name is exactly the slug of `$TMPDIR/island-mila-llm-<UUID>` — the `$TMPDIR` above, character for character. The same slug rule holds for the user's real projects (`/Users/uri/ai/work/Mila/.claude/worktrees/x` → `-Users-uri-ai-work-Mila--claude-worktrees-x`), so the mechanism is not in doubt. Each orphan contains a single `<session-uuid>.jsonl` — one run's conversation — and the temp path it is named after was deleted by the `defer` in `executeProcess`, which is why `claude --resume` could never find those conversations again.

This matches the issue's stated root cause, including the file/line references.

### The fix

One stable directory Mila owns — `~/Library/Application Support/Mila/llm-sandbox/` — used as the cwd for **every** invocation (`run`, session and non-session, plus `diagnose`). Both properties the per-run sandbox existed for survive:

- **TCC isolation.** It is still an empty directory Mila owns, so a CLI that scans its cwd for project context finds nothing and no "Mila would like to access Desktop" prompts fire.
- **`--resume` continuity.** Session identity comes from the UUID in `--session-id` / `--resume`, never from the cwd, so Live AI's resume still resolves — inside the shared project now. Side benefit the issue asked for: the conversations are finally resumable by hand (`cd "~/Library/Application Support/Mila/llm-sandbox" && claude --resume <uuid>`), which is the practical way to debug a bad title or summary.

Application Support rather than a fixed `$TMPDIR/island-mila-llm/` because the slug must stay stable across reboots: macOS both rotates the per-user temp directory and periodically purges it, either of which would fragment the project directory again.

`stableSandboxDirectory(key:)` / `cleanupStableSandbox(key:)` are deleted, and with them the cleanup-on-cancel obligation #112 put on `LiveAISession` (two call sites) — there is nothing per-run left to tear down. The now-stale "second reason" in `QuickActionsController.stopRecording`'s comment is updated; the first reason (a `pendingKickTask` waking up after the meeting) still stands, so the `cancel()` call stays.

On the issue's "worth verifying" list: **concurrent runs sharing a cwd** — a Live AI tick can overlap a title-generation run. They write different `<uuid>.jsonl` files, `createDirectory(withIntermediateDirectories: true)` is idempotent, and nothing in Mila writes into the cwd itself, so there is no new contention on Mila's side; any locking inside `claude`'s own per-project state is unchanged from the single-project case it is designed for (a human running two `claude` sessions in one repo).

### Why the 175 existing orphans are *not* cleaned up here

Deliberate, and I'd argue this is the right split:

1. **It is another tool's data store, and it holds conversations.** `~/.claude/projects/` belongs to Claude Code, not Mila. Each orphan is a real transcript of what the LLM did for one recording. The issue itself argues that being able to go read that back matters for debugging bad titles and summaries — so blanket-deleting the backlog works against one of the issue's own stated goals.
2. **The leak stops dead with this PR.** What remains is a bounded, static, one-time ~46 MB. It is not growing any more, so there is no urgency that justifies bundling data deletion into a leak fix.
3. **Doing it *well* needs its own design + UI review.** Silent deletion at launch is the worst option. The defensible shape is opt-in and visible (Settings → AI Provider: "N old LLM session folders, X MB — Remove"), with a strict name filter so nothing outside `*island-mila-llm-*` can ever match. That is a UI change needing human verification, and it does not belong in the review surface of a three-file leak fix.

Users who want the space back today can have it with the exact, narrowly-scoped one-liner (only Mila-generated names can match; no other project can):

```sh
rm -rf ~/.claude/projects/*island-mila-llm-*
```

Worth a line in the release notes for whichever version ships this — I have not added a `RELEASE_NOTES/` file because the version is not bumped here and post-1.9.2 PRs on `main` (e.g. #171) don't carry one either.

I have not opened a follow-up issue for the opt-in cleanup UI — that was not asked for and I would rather a maintainer decide whether it is wanted at all than leave an unrequested tracking issue behind. Happy to file it on request.

## How it was tested

- `make build` → **BUILD SUCCEEDED** (fresh worktree, with the local `PythonRuntime` symlink; removed again before committing).
- `xcodebuild test -only-testing:MilaTests/LLMSandboxDirectoryTests` → **Executed 6 tests, 0 failures**. All six new tests below ran and passed locally.

**Tests written but NOT executed locally**, and why: partway through this work I was told to stop running app-hosted tests on this machine — `MilaTests` is hosted in the app, every run launches a freshly ad-hoc-signed `Mila.app`, and test files touching `KeychainHelper` make macOS pop a keychain-authorisation dialog the user has to dismiss by hand. So the following did **not** run here and are relying on CI's `unit-and-ui-tests`:

- `MilaTests/LLMRunnerTests/test_runner_spawns_child_in_isolated_empty_directory` — the existing TCC-popup regression guard, renamed (it no longer asserts "under $TMPDIR") and now asserting the cwd *is* `LLMRunner.sandboxDirectory()`. Its empty-directory assertion was also switched from `ls -A` to `ls`: the sandbox is shared and persistent now, so an LLM CLI is free to leave its own dot-files there, while "the child sees no *user* content" — the actual TCC-relevant invariant — is what a visible-entry count proves, and it still fails loudly if the cwd ever became `$HOME`.
- `MilaTests/LiveAISessionTests`, `MilaTests/LiveAIThrottleTests` — not modified, but they cover the `LiveAISession.cancel()` / context-restart paths this PR edits. I started this run and it was killed before producing results.

It compiles: the `LLMSandboxDirectoryTests` run above builds the whole `MilaTests` target, including the modified `LLMRunnerTests.swift`.

New tests (`MilaTests/LLMSandboxDirectoryTests.swift`, kept out of `LLMRunnerTests` so it can be run alone — that class also holds smoke tests that invoke the real `claude` / `cursor-agent` / `gemini` binaries):

| test | pins |
| --- | --- |
| `test_sandbox_path_has_no_per_run_component` | path composition is pure and carries no UUID/PID/timestamp |
| `test_sandboxDirectory_is_stable_and_exists` | stable across calls, created on demand, under `Mila/llm-sandbox`, **not** under `$TMPDIR` |
| `test_two_oneshot_runs_share_one_working_directory` | the leak itself: two one-shot runs land in the same cwd |
| `test_session_runs_share_the_same_directory_as_oneshot_runs` | `.new` / `.resume` / a second session / one-shot all share that cwd, and the session UUID never reaches the cwd |
| `test_runner_leaves_the_shared_directory_in_place` | the cwd is not torn down after a run (a later `Process.run()` would fail, and deletion is what broke hand-resume) |
| `test_diagnose_runs_in_the_shared_directory` | the Settings → Test path, the third route into `executeProcess` |

No `~/.claude/` content was created, moved, or deleted during any of this; the tests use `/bin/sh` stand-ins that print `$PWD` and never invoke a real LLM CLI.

## Checklist

- [x] Builds locally (`make build`); tests written, partially executed locally — see above for exactly which and why
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — release-note line suggested above, not added (no version bump here)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - LLM operations now use a persistent shared workspace across one-shot commands, ongoing sessions, resumed conversations, and diagnostics.
  - The workspace is created automatically when needed and remains available for future sessions.
  - Live AI conversations can be resumed without removing stored session data.

- **Bug Fixes**
  - Added a fallback workspace when the standard application location is unavailable.
  - Improved consistency across LLM operations and prevented unnecessary workspace removal when cancelling sessions or changing context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->