### PR TITLE
fix(remote): select response_format per model so gpt-transcribe and server-side diarization are reachable

### DIFF
--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -22,9 +22,11 @@ protocol RemoteTranscribing: TranscribingEngine {
 /// The protocol hands us 16 kHz mono `Float` samples (the same buffer the
 /// local engine would consume), so the recording's audio never has to be
 /// re-read from disk — we encode the samples to a compact AAC/`.m4a` blob and
-/// upload that. We ask for `verbose_json` so we get per-segment timestamps,
-/// which map straight onto `TranscriptSegment` and keep diarization /
-/// SRT-export working exactly as they do for the local path.
+/// upload that. The requested `response_format` is chosen from the model
+/// (see `ResponseFormat.forModel(_:)`): `verbose_json` wherever it is
+/// available, so we get per-segment timestamps that map straight onto
+/// `TranscriptSegment` and keep diarization / SRT-export working exactly as
+/// they do for the local path.
 ///
 /// Config (endpoint, key, model) is injected via `configure(_:)` before each
 /// transcription — the protocol's `transcribe` signature is fixed by the local
@@ -66,6 +68,59 @@ actor RemoteWhisperEngine: RemoteTranscribing {
             }
             return String(trimmed.prefix(200))
         }
+    }
+
+    /// The `response_format` to ask a remote model for.
+    ///
+    /// **Not every model can produce every format**, and asking for the wrong
+    /// one is a hard 400, not a degraded transcript. `verbose_json` — the only
+    /// format that carries per-segment timestamps — is effectively a
+    /// `whisper-1` exclusive: the original Whisper decoder emits timestamp
+    /// tokens natively, which is also where `srt`/`vtt` fall out of. The
+    /// `gpt-*transcribe` family are audio-native models with no alignment
+    /// stage, so they reject *every* timestamped format (`verbose_json`, `srt`,
+    /// `vtt`) and accept only `json`/`text`:
+    ///
+    ///     response_format 'verbose_json' is not compatible with model
+    ///     'gpt-transcribe-api-ev3'. Use 'json' or 'text' instead.
+    ///
+    /// `gpt-4o-transcribe-diarize` is the exception — it emits structure
+    /// organised by *speaker turn* rather than decode window, under its own
+    /// `diarized_json` name. (Behaviour verified against the live OpenAI API;
+    /// issue #180.)
+    ///
+    /// Hardcoding `verbose_json` is what previously locked remote
+    /// transcription to `whisper-1`.
+    enum ResponseFormat: String {
+        /// Timestamped segments. `whisper-1` and self-hosted Whisper servers.
+        case verboseJSON = "verbose_json"
+        /// Text only, no timing. The `gpt-*transcribe` models.
+        case json = "json"
+        /// Speaker-turn segments with timing. `gpt-4o-transcribe-diarize`.
+        case diarizedJSON = "diarized_json"
+
+        /// The format `model` can actually produce.
+        ///
+        /// Matched on the id's last path component, lowercased, so a
+        /// vendor-prefixed mirror (`openai/gpt-4o-transcribe`) resolves the
+        /// same way as the bare id — the same tolerant substring style as
+        /// `RemoteTranscriptionSettings.isHebrewOnlyModel(_:)`. Anything that
+        /// isn't a `gpt-` model keeps requesting `verbose_json` exactly as
+        /// before, so self-hosted Whisper deployments are unaffected.
+        static func forModel(_ model: String) -> ResponseFormat {
+            let id = (model.split(separator: "/").last.map(String.init) ?? model)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            guard id.hasPrefix("gpt-") else { return .verboseJSON }
+            return id.contains("diarize") ? .diarizedJSON : .json
+        }
+
+        /// Whether the request must also carry a `chunking_strategy`.
+        ///
+        /// The diarization models require one explicitly for audio longer than
+        /// 30s — without it the API answers "chunking_strategy is required".
+        /// No other format takes the parameter.
+        var needsChunkingStrategy: Bool { self == .diarizedJSON }
     }
 
     private var config: RemoteTranscriptionConfig?
