### PR TITLE
feat(settings): replace the tab strip with a sidebar so sections scale past nine

### DIFF
--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2,85 +2,183 @@ import SwiftUI
 import AppKit
 import Carbon.HIToolbox
 
-enum SettingsTab: Int, Hashable {
+/// One destination in Settings.
+///
+/// Still called `SettingsTab` even though Settings is no longer a `TabView`
+/// (#177 replaced the strip with a sidebar). The name is deliberately kept:
+/// it is the key of the deep-link contract (`SettingsNavigation.pendingTab`),
+/// its raw values are pinned by `AISettingsKeyCompatibilityTests`, and the
+/// per-destination views are all still named `…SettingsTab`. Renaming the
+/// type would churn all three for no behavioural gain.
+///
+/// `allCases` order IS the sidebar order, top to bottom. Adding a case adds a
+/// row; it costs vertical space in a scrollable list, so — unlike the old tab
+/// strip — there is no width budget to re-measure. See `SettingsView.body`.
+enum SettingsTab: Int, Hashable, CaseIterable, Identifiable {
     /// `aiProvider` + `aiFeatures` replace the former separate `llm` and
     /// `liveAI` tabs. The split is by *how often you touch it*: the provider
     /// is technical and set once (often via a `.milaconfig` import), while the
     /// feature switches are what people come back for. Keeping them on one
     /// screen forced every feature below the fold behind a disclosure arrow.
-    ///
-    /// Net tab count is unchanged from before the AI work (two AI tabs
-    /// replacing two AI tabs), which matters: the strip has to stay inside
-    /// the run measured in `SettingsView.body` below.
     case general, audio, models, aiProvider, aiFeatures, speakers, meetings, voiceMemos, storage
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .audio: return "Audio"
+        case .models: return "Models"
+        case .aiProvider: return "AI Provider"
+        case .aiFeatures: return "AI Features"
+        case .speakers: return "Speakers"
+        case .meetings: return "Meetings"
+        case .voiceMemos: return "Voice Memos"
+        case .storage: return "Storage"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape"
+        case .audio: return "mic"
+        case .models: return "cube.box"
+        case .aiProvider: return "sparkles"
+        case .aiFeatures: return "wand.and.stars"
+        case .speakers: return "person.2"
+        case .meetings: return "video.fill"
+        case .voiceMemos: return "waveform"
+        case .storage: return "externaldrive"
+        }
+    }
+
+    /// Stable per-row accessibility identifier, so GUI tests can select a
+    /// destination without matching on the (localisable) visible label.
+    var accessibilityID: String {
+        switch self {
+        case .general: return "settings.section.general"
+        case .audio: return "settings.section.audio"
+        case .models: return "settings.section.models"
+        case .aiProvider: return "settings.section.aiProvider"
+        case .aiFeatures: return "settings.section.aiFeatures"
+        case .speakers: return "settings.section.speakers"
+        case .meetings: return "settings.section.meetings"
+        case .voiceMemos: return "settings.section.voiceMemos"
+        case .storage: return "settings.section.storage"
+        }
+    }
 }
 
 @Observable
 final class SettingsNavigation {
     @MainActor static let shared = SettingsNavigation()
+
+    /// Set this to jump Settings to a destination. Consumed (reset to nil) by
+    /// `SettingsView` as soon as it applies. Cross-references inside Settings
+    /// use it to become real navigation instead of prose — see
+    /// `AIFeaturesSettingsTab.notConfiguredBanner`.
     var pendingTab: SettingsTab?
 }
 
