### PR TITLE
feat(settings): pick remote transcription models from a known-good list

### DIFF
--- a/Mila/Models/RemoteModelPreset.swift
+++ b/Mila/Models/RemoteModelPreset.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// One entry in the remote-transcription model picker: a model id Mila is
+/// known to be able to *talk to*, together with the endpoint it belongs to.
+///
+/// The picker exists because the Model field used to be plain free text whose
+/// only guidance was a placeholder, and most of OpenAI's transcription models
+/// answer a request Mila can't form with an opaque HTTP 400. Naming the ones
+/// that work turns "type a model id and find out" into a choice (issue #178).
+///
+/// **Every preset must be reachable by `RemoteWhisperEngine`.** That is not a
+/// convention to remember: `timestamps` is read off
+/// `RemoteWhisperEngine.ResponseFormat.forModel(id)`, so a preset is described
+/// by the same code that decides what to send for it. There is no second
+/// model→format table to drift out of step with the first.
+struct RemoteModelPreset: Identifiable, Hashable, Sendable {
+
+    /// Where the model runs — the picker's section headers.
+    enum Group: String, CaseIterable, Sendable {
+        /// OpenAI's hosted API. Fixed endpoint, key required.
+        case openAI
+        /// A server the user runs (`speaches`, faster-whisper, vLLM, …).
+        case selfHosted
+
+        var displayName: String {
+            switch self {
+            case .openAI:     return "OpenAI hosted"
+            case .selfHosted: return "Self-hosted (speaches / faster-whisper)"
+            }
+        }
+    }
+
+    /// The model id sent as the multipart `model` field. Doubles as the
+    /// identity, since a picker never needs two rows for one id.
+    let id: String
+    /// Short label for the picker row.
+    let displayName: String
+    let group: Group
+    /// The endpoint this model lives behind, when there is a canonical one.
+    ///
+    /// Applied by `RemoteTranscriptionSettings.apply(_:)` only when the
+    /// endpoint currently configured is another preset's canonical endpoint (or
+    /// unusable) — a URL the user typed themselves is never overwritten, since
+    /// a private gateway can proxy any of these models.
+    let endpoint: String
+    /// One line under the picker explaining what this choice is for.
+    let detail: String
+
+    /// What timings a transcript from this model will carry. Derived, never
+    /// declared: see the type's note.
+    var timestamps: RemoteWhisperEngine.ResponseFormat.TimestampSupport {
+        RemoteWhisperEngine.ResponseFormat.forModel(id).timestamps
+    }
+
+    /// The endpoints presets own, and may therefore replace when the user
+    /// switches groups. Anything else is the user's and is left alone.
+    static var canonicalEndpoints: Set<String> {
+        Set(all.map { Self.normalizeEndpoint($0.endpoint) })
+    }
+
+    /// Compare endpoints ignoring case and a trailing slash, so
+    /// `https://API.openai.com/v1/` counts as the OpenAI endpoint.
+    static func normalizeEndpoint(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        while s.hasSuffix("/") { s.removeLast() }
+        return s
+    }
+
+    /// The endpoint the docs' self-hosted quickstart uses
+    /// (`docs/REMOTE_TRANSCRIPTION_SERVER.md`, Option A).
+    static let selfHostedEndpoint = "http://localhost:8000/v1"
+
+    /// Every configuration Mila is known to work with.
+    ///
+    /// The OpenAI half is the full transcription line-up as of 2026-08, all of
+    /// which `RemoteWhisperEngine` can now reach — `whisper-1` via
+    /// `verbose_json`, the `gpt-*` family via `json`, and the diarizing variant
+    /// via `diarized_json` (issue #180 / PR #189). Before that the engine
+    /// hardcoded `verbose_json` and only `whisper-1` worked, which is why this
+    /// list could not have been offered earlier.
+    static let all: [RemoteModelPreset] = [
+        RemoteModelPreset(
+            id: RemoteTranscriptionSettings.defaultModel, // "whisper-1"
+            displayName: "whisper-1",
+            group: .openAI,
+            endpoint: RemoteTranscriptionSettings.defaultEndpoint,
+            detail: "Multilingual, with per-segment timings. The safe default — SRT export and local speaker labels both work."),
+        RemoteModelPreset(
+            id: "gpt-transcribe",
+            displayName: "gpt-transcribe",
+            group: .openAI,
+            endpoint: RemoteTranscriptionSettings.defaultEndpoint,
+            detail: "OpenAI's current general-purpose transcriber. Usually more accurate text than whisper-1."),
+        RemoteModelPreset(
+            id: "gpt-4o-transcribe",
+            displayName: "gpt-4o-transcribe",
+            group: .openAI,
+            endpoint: RemoteTranscriptionSettings.defaultEndpoint,
+            detail: "GPT-4o audio transcription."),
+        RemoteModelPreset(
+            id: "gpt-4o-mini-transcribe",
+            displayName: "gpt-4o-mini-transcribe",
+            group: .openAI,
+            endpoint: RemoteTranscriptionSettings.defaultEndpoint,
+            detail: "Cheaper and faster than gpt-4o-transcribe, slightly less accurate."),
+        RemoteModelPreset(
+            id: "gpt-4o-transcribe-diarize",
+            displayName: "gpt-4o-transcribe-diarize",
+            group: .openAI,
+            endpoint: RemoteTranscriptionSettings.defaultEndpoint,
+            detail: "Labels speakers itself, per turn. Mila keeps its labels and skips the local diarization pass."),
+        RemoteModelPreset(
+            id: "ivrit-ai/whisper-large-v3-turbo-ct2",
+            displayName: "ivrit.ai large-v3-turbo (Hebrew)",
+            group: .selfHosted,
+            endpoint: RemoteModelPreset.selfHostedEndpoint,
+            detail: "Hebrew-only finetune. Mila fills in a multilingual English model below, because this one renders English speech with Hebrew words."),
+        RemoteModelPreset(
+            id: RemoteTranscriptionSettings.defaultEnglishModel, // deepdml/…-turbo-ct2
+            displayName: "faster-whisper large-v3-turbo (multilingual)",
+            group: .selfHosted,
+            endpoint: RemoteModelPreset.selfHostedEndpoint,
+            detail: "Multilingual CTranslate2 build of Whisper large-v3-turbo, with per-segment timings."),
+    ]
+
+    /// The preset naming `modelID`, or `nil` for a model id Mila has no entry
+    /// for — which the picker renders as *Custom…* rather than silently
+    /// snapping the user's value to something nearby.
+    ///
+    /// Exact match on the trimmed, lowercased id. Deliberately not the tolerant
+    /// substring style of `isHebrewOnlyModel(_:)`: this decides whether to
+    /// *describe* a model to the user, and describing a near-miss id with a
+    /// preset's guarantees would be a lie. `ResponseFormat.forModel(_:)`
+    /// remains tolerant, so a near-miss still gets the right wire format.
+    static func matching(_ modelID: String) -> RemoteModelPreset? {
+        let id = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !id.isEmpty else { return nil }
+        return all.first { $0.id.lowercased() == id }
+    }
+
+    static func presets(in group: Group) -> [RemoteModelPreset] {
+        all.filter { $0.group == group }
+    }
+}
+
+extension RemoteWhisperEngine.ResponseFormat.TimestampSupport {
+    /// Whether a recording transcribed this way arrives as one untimed blob —
+    /// the tradeoff the picker has to surface, because losing per-segment
+    /// timings silently costs SRT timings *and* speaker assignment.
+    var isUntimed: Bool { self == .none }
+}

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -178,7 +178,11 @@ final class RemoteTranscriptionSettings: ObservableObject {
     /// (`MilaConfigImporter`), as does anything editing the raw field. Deriving
     /// it means an imported configuration shows up correctly identified in the
     /// picker with no import-side change at all.
-    var selectedPreset: RemoteModelPreset? { RemoteModelPreset.matching(model) }
+    /// Matched against the **effective** model, not the raw field. `resolve`
+    /// turns a blank or whitespace-only value into `defaultModel`, so an empty
+    /// field transcribes as `whisper-1` — matching the raw text would show
+    /// "Custom..." for a configuration that is in fact the default preset.
+    var selectedPreset: RemoteModelPreset? { RemoteModelPreset.matching(Self.resolve(model)) }
 
     /// Adopt a preset: its model id, and its endpoint when the one configured
     /// isn't the user's own.

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -87,6 +87,11 @@ final class RemoteTranscriptionSettings: ObservableObject {
             // again when the primary stops being Hebrew-only, because it
             // belongs to that primary and breaks the next one.
             reconcileEnglishModelForCurrentPrimary()
+            // The probe is model-specific -- it uploads a clip and asks this
+            // model to transcribe it -- so a green tick earned by the previous
+            // model says nothing about the new one. Same reset that `endpoint`
+            // and `apiKey` already do.
+            testStatus = .idle
         }
     }
 
