### PR TITLE
feat(llm): log every LLM CLI invocation to the unified log

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1,6 +1,45 @@
 import Foundation
 import os
 
+/// Unified-log destination for every LLM invocation. Same subsystem as the
+/// rest of the app so `log stream --predicate 'subsystem == "…"'` catches
+/// runner lines alongside the callers' own lifecycle lines
+/// (`PostRecordingCoordinator`, `RecordingSummarizer`).
+///
+/// File-level rather than a member of `LLMRunner` so `ProcessHandle` and the
+/// error types can reach it too, matching `PostRecordingCoordinator`'s
+/// `postRecordingLog`.
+private let llmRunnerLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                     category: "LLMRunner")
+
+/// Which product surface an LLM invocation belongs to.
+///
+/// Exists purely for observability: without it every line in the log reads
+/// "some CLI ran", and the question users actually ask — "did the *title*
+/// generation fire for this recording?" — stays unanswerable. `LLMRunner`
+/// itself behaves identically for every case.
+///
+/// `rawValue`s are the log tokens, so they are deliberately short, lowercase,
+/// and stable — grep-ability is the whole point, and renaming one silently
+/// breaks anyone's saved log predicate.
+enum LLMFeature: String {
+    /// Recording title suggestion (rename sheet's "Suggest", and the
+    /// hands-off auto-title in `PostRecordingCoordinator`).
+    case name
+    /// The automatic post-transcription summary (`RecordingSummarizer`).
+    case summary
+    /// The user-triggered "Send to <tool>" post-recording action.
+    case action
+    /// Live AI's periodic in-meeting tick.
+    case liveAI = "live-ai"
+    /// Settings → AI Provider's "Test" button (the `diagnose` path).
+    case settingsTest = "settings-test"
+    /// Caller didn't say. Present so adding the parameter couldn't break any
+    /// existing call site — a line tagged this way means a caller wasn't
+    /// updated, which is itself worth seeing in the log.
+    case unspecified
+}
+
 /// Errors surfaced from the CLI invocation. The Settings UI / rename sheet
 /// renders `errorDescription` directly so users can self-diagnose path /
 /// permission issues without reading logs.