-/// Standard `Settings` scene. Opened via `Cmd+,` from the menu bar.
+/// Standard `Settings` scene. Opened via `Cmd+,` from the menu bar, and via
+/// `SettingsLink` in the sidebar footer.
+///
+/// ## Why a sidebar and not a tab strip (#177)
+///
+/// This used to be a `TabView`, and the window width was load-bearing because
+/// of it: AppKit's `NSTabView` collapses whatever does not fit into a `>>`
+/// overflow menu, which reads as a stray "expand button" and makes the
+/// collapsed tabs look disabled. That was reported as #131 and fixed in #137
+/// by pinning the window to 700×560 (740 pt of strip room) to hold the
+/// measured 599 pt run of nine tab items. #144 then concluded the obvious:
+/// nine fits, "with no room for a tenth". Every remaining move — widen again,
+/// or merge tabs — was spent, so new settings were being parked inside the
+/// Storage tab for want of a slot.
+///
+/// A sidebar list removes the ceiling instead of raising it. Destinations cost
+/// vertical space, which scrolls, rather than horizontal strip width, which
+/// does not. There is no `NSTabView`, so the `>>` chevron of #131 cannot come
+/// back at any count, and the window no longer needs a hardcoded size — it is
+/// resizable, which also settles the "dense tab can't be given more room"
+/// complaint in #177.
+///
+/// Settings stays its own `Settings` scene rather than becoming a page inside
+/// the main window: that keeps `Cmd+,`, `SettingsLink` and the App-menu item
+/// working for free (no hand-rolled `.appSettings` command, no "reopen the
+/// main window first" path when it is closed), keeps the macOS-native
+/// idiom, and — being a real window — can actually be put side by side with
+/// the main window, which an in-app page that takes over the content area
+/// cannot.
 struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .general
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            GeneralSettingsTab()
-                .tabItem { Label("General", systemImage: "gearshape") }
-                .tag(SettingsTab.general)
-            AudioSettingsTab()
-                .tabItem { Label("Audio", systemImage: "mic") }
-                .tag(SettingsTab.audio)
-            ModelsSettingsTab()
-                .tabItem { Label("Models", systemImage: "cube.box") }
-                .tag(SettingsTab.models)
-            AIProviderSettingsTab()
-                .tabItem { Label("AI Provider", systemImage: "sparkles") }
-                .tag(SettingsTab.aiProvider)
-            AIFeaturesSettingsTab()
-                .tabItem { Label("AI Features", systemImage: "wand.and.stars") }
-                .tag(SettingsTab.aiFeatures)
-            DiarizationSettingsTab()
-                .tabItem { Label("Speakers", systemImage: "person.2") }
-                .tag(SettingsTab.speakers)
-            MeetingsSettingsTab()
-                .tabItem { Label("Meetings", systemImage: "video.fill") }
-                .tag(SettingsTab.meetings)
-            VoiceMemosSettingsTab()
-                .tabItem { Label("Voice Memos", systemImage: "waveform") }
-                .tag(SettingsTab.voiceMemos)
-            StorageSettingsTab()
-                .tabItem { Label("Storage", systemImage: "externaldrive") }
-                .tag(SettingsTab.storage)
+        NavigationSplitView {
+            List(SettingsTab.allCases, selection: sidebarSelection) { tab in
+                Label(tab.title, systemImage: tab.systemImage)
+                    .accessibilityIdentifier(tab.accessibilityID)
+                    .tag(tab)
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 168, ideal: 184, max: 240)
+            // Every destination lives in this list, so collapsing it would
+            // hide all navigation — the sidebar-toggle button a
+            // NavigationSplitView adds by default is exactly the kind of
+            // stray chrome #131 complained about.
+            .toolbar(removing: .sidebarToggle)
+        } detail: {
+            detail
+                // The old `TabView` was wrapped in `.padding(20)`, so every
+                // destination's content was written assuming an outer inset.
+                // Keep it, here, so the per-destination layouts are untouched.
+                .padding(20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                // Puts the destination name in the window title, which is
+                // what the tab strip used to do.
+                .navigationTitle(selectedTab.title)
         }
-        // The width is load-bearing: it has to hold the whole tab strip.
-        // AppKit's NSTabView collapses whatever doesn't fit into a `>>`
-        // overflow menu, which reads as a stray "expand button" and makes
-        // the collapsed tabs look disabled (reported in #131, fixed here
-        // per #137).
+        .navigationSplitViewStyle(.balanced)
+        // No fixed size any more — the window is resizable, which is half the
+        // point of #177. The ideal is the old 740 pt content width plus the
+        // sidebar, so first launch looks like it always did.
         //
-        // Measured on macOS 26 at the default system font: the ten tab
-        // items occupy a 599 pt run (widest single item — "Voice Memos" —
-        // is 82 pt).
-        //
-        // The strip is NOT laid out inside this 700 pt frame. `.padding(20)`
-        // below sizes the Settings window to 740 pt, and AppKit draws the
-        // tab strip edge-to-edge across the whole window, so the run has the
-        // full 740 pt to sit in — measured item origins are 70 pt from the
-        // left window edge and 71 pt from the right. That is why 560 failed:
-        // it gave the strip 600 pt for a 599 pt run.
-        //
-        // If you add a tab, re-check Settings for the `>>` chevron rather
-        // than assuming it still fits.
-        .frame(width: 700, height: 560)
-        .padding(20)
+        // The floor is a judgement call, not a measurement: every destination
+        // lays out flexibly (`maxWidth:`), and the widest RIGID element in any
+        // of them is a 160 pt label, so ~500 pt of detail column is
+        // comfortable. It exists only to stop the two columns being dragged
+        // into nonsense.
+        .frame(minWidth: 700, idealWidth: 920,
+               minHeight: 440, idealHeight: 620)
         .onChange(of: SettingsNavigation.shared.pendingTab, initial: true) { _, newTab in
             if let tab = newTab {
                 selectedTab = tab
                 SettingsNavigation.shared.pendingTab = nil
             }
+        }
+    }
+
+    /// `List`'s selection binding is `Optional` — Escape or a click on empty
+    /// sidebar space clears it, which would blank the detail pane. Swallowing
+    /// the nil keeps a destination always selected.
+    private var sidebarSelection: Binding<SettingsTab?> {
+        Binding(
+            get: { selectedTab },
+            set: { if let new = $0 { selectedTab = new } }
+        )
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        switch selectedTab {
+        case .general: GeneralSettingsTab()
+        case .audio: AudioSettingsTab()
+        case .models: ModelsSettingsTab()
+        case .aiProvider: AIProviderSettingsTab()
+        case .aiFeatures: AIFeaturesSettingsTab()
+        case .speakers: DiarizationSettingsTab()
+        case .meetings: MeetingsSettingsTab()
+        case .voiceMemos: VoiceMemosSettingsTab()
+        case .storage: StorageSettingsTab()
         }
     }
 }