@@ -484,11 +489,15 @@ final class RemoteTranscriptionSettings: ObservableObject {
 
         do {
             let (data, response) = try await urlSession.upload(for: request, from: body)
-            // Drop the result if the user edited the endpoint/key while the
-            // request was in flight — `didSet` already reset status to .idle,
-            // and a stale result for the previous values would be misleading.
+            // Drop the result if the user changed the endpoint, key or model
+            // while the request was in flight — `didSet` already reset status
+            // to .idle, and a stale result for the previous values would be
+            // misleading. The model matters as much as the other two: the probe
+            // asks one specific model to transcribe, so applying its verdict
+            // after a switch would show a pass earned by a different model.
             guard endpointURL == url,
-                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key else { return }
+                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key,
+                  (currentConfig()?.model ?? Self.defaultModel) == model else { return }
             guard let http = response as? HTTPURLResponse else {
                 testStatus = .failed("No HTTP response.")
                 return
@@ -496,7 +505,8 @@ final class RemoteTranscriptionSettings: ObservableObject {
             testStatus = Self.evaluateProbe(statusCode: http.statusCode, data: data)
         } catch {
             guard endpointURL == url,
-                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key else { return }
+                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines) == key,
+                  (currentConfig()?.model ?? Self.defaultModel) == model else { return }
             testStatus = .failed(error.localizedDescription)
         }
     }

--- a/Mila/Models/RemoteTranscriptionSettings.swift
+++ b/Mila/Models/RemoteTranscriptionSettings.swift
@@ -162,6 +162,50 @@ final class RemoteTranscriptionSettings: ObservableObject {
         modelID.lowercased().contains("ivrit")
     }
 
+    // MARK: - Known-good presets
+
+    /// The catalogue entry the current `model` names, or `nil` for a model id
+    /// Mila has no entry for (the picker's *Custom…*).
+    ///
+    /// **Derived, not stored.** A persisted "selected preset" would be a second
+    /// copy of a fact `model` already carries, and the two have several ways to
+    /// disagree — a `.milaconfig` import writes `model` directly
+    /// (`MilaConfigImporter`), as does anything editing the raw field. Deriving
+    /// it means an imported configuration shows up correctly identified in the
+    /// picker with no import-side change at all.
+    var selectedPreset: RemoteModelPreset? { RemoteModelPreset.matching(model) }
+
+    /// Adopt a preset: its model id, and its endpoint when the one configured
+    /// isn't the user's own.
+    ///
+    /// The endpoint rule is deliberately conservative. Switching from the
+    /// OpenAI group to a self-hosted model has to move the endpoint or the
+    /// choice is incoherent, but a URL the user typed — a private gateway, a
+    /// reverse proxy — can serve any of these ids, so overwriting it would
+    /// break a working setup on an unrelated edit. Preset endpoints are
+    /// therefore only ever replaced by other preset endpoints (or filled in
+    /// when the current value can't be parsed at all).
+    ///
+    /// `englishModel` is *not* touched here: `model`'s own `didSet` already
+    /// reconciles it for a Hebrew-only primary, so picking the ivrit preset
+    /// gets the English prefill — and picking anything else gets the matching
+    /// withdrawal — through the one code path that owns that rule.
+    func apply(_ preset: RemoteModelPreset) {
+        if shouldAdoptEndpoint(of: preset) {
+            endpoint = preset.endpoint
+        }
+        model = preset.id
+    }
+
+    /// Whether `apply(_:)` may replace the configured endpoint. True when the
+    /// current value is one the presets own, or isn't a usable URL.
+    private func shouldAdoptEndpoint(of preset: RemoteModelPreset) -> Bool {
+        guard endpointURL != nil else { return true }
+        let current = RemoteModelPreset.normalizeEndpoint(endpoint)
+        guard RemoteModelPreset.canonicalEndpoints.contains(current) else { return false }
+        return current != RemoteModelPreset.normalizeEndpoint(preset.endpoint)
+    }
+
     private let defaults: UserDefaults
     private let urlSession: URLSession
     /// Keychain item the API token is stored under. Injectable so tests /

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -115,6 +115,29 @@ actor RemoteWhisperEngine: RemoteTranscribing {
             return id.contains("diarize") ? .diarizedJSON : .json
         }
 
+        /// What timing information a response in this format carries.
+        ///
+        /// A property of the *format*, so the UI can describe the tradeoff of
+        /// a model without re-deriving it from the model id — the mapping from
+        /// id to format lives in `forModel(_:)` and nowhere else.
+        enum TimestampSupport {
+            /// Per-decode-window segments (`verbose_json`). SRT export and the
+            /// local pyannote pass both have something to align to.
+            case perSegment
+            /// Per-speaker-turn segments (`diarized_json`), already labelled.
+            case perSpeakerTurn
+            /// None: the whole recording arrives as one untimed segment.
+            case none
+        }
+
+        var timestamps: TimestampSupport {
+            switch self {
+            case .verboseJSON:  return .perSegment
+            case .diarizedJSON: return .perSpeakerTurn
+            case .json:         return .none
+            }
+        }
+
         /// Whether the request must also carry a `chunking_strategy`.
         ///
         /// The diarization models require one explicitly for audio longer than

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -821,6 +821,15 @@ private struct RemoteBackendSection: View {
             .padding(.top, 6)
         }
         .font(.callout)
+        // `showAdvanced` is @State, so its initial value is used once and never
+        // recomputed. If `model` changes to a custom id while this section is on
+        // screen -- a `.milaconfig` import is the realistic way -- the picker
+        // flips to "Custom..." while the Model id field stays collapsed, leaving
+        // the value visible nowhere and un-editable. Open the disclosure when
+        // the configured id stops being one of the presets.
+        .onChange(of: remote.model) { _, _ in
+            if remote.selectedPreset == nil { showAdvanced = true }
+        }
     }
 
     private var privacyWarning: some View {

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -734,12 +734,19 @@ private struct RemoteBackendSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
-            if preset.timestamps.isUntimed { noTimestampsWarning }
         } else {
             Text("Custom model id — set it under **Advanced** below. Mila can't vouch for a model it doesn't know; use **Test connection** to confirm the server accepts it.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+        // Asked of the engine, not of the preset. `forModel(_:)` sends ANY
+        // `gpt-*` id as `json`, preset or not, so a hand-typed
+        // `gpt-4o-transcribe-something` loses timestamps just as surely as a
+        // listed one -- and gating the warning on a preset match is exactly
+        // how it would lose them silently.
+        if RemoteWhisperEngine.ResponseFormat.forModel(remote.model).timestamps.isUntimed {
+            noTimestampsWarning
         }
     }
 
@@ -795,7 +802,7 @@ private struct RemoteBackendSection: View {
                         .autocorrectionDisabled()
                         .accessibilityIdentifier("remote.model.custom")
                 }
-                Text("Any model id your server accepts. Mila picks the response format from the id, so an unknown id is sent as a Whisper-style request (`verbose_json`).")
+                Text("Any model id your server accepts. Mila derives the response format from the id — `gpt-*` ids are sent without timestamps, anything else as a Whisper-style request (`verbose_json`).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -626,10 +626,32 @@ private struct ModelsSettingsTab: View {
 /// Endpoint / model / API-key configuration for the remote transcription
 /// backend, plus a connectivity test and the mandatory "audio leaves your
 /// device" warning.
+///
+/// The **Model** row is a picker over `RemoteModelPreset.all`, not free text.
+/// It used to be a `TextField` whose only guidance was a `whisper-1`
+/// placeholder, which invited model ids that fail with an opaque HTTP 400 —
+/// and, before PR #189, that was *most* of OpenAI's transcription line-up
+/// (issue #178). Free text still exists, behind **Advanced**, for a
+/// self-hosted id no catalogue could enumerate.
 private struct RemoteBackendSection: View {
     @ObservedObject var remote: RemoteTranscriptionSettings
 
     private static let setupGuideURL = URL(string: "https://github.com/island-io/mila/blob/main/docs/REMOTE_TRANSCRIPTION_SERVER.md")!
+
+    /// Picker tag for "a model id Mila has no entry for". A `nil` selection
+    /// can't be a `Picker` tag, so `Custom…` gets its own sentinel.
+    private static let customTag = "__mila.remote.model.custom__"
+
+    /// Opens itself when the configured model isn't one of the presets — a
+    /// custom id (typed, or arriving via a `.milaconfig` import) must not be
+    /// invisible just because it doesn't fit the picker.
+    @State private var showAdvanced: Bool
+
+    @MainActor
+    init(remote: RemoteTranscriptionSettings) {
+        self.remote = remote
+        _showAdvanced = State(initialValue: remote.selectedPreset == nil)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -641,26 +663,12 @@ private struct RemoteBackendSection: View {
                         .textFieldStyle(.roundedBorder)
                         .autocorrectionDisabled()
                 }
-                Text("Base URL of an OpenAI-compatible API. Mila appends `/audio/transcriptions`. Defaults to OpenAI; point it at your own server for ivrit.ai or other models.")
+                Text("Base URL of an OpenAI-compatible API. Mila appends `/audio/transcriptions`. Picking a model below fills this in; edit it to point at your own server.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                fieldRow(label: "Model") {
-                    TextField(RemoteTranscriptionSettings.defaultModel, text: $remote.model)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-                }
-
-                fieldRow(label: "English model") {
-                    TextField("Same as above", text: $remote.englishModel)
-                        .textFieldStyle(.roundedBorder)
-                        .autocorrectionDisabled()
-                }
-                Text("Optional. Set this when the model above only handles one language — an ivrit.ai server, for example, returns Hebrew words for English speech. English recordings then use this model instead. Leave blank for multilingual endpoints like OpenAI.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                modelPickerRow
 
                 fieldRow(label: "API key") {
                     SecureField("Stored in your Keychain", text: $remote.apiKey)
@@ -671,6 +679,8 @@ private struct RemoteBackendSection: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            advancedDisclosure
 
             HStack(spacing: 10) {
                 Button {
@@ -695,6 +705,115 @@ private struct RemoteBackendSection: View {
                     .font(.callout)
             }
         }
+    }
+
+    // MARK: - Model
+
+    /// The picker, plus one caption describing the selection and — when the
+    /// model can't return timings — the warning that says so *before* the user
+    /// records an hour-long meeting with it.
+    @ViewBuilder
+    private var modelPickerRow: some View {
+        fieldRow(label: "Model") {
+            Picker("Model", selection: modelSelection) {
+                ForEach(RemoteModelPreset.Group.allCases, id: \.self) { group in
+                    Section(group.displayName) {
+                        ForEach(RemoteModelPreset.presets(in: group)) { preset in
+                            Text(preset.displayName).tag(preset.id)
+                        }
+                    }
+                }
+                Text("Custom…").tag(Self.customTag)
+            }
+            .labelsHidden()
+            .accessibilityIdentifier("remote.model.picker")
+        }
+
+        if let preset = remote.selectedPreset {
+            Text(preset.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if preset.timestamps.isUntimed { noTimestampsWarning }
+        } else {
+            Text("Custom model id — set it under **Advanced** below. Mila can't vouch for a model it doesn't know; use **Test connection** to confirm the server accepts it.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Bridges the picker's `String` tag to the settings' model id.
+    ///
+    /// Reads as `customTag` whenever the configured id isn't a preset, so a
+    /// hand-typed model shows as *Custom…* rather than snapping the display to
+    /// some unrelated row. Selecting `Custom…` deliberately leaves `model`
+    /// alone — it opens the free-text field rather than clearing the value the
+    /// user is about to edit.
+    private var modelSelection: Binding<String> {
+        Binding(
+            get: { remote.selectedPreset?.id ?? Self.customTag },
+            set: { tag in
+                guard let preset = RemoteModelPreset.matching(tag) else {
+                    showAdvanced = true
+                    return
+                }
+                remote.apply(preset)
+            }
+        )
+    }
+
+    /// Losing per-segment timings is not a cosmetic downgrade — it costs SRT
+    /// timings *and* speaker labels, because local diarization has nothing to
+    /// align its speaker turns to. Say so at the point of choice; silently
+    /// degrading transcripts is what this picker exists to stop.
+    private var noTimestampsWarning: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "clock.badge.exclamationmark")
+                .foregroundStyle(.orange)
+            Text("No timestamps. This model can only return plain text, so the recording arrives as one segment: SRT export has no timings and speaker labels can't be aligned. Fine for dictation, poor for meetings.")
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 6))
+        .accessibilityIdentifier("remote.model.noTimestamps")
+    }
+
+    // MARK: - Advanced
+
+    /// The raw ids. Free text is still fully supported — a self-hosted server
+    /// can serve any model id — it just stops being the first thing the user
+    /// sees, the same treatment #144 gave "technical, set once" configuration.
+    private var advancedDisclosure: some View {
+        DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
+            VStack(alignment: .leading, spacing: 8) {
+                fieldRow(label: "Model id") {
+                    TextField(RemoteTranscriptionSettings.defaultModel, text: $remote.model)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("remote.model.custom")
+                }
+                Text("Any model id your server accepts. Mila picks the response format from the id, so an unknown id is sent as a Whisper-style request (`verbose_json`).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                fieldRow(label: "English model") {
+                    TextField("Same as above", text: $remote.englishModel)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("remote.model.english")
+                }
+                Text("Optional. Set this when the model above only handles one language — an ivrit.ai server, for example, returns Hebrew words for English speech. English recordings then use this model instead. Leave blank for multilingual endpoints like OpenAI.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.top, 6)
+        }
+        .font(.callout)
     }
 
     private var privacyWarning: some View {

--- a/MilaTests/RemoteModelPresetTests.swift
+++ b/MilaTests/RemoteModelPresetTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+/// Guards on the remote-transcription model catalogue (issue #178).
+///
+/// The load-bearing one is `test_everyPreset_isReachableByTheEngine`: the whole
+/// point of the picker is that it cannot offer a model Mila will then fail to
+/// talk to, and the only way to keep that true as the list grows is to assert
+/// it rather than to remember it.
+final class RemoteModelPresetTests: XCTestCase {
+
+    // MARK: - The catalogue only lists what the engine can reach
+
+    func test_everyPreset_hasANonEmptyIDAndEndpoint() {
+        for preset in RemoteModelPreset.all {
+            XCTAssertFalse(preset.id.trimmingCharacters(in: .whitespaces).isEmpty,
+                           "\(preset.displayName) has no model id")
+            XCTAssertFalse(preset.detail.isEmpty, "\(preset.id) has no caption")
+            XCTAssertNotNil(URL(string: preset.endpoint)?.host,
+                            "\(preset.id) has an unusable endpoint")
+        }
+    }
+
+    /// Every preset must resolve to a `response_format` the model actually
+    /// accepts. `forModel(_:)` returning *something* isn't enough — it has a
+    /// `verbose_json` fallback for unknown ids, which is exactly the request
+    /// the `gpt-*` models reject with HTTP 400. So assert the mapping per
+    /// model family, which is what "reachable" means on the wire.
+    func test_everyPreset_isReachableByTheEngine() {
+        for preset in RemoteModelPreset.all {
+            let format = RemoteWhisperEngine.ResponseFormat.forModel(preset.id)
+            let id = preset.id.lowercased()
+            if id.contains("diarize") {
+                XCTAssertEqual(format, .diarizedJSON, "\(preset.id)")
+            } else if id.hasPrefix("gpt-") {
+                XCTAssertEqual(format, .json,
+                               "\(preset.id) must not be sent a timestamped format")
+            } else {
+                XCTAssertEqual(format, .verboseJSON, "\(preset.id)")
+            }
+        }
+    }
+
+    func test_noPresetIsListedTwice() {
+        let ids = RemoteModelPreset.all.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "duplicate preset ids: \(ids)")
+    }
+
+    /// The picker must be able to reach every preset: a group with no rows
+    /// would be a section header over nothing.
+    func test_everyGroupHasPresets() {
+        for group in RemoteModelPreset.Group.allCases {
+            XCTAssertFalse(RemoteModelPreset.presets(in: group).isEmpty,
+                           "\(group) is empty")
+        }
+        XCTAssertEqual(RemoteModelPreset.Group.allCases
+            .flatMap(RemoteModelPreset.presets(in:)).count,
+                       RemoteModelPreset.all.count,
+                       "a preset belongs to no listed group")
+    }
+
+    func test_theDefaultModelIsAPreset() {
+        // Otherwise a fresh install opens Settings already showing "Custom…".
+        XCTAssertNotNil(RemoteModelPreset.matching(RemoteTranscriptionSettings.defaultModel))
+    }
+
+    // MARK: - Timestamp tradeoff (what the UI has to surface)
+
+    func test_whisperPresetsKeepPerSegmentTimestamps() throws {
+        let preset = try XCTUnwrap(RemoteModelPreset.matching("whisper-1"))
+        XCTAssertEqual(preset.timestamps, .perSegment)
+        XCTAssertFalse(preset.timestamps.isUntimed)
+    }
+
+    func test_gptPresetsAreFlaggedAsUntimed() throws {
+        for id in ["gpt-transcribe", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"] {
+            let preset = try XCTUnwrap(RemoteModelPreset.matching(id), id)
+            XCTAssertEqual(preset.timestamps, RemoteWhisperEngine.ResponseFormat.TimestampSupport.none,
+                           "\(id) cannot return timings")
+            XCTAssertTrue(preset.timestamps.isUntimed, id)
+        }
+    }
+
+    func test_diarizePresetReportsSpeakerTurnTimestamps() throws {
+        let preset = try XCTUnwrap(RemoteModelPreset.matching("gpt-4o-transcribe-diarize"))
+        XCTAssertEqual(preset.timestamps, .perSpeakerTurn)
+        XCTAssertFalse(preset.timestamps.isUntimed,
+                       "the diarize model does carry timings — it must not be warned about")
+    }
+
+    func test_selfHostedHebrewPresetKeepsTimestamps() throws {
+        let preset = try XCTUnwrap(
+            RemoteModelPreset.matching("ivrit-ai/whisper-large-v3-turbo-ct2"))
+        XCTAssertEqual(preset.group, .selfHosted)
+        XCTAssertEqual(preset.timestamps, .perSegment)
+    }
+
+    // MARK: - matching()
+
+    func test_matching_isExactAndCaseInsensitive() {
+        XCTAssertNotNil(RemoteModelPreset.matching("  WHISPER-1 "))
+        XCTAssertNotNil(RemoteModelPreset.matching("IVRIT-AI/whisper-large-v3-turbo-ct2"))
+    }
+
+    /// Deliberately *not* the tolerant substring style of
+    /// `isHebrewOnlyModel(_:)`. A near-miss id is a custom id, and describing
+    /// it with a preset's guarantees ("per-segment timings", "labels speakers
+    /// itself") would be a claim about a model Mila has never seen.
+    func test_matching_rejectsNearMisses() {
+        XCTAssertNil(RemoteModelPreset.matching("whisper-1-preview"))
+        XCTAssertNil(RemoteModelPreset.matching("openai/gpt-4o-transcribe"))
+        XCTAssertNil(RemoteModelPreset.matching("ivrit-ai/whisper-large-v3-ggml"))
+        XCTAssertNil(RemoteModelPreset.matching(""))
+        XCTAssertNil(RemoteModelPreset.matching("   "))
+    }
+
+    func test_normalizeEndpoint_ignoresCaseAndTrailingSlash() {
+        XCTAssertEqual(RemoteModelPreset.normalizeEndpoint(" https://API.OpenAI.com/v1/ "),
+                       "https://api.openai.com/v1")
+    }
+}
+
+@MainActor
+final class RemoteModelPresetSettingsTests: XCTestCase {
+
+    private func makeSettings(_ label: String = #function) -> RemoteTranscriptionSettings {
+        let name = "RemoteModelPresetSettingsTests.\(label)"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        return RemoteTranscriptionSettings(defaults: suite,
+                                           apiKeyKeychainKey: "\(name).apiKey")
+    }
+
+    func test_selectedPreset_isDerivedFromTheModelID() {
+        let settings = makeSettings()
+        // Fresh install: the default model is a preset, so the picker opens on
+        // a real row rather than "Custom…".
+        XCTAssertEqual(settings.selectedPreset?.id, "whisper-1")
+
+        settings.model = "gpt-4o-transcribe-diarize"
+        XCTAssertEqual(settings.selectedPreset?.id, "gpt-4o-transcribe-diarize")
+
+        settings.model = "my-org/some-private-finetune"
+        XCTAssertNil(settings.selectedPreset, "an unknown id must read as Custom")
+    }
+
+    func test_apply_setsModelAndEndpointTogether() throws {
+        let settings = makeSettings()
+        let hebrew = try XCTUnwrap(
+            RemoteModelPreset.matching("ivrit-ai/whisper-large-v3-turbo-ct2"))
+        settings.apply(hebrew)
+        XCTAssertEqual(settings.model, hebrew.id)
+        XCTAssertEqual(settings.endpoint, RemoteModelPreset.selfHostedEndpoint,
+                       "leaving OpenAI's endpoint behind a self-hosted model would 404")
+    }
+
+    /// The prefill/withdraw rule stays owned by `model.didSet`; `apply` must
+    /// ride on it rather than reimplement it.
+    func test_apply_inheritsTheEnglishModelPrefill() throws {
+        let settings = makeSettings()
+        let hebrew = try XCTUnwrap(
+            RemoteModelPreset.matching("ivrit-ai/whisper-large-v3-turbo-ct2"))
+        settings.apply(hebrew)
+        XCTAssertEqual(settings.englishModel,
+                       RemoteTranscriptionSettings.defaultEnglishModel)
+
+        let whisper = try XCTUnwrap(RemoteModelPreset.matching("whisper-1"))
+        settings.apply(whisper)
+        XCTAssertEqual(settings.englishModel, "",
+                       "the prefill must be withdrawn for a multilingual primary")
+    }
+
+    func test_apply_movesBackToOpenAIsEndpoint() throws {
+        let settings = makeSettings()
+        settings.apply(try XCTUnwrap(
+            RemoteModelPreset.matching("ivrit-ai/whisper-large-v3-turbo-ct2")))
+        settings.apply(try XCTUnwrap(RemoteModelPreset.matching("gpt-4o-transcribe")))
+        XCTAssertEqual(settings.endpoint, RemoteTranscriptionSettings.defaultEndpoint)
+    }
+
+    /// A private gateway or reverse proxy can serve any of these model ids, so
+    /// switching model must not silently repoint the user's own URL.
+    func test_apply_leavesAUserTypedEndpointAlone() throws {
+        let settings = makeSettings()
+        settings.endpoint = "https://mila-asr.example.internal/v1"
+        settings.apply(try XCTUnwrap(RemoteModelPreset.matching("gpt-4o-transcribe")))
+        XCTAssertEqual(settings.endpoint, "https://mila-asr.example.internal/v1")
+        XCTAssertEqual(settings.model, "gpt-4o-transcribe")
+    }
+
+    func test_apply_fillsInAnUnusableEndpoint() throws {
+        let settings = makeSettings()
+        settings.endpoint = "not a url"
+        settings.apply(try XCTUnwrap(RemoteModelPreset.matching("whisper-1")))
+        XCTAssertEqual(settings.endpoint, RemoteTranscriptionSettings.defaultEndpoint)
+    }
+
+    /// Re-selecting the same group keeps a preset endpoint that only differs
+    /// by case/trailing slash, instead of rewriting it for no reason.
+    func test_apply_treatsAnEquivalentPresetEndpointAsAlreadyCorrect() throws {
+        let settings = makeSettings()
+        settings.endpoint = "https://api.openai.com/v1/"
+        settings.apply(try XCTUnwrap(RemoteModelPreset.matching("gpt-transcribe")))
+        XCTAssertEqual(settings.endpoint, "https://api.openai.com/v1/")
+    }
+
+    func test_apply_persistsLikeAnyOtherEdit() throws {
+        let name = "RemoteModelPresetSettingsTests.persist"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        let first = RemoteTranscriptionSettings(defaults: suite,
+                                                apiKeyKeychainKey: "\(name).apiKey")
+        first.apply(try XCTUnwrap(RemoteModelPreset.matching("gpt-4o-transcribe-diarize")))
+
+        let second = RemoteTranscriptionSettings(defaults: suite,
+                                                 apiKeyKeychainKey: "\(name).apiKey")
+        XCTAssertEqual(second.model, "gpt-4o-transcribe-diarize")
+        XCTAssertEqual(second.selectedPreset?.id, "gpt-4o-transcribe-diarize")
+    }
+}

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -126,8 +126,11 @@ picker also states inline:
 | `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` | **no** | Newer, usually more accurate text. These models can only return plain text, so the whole recording arrives as one segment: no SRT timings, and local speaker diarization has nothing to align to. Good for dictation, poor for meetings. |
 | `gpt-4o-transcribe-diarize` | yes (per speaker turn) | Returns speakers itself, so Mila keeps its labels and skips the local pyannote pass. |
 
-The timestamp column is a model limitation, not a Mila one: the `gpt-*`
-transcription models reject every timestamped response format the API offers.
+The timestamp column is a model limitation, not a Mila one: the *non-diarizing*
+`gpt-*` transcription models reject every timestamped response format the API
+offers. `gpt-4o-transcribe-diarize` is the exception — it accepts
+`diarized_json` and returns timed speaker segments, which is why it is the one
+`gpt-*` entry above that keeps its timings.
 Mila warns next to the picker when the selected model is one of them, rather
 than letting the missing timings turn up in the transcript.
 

--- a/docs/REMOTE_TRANSCRIPTION_SERVER.md
+++ b/docs/REMOTE_TRANSCRIPTION_SERVER.md
@@ -84,8 +84,15 @@ In **Settings → Models**:
 |------------|------------------------------------------------|
 | Backend    | **Remote API**                                 |
 | Endpoint   | `http://localhost:8000/v1`                     |
-| Model      | `ivrit-ai/whisper-large-v3-turbo-ct2`          |
+| Model      | **ivrit.ai large-v3-turbo (Hebrew)**            |
 | API key    | *(leave blank — speaches doesn't require auth)* |
+
+**Model** is a picker of the configurations Mila is known to work with, grouped
+into OpenAI-hosted and self-hosted. Choosing the ivrit.ai entry sets the model
+id (`ivrit-ai/whisper-large-v3-turbo-ct2`), fills in the endpoint above, and
+pre-fills the English model — see *Language* under Notes. If your server serves
+a model id that isn't in the list, pick **Custom…** and type it under
+**Advanced**; free text is still fully supported.
 
 Click **Test connection**, then record. Mila uploads each recording as a compact
 `.m4a` and asks for `verbose_json`, so per-segment timestamps (and therefore
@@ -101,15 +108,17 @@ No server to run. In **Settings → Models**:
 |------------|--------------------------------|
 | Backend    | **Remote API**                 |
 | Endpoint   | `https://api.openai.com/v1`    |
-| Model      | `whisper-1`                    |
+| Model      | **whisper-1**                  |
 | API key    | your OpenAI API key            |
 
 This uses OpenAI's general-purpose Whisper model (not the ivrit.ai Hebrew
 finetune). Note OpenAI's per-request file-size limit (25 MB at time of writing);
 Mila's `.m4a` encoding keeps roughly 1.5 hours of audio under that.
 
-**Which model to put in that field.** Mila picks the `response_format` from the
-model id, so OpenAI's newer transcription models work too — with one tradeoff:
+**Which model to pick.** Every model below is an entry in the **Model** picker
+under *OpenAI hosted*. Mila selects the `response_format` from the model id, so
+OpenAI's newer transcription models work too — with one tradeoff, which the
+picker also states inline:
 
 | Model                       | Timestamps         | Notes                                          |
 |-----------------------------|--------------------|------------------------------------------------|
@@ -119,6 +128,8 @@ model id, so OpenAI's newer transcription models work too — with one tradeoff:
 
 The timestamp column is a model limitation, not a Mila one: the `gpt-*`
 transcription models reject every timestamped response format the API offers.
+Mila warns next to the picker when the selected model is one of them, rather
+than letting the missing timings turn up in the transcript.
 
 ---
 


### PR DESCRIPTION
Closes #178

## What was wrong

Settings → Models configured the remote backend with a free-text **Model** field whose only guidance was a `whisper-1` placeholder. Nothing told you which model ids Mila could actually talk to, so picking one was trial and error — and before #180 / #189 most of OpenAI's transcription line-up answered Mila's request with an opaque HTTP 400, because `response_format=verbose_json` was hardcoded.

#189 fixed the engineering half: `RemoteWhisperEngine.ResponseFormat.forModel(_:)` now selects the format per model, so `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` and `gpt-4o-transcribe-diarize` are genuinely reachable. This PR is the UI half the issue deferred.

## What changed

**Model is a picker, not a text field.** `RemoteModelPreset.all` (new, `Mila/Models/RemoteModelPreset.swift`) is the catalogue, grouped into two picker sections plus a `Custom…` row:

| Group | Entries |
|---|---|
| OpenAI hosted | `whisper-1`, `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize` |
| Self-hosted (speaches / faster-whisper) | `ivrit-ai/whisper-large-v3-turbo-ct2`, `deepdml/faster-whisper-large-v3-turbo-ct2` |

Selecting an entry sets the model id and, where the configured endpoint is another preset's canonical endpoint (or isn't a usable URL), the endpoint too — so a choice lands coherent instead of as three fields the user has to reconcile. A URL the user typed themselves is **never** overwritten: a private gateway or reverse proxy can serve any of these ids, and repointing it on an unrelated model change would break a working setup.

**The timestamp tradeoff is stated at the point of choice.** The `gpt-*` models reject every timestamped format, so a transcript from one arrives as a single untimed segment — no SRT timings, and local diarization has nothing to align its speaker turns to. The picker shows a caption per selection and an orange notice for the untimed models, rather than letting that surface later as a mysteriously flat transcript. `gpt-4o-transcribe-diarize` is deliberately *not* warned about: it returns per-speaker-turn timings.

**Free text is demoted, not removed.** The raw **Model id** and **English model** fields moved into an `Advanced` disclosure, matching how #144 treated "technical, set once" configuration. It opens itself when the configured model isn't a preset, so a hand-typed id — or one arriving via `.milaconfig` — is visible immediately rather than hidden behind a collapsed row.

### Two structural choices worth reviewing

1. **No second model→format table.** `RemoteModelPreset.timestamps` is read off `RemoteWhisperEngine.ResponseFormat.forModel(id).timestamps` — the same code that decides what to put on the wire. `#189`'s `ResponseFormat` gained a `TimestampSupport` property (`perSegment` / `perSpeakerTurn` / `none`) so the capability lives with the format that determines it. Nothing in the UI re-derives anything from a model id.
2. **`selectedPreset` is derived from `model`, not persisted beside it.** A stored "selected preset" would be a second copy of a fact `model` already carries, and `MilaConfigImporter` writes `model` directly — so it could disagree. Deriving it means an imported configuration shows up correctly identified in the picker with **no importer change at all**. Likewise `apply(_:)` sets `model` and lets its existing `didSet` reconcile `englishModel`, so the ivrit.ai prefill/withdraw rule stays in the one place that owns it.

## Deviations from the issue, and why

- **Endpoint and API key stay at the top level** rather than moving into Advanced. They are per-deployment necessities — a self-hosted user (the `mila-asr` case) must type a URL every time — and neither is the trap the issue is about. Burying the endpoint would make Mila's primary real-world configuration harder, not easier. The model field is what invited a silent 400.
- **No "endpoint doesn't match this model's host" warning.** It would have been the natural companion, but **Test connection** was since upgraded to perform a real one-shot transcription of the bundled clip (it no longer probes `GET /models` — the issue's complaint #1 is already stale on `main`), so a mispaired endpoint/model already fails loudly and specifically. A second heuristic warning would just be noise.
- **`matching(_:)` is an exact match, not the tolerant substring style of `isHebrewOnlyModel(_:)`.** It decides whether to *describe* a model to the user with a preset's guarantees; doing that for a near-miss id (`whisper-1-preview`, `openai/gpt-4o-transcribe`) would be a claim about a model Mila has never seen. `forModel(_:)` stays tolerant, so a near-miss still gets the right wire format — it just reads as `Custom…`.

Model ids and their accepted `response_format` values were re-checked against the OpenAI docs, not taken from the issue text; they agree with #189's table, which `docs/REMOTE_TRANSCRIPTION_SERVER.md` keeps (now cross-referenced to the picker).

## Verification

`make build` — **BUILD SUCCEEDED**, no new warnings.
`xcodebuild … build-for-testing` — **TEST BUILD SUCCEEDED**, so the new test sources compile.

**Tests written but not executed locally.** `MilaTests/RemoteModelPresetTests.swift` (17 tests, in two classes) is committed and compile-verified, but **I did not run it.** App-hosted `MilaTests` launch a freshly ad-hoc-signed `Mila.app`, and several files in that target read the real login keychain, which pops a macOS password dialog on the maintainer's machine; they asked for that to stop. CI's `unit-and-ui-tests` job is the first execution of these:

- `RemoteModelPresetTests` — every preset has a usable id/endpoint/caption; **every preset resolves to a `response_format` its model family actually accepts** (the load-bearing one: `forModel` falls back to `verbose_json` for unknown ids, which is precisely what the `gpt-*` models reject, so "it returned something" is not evidence of reachability); no duplicate ids; every group is non-empty and every preset belongs to a listed group; the default model is a preset (otherwise a fresh install opens on `Custom…`); timestamp classification per family; `matching(_:)` is case-insensitive, whitespace-tolerant, and rejects near-misses; endpoint normalisation.
- `RemoteModelPresetSettingsTests` — `selectedPreset` derives from the model id; `apply(_:)` sets model + endpoint together, inherits the English-model prefill and its withdrawal, moves back to OpenAI's endpoint, **leaves a user-typed endpoint alone**, fills in an unusable one, treats a case/slash-equivalent preset endpoint as already correct, and persists across instances.

Each uses an isolated `UserDefaults` suite and an isolated keychain item key, per the repo convention.

## Not done

- No `TranscriptionBackend`-level change and no new `@EnvironmentObject`: this adds no app-wide settings object, only a pure value type plus two members on the existing `RemoteTranscriptionSettings`, so the Environment Objects convention doesn't come into play.
- The picker is not populated from `GET /models` — for the reason the issue gives: that list is mostly non-transcription models and says nothing about format compatibility.
- UI not visually confirmed on a running app. Verified by build only, per the maintainer's standing request not to launch app-hosted tests or steal focus; the screenshot check is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable presets for hosted and self-hosted remote transcription models.
  * Automatically configure compatible model, endpoint, and English-model settings.
  * Preserved support for custom models and endpoints.
  * Added warnings for models without timestamp support and related SRT or speaker-label limitations.
  * Improved grouped model selection and endpoint guidance in Settings.

* **Documentation**
  * Updated remote transcription setup instructions with available models and timestamp behavior.

* **Tests**
  * Added coverage for presets, matching, endpoint handling, and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->