@@ -144,7 +199,7 @@ actor RemoteWhisperEngine: RemoteTranscribing {
 
         // Endpoint kept .private — a user-configured URL can carry private
         // hostnames or credentials/query tokens we must not leak to the log.
-        remoteLog.log("transcribe: POST \(request.url?.absoluteString ?? "?", privacy: .private) model=\(config.model, privacy: .public) lang=\(language, privacy: .public) bytes=\(body.count, privacy: .public)")
+        remoteLog.log("transcribe: POST \(request.url?.absoluteString ?? "?", privacy: .private) model=\(config.model, privacy: .public) format=\(Self.ResponseFormat.forModel(config.model).rawValue, privacy: .public) lang=\(language, privacy: .public) bytes=\(body.count, privacy: .public)")
 
         // The protocol's `isCancelled` is a polled flag (the batch Cancel
         // button), not Swift task cancellation. Bridge it: run the upload in a
@@ -203,8 +258,10 @@ actor RemoteWhisperEngine: RemoteTranscribing {
     }
 
     /// Build a `multipart/form-data` body for the transcription request.
-    /// Fields: `file` (the m4a), `model`, `response_format=verbose_json`, and
-    /// `language` (omitted when "auto" so the server detects it).
+    /// Fields: `file` (the m4a), `model`, `response_format` (chosen from the
+    /// model — see `ResponseFormat.forModel(_:)`), `chunking_strategy` where
+    /// the format requires it, and `language` (omitted when "auto" so the
+    /// server detects it).
     static func multipartBody(boundary: String,
                               audio: Data,
                               model: String,
@@ -217,7 +274,11 @@ actor RemoteWhisperEngine: RemoteTranscribing {
         }
 
         appendField("model", model)
-        appendField("response_format", "verbose_json")
+        let format = ResponseFormat.forModel(model)
+        appendField("response_format", format.rawValue)
+        if format.needsChunkingStrategy {
+            appendField("chunking_strategy", "auto")
+        }
         let lang = language.lowercased()
         if !lang.isEmpty && lang != "auto" {
             // OpenAI expects ISO-639-1; Mila already uses "he"/"en".
@@ -235,20 +296,29 @@ actor RemoteWhisperEngine: RemoteTranscribing {
 
     // MARK: - Parsing
 
+    /// The shape shared by every transcription response Mila asks for.
+    ///
+    /// `verbose_json` and `diarized_json` differ only in the extra keys they
+    /// add (decoder internals like `seek`/`avg_logprob` for the former, a
+    /// `speaker` per turn for the latter), and `json` simply omits `segments`.
+    /// `Decodable` ignores unknown keys, so one struct decodes all three.
     private struct VerboseResponse: Decodable {
         struct Segment: Decodable {
             let start: Double
             let end: Double
             let text: String
+            /// Present only in `diarized_json` — the server's own turn label
+            /// ("A", "B", …) from `gpt-4o-transcribe-diarize`.
+            let speaker: String?
         }
         let text: String?
         let duration: Double?
         let segments: [Segment]?
     }
 
-    /// Parse a `verbose_json` (preferred) or plain `json` transcription
-    /// response into `TranscriptSegment`s. Static + pure so it can be unit
-    /// tested without a server.
+    /// Parse a `verbose_json` / `diarized_json` (preferred) or plain `json`
+    /// transcription response into `TranscriptSegment`s. Static + pure so it
+    /// can be unit tested without a server.
     static func parseSegments(data: Data) throws -> [TranscriptSegment] {
         let decoder = JSONDecoder()
         guard let parsed = try? decoder.decode(VerboseResponse.self, from: data) else {
@@ -259,9 +329,20 @@ actor RemoteWhisperEngine: RemoteTranscribing {
             let mapped = segments.compactMap { seg -> TranscriptSegment? in
                 let text = seg.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { return nil }
-                return TranscriptSegment(start: seg.start, end: seg.end, text: seg.text)
+                return TranscriptSegment(start: seg.start, end: seg.end,
+                                         text: seg.text, speaker: seg.speaker)
             }
-            if !mapped.isEmpty { return mapped }
+            if !mapped.isEmpty {
+                // A `diarized_json` body labels turns "A", "B", … — a
+                // different label space from the one the rest of the app
+                // speaks (`SPEAKER_00`, which is what `friendlySpeakerLabel`
+                // renders as "Speaker A" / "דובר א׳", what `speakerNames` is
+                // keyed by, and what the exporters emit). Re-key at the
+                // boundary where the foreign labels enter, so server-side
+                // diarization is indistinguishable downstream from the local
+                // pyannote pass. No-op for an unlabelled response.
+                return SpeakerLabels.normalized(in: mapped)
+            }
         }
 
         // No segment array (server returned `response_format=json`, or an empty

--- a/Mila/Transcription/SpeakerLabel.swift
+++ b/Mila/Transcription/SpeakerLabel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TranscriptionCore
 
 /// Translation of the diarizer's raw `SPEAKER_00` / `SPEAKER_01` /…
 /// identifiers into a label the user actually wants to see — `Speaker A`
@@ -61,5 +62,41 @@ extension String {
             return "\(letters[index])׳"
         }
         return "\(index + 1)"
+    }
+}
+
+/// Canonicalisation of raw speaker IDs, kept out of `TranscriptionService` so
+/// it is reachable from non-`@MainActor` code (`RemoteWhisperEngine`, which
+/// has to re-key the labels a server-side diarizer returns).
+enum SpeakerLabels {
+    /// Re-key every speaker ID in `segments` to a sequential `SPEAKER_NN` in
+    /// order of first appearance.
+    ///
+    /// Two reasons this exists. Pyannote's clustering can leave gaps
+    /// (`SPEAKER_00` then `SPEAKER_02` when an intermediate cluster is merged
+    /// away), which surfaces as "Speaker A" + "Speaker C" with no B. And a
+    /// remote diarization model uses a different label space altogether
+    /// (`"A"`, `"B"`, …), which `friendlySpeakerLabel(language:)` would pass
+    /// through verbatim — English-looking labels in a Hebrew transcript, and
+    /// no stable key for `Recording.speakerNames`. Both become 00, 01, 02… in
+    /// transcript order.
+    ///
+    /// Segments with no label (or an empty one) are left exactly as they are.
+    static func normalized(in segments: [TranscriptSegment]) -> [TranscriptSegment] {
+        var mapping: [String: String] = [:]
+        var nextIndex = 0
+        var output = segments
+        for i in output.indices {
+            guard let original = output[i].speaker, !original.isEmpty else { continue }
+            if let remapped = mapping[original] {
+                output[i].speaker = remapped
+            } else {
+                let remapped = String(format: "SPEAKER_%02d", nextIndex)
+                mapping[original] = remapped
+                output[i].speaker = remapped
+                nextIndex += 1
+            }
+        }
+        return output
     }
 }

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -755,7 +755,19 @@ final class TranscriptionService: ObservableObject {
             }
 
             var enrichedSegments = segments
-            if !speakerTurns.isEmpty {
+            // A server-side diarizer (`gpt-4o-transcribe-diarize`, whose
+            // `diarized_json` segments already carry speakers) has done this
+            // job already, on the whole file, and its labels are the ones the
+            // transcript's own turn boundaries were cut on. The local pyannote
+            // pass ran concurrently with transcription, so we cannot know in
+            // advance whether it will be needed — but overwriting labels the
+            // transcript already has would re-cluster the same audio worse
+            // and, because the offline pass has its own segment boundaries,
+            // silently misalign the result. Server labels win. (issue #180)
+            if Self.hasSpeakerLabels(segments) {
+                let distinct = Set(segments.compactMap(\.speaker)).count
+                print("Transcribe: keeping the \(distinct) server-side speaker labels — not overwriting them with the offline pass")
+            } else if !speakerTurns.isEmpty {
                 for i in enrichedSegments.indices {
                     enrichedSegments[i].speaker = SpeakerDiarizer.assignSpeaker(
                         segmentStart: enrichedSegments[i].start,
@@ -867,6 +879,14 @@ final class TranscriptionService: ObservableObject {
         }
     }
 
+    /// Whether `segments` already carry speaker labels — i.e. whoever produced
+    /// them diarized them too. True for a `diarized_json` response from a
+    /// remote diarization model; false for every local whisper.cpp result and
+    /// for `verbose_json`/`json`, which have no speaker field at all.
+    static func hasSpeakerLabels(_ segments: [TranscriptSegment]) -> Bool {
+        segments.contains { $0.speaker?.isEmpty == false }
+    }
+
     /// Re-key speaker labels in transcript order so the SET of labels
     /// is contiguous `SPEAKER_00`, `SPEAKER_01`, … with no gaps. The
     /// diarizer can return `{SPEAKER_00, SPEAKER_02}` when an
@@ -877,21 +897,10 @@ final class TranscriptionService: ObservableObject {
     /// First-appearance order is preferred over alphabetical so the
     /// person who spoke first is always `SPEAKER_00`.
     static func normalizeSpeakerLabels(in segments: [TranscriptSegment]) -> [TranscriptSegment] {
-        var mapping: [String: String] = [:]
-        var nextIndex = 0
-        var output = segments
-        for i in output.indices {
-            guard let original = output[i].speaker, !original.isEmpty else { continue }
-            if let remapped = mapping[original] {
-                output[i].speaker = remapped
-            } else {
-                let remapped = String(format: "SPEAKER_%02d", nextIndex)
-                mapping[original] = remapped
-                output[i].speaker = remapped
-                nextIndex += 1
-            }
-        }
-        return output
+        // Implementation lives in `SpeakerLabels` so the remote engine — which
+        // has to re-key a server-side diarizer's labels and is not on the main
+        // actor — can share it instead of duplicating it.
+        SpeakerLabels.normalized(in: segments)
     }
 
     private func markFailed(_ recording: Recording) {

--- a/MilaTests/RemoteTranscriptionTests.swift
+++ b/MilaTests/RemoteTranscriptionTests.swift
@@ -618,6 +618,138 @@ final class RemoteWhisperEngineParsingTests: XCTestCase {
         }
     }
 
+    // MARK: - response_format is chosen from the model (issue #180)
+
+    /// Read one multipart field's value back out of a built body, so these
+    /// tests assert on the *value* Mila sends rather than on a substring that
+    /// could match anywhere in the blob.
+    private func multipartField(_ name: String, in body: Data) -> String? {
+        let text = String(decoding: body, as: UTF8.self)
+        let marker = "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n"
+        guard let marked = text.range(of: marker) else { return nil }
+        let rest = text[marked.upperBound...]
+        guard let end = rest.range(of: "\r\n") else { return nil }
+        return String(rest[..<end.lowerBound])
+    }
+
+    func test_responseFormat_isVerboseJSONForWhisperAndSelfHostedModels() {
+        // The only family that can actually produce timestamped output, so the
+        // default must stay `verbose_json` — SRT export and speaker
+        // assignment depend on the segment timings it carries.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("whisper-1"), .verboseJSON)
+        // Self-hosted (speaches / faster-whisper / ivrit) ids are unaffected.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("ivrit-ai/whisper-large-v3-turbo-ct2"), .verboseJSON)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("Systran/faster-whisper-large-v3"), .verboseJSON)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("deepdml/faster-whisper-large-v3-turbo-ct2"), .verboseJSON)
+        // A blank model id falls back to the config default (`whisper-1`)
+        // upstream; it must not be mistaken for a gpt- model here.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel(""), .verboseJSON)
+        // "gpt" has to be the model's own prefix, not just present somewhere.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("my-gpt-whisper-mirror/whisper-large-v3"), .verboseJSON)
+    }
+
+    func test_responseFormat_isPlainJSONForGPTTranscribeModels() {
+        // These 400 on every timestamped format — `verbose_json`, `srt` and
+        // `vtt` alike — and accept only `json`/`text`.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("gpt-4o-transcribe"), .json)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("gpt-4o-mini-transcribe"), .json)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("gpt-transcribe"), .json)
+        // Vendor-prefixed and shouty ids resolve the same way.
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("openai/gpt-4o-transcribe"), .json)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("GPT-4o-Transcribe"), .json)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("  gpt-transcribe  "), .json)
+    }
+
+    func test_responseFormat_isDiarizedJSONForTheDiarizeVariant() {
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("gpt-4o-transcribe-diarize"), .diarizedJSON)
+        XCTAssertEqual(RemoteWhisperEngine.ResponseFormat.forModel("openai/gpt-4o-transcribe-diarize"), .diarizedJSON)
+        // Only the diarize format takes a chunking strategy.
+        XCTAssertTrue(RemoteWhisperEngine.ResponseFormat.diarizedJSON.needsChunkingStrategy)
+        XCTAssertFalse(RemoteWhisperEngine.ResponseFormat.json.needsChunkingStrategy)
+        XCTAssertFalse(RemoteWhisperEngine.ResponseFormat.verboseJSON.needsChunkingStrategy)
+    }
+
+    func test_multipartBody_asksGPTModelsForPlainJSON() {
+        let body = RemoteWhisperEngine.multipartBody(boundary: "B",
+                                                     audio: Data([0x00]),
+                                                     model: "gpt-transcribe",
+                                                     language: "en")
+        XCTAssertEqual(multipartField("response_format", in: body), "json",
+                       "gpt-* models 400 on verbose_json — hardcoding it is what locked remote transcription to whisper-1")
+        XCTAssertNil(multipartField("chunking_strategy", in: body),
+                     "Only the diarization models take a chunking strategy")
+        XCTAssertEqual(multipartField("model", in: body), "gpt-transcribe")
+        XCTAssertEqual(multipartField("language", in: body), "en")
+    }
+
+    func test_multipartBody_asksDiarizeModelForDiarizedJSONWithChunking() {
+        let body = RemoteWhisperEngine.multipartBody(boundary: "B",
+                                                     audio: Data([0x00]),
+                                                     model: "gpt-4o-transcribe-diarize",
+                                                     language: "he")
+        XCTAssertEqual(multipartField("response_format", in: body), "diarized_json")
+        XCTAssertEqual(multipartField("chunking_strategy", in: body), "auto",
+                       "The diarize model rejects the request outright without one past 30s of audio")
+    }
+
+    func test_multipartBody_keepsVerboseJSONForSelfHostedModels() {
+        let body = RemoteWhisperEngine.multipartBody(boundary: "B",
+                                                     audio: Data([0x00]),
+                                                     model: "ivrit-ai/whisper-large-v3-turbo-ct2",
+                                                     language: "he")
+        XCTAssertEqual(multipartField("response_format", in: body), "verbose_json",
+                       "Self-hosted Whisper servers must keep getting the timestamped format")
+        XCTAssertNil(multipartField("chunking_strategy", in: body))
+    }
+
+    // MARK: - diarized_json carries speakers through (issue #180)
+
+    func test_parsesDiarizedJSONSpeakersIntoCanonicalLabels() throws {
+        // Shape of a real `gpt-4o-transcribe-diarize` body: turn-oriented
+        // segments with a `speaker`, plus keys we don't model (`type`, string
+        // `id`, `usage`) that `Decodable` must ignore.
+        let json = """
+        {
+          "task": "transcribe",
+          "duration": 6.0,
+          "text": "Morning. Morning to you. Shall we start?",
+          "segments": [
+            { "id": "seg_0", "type": "transcript.text.segment", "speaker": "A",
+              "start": 0.0, "end": 1.5, "text": "Morning." },
+            { "id": "seg_1", "type": "transcript.text.segment", "speaker": "B",
+              "start": 1.5, "end": 3.0, "text": " Morning to you." },
+            { "id": "seg_2", "type": "transcript.text.segment", "speaker": "A",
+              "start": 3.0, "end": 6.0, "text": " Shall we start?" }
+          ],
+          "usage": { "type": "duration", "seconds": 6 }
+        }
+        """.data(using: .utf8)!
+
+        let segments = try RemoteWhisperEngine.parseSegments(data: json)
+        XCTAssertEqual(segments.count, 3)
+        // Re-keyed into the label space the rest of the app speaks: the raw
+        // "A"/"B" would render verbatim ("A" instead of "Speaker A" / "דובר
+        // א׳") and give `Recording.speakerNames` a foreign key.
+        XCTAssertEqual(segments.map(\.speaker), ["SPEAKER_00", "SPEAKER_01", "SPEAKER_00"],
+                       "Server turn labels must map to SPEAKER_NN by first appearance")
+        XCTAssertEqual(segments[1].start, 1.5, "Timestamps must survive the speaker mapping")
+        XCTAssertEqual(segments[2].text, " Shall we start?")
+    }
+
+    func test_verboseJSONSegmentsCarryNoSpeaker() throws {
+        let json = """
+        {
+          "duration": 2.0,
+          "text": "hello",
+          "segments": [ { "id": 0, "start": 0.0, "end": 2.0, "text": "hello" } ]
+        }
+        """.data(using: .utf8)!
+        let segments = try RemoteWhisperEngine.parseSegments(data: json)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertNil(segments[0].speaker,
+                     "Whisper responses have no speaker field — the local diarizer owns labelling there")
+    }
+
     func test_multipartBodyOmitsLanguageWhenAuto() {
         let body = RemoteWhisperEngine.multipartBody(boundary: "B",
                                                      audio: Data(),

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -1141,6 +1141,50 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertNil(normalized[1].speaker)
         XCTAssertEqual(normalized[2].speaker, "SPEAKER_01")
     }
+
+    // MARK: - Server-side speaker labels survive the offline pass (issue #180)
+
+    func test_hasSpeakerLabels_distinguishes_server_diarized_transcripts() {
+        // What the batch worker branches on: a `diarized_json` response
+        // already carries speakers, so the local pyannote pass must not
+        // relabel it. Everything else (local whisper, `verbose_json`, `json`)
+        // arrives unlabelled and does need the offline pass.
+        XCTAssertTrue(TranscriptionService.hasSpeakerLabels([
+            .init(start: 0, end: 1, text: "hi", speaker: "SPEAKER_00"),
+            .init(start: 1, end: 2, text: "yo", speaker: "SPEAKER_01"),
+        ]))
+        XCTAssertFalse(TranscriptionService.hasSpeakerLabels([
+            .init(start: 0, end: 1, text: "hi"),
+            .init(start: 1, end: 2, text: "yo"),
+        ]))
+        XCTAssertFalse(TranscriptionService.hasSpeakerLabels([]))
+        // A present-but-empty label is not a label — an empty string would
+        // otherwise suppress diarization and render as a blank speaker.
+        XCTAssertFalse(TranscriptionService.hasSpeakerLabels([
+            .init(start: 0, end: 1, text: "hi", speaker: ""),
+        ]))
+        // One labelled segment is enough: a diarize response can leave a
+        // stretch unattributed, and mixing the two label spaces is exactly
+        // what the guard exists to prevent.
+        XCTAssertTrue(TranscriptionService.hasSpeakerLabels([
+            .init(start: 0, end: 1, text: "hi"),
+            .init(start: 1, end: 2, text: "yo", speaker: "SPEAKER_00"),
+        ]))
+    }
+
+    func test_normalizeSpeakerLabels_rekeys_foreign_server_labels() {
+        // A remote diarizer speaks its own label space ("A", "B", …), which
+        // `friendlySpeakerLabel(language:)` would pass through verbatim.
+        let segments: [TranscriptSegment] = [
+            .init(start: 0, end: 1, text: "hi", speaker: "B"),
+            .init(start: 1, end: 2, text: "yo", speaker: "A"),
+            .init(start: 2, end: 3, text: "ya", speaker: "B"),
+        ]
+        let normalized = TranscriptionService.normalizeSpeakerLabels(in: segments)
+        XCTAssertEqual(normalized.map(\.speaker),
+                       ["SPEAKER_00", "SPEAKER_01", "SPEAKER_00"])
+        XCTAssertEqual(normalized[0].speaker?.friendlySpeakerLabel(language: "en"), "Speaker A")
+    }
 }
 
 /// Returns 401 for any request — lets the record-start probe reach `.failed`

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -108,6 +108,18 @@ This uses OpenAI's general-purpose Whisper model (not the ivrit.ai Hebrew
 finetune). Note OpenAI's per-request file-size limit (25 MB at time of writing);
 Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
 
+**Which model to put in that field.** Mila picks the `response_format` from the
+model id, so OpenAI's newer transcription models work too — with one tradeoff:
+
+| Model                       | Timestamps         | Notes                                          |
+|-----------------------------|--------------------|------------------------------------------------|
+| `whisper-1`                 | yes (per segment)  | The safe default. SRT export + local diarization both work. |
+| `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` | **no** | Newer, usually more accurate text. These models can only return plain text, so the whole recording arrives as one segment: no SRT timings, and local speaker diarization has nothing to align to. Good for dictation, poor for meetings. |
+| `gpt-4o-transcribe-diarize` | yes (per speaker turn) | Returns speakers itself, so Mila keeps its labels and skips the local pyannote pass. |
+
+The timestamp column is a model limitation, not a Mila one: the `gpt-*`
+transcription models reject every timestamped response format the API offers.
+
 ---
 
 ## Notes & caveats
@@ -126,4 +138,6 @@ Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
   There's no auto-detect: the speaker picks the language in the toolbar, because
   the model is chosen *from* that choice.
 - **Diarization** still runs locally (it reads the on-disk audio), so speaker
-  labels work regardless of which transcription backend you choose.
+  labels work regardless of which transcription backend you choose. The one
+  exception is `gpt-4o-transcribe-diarize`, which diarizes server-side: Mila
+  keeps the speakers it returns rather than relabelling them locally.


### PR DESCRIPTION
Closes #180

## What & why

`RemoteWhisperEngine.multipartBody` asked **every** remote model for
`response_format=verbose_json`. Only `whisper-1` can produce it, so against
OpenAI the remote backend was locked to that one 2023 model — every `gpt-*`
transcription model 400s:

> `response_format 'verbose_json' is not compatible with model 'gpt-transcribe-api-ev3'. Use 'json' or 'text' instead.`

I checked the issue's premise rather than taking it on trust, and it holds.
OpenAI's own Whisper→gpt-transcribe migration guide says: *"If the existing
application requests `text`, `verbose_json`, `srt`, or `vtt`, do not assume the
same response_format remains valid"*, and the API reference/community threads
confirm `gpt-4o-transcribe-diarize` + `diarized_json` needs
`chunking_strategy` (it errors with "chunking_strategy is required" without
one). So the rejected set really is *every timestamped format*, and the
`gpt-*transcribe` family accepts only `json`/`text`.

### The fix — derive the format from the model id

New `RemoteWhisperEngine.ResponseFormat` with a pure, testable
`forModel(_:)`:

| Model id | `response_format` | extra |
|---|---|---|
| `whisper-1`, `ivrit-ai/…`, `Systran/faster-whisper-…`, anything else | `verbose_json` | — |
| `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` | `json` | — |
| `gpt-4o-transcribe-diarize` | `diarized_json` | `chunking_strategy=auto` |

Matching mirrors the existing `RemoteTranscriptionSettings.isHebrewOnlyModel(_:)`
convention rather than introducing a second style, and tolerates casing plus a
vendor prefix (`openai/gpt-4o-transcribe`).

**Self-hosted servers are unaffected** — their ids don't start with `gpt-`, so
they keep requesting `verbose_json` byte-for-byte as before.

### Carrying server-side speakers through

Now that the diarize model is reachable, `diarized_json`'s `speaker` is decoded
and passed to `TranscriptSegment`. Two things the "two-line" version in the
issue would have missed:

- **Label space.** The server labels turns `"A"`, `"B"`, … but the rest of the
  app speaks `SPEAKER_NN` — that's what `friendlySpeakerLabel` renders as
  "Speaker A" / "דובר א׳", what `Recording.speakerNames` is keyed by, and what
  the exporters emit. Raw `"A"` would render verbatim (in Hebrew transcripts
  too) and leave renames keyed to a foreign id. Re-keyed at the parse boundary.
  The re-keying moved out of `TranscriptionService` into
  `SpeakerLabels.normalized(in:)` so the non-`@MainActor` engine can share it;
  `normalizeSpeakerLabels` delegates there, so its existing tests and callers
  are unchanged.
- **The overwrite the issue flagged.** The batch worker assigned pyannote's
  labels unconditionally. It can't be skipped up front (the local pass runs
  *concurrently* with transcription, before we know whether the response has
  speakers), so it's now guarded by `hasSpeakerLabels(_:)` on the result.

`rediarizeSegments` is **deliberately not** guarded, contrary to the issue's
suggestion: that's the live/meeting-stop path, whose entire purpose is to
replace the online diarizer's per-chunk labels with global clustering. The live
path also discards the engine's speaker (`LiveSegment(… speaker: nil)`), so no
server label ever reaches it.

Also documents the tradeoff in `docs/REMOTE_TRANSCRIPTION_SERVER.md`: the
`gpt-*` models return no segment timings, so they're a text-quality win for
dictation and a bad fit for meetings (no SRT timings, nothing for the local
diarizer to align to).

## How it was tested

- **`make build` — passes** (run on the exact committed tree).
- **Added 12 unit tests, NOT executed locally.** Per maintainer instruction I
  did not run app-hosted `MilaTests` on this machine: `MilaTests` is hosted in
  the app, so each run launches a freshly ad-hoc-signed `Mila.app` and the
  suite's `KeychainHelper` usage triggers a macOS keychain-authorisation
  password dialog. CI's `unit-and-ui-tests` job is the verification for them.
  - `RemoteWhisperEngineParsingTests`: `forModel` for whisper/self-hosted vs
    `gpt-*` vs the diarize variant (incl. vendor prefix, casing, whitespace,
    and `my-gpt-whisper-mirror/…` which must *not* match);
    `needsChunkingStrategy`; three `multipartBody` tests that parse the built
    multipart body and assert the **field values** (`json` + no
    `chunking_strategy`; `diarized_json` + `chunking_strategy=auto`;
    `verbose_json` preserved for a self-hosted id);
    `diarized_json` parsing → `["SPEAKER_00","SPEAKER_01","SPEAKER_00"]` with
    timestamps intact, using a body that includes the real response's extra
    keys (`type`, string `id`, `usage`); and `verbose_json` → `speaker == nil`.
  - `TranscriptionServiceTests`: `hasSpeakerLabels` (labelled / unlabelled /
    empty array / empty-string label / partially labelled) and
    `normalizeSpeakerLabels` re-keying foreign `"A"`/`"B"` labels.

## Deliberately out of scope

- **#178's known-good model picker.** This is only the engineering half #178
  defers to; the Settings UI still takes a free-text model id.
- **A 400-retry-with-`json` safety net.** The format is knowable from the model
  id up front, and a silent retry would drop `segments` (and therefore
  timestamps and speaker assignment) without telling anyone.
- **"Test connection" still only probes `GET /models`,** so it cannot detect a
  model/format mismatch; and uploads are still a single request against
  OpenAI's 25 MB cap. Both are noted in #180 as separate limits.

## Checklist

- [x] Builds locally (`make build`); tests written but not run locally — see above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (n/a — changelog is per release; no version bump here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for model-specific transcription response formats.
  * Added speaker labels from diarized transcription results.
  * Normalized speaker identifiers consistently across transcripts.
  * Added automatic chunking for diarization requests.

* **Bug Fixes**
  * Preserved server-provided speaker labels instead of replacing them locally.

* **Documentation**
  * Clarified model capabilities, timestamp limitations, and speaker-label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->