@@ -232,6 +330,10 @@ private struct AudioSettingsTab: View {
 /// didn't justify a tenth tab — and the tab strip had already overflowed into
 /// AppKit's ">>" overflow chevron at that width, which is what made the
 /// Updates tab look "disabled" (see PR discussion).
+///
+/// The strip is gone as of #177, so the width argument no longer applies;
+/// the "a toggle and a version string don't deserve their own destination"
+/// one still does, which is why this stays folded in.
 private struct GeneralSettingsTab: View {
     @EnvironmentObject private var hotkeys: HotkeySettings
 
@@ -1424,14 +1526,26 @@ private struct AIFeaturesSettingsTab: View {
 
     /// Shown once, at the top, instead of repeating "no provider" inside every
     /// feature that needs one.
+    ///
+    /// The pointer at the AI Provider destination is a button rather than
+    /// prose: with the sidebar (#177) a cross-reference inside Settings can
+    /// actually navigate, so it does.
     private var notConfiguredBanner: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-            Text("No AI provider yet — set one up in Settings → AI Provider.")
+            VStack(alignment: .leading, spacing: 2) {
+                Text("No AI provider yet.")
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Set one up in AI Provider") {
+                    SettingsNavigation.shared.pendingTab = .aiProvider
+                }
+                .buttonStyle(.link)
                 .font(.caption)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                .accessibilityIdentifier("ai.features.notConfigured.link")
+            }
+            .frame(maxWidth: aiCaptionWidth, alignment: .leading)
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -46,10 +46,17 @@ struct StorageSettingsTab: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 // Obsidian vault destination lives under Storage rather than
-                // in a top-level tab (keeps the tab bar from overflowing), and
-                // renders as one more card in this stack rather than a titled
-                // section — off by default, it's a single toggle. It expands
-                // itself once enabled; see `ObsidianSettingsSection`.
+                // in a top-level tab (originally to keep the tab bar from
+                // overflowing), and renders as one more card in this stack
+                // rather than a titled section — off by default, it's a
+                // single toggle. It expands itself once enabled; see
+                // `ObsidianSettingsSection`.
+                //
+                // #177 removed the overflow constraint, so the original
+                // reason for parking it here is gone and promoting it to its
+                // own sidebar destination is now possible. Deliberately NOT
+                // done in #177 (container change only) — it is a separate,
+                // reviewable UX call.
                 ObsidianSettingsSection()
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/MilaTests/AISettingsKeyCompatibilityTests.swift
+++ b/MilaTests/AISettingsKeyCompatibilityTests.swift
@@ -187,9 +187,10 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
         // is in-memory only, which is why this PR could renumber freely), so
         // this is a tripwire for whoever first writes one to disk or a URL.
         //
-        // The list is also the authoritative tab inventory: nine tabs, which
-        // is what the measured tab-strip run in `SettingsView` assumes. Adding
-        // a tenth needs that measurement redone, not just a line here.
+        // The list is also the authoritative destination inventory. Since
+        // #177 it is no longer capped: destinations are sidebar rows, so a
+        // tenth costs scrollable vertical space rather than a re-measured tab
+        // strip. Adding one here plus a case is the whole job.
         XCTAssertEqual(SettingsTab.general.rawValue, 0)
         XCTAssertEqual(SettingsTab.audio.rawValue, 1)
         XCTAssertEqual(SettingsTab.models.rawValue, 2)
@@ -199,6 +200,44 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
         XCTAssertEqual(SettingsTab.meetings.rawValue, 6)
         XCTAssertEqual(SettingsTab.voiceMemos.rawValue, 7)
         XCTAssertEqual(SettingsTab.storage.rawValue, 8)
+    }
+
+    // MARK: - Sidebar destination inventory (#177)
+
+    func test_every_settings_destination_is_reachable_from_the_sidebar() {
+        // `SettingsView` builds the sidebar from `allCases` and switches the
+        // detail pane on the same enum, so a case with no `switch` arm is a
+        // compile error and a case missing from `allCases` is impossible.
+        // What CAN silently break is the presentation: a destination with a
+        // blank title is an unclickable-looking empty row, and a duplicate
+        // title or identifier makes deep links and GUI tests ambiguous.
+        let all = SettingsTab.allCases
+        XCTAssertEqual(all.count, 9, "Destination count changed — intended?")
+
+        for tab in all {
+            XCTAssertFalse(tab.title.isEmpty, "\(tab) has no sidebar title")
+            XCTAssertFalse(tab.systemImage.isEmpty, "\(tab) has no sidebar icon")
+            XCTAssertTrue(tab.accessibilityID.hasPrefix("settings.section."),
+                          "\(tab) identifier must stay namespaced — GUI tests match on it")
+        }
+
+        XCTAssertEqual(Set(all.map(\.title)).count, all.count,
+                       "Two destinations share a sidebar title")
+        XCTAssertEqual(Set(all.map(\.accessibilityID)).count, all.count,
+                       "Two destinations share an accessibility identifier")
+        XCTAssertEqual(Set(all.map(\.id)).count, all.count,
+                       "Two destinations share a List identity")
+
+        // `SpeakerSelfHealUITests` hardcodes this string — the UI-test target
+        // cannot import the app's types, so this is the only thing keeping
+        // the two in sync.
+        XCTAssertEqual(SettingsTab.speakers.accessibilityID,
+                       "settings.section.speakers")
+
+        // Sidebar order is `allCases` order, which is the declaration order,
+        // which is the raw-value order. The old left-to-right tab order is
+        // preserved top-to-bottom.
+        XCTAssertEqual(all.map(\.rawValue), Array(0..<all.count))
     }
 
     // MARK: - Controls the two-tab split moved between screens

--- a/MilaUITests/SpeakerSelfHealUITests.swift
+++ b/MilaUITests/SpeakerSelfHealUITests.swift
@@ -63,13 +63,22 @@ final class SpeakerSelfHealUITests: XCTestCase {
         let settingsApp = XCUIApplication()
         settingsApp.typeKey(",", modifierFlags: .command)
 
-        // The SettingsView is a TabView. macOS exposes each tab as a
-        // toolbar button; "Speakers" is the label.
-        let speakersTab = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label == 'Speakers'"))
+        // SettingsView is a NavigationSplitView (#177): destinations are rows
+        // in the sidebar list, each carrying a stable identifier. Fall back to
+        // the visible label for older builds / if the identifier is dropped by
+        // the AX tree.
+        var speakersTab = app.descendants(matching: .any)
+            // Mirrors `SettingsTab.speakers.accessibilityID`; the UI-test
+            // target can't import the app's types.
+            .matching(identifier: "settings.section.speakers")
             .firstMatch
+        if !speakersTab.waitForExistence(timeout: 10) {
+            speakersTab = app.descendants(matching: .any)
+                .matching(NSPredicate(format: "label == 'Speakers'"))
+                .firstMatch
+        }
         XCTAssertTrue(speakersTab.waitForExistence(timeout: 10),
-                      "Speakers settings tab not found")
+                      "Speakers settings destination not found")
         speakersTab.click()
 
         // Toggle "Enable speaker diarization" on.


### PR DESCRIPTION
Closes #177

## What & why

Settings was a `TabView` (AppKit `NSTabView`) pinned to `700x560`, and that
size was load-bearing: AppKit collapses whatever does not fit the tab strip
into a `>>` overflow menu, which reads as a stray "expand button" and makes
the collapsed tabs look disabled — reported as #131, fixed in #137 by sizing
the window to hold the whole strip. #144 then measured the result: nine tabs
in a 599 pt run against ~740 pt of strip room, *"it fits, with no room for a
tenth."* Both remaining moves (widen again, merge tabs) were spent, so new
settings — the Obsidian vault section, and the MCP section on its way — were
being parked inside the Storage tab for want of a slot.

**This PR replaces the tab strip with a `NavigationSplitView` sidebar list.**
Destinations now cost vertical space, which scrolls, instead of horizontal
strip width, which does not. The window loses its hardcoded frame and becomes
resizable.

### I did not implement the change the issue asked for — here is why

#177 proposes making Settings a page inside the main window. I judged the
narrower fix better and implemented that instead. The reasoning, so it can be
argued with:

1. **The overflow ceiling is the actual defect, and a sidebar removes it
   completely.** There is no `NSTabView` in the view tree any more, so the
   `>>` chevron of #131 cannot come back at *any* section count. A tenth and
   eleventh section are now one enum case each. This is also what macOS System
   Settings itself does.

2. **`Cmd+,` and `SettingsLink` keep working for free.** Keeping the `Settings`
   scene means zero changes to `MilaApp.swift`: no hand-rolled
   `CommandGroup(replacing: .appSettings)`, no "the main window is closed, so
   reopen it before you can reach Settings" path, no divergence from the
   platform idiom users have muscle memory for.

3. **The issue's strongest argument actually favours the window.** #177 wants
   to "see a setting and the thing it affects at the same time" — but a
   sidebar destination in the main window *replaces* the recording list and
   detail, so you still cannot see both. Two windows can be tiled side by
   side; one window showing a settings page cannot. Keeping the window is the
   better answer to that goal, not the worse one.

4. **The other two costs #177 lists are fixed here anyway.** "Dense tabs can't
   be given more room" — the window is resizable now. "Cross-references aren't
   navigable" — they are: see below.

What the issue asked for that this does *not* deliver is Settings and a
recording visible simultaneously in one window. If that is genuinely wanted,
it is a separate (and much larger) piece of work; happy to be overruled.

### Changes

- `SettingsView` is a `NavigationSplitView`: sidebar `List` over
  `SettingsTab.allCases`, detail switches on the selection.
- Same nine destinations, **same order** (old left-to-right becomes
  top-to-bottom), same titles, same SF Symbols. Nothing is renamed or moved.
- `.frame(width: 700, height: 560)` → `minWidth: 700, idealWidth: 920,
  minHeight: 440, idealHeight: 620`. The ideal reproduces the old content
  width plus the sidebar; the floor is an explicit judgement call (documented
  as such in the code — the widest *rigid* element in any destination is a
  160 pt label; everything else is `maxWidth:`), not a measurement.
- `.padding(20)` moves from around the old `TabView` to around the detail
  content, so every per-destination layout keeps the exact inset it was
  written against.
- `.toolbar(removing: .sidebarToggle)` — every destination lives in that list,
  so a collapse button would hide all navigation. (macOS 14.0+, matches the
  deployment target.)
- `.navigationTitle(section.title)` on the detail preserves the old behaviour
  where the window title tracks the selected section.
- The `List` selection binding swallows `nil` sets, so Escape or a click on
  empty sidebar space cannot blank the detail pane.
- `SettingsTab` gains `CaseIterable`/`Identifiable` plus `title`,
  `systemImage`, `accessibilityID`. The **type name is deliberately kept** —
  it is the key of the `SettingsNavigation.pendingTab` deep-link contract, its
  raw values are pinned by `AISettingsKeyCompatibilityTests`, and the
  per-destination views are all still `…SettingsTab` (two of them in their own
  files). Renaming would churn all three for no behavioural gain.
- **One cross-reference becomes real navigation**, because it can now: AI
  Features' "No AI provider yet — set one up in Settings → AI Provider" prose
  is now a link that selects AI Provider. This is the first producer for
  `SettingsNavigation.pendingTab`, which until now had none.
- Comments that recorded the width constraint (`SettingsView`,
  `GeneralSettingsTab`'s "didn't justify a tenth tab", `StorageSettingsTab`'s
  note on why Obsidian is parked there) are updated in place rather than
  deleted — the #131/#137/#144 history is why the strip existed and is worth
  keeping.

### Explicitly out of scope

**The Obsidian section stays inside Storage.** So does the MCP section when it
lands. Both were put there *because a tenth tab wouldn't fit*; that reason is
now gone, so promoting them to their own sidebar destinations is possible —
but it is a UX call that deserves its own review, and folding it in here would
bloat a container-only diff. `StorageSettingsTab` carries a comment saying
exactly this.

### Notes for maintainers

- **The `.environmentObject`-on-both-scenes convention in `CLAUDE.md` is
  unchanged.** Settings is still a `Settings` scene, so new app-wide settings
  objects still have to be injected into *both* the main window and the
  Settings scene. `MilaApp.swift` is untouched by this PR. (Had this gone the
  in-app-page route, that rule would have become a trap — one more reason it
  didn't.)
- Every persisted `UserDefaults` key and all Keychain items are untouched;
  this is a container change only, so `AISettingsKeyCompatibilityTests` holds
  as-is.
- **Conflicts with #191** (`feat/remote-model-picker`, still open at time of
  writing) should be small and mechanical: that PR edits `RemoteBackendSection`
  in the middle of the file, this one rewrites the first ~150 lines plus three
  comment blocks. Will rebase once it lands.

## How it was tested

- `make build` — **BUILD SUCCEEDED**, no new warnings.
- `xcodebuild … build-for-testing` — **TEST BUILD SUCCEEDED**; both test
  bundles compile.
- Tests **written but deliberately not run**: a new
  `test_every_settings_destination_is_reachable_from_the_sidebar` in
  `MilaTests/AISettingsKeyCompatibilityTests.swift` pins the destination
  inventory (count, unique titles/identifiers/ids, non-empty title + icon,
  order == raw-value order) and asserts the `settings.section.speakers`
  identifier that `SpeakerSelfHealUITests` hardcodes. The app-hosted test
  targets read the real login keychain and pop a password prompt on every run
  on the maintainer's machine, so they were compiled, not executed. CI should
  run them.
- `SpeakerSelfHealUITests` is updated: its stale "SettingsView is a TabView,
  macOS exposes each tab as a toolbar button" lookup now prefers the
  `settings.section.speakers` identifier and falls back to the `Speakers`
  label. Not run (it is skipped on CI and is an 8-minute local network test).

### ⚠️ Not visually verified — please eyeball

**I did not launch the app**, so no claim here about how it looks is based on
observation. A human should check, on a real build:

1. `Cmd+,` from the main window opens Settings; so does the sidebar footer
   **Settings** row; the App menu ▸ Settings… item works. Only one Settings
   window opens (no duplicate on repeat `Cmd+,`).
2. The sidebar shows all nine rows — General, Audio, Models, AI Provider, AI
   Features, Speakers, Meetings, Voice Memos, Storage — in that order, with
   icons, **and no `>>` chevron and no sidebar-collapse button** in the
   titlebar.
3. Clicking each of the nine renders the right pane, and the window title
   changes to the section name.
4. The window resizes, and shrinking it to the ~700 pt floor does not clip
   anything — worth a specific look at **Models** (remote backend block) and
   **AI Provider** (label/field rows), which are the widest.
5. The first-open size looks sane, i.e. roughly the old window plus a sidebar,
   not a hairline or a full screen.
6. **Audio**: the input-level VU meter still starts when you select Audio and
   stops when you navigate away (it hangs off `.task`/`.onDisappear`, which
   now fire on section switch rather than tab switch).
7. **AI Features** with no provider configured: the orange banner's "Set one
   up in AI Provider" link jumps to AI Provider.
8. Pressing Escape with the sidebar focused does not blank the right pane.

## Checklist

- [x] Builds locally (`make build`); tests compile (`build-for-testing`) but
      were **not run** — app-hosted targets prompt for the login keychain
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — deferred to the
      release that ships it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the fixed settings tab bar with a resizable, scrollable sidebar for easier navigation.
  * Added labeled icons and accessibility identifiers to settings destinations.
  * Added direct navigation from the AI provider banner to AI Provider settings.

* **Bug Fixes**
  * Improved deep-link and destination selection behavior when opening settings.

* **Tests**
  * Added coverage to verify settings destinations are reachable, uniquely identified, and consistently ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->