@@ -142,6 +181,11 @@ enum LLMRunner {
     ///
     /// `timeout` defaults to 5 minutes. Pass a smaller value for foreground
     /// callers that block UI (e.g. the Suggest button).
+    ///
+    /// `feature` only tags the unified-log lines this call emits — it changes
+    /// no behaviour. It is the LAST parameter (rather than the first, where it
+    /// would read better) because Swift requires arguments in declaration
+    /// order: appending it keeps every existing call site compiling untouched.
     static func run(tool: LLMTool,
                     prompt: String,
                     transcript: String,
@@ -163,8 +207,13 @@ enum LLMRunner {
                     openAIAPIKey: String? = nil,
                     jsonMode: Bool = false,
                     temperature: Double? = nil,
-                    transport: OpenAITransport? = nil) async throws -> String {
-        guard tool != .none else { throw LLMRunnerError.toolDisabled }
+                    transport: OpenAITransport? = nil,
+                    feature: LLMFeature = .unspecified) async throws -> String {
+        guard tool != .none else {
+            logSetupFailure(feature: feature, tool: tool,
+                            error: LLMRunnerError.toolDisabled)
+            throw LLMRunnerError.toolDisabled
+        }
 
         // OpenAI-compatible HTTP path — handled before any CLI resolution, so
         // `executablePathOverride` / `session` / `extraArgs` (CLI-only) are
@@ -174,7 +223,11 @@ enum LLMRunner {
         if tool == .openaiCompatible {
             guard let baseURL = openAIBaseURL,
                   !baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            else { throw LLMRunnerError.toolDisabled }
+            else {
+                logSetupFailure(feature: feature, tool: tool,
+                                error: LLMRunnerError.toolDisabled)
+                throw LLMRunnerError.toolDisabled
+            }
             let t = transport ?? URLSessionTransport(URLSession.shared)
             return try await runOpenAICompatible(prompt: prompt,
                                                  transcript: transcript,
@@ -185,21 +238,41 @@ enum LLMRunner {
                                                  apiKey: openAIAPIKey ?? "",
                                                  jsonMode: jsonMode,
                                                  temperature: temperature,
-                                                 transport: t)
+                                                 transport: t,
+                                                 feature: feature)
         }
 
-        let executable = try resolveExecutable(tool: tool,
+        let executable: URL
+        do {
+            executable = try resolveExecutable(tool: tool,
                                                override: executablePathOverride)
+        } catch {
+            // A stale or missing executable path is the single most common
+            // real-world failure, and it never reaches `executeProcess` — so
+            // without this it produced no log line whatsoever.
+            logSetupFailure(feature: feature, tool: tool, error: error)
+            throw error
+        }
         let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary)
-        let modelTag = (model?.isEmpty ?? true) ? "(default)" : (model ?? "")
-        let sessionTag: String = {
-            switch session {
-            case .none: return "none"
-            case .new(let id): return "new:\(id.uuidString.prefix(8))"
-            case .resume(let id): return "resume:\(id.uuidString.prefix(8))"
-            }
-        }()
-        print("LLMRunner: \(executable.lastPathComponent) model=\(modelTag) session=\(sessionTag) prompt=\(fullPrompt.count)c timeout=\(Int(timeout))s")
+        let arguments = tool.arguments(prompt: fullPrompt,
+                                       model: model,
+                                       session: session) + extraArgs
+        let command = redactedCommand(executable: executable,
+                                      arguments: arguments,
+                                      prompt: fullPrompt)
+        let started = Date()
+        logRunStart(feature: feature,
+                    tool: tool,
+                    executable: executable,
+                    model: model,
+                    session: session,
+                    extraArgsCount: extraArgs.count,
+                    promptChars: prompt.count,
+                    summaryChars: summary.count,
+                    transcriptChars: transcript.count,
+                    composedChars: fullPrompt.count,
+                    timeout: timeout,
+                    command: command)
         // ProcessHandle bridges Swift task cancellation to the underlying
         // `Process`. The continuation thread `attach`es the real Process
         // once it's spawned; if the Task was already cancelled by then
@@ -213,9 +286,21 @@ enum LLMRunner {
                 DispatchQueue.global(qos: .userInitiated).async {
                     do {
                         let outcome = try executeProcess(executable: executable,
-                                                         arguments: tool.arguments(prompt: fullPrompt, model: model, session: session) + extraArgs,
+                                                         arguments: arguments,
                                                          timeout: timeout,
                                                          handle: handle)
+                        // Log the FULL outcome — exit code, stderr tail, byte
+                        // counts — before the throw below collapses it into a
+                        // single localized sentence. This is the "route real
+                        // runs through the capture `diagnose` uses" half of
+                        // issue #175: `run`'s contract still throws, but the
+                        // exit code and stderr no longer vanish with it.
+                        logRunEnd(feature: feature,
+                                  tool: tool,
+                                  outcome: outcome,
+                                  duration: Date().timeIntervalSince(started),
+                                  timeout: timeout,
+                                  command: command)
                         // The Swift Task that drove us was cancelled mid-flight
                         // — `handle` SIGTERM'd the process, so the user-visible
                         // truth is "we cancelled it", not "the CLI crashed".
@@ -231,6 +316,13 @@ enum LLMRunner {
                             continuation.resume(returning: outcome.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
                         }
                     } catch {
+                        // Only `launchFailed` reaches here (the executable
+                        // resolved but `Process.run()` refused).
+                        logLaunchFailure(feature: feature,
+                                         tool: tool,
+                                         duration: Date().timeIntervalSince(started),
+                                         command: command,
+                                         error: error)
                         continuation.resume(throwing: error)
                     }
                 }
@@ -268,7 +360,8 @@ enum LLMRunner {
                                     apiKey: String,
                                     jsonMode: Bool,
                                     temperature: Double?,
-                                    transport: OpenAITransport) async throws -> String {
+                                    transport: OpenAITransport,
+                                    feature: LLMFeature = .unspecified) async throws -> String {
         // `makeRequest` throws `OpenAIRequestError.invalidEndpoint` for a
         // malformed base URL (issue celarent7/mila#1). It's an
         // `OpenAIRequestError`, so the typed-rethrow catch below surfaces it
@@ -282,6 +375,22 @@ enum LLMRunner {
                                                jsonMode: jsonMode,
                                                temperature: temperature)
         if timeout > 0 { request.timeoutInterval = timeout }
+        // Host only, never the full URL: a user's endpoint can carry a token
+        // in its query string, and the privacy rule is "no secrets in logged
+        // URLs". The host is enough to tell "wrong endpoint" from "endpoint
+        // rejected us".
+        let host = URL(string: baseURL)?.host ?? "(unparsed)"
+        let started = Date()
+        llmRunnerLog.notice("""
+            llm http start feature=\(feature.rawValue, privacy: .public) \
+            host=\(host, privacy: .public) \
+            model=\(modelTag(model), privacy: .public) \
+            prompt=\(prompt.count, privacy: .public)c \
+            summary=\(summary.count, privacy: .public)c \
+            transcript=\(transcript.count, privacy: .public)c \
+            jsonMode=\(jsonMode, privacy: .public) \
+            timeout=\(Int(timeout.rounded(.up)), privacy: .public)s
+            """)
 
         do {
             // Already cancelled before we even dispatch (e.g. the rename sheet
@@ -299,24 +408,48 @@ enum LLMRunner {
                 // Re-check after the (possibly slow) transport returned: a
                 // late response to a cancelled task shouldn't be delivered.
                 try Task.checkCancellation()
+                llmRunnerLog.notice("""
+                    llm http end feature=\(feature.rawValue, privacy: .public) \
+                    host=\(host, privacy: .public) \
+                    status=\(http.statusCode, privacy: .public) \
+                    duration=\(durationTag(Date().timeIntervalSince(started)), privacy: .public)s \
+                    response=\(content.count, privacy: .public)c
+                    """)
                 return content
             case .failure(let error):
                 throw error
             }
         } catch let error as OpenAIRequestError {
+            logHTTPFailure(feature: feature, host: host,
+                           duration: Date().timeIntervalSince(started), error: error)
             throw error
         } catch is CancellationError {
+            // Not a failure — the user closed the sheet / discarded the
+            // recording. Debug level so it's there when someone asks "why did
+            // my summary never appear?" without adding noise to normal runs.
+            llmRunnerLog.debug("""
+                llm http cancelled feature=\(feature.rawValue, privacy: .public) \
+                host=\(host, privacy: .public) \
+                duration=\(durationTag(Date().timeIntervalSince(started)), privacy: .public)s
+                """)
             throw LLMRunnerError.cancelled
         } catch let urlError as URLError {
             switch urlError.code {
             case .cancelled:
                 throw LLMRunnerError.cancelled
             case .timedOut:
+                logHTTPFailure(feature: feature, host: host,
+                               duration: Date().timeIntervalSince(started),
+                               error: LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up))))
                 throw LLMRunnerError.timedOut(seconds: Int(timeout.rounded(.up)))
             default:
+                logHTTPFailure(feature: feature, host: host,
+                               duration: Date().timeIntervalSince(started), error: urlError)
                 throw LLMRunnerError.launchFailed(urlError)
             }
         } catch {
+            logHTTPFailure(feature: feature, host: host,
+                           duration: Date().timeIntervalSince(started), error: error)
             throw LLMRunnerError.launchFailed(error)
         }
     }
@@ -349,8 +482,11 @@ enum LLMRunner {
                          openAIBaseURL: String? = nil,
                          openAIAPIKey: String? = nil,
                          jsonMode: Bool = false,
-                         transport: OpenAITransport? = nil) async -> LLMTestResult {
+                         transport: OpenAITransport? = nil,
+                         feature: LLMFeature = .settingsTest) async -> LLMTestResult {
         guard tool != .none else {
+            logSetupFailure(feature: feature, tool: tool,
+                            error: LLMRunnerError.toolDisabled)
             return LLMTestResult(setupError: LLMRunnerError.toolDisabled.errorDescription ?? "No LLM configured.")
         }
         // OpenAI HTTP path — handled before CLI resolution, so no
@@ -371,12 +507,32 @@ enum LLMRunner {
             executable = try resolveExecutable(tool: tool, override: executablePathOverride)
         } catch {
             let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+            logSetupFailure(feature: feature, tool: tool, error: error)
             return LLMTestResult(setupError: msg)
         }
         let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary)
         let args = tool.arguments(prompt: fullPrompt, model: model) + extraArgs
+        // The panel's copy-pasteable command keeps the real prompt — it is
+        // shown only to the user who owns the transcript, in their own UI. The
+        // *logged* command is the redacted twin below; the two must not be
+        // confused.
         let command = ([executable.path] + args).map(shellQuote).joined(separator: " ")
+        let loggedCommand = redactedCommand(executable: executable,
+                                            arguments: args,
+                                            prompt: fullPrompt)
         let start = Date()
+        logRunStart(feature: feature,
+                    tool: tool,
+                    executable: executable,
+                    model: model,
+                    session: .none,
+                    extraArgsCount: extraArgs.count,
+                    promptChars: prompt.count,
+                    summaryChars: summary.count,
+                    transcriptChars: transcript.count,
+                    composedChars: fullPrompt.count,
+                    timeout: timeout,
+                    command: loggedCommand)
         // Bridge Task cancellation to the child process, same as `run` — if
         // the test is cancelled (Settings closed, a newer run started), SIGTERM
         // the CLI instead of leaving it alive until the timeout.
@@ -390,6 +546,12 @@ enum LLMRunner {
                                                          arguments: args,
                                                          timeout: timeout,
                                                          handle: handle)
+                        logRunEnd(feature: feature,
+                                  tool: tool,
+                                  outcome: outcome,
+                                  duration: elapsed(),
+                                  timeout: timeout,
+                                  command: loggedCommand)
                         continuation.resume(returning: LLMTestResult(
                             command: command,
                             succeeded: !outcome.timedOut && outcome.exitCode == 0,
@@ -401,6 +563,11 @@ enum LLMRunner {
                     } catch {
                         // Only `launchFailed` reaches here now.
                         let msg = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+                        logLaunchFailure(feature: feature,
+                                         tool: tool,
+                                         duration: elapsed(),
+                                         command: loggedCommand,
+                                         error: error)
                         continuation.resume(returning: LLMTestResult(
                             command: command,
                             durationSeconds: elapsed(),
@@ -575,6 +742,223 @@ enum LLMRunner {
         return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
+    // MARK: - Observability (issue #175)
+    //
+    // Everything below exists so a failed title / summary / Send leaves an
+    // artifact behind. The hard constraint is that a transcript must NEVER
+    // reach the unified log: it is meeting content, the log is world-readable
+    // to anything with the right entitlement, and it persists for days. So the
+    // rule enforced here is *shape*, not annotation discipline: the only
+    // strings that reach a `Logger` call are ones these pure helpers built out
+    // of metadata. Prompt, summary and transcript appear as `.count` and
+    // nothing else.
+    //
+    // Every interpolation is `privacy: .public` on purpose. `.private` would
+    // render as `<private>` for the very person reading their own log with
+    // `/usr/bin/log show`, which is the entire audience — so a field is either
+    // safe to be public or it is not logged at all.
+
+    /// Cap on the stderr excerpt copied into a failure log line. Generous
+    /// enough for a stack-trace-ish CLI error, small enough that a CLI which
+    /// dumps megabytes to stderr can't flood the log.
+    static let stderrLogLimit = 512
+
+    /// `model=` token. Distinguishes "the CLI picked its own default" from
+    /// "we pinned one", which matters because a wrong pinned model is a
+    /// common cause of a non-zero exit.
+    static func modelTag(_ model: String?) -> String {
+        let trimmed = model?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "(default)" : trimmed
+    }
+
+    /// `session=` token. Only the first 8 characters of the UUID: enough to
+    /// correlate a `--resume` chain across lines (and with the jsonl filename
+    /// under `~/.claude/projects/`) without making the line unreadable.
+    static func sessionTag(_ session: LLMSession) -> String {
+        switch session {
+        case .none: return "none"
+        case .new(let id): return "new:\(id.uuidString.prefix(8))"
+        case .resume(let id): return "resume:\(id.uuidString.prefix(8))"
+        }
+    }
+
+    /// Fixed 2-decimal seconds, so durations line up when scanning a log and
+    /// a sub-second run doesn't print as `0.0009999999`.
+    static func durationTag(_ seconds: TimeInterval) -> String {
+        String(format: "%.2f", seconds)
+    }
+
+    /// The argv we launched, shell-quoted for readability, with the composed
+    /// prompt replaced by `<prompt:Nc>`.
+    ///
+    /// This is the log-safe twin of `diagnose`'s `command`. The real command
+    /// line is *mostly* metadata a user needs (which binary, which flags,
+    /// which `--session-id`, which extra args they typed) plus exactly one
+    /// argument that is the meeting transcript. Redacting that one argument
+    /// keeps the diagnostically useful 95% loggable. The result is
+    /// deliberately NOT copy-pasteable — the placeholder is unquoted so it
+    /// can't be mistaken for a runnable command.
+    static func redactedCommand(executable: URL,
+                                arguments: [String],
+                                prompt: String) -> String {
+        let redacted = arguments.map { arg -> String in
+            // Empty-prompt guard: without it an empty `prompt` would match
+            // every empty argument in argv and redact unrelated tokens.
+            if !prompt.isEmpty && arg == prompt {
+                return "<prompt:\(prompt.count)c>"
+            }
+            return shellQuote(arg)
+        }
+        return ([shellQuote(executable.path)] + redacted).joined(separator: " ")
+    }
+
+    /// One-line, bounded excerpt of a CLI's stderr for a failure log line.
+    ///
+    /// Keeps the **tail**: CLIs print the fatal error last, after any
+    /// progress/warning chatter. Newlines are folded to ` | ` because a
+    /// multi-line unified-log entry is painful to read and impossible to grep.
+    ///
+    /// Logged `.public` — a defensible line to draw, because the *same* stderr
+    /// already reaches the log in full today: `LLMRunnerError.nonZeroExit`
+    /// embeds it verbatim in `errorDescription`, and
+    /// `PostRecordingCoordinator` logs that as `.public`. A bounded excerpt is
+    /// therefore strictly less exposure than the status quo, and it is CLI
+    /// diagnostic output rather than user content.
+    static func stderrTail(_ stderr: String, limit: Int = stderrLogLimit) -> String {
+        let flattened = stderr
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " | ")
+        guard flattened.count > limit else { return flattened }
+        return "…" + String(flattened.suffix(limit))
+    }
+
+    /// "A run is starting, and here is everything about it that isn't user
+    /// content." `notice` (not `debug`) because the question this answers —
+    /// "is a title being generated right now, and with what?" — has to be
+    /// answerable from a plain `log show` without `--info --debug`. One line
+    /// per invocation, and invocations are user-paced, so the volume is fine.
+    ///
+    /// `exe=` is the fully resolved path and is public: "Mila is running a
+    /// different binary than my shell is" is one of the failures this is meant
+    /// to catch, and the path is useless when redacted. It can contain the
+    /// account's short name — the same exposure the pre-existing sandbox-path
+    /// line already accepts.
+    static func logRunStart(feature: LLMFeature,
+                            tool: LLMTool,
+                            executable: URL,
+                            model: String?,
+                            session: LLMSession,
+                            extraArgsCount: Int,
+                            promptChars: Int,
+                            summaryChars: Int,
+                            transcriptChars: Int,
+                            composedChars: Int,
+                            timeout: TimeInterval,
+                            command: String) {
+        llmRunnerLog.notice("""
+            llm run start feature=\(feature.rawValue, privacy: .public) \
+            tool=\(tool.rawValue, privacy: .public) \
+            exe=\(executable.path, privacy: .public) \
+            model=\(modelTag(model), privacy: .public) \
+            session=\(sessionTag(session), privacy: .public) \
+            extraArgs=\(extraArgsCount, privacy: .public) \
+            prompt=\(promptChars, privacy: .public)c \
+            summary=\(summaryChars, privacy: .public)c \
+            transcript=\(transcriptChars, privacy: .public)c \
+            composed=\(composedChars, privacy: .public)c \
+            timeout=\(Int(timeout.rounded(.up)), privacy: .public)s
+            """)
+        // The redacted argv is `debug`: it repeats what the start line already
+        // says for a healthy run, and duplicating it at notice level would
+        // double the log volume for no gain. The failure lines below carry it
+        // at their own level, so it is never missing when it matters.
+        llmRunnerLog.debug("llm run cmd feature=\(feature.rawValue, privacy: .public) \(command, privacy: .public)")
+    }
+
+    /// The end of a run that actually reached the process. Level is chosen by
+    /// outcome, because "invisible by default" is exactly the bug:
+    ///  - success → `notice`
+    ///  - cancelled → `debug` (deliberate; the user discarded or re-ran)
+    ///  - timeout / non-zero exit → `error`, with the redacted argv and the
+    ///    stderr tail, so a failed summary is diagnosable from the log alone.
+    static func logRunEnd(feature: LLMFeature,
+                          tool: LLMTool,
+                          outcome: ProcessOutcome,
+                          duration: TimeInterval,
+                          timeout: TimeInterval,
+                          command: String) {
+        let common = """
+            feature=\(feature.rawValue) tool=\(tool.rawValue) \
+            exit=\(outcome.exitCode) duration=\(durationTag(duration))s \
+            stdout=\(outcome.stdout.utf8.count)B stderr=\(outcome.stderr.utf8.count)B
+            """
+        if outcome.cancelled {
+            llmRunnerLog.debug("llm run cancelled \(common, privacy: .public)")
+        } else if outcome.timedOut {
+            llmRunnerLog.error("""
+                llm run timed out \(common, privacy: .public) \
+                limit=\(Int(timeout.rounded(.up)), privacy: .public)s \
+                cmd=\(command, privacy: .public) \
+                stderr-tail=\(stderrTail(outcome.stderr), privacy: .public)
+                """)
+        } else if outcome.exitCode != 0 {
+            llmRunnerLog.error("""
+                llm run failed \(common, privacy: .public) \
+                cmd=\(command, privacy: .public) \
+                stderr-tail=\(stderrTail(outcome.stderr.isEmpty ? outcome.stdout : outcome.stderr), privacy: .public)
+                """)
+        } else {
+            llmRunnerLog.notice("llm run end \(common, privacy: .public)")
+        }
+    }
+
+    /// A run that never got as far as a process: no tool configured, no
+    /// executable found, or (for the HTTP path) no base URL. `error` because
+    /// the user asked for something and got nothing, and the message is
+    /// `errorDescription` — the same sentence the UI shows, which contains
+    /// only the tool/path the user typed.
+    static func logSetupFailure(feature: LLMFeature, tool: LLMTool, error: Error) {
+        let message = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+        llmRunnerLog.error("""
+            llm run setup failed feature=\(feature.rawValue, privacy: .public) \
+            tool=\(tool.rawValue, privacy: .public): \(message, privacy: .public)
+            """)
+    }
+
+    /// `Process.run()` itself refused (bad architecture, permissions, a shim
+    /// that isn't really executable). Distinct from a setup failure because
+    /// the path resolved — knowing that changes where the user looks next.
+    static func logLaunchFailure(feature: LLMFeature,
+                                 tool: LLMTool,
+                                 duration: TimeInterval,
+                                 command: String,
+                                 error: Error) {
+        let message = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+        llmRunnerLog.error("""
+            llm run launch failed feature=\(feature.rawValue, privacy: .public) \
+            tool=\(tool.rawValue, privacy: .public) \
+            duration=\(durationTag(duration), privacy: .public)s \
+            cmd=\(command, privacy: .public): \(message, privacy: .public)
+            """)
+    }
+
+    /// Failure on the OpenAI-compatible HTTP path. `host` rather than the full
+    /// URL — see the call site for why.
+    static func logHTTPFailure(feature: LLMFeature,
+                               host: String,
+                               duration: TimeInterval,
+                               error: Error) {
+        let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        llmRunnerLog.error("""
+            llm http failed feature=\(feature.rawValue, privacy: .public) \
+            host=\(host, privacy: .public) \
+            duration=\(durationTag(duration), privacy: .public)s: \
+            \(message, privacy: .public)
+            """)
+    }
+
     /// Raw result of a single CLI invocation, before any success/failure
     /// interpretation. `run` maps this onto its throwing contract; `diagnose`
     /// surfaces every field verbatim so the Settings test panel can show the
@@ -685,7 +1069,10 @@ enum LLMRunner {
                 // status is already being discarded — don't hang the caller
                 // (and its awaiting continuation) on the obituary.
                 if runningGroup.wait(timeout: .now() + 5) == .timedOut {
-                    print("LLMRunner: waitUntilExit didn't return after SIGKILL — abandoning the wait")
+                    // `error`: a child that outlives SIGKILL is a genuine
+                    // anomaly (see the comment above), and it explains a
+                    // truncated result — it must not need `--debug` to see.
+                    llmRunnerLog.error("llm reap abandoned pid=\(process.processIdentifier, privacy: .public) — waitUntilExit didn't return after SIGKILL")
                 }
             }
         }
@@ -700,7 +1087,10 @@ enum LLMRunner {
             // so after the grace we move on; the leaked reader threads
             // exit when the pipes finally close.
             if group.wait(timeout: .now() + 3) == .timedOut {
-                print("LLMRunner: pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
+                // `notice`, not `error`: on the kill path the output is being
+                // discarded anyway (the caller sees .timedOut / .cancelled),
+                // so this is expected bookkeeping rather than a fault.
+                llmRunnerLog.notice("llm pipe drain timed out after kill — an orphaned grandchild is still holding stdout/stderr; returning partial output")
             }
         } else {
             // Normal exit: bounded too, but with a GENEROUS grace. Two
@@ -719,7 +1109,11 @@ enum LLMRunner {
             // returning the (fully buffered by then) output if a
             // pipe-holding helper never lets EOF arrive.
             if group.wait(timeout: .now() + 30) == .timedOut {
-                print("LLMRunner: pipe drain timed out after normal exit — a helper process is still holding stdout/stderr; returning buffered output")
+                // `error`: unlike the kill path, this output IS returned to
+                // the caller and may be truncated mid-stream — a silently
+                // short summary is exactly the kind of thing that needs a
+                // default-visible breadcrumb.
+                llmRunnerLog.error("llm pipe drain timed out after normal exit — a helper process is still holding stdout/stderr; returning buffered output")
             }
         }
 
@@ -787,10 +1181,14 @@ enum LLMRunner {
             // `currentDirectoryURL` does not exist. Degrade to a temp directory
             // instead: the Claude project slug stops being stable, which costs
             // resumability, but LLM calls keep working.
-            os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "LLMRunner").error("llm sandbox unavailable at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public) -- falling back to a temp directory")
+            llmRunnerLog.error("llm sandbox unavailable at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public) -- falling back to a temp directory")
             let fallback = sandboxDirectory(appSupportRoot: FileManager.default.temporaryDirectory)
             try? FileManager.default.createDirectory(at: fallback,
                                                      withIntermediateDirectories: true)
+            // Say where we landed as well as what broke: the fallback costs
+            // Claude Code project-slug stability (#187), so "why did my
+            // resumable conversations scatter?" is answerable from the log.
+            llmRunnerLog.notice("llm sandbox fallback in use at \(fallback.path, privacy: .public) — claude project slugs will not be stable across reboots")
             return fallback
         }
     }

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -259,7 +259,8 @@ enum LLMRunner {
                                        session: session) + extraArgs
         let command = redactedCommand(executable: executable,
                                       arguments: arguments,
-                                      prompt: fullPrompt)
+                                      prompt: fullPrompt,
+                                      extraArgsCount: extraArgs.count)
         let started = Date()
         logRunStart(feature: feature,
                     tool: tool,
@@ -362,19 +363,12 @@ enum LLMRunner {
                                     temperature: Double?,
                                     transport: OpenAITransport,
                                     feature: LLMFeature = .unspecified) async throws -> String {
-        // `makeRequest` throws `OpenAIRequestError.invalidEndpoint` for a
-        // malformed base URL (issue celarent7/mila#1). It's an
-        // `OpenAIRequestError`, so the typed-rethrow catch below surfaces it
-        // to the caller as a readable LocalizedError — not a crash.
-        var request = try OpenAIClient.makeRequest(baseURL: baseURL,
-                                               model: model ?? "",
-                                               prompt: prompt,
-                                               transcript: transcript,
-                                               summary: summary,
-                                               apiKey: apiKey,
-                                               jsonMode: jsonMode,
-                                               temperature: temperature)
-        if timeout > 0 { request.timeoutInterval = timeout }
+        // Log metadata FIRST, before anything that can throw. Request
+        // construction itself fails on a malformed base URL, and computing
+        // `host`/`started` afterwards meant that failure had neither a start
+        // line nor a failure line — invisible, which is the exact defect #175
+        // is about.
+        //
         // Host only, never the full URL: a user's endpoint can carry a token
         // in its query string, and the privacy rule is "no secrets in logged
         // URLs". The host is enough to tell "wrong endpoint" from "endpoint
@@ -391,6 +385,28 @@ enum LLMRunner {
             jsonMode=\(jsonMode, privacy: .public) \
             timeout=\(Int(timeout.rounded(.up)), privacy: .public)s
             """)
+
+        // `makeRequest` throws `OpenAIRequestError.invalidEndpoint` for a
+        // malformed base URL (issue celarent7/mila#1). It's an
+        // `OpenAIRequestError`, so the rethrow surfaces it to the caller as a
+        // readable LocalizedError — not a crash — and it is now recorded on
+        // the way past instead of vanishing.
+        var request: URLRequest
+        do {
+            request = try OpenAIClient.makeRequest(baseURL: baseURL,
+                                                   model: model ?? "",
+                                                   prompt: prompt,
+                                                   transcript: transcript,
+                                                   summary: summary,
+                                                   apiKey: apiKey,
+                                                   jsonMode: jsonMode,
+                                                   temperature: temperature)
+        } catch {
+            logHTTPFailure(feature: feature, host: host,
+                           duration: Date().timeIntervalSince(started), error: error)
+            throw error
+        }
+        if timeout > 0 { request.timeoutInterval = timeout }
 
         do {
             // Already cancelled before we even dispatch (e.g. the rename sheet
@@ -424,18 +440,18 @@ enum LLMRunner {
                            duration: Date().timeIntervalSince(started), error: error)
             throw error
         } catch is CancellationError {
-            // Not a failure — the user closed the sheet / discarded the
-            // recording. Debug level so it's there when someone asks "why did
-            // my summary never appear?" without adding noise to normal runs.
-            llmRunnerLog.debug("""
-                llm http cancelled feature=\(feature.rawValue, privacy: .public) \
-                host=\(host, privacy: .public) \
-                duration=\(durationTag(Date().timeIntervalSince(started)), privacy: .public)s
-                """)
+            logHTTPCancelled(feature: feature, host: host,
+                             duration: Date().timeIntervalSince(started))
             throw LLMRunnerError.cancelled
         } catch let urlError as URLError {
             switch urlError.code {
             case .cancelled:
+                // Same event as `CancellationError` above, just delivered by
+                // URLSession instead of the task. It went unlogged, so a
+                // cancel was recorded on the process path but silently
+                // dropped here.
+                logHTTPCancelled(feature: feature, host: host,
+                                 duration: Date().timeIntervalSince(started))
                 throw LLMRunnerError.cancelled
             case .timedOut:
                 logHTTPFailure(feature: feature, host: host,
@@ -519,7 +535,8 @@ enum LLMRunner {
         let command = ([executable.path] + args).map(shellQuote).joined(separator: " ")
         let loggedCommand = redactedCommand(executable: executable,
                                             arguments: args,
-                                            prompt: fullPrompt)
+                                            prompt: fullPrompt,
+                                            extraArgsCount: extraArgs.count)
         let start = Date()
         logRunStart(feature: feature,
                     tool: tool,
@@ -788,28 +805,68 @@ enum LLMRunner {
         String(format: "%.2f", seconds)
     }
 
-    /// The argv we launched, shell-quoted for readability, with the composed
-    /// prompt replaced by `<prompt:Nc>`.
+    /// The argv we launched, shell-quoted for readability, with everything
+    /// that could carry a secret or meeting content replaced by a
+    /// `<kind:Nc>` placeholder.
     ///
-    /// This is the log-safe twin of `diagnose`'s `command`. The real command
-    /// line is *mostly* metadata a user needs (which binary, which flags,
-    /// which `--session-id`, which extra args they typed) plus exactly one
-    /// argument that is the meeting transcript. Redacting that one argument
-    /// keeps the diagnostically useful 95% loggable. The result is
-    /// deliberately NOT copy-pasteable — the placeholder is unquoted so it
-    /// can't be mistaken for a runnable command.
+    /// This is the log-safe twin of `diagnose`'s `command`. A command line is
+    /// *mostly* metadata a user needs — which binary, which flags, which
+    /// `--session-id` — so redacting the few positions that can hold a
+    /// payload keeps the shape diagnosable without publishing the payload.
+    /// Two things get redacted:
+    ///
+    /// 1. **The composed prompt**, which is the meeting transcript.
+    /// 2. **The values of the user's own "Extra args"** (the trailing
+    ///    `extraArgsCount` tokens). These are free text from Settings → AI
+    ///    Provider and people do put credentials in them — `--api-key sk-…`,
+    ///    a bearer token, an `--append-system-prompt` blob. Mila cannot know
+    ///    which of a third-party CLI's flags take a secret, so the only safe
+    ///    default is that no extra-argument *value* is ever logged.
+    ///
+    /// Flag *names* survive, including the `--flag=value` form (name kept,
+    /// value redacted), because "which flags did it run with" is the
+    /// diagnostic question and a flag name is not a secret. Mila's own
+    /// generated arguments (`--model`, `--session-id`, `--resume`, `-f`,
+    /// `--skip-trust`) stay visible: those values are ones Mila chose, not
+    /// user input, and a wrong model name is a common cause of a non-zero
+    /// exit.
+    ///
+    /// The result is deliberately NOT copy-pasteable — placeholders are
+    /// unquoted so it can't be mistaken for a runnable command.
     static func redactedCommand(executable: URL,
                                 arguments: [String],
-                                prompt: String) -> String {
-        let redacted = arguments.map { arg -> String in
+                                prompt: String,
+                                extraArgsCount: Int = 0) -> String {
+        // argv is always `tool.arguments(...) + extraArgs`, so the
+        // user-supplied tokens are exactly the trailing slice. Position beats
+        // value-matching here: an extra arg that happened to equal one of
+        // Mila's own values would otherwise be treated as trusted.
+        let firstExtraArg = arguments.count - max(0, extraArgsCount)
+        let redacted = arguments.enumerated().map { index, arg -> String in
             // Empty-prompt guard: without it an empty `prompt` would match
             // every empty argument in argv and redact unrelated tokens.
             if !prompt.isEmpty && arg == prompt {
                 return "<prompt:\(prompt.count)c>"
             }
-            return shellQuote(arg)
+            guard index >= firstExtraArg else { return shellQuote(arg) }
+            return redactedExtraArg(arg)
         }
         return ([shellQuote(executable.path)] + redacted).joined(separator: " ")
+    }
+
+    /// One token of the user's "Extra args", reduced to what is safe to log.
+    ///
+    ///     --verbose          -> --verbose            (a flag name, not a secret)
+    ///     --api-key=sk-abc   -> --api-key=<value:6c> (glued form still splits)
+    ///     sk-abc             -> <value:6c>           (bare value — could be anything)
+    static func redactedExtraArg(_ arg: String) -> String {
+        guard arg.hasPrefix("-") else { return "<value:\(arg.count)c>" }
+        // `--flag=value`: keep the name, redact the payload. Split on the
+        // FIRST `=` only — a value may legitimately contain more of them.
+        guard let eq = arg.firstIndex(of: "=") else { return shellQuote(arg) }
+        let name = String(arg[arg.startIndex..<eq])
+        let value = String(arg[arg.index(after: eq)...])
+        return "\(shellQuote(name))=<value:\(value.count)c>"
     }
 
     /// One-line, bounded excerpt of a CLI's stderr for a failure log line.
@@ -818,12 +875,28 @@ enum LLMRunner {
     /// progress/warning chatter. Newlines are folded to ` | ` because a
     /// multi-line unified-log entry is painful to read and impossible to grep.
     ///
-    /// Logged `.public` — a defensible line to draw, because the *same* stderr
-    /// already reaches the log in full today: `LLMRunnerError.nonZeroExit`
-    /// embeds it verbatim in `errorDescription`, and
-    /// `PostRecordingCoordinator` logs that as `.public`. A bounded excerpt is
-    /// therefore strictly less exposure than the status quo, and it is CLI
-    /// diagnostic output rather than user content.
+    /// Logged **`privacy: .private`**, unlike every other field here.
+    ///
+    /// A CLI run verbosely can echo the prompt — i.e. the transcript — back
+    /// on stderr, and the non-zero-exit path falls back to stdout, which is
+    /// the model's answer *about* the meeting. Neither is CLI chatter; both
+    /// are the content this file reduces to character counts everywhere else.
+    /// Mila's whole premise is that recordings stay on the machine, and the
+    /// unified log is a plaintext store other processes can read, so a
+    /// structured always-on excerpt of that content is not something to
+    /// enable by default.
+    ///
+    /// The precedent that `LLMRunnerError.nonZeroExit` already embeds stderr
+    /// verbatim in `errorDescription` — which `PostRecordingCoordinator` logs
+    /// `.public` — argues that the *existing* line is too loose, not that a
+    /// new and broader one is fine. (Worth tightening separately.)
+    ///
+    /// What stays `.public` is the part that answers the question at a
+    /// glance: exit code, stderr/stdout byte counts, duration, and the
+    /// redacted command. "exit 1, 4 KB of stderr" is the triage signal; the
+    /// bytes themselves are available to the user who asks for them, via
+    /// Settings → AI Provider's test panel (which shows full stderr in the
+    /// UI, at the user's request) or by enabling private-data logging.
     static func stderrTail(_ stderr: String, limit: Int = stderrLogLimit) -> String {
         let flattened = stderr
             .components(separatedBy: .newlines)
@@ -883,6 +956,12 @@ enum LLMRunner {
     ///  - cancelled → `debug` (deliberate; the user discarded or re-ran)
     ///  - timeout / non-zero exit → `error`, with the redacted argv and the
     ///    stderr tail, so a failed summary is diagnosable from the log alone.
+    ///
+    /// Every field is `.public` except `stderr-tail`, which is `.private`
+    /// because it can echo transcript or answer text — see `stderrTail`. The
+    /// triage signal (exit code, byte counts, duration, redacted argv) is
+    /// public, so a failure is still legible without private-data logging;
+    /// only the payload is held back.
     static func logRunEnd(feature: LLMFeature,
                           tool: LLMTool,
                           outcome: ProcessOutcome,
@@ -901,13 +980,13 @@ enum LLMRunner {
                 llm run timed out \(common, privacy: .public) \
                 limit=\(Int(timeout.rounded(.up)), privacy: .public)s \
                 cmd=\(command, privacy: .public) \
-                stderr-tail=\(stderrTail(outcome.stderr), privacy: .public)
+                stderr-tail=\(stderrTail(outcome.stderr), privacy: .private)
                 """)
         } else if outcome.exitCode != 0 {
             llmRunnerLog.error("""
                 llm run failed \(common, privacy: .public) \
                 cmd=\(command, privacy: .public) \
-                stderr-tail=\(stderrTail(outcome.stderr.isEmpty ? outcome.stdout : outcome.stderr), privacy: .public)
+                stderr-tail=\(stderrTail(outcome.stderr.isEmpty ? outcome.stdout : outcome.stderr), privacy: .private)
                 """)
         } else {
             llmRunnerLog.notice("llm run end \(common, privacy: .public)")
@@ -941,6 +1020,20 @@ enum LLMRunner {
             tool=\(tool.rawValue, privacy: .public) \
             duration=\(durationTag(duration), privacy: .public)s \
             cmd=\(command, privacy: .public): \(message, privacy: .public)
+            """)
+    }
+
+    /// A cancelled HTTP call. Not a failure — the user closed the sheet or
+    /// discarded the recording — so `debug`, matching how the process path
+    /// records `outcome.cancelled`. Both delivery shapes (`CancellationError`
+    /// and `URLError.cancelled`) route here so neither can go unrecorded.
+    static func logHTTPCancelled(feature: LLMFeature,
+                                 host: String,
+                                 duration: TimeInterval) {
+        llmRunnerLog.debug("""
+            llm http cancelled feature=\(feature.rawValue, privacy: .public) \
+            host=\(host, privacy: .public) \
+            duration=\(durationTag(duration), privacy: .public)s
             """)
     }
 

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -90,7 +90,8 @@ final class LiveAISession: ObservableObject {
             openAIAPIKey: call.openAIAPIKey,
             jsonMode: call.jsonMode,
             temperature: call.temperature,
-            transport: call.transport
+            transport: call.transport,
+            feature: .liveAI
         )
     }
 

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -48,7 +48,11 @@ final class PostRecordingCoordinator: ObservableObject {
         _ openAIBaseURL: String?,
         _ openAIAPIKey: String?,
         _ jsonMode: Bool,
-        _ transport: OpenAITransport?
+        _ transport: OpenAITransport?,
+        // Which surface this call is for — the auto-title path and the Send
+        // path share this one seam, so the label has to come from the call
+        // site or the log can't tell them apart (issue #175).
+        _ feature: LLMFeature
     ) async throws -> String
     private let runLLM: RunLLM
 
@@ -83,7 +87,7 @@ final class PostRecordingCoordinator: ObservableObject {
     init(store: RecordingStore,
          transcription: TranscriptionService,
          llm: LLMSettings,
-         runLLM: @escaping RunLLM = { tool, prompt, transcript, summary, executablePathOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport in
+         runLLM: @escaping RunLLM = { tool, prompt, transcript, summary, executablePathOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport, feature in
         try await LLMRunner.run(
             tool: tool,
             prompt: prompt,
@@ -96,7 +100,8 @@ final class PostRecordingCoordinator: ObservableObject {
             openAIBaseURL: openAIBaseURL,
             openAIAPIKey: openAIAPIKey,
             jsonMode: jsonMode,
-            transport: transport)
+            transport: transport,
+            feature: feature)
     }) {
         self.store = store
         self.transcription = transcription
@@ -188,7 +193,8 @@ final class PostRecordingCoordinator: ObservableObject {
                     openAIBaseURL,
                     openAIAPIKey,
                     false,
-                    nil)
+                    nil,
+                    .name)
                 if Task.isCancelled { return }
                 let title = Self.cleanedTitle(from: suggestion)
                 guard !title.isEmpty else { return }
@@ -352,7 +358,8 @@ final class PostRecordingCoordinator: ObservableObject {
                     openAIBaseURL,
                     openAIAPIKey,
                     false,
-                    nil)
+                    nil,
+                    .action)
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")
                     .prefix(80)

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -135,7 +135,10 @@ final class RecordingSummarizer: ObservableObject {
                  openAIBaseURL: openAIBaseURL,
                  openAIAPIKey: openAIAPIKey,
                  jsonMode: jsonMode,
-                 transport: transport
+                 transport: transport,
+                 // The summarizer has exactly one purpose, so the label is
+                 // fixed here rather than threaded through the `RunLLM` seam.
+                 feature: .summary
              )
          }) {
         self.store = store

--- a/Mila/Views/RenameRecordingSheet.swift
+++ b/Mila/Views/RenameRecordingSheet.swift
@@ -500,7 +500,8 @@ struct RenameRecordingSheet: View {
                 timeout: llm.cliTimeout,
                 openAIBaseURL: llm.openAIBaseURL,
                 openAIAPIKey: llm.openAIAPIKey,
-                jsonMode: false
+                jsonMode: false,
+                feature: .name
             )
             let cleaned = PostRecordingCoordinator.cleanedTitle(from: suggestion)
             if cleaned.isEmpty {

--- a/MilaTests/LLMRunnerObservabilityTests.swift
+++ b/MilaTests/LLMRunnerObservabilityTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import Mila
+
+/// Issue #175 — "LLM CLI runs are unobservable".
+///
+/// `LLMRunner` now emits a start/end pair per invocation to the unified log.
+/// The unified log itself isn't assertable from a unit test, so what these
+/// tests pin is the part that matters and *is* pure: the helpers that build
+/// every string handed to a `Logger`.
+///
+/// That is deliberately where the safety property lives. A transcript must
+/// never reach the system log, and the way that is guaranteed is structural —
+/// the only strings interpolated into a log line come from these functions,
+/// and none of them can carry prompt or transcript text. So testing them is
+/// testing the privacy invariant, not just formatting.
+///
+/// Kept out of `LLMRunnerTests` on purpose: that class also holds smoke tests
+/// that invoke the real `claude` / `cursor-agent` / `gemini` binaries, so it
+/// can't be run casually. Nothing here spawns a process.
+final class LLMRunnerObservabilityTests: XCTestCase {
+
+    // MARK: - redactedCommand
+
+    /// The whole point: the flags survive so a user can see *what* was run,
+    /// and the one argument that is the meeting transcript does not.
+    func test_redacted_command_replaces_the_prompt_with_a_character_count() {
+        let prompt = "Summarize this.\n\n---\nTranscript:\nWe agreed to ship on Friday."
+        let args = LLMTool.claude.arguments(prompt: prompt, model: "haiku")
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/opt/homebrew/bin/claude"),
+            arguments: args,
+            prompt: prompt)
+
+        XCTAssertEqual(command,
+                       "/opt/homebrew/bin/claude -p <prompt:\(prompt.count)c> --model haiku")
+    }
+
+    /// The privacy invariant stated directly, so a future refactor that stops
+    /// redacting fails here rather than in a user's log.
+    func test_redacted_command_never_contains_transcript_text() {
+        let secret = "Acme is acquiring Globex for $4.2M"
+        let prompt = LLMRunner.composedPrompt("Name this call.", transcript: secret)
+        let session = UUID()
+        let args = LLMTool.claude.arguments(prompt: prompt,
+                                            model: nil,
+                                            session: .resume(session))
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/usr/local/bin/claude"),
+            arguments: args,
+            prompt: prompt)
+
+        XCTAssertFalse(command.contains(secret),
+                       "transcript text leaked into the logged command: \(command)")
+        XCTAssertFalse(command.contains("Name this call."),
+                       "user prompt leaked into the logged command: \(command)")
+        // …while the diagnostically useful parts are all still there.
+        XCTAssertTrue(command.contains("--resume \(session.uuidString)"))
+        XCTAssertTrue(command.contains("/usr/local/bin/claude"))
+    }
+
+    /// An empty prompt must not turn into a wildcard that redacts every empty
+    /// argument in argv.
+    func test_redacted_command_leaves_empty_arguments_alone_when_prompt_is_empty() {
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/bin/echo"),
+            arguments: ["-p", "", "--flag"],
+            prompt: "")
+
+        XCTAssertEqual(command, "/bin/echo -p '' --flag")
+        XCTAssertFalse(command.contains("<prompt:"))
+    }
+
+    /// Paths and args with spaces stay unambiguous — the line is read by a
+    /// human trying to work out which binary ran.
+    func test_redacted_command_quotes_paths_containing_spaces() {
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/Users/x/My Tools/claude"),
+            arguments: ["--model", "claude sonnet"],
+            prompt: "unused")
+
+        XCTAssertEqual(command, "'/Users/x/My Tools/claude' --model 'claude sonnet'")
+    }
+
+    /// Extra args the user typed in Settings are metadata, not content, so
+    /// they are kept verbatim — a wrong flag is a thing people need to see.
+    func test_redacted_command_keeps_user_extra_args() {
+        let prompt = "p"
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/bin/claude"),
+            arguments: LLMTool.claude.arguments(prompt: prompt) + ["--debug", "--permission-mode", "plan"],
+            prompt: prompt)
+
+        XCTAssertEqual(command, "/bin/claude -p <prompt:1c> --debug --permission-mode plan")
+    }
+
+    // MARK: - stderrTail
+
+    /// Multi-line stderr is folded to one greppable line, and blank lines /
+    /// indentation are dropped rather than padding the excerpt out.
+    func test_stderr_tail_flattens_newlines_and_drops_blank_lines() {
+        let stderr = "warning: deprecated flag\n\n   Error: auth token expired\n"
+        XCTAssertEqual(LLMRunner.stderrTail(stderr),
+                       "warning: deprecated flag | Error: auth token expired")
+    }
+
+    /// Truncation keeps the END. CLIs print the fatal error last, after the
+    /// progress chatter, so a head-biased excerpt would reliably capture the
+    /// least useful part.
+    func test_stderr_tail_keeps_the_tail_when_over_the_limit() {
+        let stderr = String(repeating: "n", count: 40) + "FATAL"
+        let tail = LLMRunner.stderrTail(stderr, limit: 10)
+
+        XCTAssertEqual(tail, "…nnnnnFATAL")
+        XCTAssertEqual(tail.count, 11, "ellipsis plus exactly `limit` characters")
+    }
+
+    /// A log line reading `stderr-tail=` with nothing after it is the correct
+    /// rendering of "the CLI said nothing" — better than a run of spaces.
+    func test_stderr_tail_of_whitespace_only_stderr_is_empty() {
+        XCTAssertEqual(LLMRunner.stderrTail("\n \n\t\n"), "")
+        XCTAssertEqual(LLMRunner.stderrTail(""), "")
+    }
+
+    /// Under the limit, the text is returned whole — no ellipsis noise.
+    func test_stderr_tail_under_the_limit_is_untruncated() {
+        XCTAssertEqual(LLMRunner.stderrTail("boom", limit: 512), "boom")
+    }
+
+    // MARK: - field tags
+
+    /// "The CLI chose" and "we pinned a model" are different diagnoses, so
+    /// they must not both render as an empty `model=`.
+    func test_model_tag_distinguishes_default_from_pinned() {
+        XCTAssertEqual(LLMRunner.modelTag(nil), "(default)")
+        XCTAssertEqual(LLMRunner.modelTag(""), "(default)")
+        XCTAssertEqual(LLMRunner.modelTag("   "), "(default)")
+        XCTAssertEqual(LLMRunner.modelTag("  haiku  "), "haiku")
+    }
+
+    /// The session tag has to make a `--resume` chain correlatable across
+    /// lines (and with the jsonl filename claude writes) without printing a
+    /// full UUID in every line.
+    func test_session_tag_renders_each_mode() {
+        let id = UUID(uuidString: "DEADBEEF-1234-5678-9ABC-DEF012345678")!
+        XCTAssertEqual(LLMRunner.sessionTag(.none), "none")
+        XCTAssertEqual(LLMRunner.sessionTag(.new(id)), "new:DEADBEEF")
+        XCTAssertEqual(LLMRunner.sessionTag(.resume(id)), "resume:DEADBEEF")
+    }
+
+    func test_duration_tag_is_fixed_precision() {
+        XCTAssertEqual(LLMRunner.durationTag(0), "0.00")
+        XCTAssertEqual(LLMRunner.durationTag(0.0009), "0.00")
+        XCTAssertEqual(LLMRunner.durationTag(4.20666), "4.21")
+        XCTAssertEqual(LLMRunner.durationTag(301), "301.00")
+    }
+
+    // MARK: - feature labels
+
+    /// These `rawValue`s are the grep tokens in the log — a saved predicate
+    /// like `eventMessage CONTAINS "feature=live-ai"` breaks silently if one
+    /// is renamed, so they are pinned here on purpose.
+    func test_feature_log_tokens_are_stable() {
+        XCTAssertEqual(LLMFeature.name.rawValue, "name")
+        XCTAssertEqual(LLMFeature.summary.rawValue, "summary")
+        XCTAssertEqual(LLMFeature.action.rawValue, "action")
+        XCTAssertEqual(LLMFeature.liveAI.rawValue, "live-ai")
+        XCTAssertEqual(LLMFeature.settingsTest.rawValue, "settings-test")
+        XCTAssertEqual(LLMFeature.unspecified.rawValue, "unspecified")
+    }
+
+    /// Tokens must be single words: a space would split a `key=value` pair in
+    /// the log line and break naive parsing of it.
+    func test_feature_log_tokens_have_no_whitespace() {
+        for feature in [LLMFeature.name, .summary, .action, .liveAI,
+                        .settingsTest, .unspecified] {
+            XCTAssertFalse(feature.rawValue.contains(where: { $0.isWhitespace }),
+                           "\(feature) has whitespace in its log token")
+            XCTAssertFalse(feature.rawValue.isEmpty)
+        }
+    }
+}

--- a/MilaTests/LLMRunnerObservabilityTests.swift
+++ b/MilaTests/LLMRunnerObservabilityTests.swift
@@ -81,16 +81,87 @@ final class LLMRunnerObservabilityTests: XCTestCase {
         XCTAssertEqual(command, "'/Users/x/My Tools/claude' --model 'claude sonnet'")
     }
 
-    /// Extra args the user typed in Settings are metadata, not content, so
-    /// they are kept verbatim — a wrong flag is a thing people need to see.
-    func test_redacted_command_keeps_user_extra_args() {
+    /// Extra args are free text from Settings and people put credentials in
+    /// them. Flag *names* survive (a wrong flag is a thing people need to
+    /// see); every value is reduced to a length.
+    func test_redacted_command_redacts_extra_argument_values() {
+        let prompt = "p"
+        let extraArgs = ["--debug", "--api-key", "sk-ant-secret", "--permission-mode", "plan"]
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/bin/claude"),
+            arguments: LLMTool.claude.arguments(prompt: prompt) + extraArgs,
+            prompt: prompt,
+            extraArgsCount: extraArgs.count)
+
+        XCTAssertEqual(command,
+                       "/bin/claude -p <prompt:1c> --debug --api-key <value:13c> "
+                       + "--permission-mode <value:4c>")
+        XCTAssertFalse(command.contains("sk-ant-secret"),
+                       "a credential in extra args leaked into the log: \(command)")
+    }
+
+    /// The glued `--flag=value` form must split, or the `hasPrefix("-")`
+    /// check would wave the whole token through with its payload attached.
+    func test_redacted_command_splits_glued_flag_values() {
+        let extraArgs = ["--api-key=sk-abc", "--url=https://x.example/v1?token=t"]
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/bin/gemini"),
+            arguments: extraArgs,
+            prompt: "unused",
+            extraArgsCount: extraArgs.count)
+
+        XCTAssertEqual(command,
+                       "/bin/gemini --api-key=<value:6c> --url=<value:28c>")
+        XCTAssertFalse(command.contains("sk-abc"))
+        XCTAssertFalse(command.contains("token=t"))
+    }
+
+    /// Only the trailing `extraArgsCount` tokens are user input. Mila's own
+    /// generated arguments are values Mila chose, and they stay readable —
+    /// a wrong `--model` is a common cause of a non-zero exit.
+    func test_redacted_command_keeps_mila_generated_arguments_visible() {
+        let prompt = "p"
+        let session = UUID()
+        let extraArgs = ["secret-positional"]
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/bin/claude"),
+            arguments: LLMTool.claude.arguments(prompt: prompt,
+                                                model: "haiku",
+                                                session: .new(session)) + extraArgs,
+            prompt: prompt,
+            extraArgsCount: extraArgs.count)
+
+        XCTAssertEqual(command,
+                       "/bin/claude -p <prompt:1c> --model haiku "
+                       + "--session-id \(session.uuidString) <value:17c>")
+    }
+
+    /// Default `extraArgsCount` of 0 must not redact the tail of a
+    /// tool-generated argv — callers that pass no extra args get the full,
+    /// readable command.
+    func test_redacted_command_with_no_extra_args_redacts_nothing_but_the_prompt() {
         let prompt = "p"
         let command = LLMRunner.redactedCommand(
             executable: URL(fileURLWithPath: "/bin/claude"),
-            arguments: LLMTool.claude.arguments(prompt: prompt) + ["--debug", "--permission-mode", "plan"],
+            arguments: LLMTool.claude.arguments(prompt: prompt, model: "sonnet"),
             prompt: prompt)
 
-        XCTAssertEqual(command, "/bin/claude -p <prompt:1c> --debug --permission-mode plan")
+        XCTAssertEqual(command, "/bin/claude -p <prompt:1c> --model sonnet")
+    }
+
+    // MARK: - redactedExtraArg
+
+    func test_redacted_extra_arg_keeps_bare_flags_and_redacts_values() {
+        XCTAssertEqual(LLMRunner.redactedExtraArg("--verbose"), "--verbose")
+        XCTAssertEqual(LLMRunner.redactedExtraArg("-v"), "-v")
+        XCTAssertEqual(LLMRunner.redactedExtraArg("sk-abc"), "<value:6c>")
+        XCTAssertEqual(LLMRunner.redactedExtraArg(""), "<value:0c>")
+    }
+
+    /// A value containing `=` must not be split more than once, or part of
+    /// the payload would survive as a "flag name".
+    func test_redacted_extra_arg_splits_on_the_first_equals_only() {
+        XCTAssertEqual(LLMRunner.redactedExtraArg("--data=a=b=c"), "--data=<value:5c>")
     }
 
     // MARK: - stderrTail

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -272,7 +272,7 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         var callCount = 0
         let openAICoordinator = PostRecordingCoordinator(
             store: store, transcription: service, llm: llm,
-            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _ in
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _ in
                 capturedModel = model
                 callCount += 1
                 return "OPENAI ANSWER"
@@ -304,7 +304,7 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         var callCount = 0
         let cliCoordinator = PostRecordingCoordinator(
             store: store, transcription: service, llm: llm,
-            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _ in
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _ in
                 capturedModel = model
                 callCount += 1
                 return "CLI ANSWER"


### PR DESCRIPTION
Closes #175

## What & why

`LLMRunner` was the one link in the LLM chain that logged nothing. It `import os` but declared no `Logger`, and its only output was four `print()` calls — which never reach the unified log for a GUI-launched `.app`, so in practice they were invisible. The rich diagnostic that already existed (`diagnose()`: argv, exit code, stdout, stderr) was wired only to the Settings → AI Provider test panel, so a real failure during a recording — stale executable path, non-zero exit, timeout — surfaced as one localized sentence with the exit code and stderr thrown away.

Now every invocation leaves an artifact behind.

**Start line** (`notice`) — feature, tool, resolved executable path, model, session mode, `extraArgs` count, and prompt/summary/transcript/composed character counts:

```
llm run start feature=name tool=claude exe=/opt/homebrew/bin/claude model=(default)
  session=none extraArgs=0 prompt=142c summary=0c transcript=8210c composed=8375c timeout=300s
```

**End line** — exit code, wall-clock duration, stdout/stderr byte counts. `notice` on success; `error` on timeout or non-zero exit, and then it also carries the redacted argv and a bounded stderr tail:

```
llm run end feature=summary tool=claude exit=0 duration=6.41s stdout=1284B stderr=0B

llm run failed feature=action tool=claude exit=1 duration=0.94s stdout=0B stderr=118B
  cmd=/opt/homebrew/bin/claude -p <prompt:8375c> --model haiku --api-key <value:41c>
  stderr-tail=<private>
```

That failure line is issue #175's item 3 — "route real runs through the same capture `diagnose()` uses". `run()`'s throwing contract is unchanged, but the full outcome is logged *before* the throw collapses it into `errorDescription`, so the exit code and stderr no longer vanish with it.

Also in scope, because each was a hole of the same kind:

- **Setup and launch failures now log.** `.toolDisabled`, `.executableNotFound`, and `Process.run()` refusing all bypass `executeProcess`, so the single most common real-world failure — a stale or missing executable path — previously produced no line at all.
- **All four `print()` calls converted**, at levels picked by meaning rather than uniformly. The post-normal-exit pipe-drain timeout is `error` because that output *is* returned to the caller and may be truncated mid-stream (a silently short summary); the post-kill one is `notice` because the output is already being discarded. A child surviving SIGKILL is `error`.
- **The OpenAI-compatible HTTP path** gets the same start/end/cancel/failure events — it was equally invisible, and "wrong endpoint" vs "endpoint rejected us" is exactly the distinction people need.
- **#187's `sandboxDirectory()` fallback** now logs a `notice` naming where it landed when it engages, not just the `error` that caused it. The fallback costs Claude Code project-slug stability, so "why did my resumable conversations scatter?" should be answerable.
- **`LLMFeature`** so a line says *why* a CLI ran: `name` / `summary` / `action` / `live-ai` / `settings-test`. Threaded through `PostRecordingCoordinator.RunLLM` because the auto-title and Send paths share that one seam and would otherwise be indistinguishable; fixed at the call site everywhere else. The parameter is last in `run()`'s signature and defaulted, so no existing call site had to change.

### Level choices

The rule was: *a user diagnosing a failed summary should not need `--info --debug`.* Most of Mila's output sits at debug level, so anything below `notice` is effectively invisible to someone running a plain `/usr/bin/log show`. So start, success, and every failure are `notice`/`error`. Deliberately `debug`: the redacted argv on a *healthy* run (it repeats what the start line already says, and would double log volume for nothing — the failure lines carry it at their own level, so it is never missing when it matters), and cancellations (the user discarded or re-ran; not a fault, but worth having when someone asks "why did my summary never appear?").

### Privacy choices

**No prompt, transcript, or credential text reaches the log by default.** Bodies appear as `.count` and nothing else — mirroring how `RecordingSummarizer` already logs `transcript=\(transcript.count)c`. The guarantee is structural rather than a matter of annotation discipline: the only strings interpolated into a `Logger` call are ones built by the pure helpers in the new `// MARK: - Observability` block, and none of them can carry body text. That is what the tests pin.

The logged command line is a **redacted twin** of the panel's copy-pasteable one. Two positions get replaced by a `<kind:Nc>` placeholder:

1. **The composed prompt** — it is the meeting transcript.
2. **The values of the user's "Extra args"** — free text from Settings, and people put credentials in them (`--api-key sk-…`, a bearer token, an `--append-system-prompt` blob). Mila can't know which of a third-party CLI's flags take a secret, so no extra-argument *value* is logged. Flag *names* survive, including the glued `--flag=value` form (name kept, value redacted, split on the first `=` only). Mila's *own* generated arguments — `--model`, `--session-id`, `--resume`, `-f`, `--skip-trust` — stay visible, because those values are ones Mila chose rather than user input, and a wrong model name is a common cause of a non-zero exit. The user slice is identified by position (argv is always `tool.arguments(…) + extraArgs`), not by value-matching, so an extra arg that happens to equal one of Mila's own values can't be mistaken for trusted.

Placeholders are left unquoted, so the result can't be mistaken for something runnable.

Fields are `privacy: .public` **except `stderr-tail`, which is `.private`.** Public is the deliberate default for metadata because `.private` renders as `<private>` for the very person reading their own log, who is the entire audience. But stderr is not metadata: a CLI run verbosely can echo the prompt (the transcript), and the non-zero-exit path falls back to stdout, which is the model's answer *about* the meeting. For an app whose premise is that recordings stay on the machine, a structured always-on excerpt of that content is not something to enable by default. What stays public is the triage signal — exit code, stderr/stdout byte counts, duration, redacted argv — so "exit 1, 4 KB of stderr" is legible without private-data logging; only the payload is held back. Full stderr remains available in the Settings test panel, which is content the user explicitly asked to see.

Two more worth naming:

- **`exe=` (the resolved executable path)** is public. "Mila is running a different binary than my shell is" is a failure this exists to catch, and the path is useless redacted. It can contain the account's short name — the same exposure the pre-existing sandbox-path line already accepts.
- **The OpenAI path logs `host=`, never the full URL** — a user's endpoint can carry a token in its query string. Its error messages stay public: they are server-generated diagnostics parallel to an HTTP status (`Authentication failed (401)`), taken from the endpoint's error body, not from a completion.

## How it was tested

`make build` — **BUILD SUCCEEDED**. Also `xcodebuild … build-for-testing` — **TEST BUILD SUCCEEDED** — to confirm the `MilaTests` target (the new file plus the two updated `runLLM` stubs) compiles. That is a *build*, not a test run: nothing was executed and no app was launched. Both were re-run after the review fixes.

### Tests written but NOT executed locally

`MilaTests/LLMRunnerObservabilityTests.swift` (20 tests) is committed and compiles, but **I did not run it**, and I have no local pass/fail evidence for it. CI's `unit-and-ui-tests` job is the first thing to actually execute it.

Why not: every `MilaTests` run is app-hosted — it launches a freshly ad-hoc-signed `Mila.app`, and several files in the target read the real login keychain, which pops a macOS password dialog at the machine's owner. `LLMRunnerTests` in the same target also holds smoke tests that invoke the real `claude` / `cursor-agent` / `gemini` binaries and can wedge. Running them on the developer's active machine was explicitly off-limits for this change.

The new tests are all pure and process-free — nothing spawns a subprocess or touches the filesystem, which is also why they live in their own class rather than in `LLMRunnerTests`:

- `redactedCommand`: replaces the prompt with `<prompt:Nc>`; **never contains transcript or prompt text** (the privacy invariant, asserted directly, so a refactor that stops redacting fails here rather than in someone's log); redacts a credential-shaped extra-argument value; splits the glued `--flag=value` form; keeps Mila's own generated arguments readable; redacts nothing but the prompt when `extraArgsCount` is 0; doesn't wildcard-match empty argv entries when the prompt is empty; quotes paths/args containing spaces.
- `redactedExtraArg`: bare flags survive, bare values don't, and a value containing `=` splits on the first one only.
- `stderrTail`: folds newlines and drops blank lines; keeps the **tail** on truncation (`…` + exactly `limit` chars); empty for whitespace-only stderr; untouched under the limit.
- `modelTag` / `sessionTag` / `durationTag`: `(default)` vs a pinned model, all three session modes, fixed 2-decimal seconds.
- `LLMFeature` raw values pinned as stable grep tokens, and asserted whitespace-free so a token can't split a `key=value` pair.

One thing the tests **cannot** cover: OSLog exposes no way to assert a field's privacy level from a unit test, so `stderr-tail=` being `.private` is enforced by code review, not by a test.

## Deliberately not included

**Issue #175 item 4, the "Recent LLM runs" list.** The issue marks it optional, and it is the only part that needs new state and a new UI surface — a ring buffer with nothing rendering it would be dead code. Worth its own issue if wanted.

**Tightening `LLMRunnerError.nonZeroExit`.** Its `errorDescription` embeds stderr verbatim, and `PostRecordingCoordinator` logs that `.public` — so full stderr already reaches the log on the failure path today, independently of this PR. Narrowing that is a behaviour change to a user-visible error string and belongs in its own change.

Also untouched on purpose, to avoid colliding with work in flight in this same file: the transcript-passing mechanism (#179) and executable discovery (#158).

## Checklist

- [x] Builds locally (`make build`); tests written and committed but **not** run locally — see above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — n/a, no user-visible behaviour change (logging only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added unified, privacy-safe logging for Live AI, summaries, title suggestions, and actions.
  * Logs now capture execution outcomes, durations, model and session details, and diagnostic information without exposing prompts, transcripts, credentials, or user-entered command values.
  * Improved diagnostics for process execution, HTTP requests, timeouts, and sandbox fallback behavior.
* **Bug Fixes**
  * Preserved existing cancellation, timeout, error-handling, and diagnostic result behavior while improving execution monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->