### PR TITLE
fix(llm): search the npm prefix the user configured, not just ~/.npm-global

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1496,13 +1496,43 @@ enum LLMRunner {
             if value.count >= 2,
                let quote = value.first, quote == "\"" || quote == "'",
                value.last == quote {
-                value = String(value.dropFirst().dropLast())
+                let inner = String(value.dropFirst().dropLast())
+                // npm decodes escapes inside DOUBLE quotes only -- it runs the
+                // value through a JSON-style unescape -- so
+                // `prefix="/opt/npm\\\\tools"` resolves to `/opt/npm\\tools`.
+                // Single-quoted values are literal.
+                value = quote == "\"" ? decodingDoubleQuotedEscapes(inner) : inner
             } else {
                 value = truncatingAtUnescapedComment(value)
             }
             found = value
         }
         return found
+    }
+
+    /// Undoes the escaping npm applies inside a double-quoted `.npmrc` value:
+    /// `\\\\` is a literal backslash and `\\"` a literal quote. Anything else is
+    /// left as written -- npm's own reader is JSON-ish here, but inventing
+    /// further escapes would corrupt paths that merely contain a backslash.
+    private static func decodingDoubleQuotedEscapes(_ value: String) -> String {
+        var out = ""
+        var pending = false
+        for character in value {
+            if pending {
+                if character == "\\" || character == "\"" {
+                    out.append(character)
+                } else {
+                    out.append("\\")
+                    out.append(character)
+                }
+                pending = false
+                continue
+            }
+            if character == "\\" { pending = true; continue }
+            out.append(character)
+        }
+        if pending { out.append("\\") }
+        return out
     }
 
     /// Cuts an unquoted value at its first *unescaped* `;` or `#`.

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1364,10 +1364,11 @@ enum LLMRunner {
     }
 
     /// Ordered candidate directories for `lookupOnPath`: the inherited `$PATH`
-    /// first, then well-known shell/version-manager `bin` dirs. Node-based CLIs
-    /// (claude, cursor-agent, gemini) are commonly installed as global npm
-    /// packages under a version manager, so those roots are enumerated too.
-    /// Exposed (internal) so the version-manager enumeration is unit-testable.
+    /// first, then the `bin` of whatever prefix npm is *configured* with, then
+    /// well-known shell/version-manager `bin` dirs. Node-based CLIs (claude,
+    /// cursor-agent, gemini) are commonly installed as global npm packages
+    /// under a version manager, so those roots are enumerated too.
+    /// Exposed (internal) so the enumeration is unit-testable.
     static func searchDirectories(
         home: String = NSHomeDirectory(),
         pathEnv: String? = ProcessInfo.processInfo.environment["PATH"],
@@ -1377,14 +1378,21 @@ enum LLMRunner {
         if let pathEnv {
             dirs += pathEnv.split(separator: ":").map(String.init)
         }
-        dirs += [
+        // Everything past the PATH entries is a *guess* at where a global npm
+        // install landed — except the configured prefix, which comes from the
+        // user's own npm config, so it leads the fallbacks.
+        var fallbacks: [String] = []
+        if let prefixBin = npmPrefixBin(home: home, fileManager: fileManager) {
+            fallbacks.append(prefixBin)
+        }
+        fallbacks += [
             "\(home)/.local/bin",
             "\(home)/bin",
             "\(home)/.cargo/bin",
             "\(home)/.bun/bin",
             "\(home)/.volta/bin",        // Volta
             "\(home)/.asdf/shims",       // asdf
-            "\(home)/.npm-global/bin",   // custom npm prefix
+            "\(home)/.npm-global/bin",   // the ~/.npm-global convention
             "/opt/homebrew/bin",
             "/usr/local/bin",
             "/usr/bin",
@@ -1396,11 +1404,109 @@ enum LLMRunner {
         // install time, so search every installed version, newest first.
         let nvmRoot = "\(home)/.nvm/versions/node"
         if let versions = try? fileManager.contentsOfDirectory(atPath: nvmRoot) {
-            dirs += versions
+            fallbacks += versions
                 .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
                 .map { "\(nvmRoot)/\($0)/bin" }
         }
+        // De-dupe, order kept: npm's *default* prefix on a node that isn't
+        // Homebrew's is /usr/local, so a configured value routinely collides
+        // with an entry already in the list (or already on PATH), and probing
+        // the same directory twice per lookup buys nothing.
+        var seen = Set(dirs)
+        dirs += fallbacks.filter { seen.insert($0).inserted }
         return dirs
+    }
+
+    /// `bin` directory of the npm prefix the user actually configured, or
+    /// `nil` when `~/.npmrc` has no usable `prefix` value.
+    ///
+    /// Parsing the file rather than shelling out to `npm config get prefix` is
+    /// deliberate: that needs `npm` on `PATH`, which is exactly what a
+    /// launchd-launched Mila does not have, and it would cost a process spawn
+    /// on every executable lookup.
+    ///
+    /// **Only the user config is read.** npm's other prefix sources cannot
+    /// help in the situation this exists for:
+    /// - `NPM_CONFIG_PREFIX` / `npm_config_prefix` and `NPM_CONFIG_USERCONFIG`
+    ///   live in the environment. A Finder- or launchd-launched Mila does not
+    ///   get the user's exported shell variables — the same stripping that
+    ///   loses `PATH` — and when Mila *is* started from a shell, that prefix's
+    ///   `bin` is already on the inherited `PATH` searched first. Honouring
+    ///   them would be dead code in the broken case and redundant in the
+    ///   working one.
+    /// - the global `$PREFIX/etc/npmrc` can only be located once the prefix is
+    ///   known, which is circular; the two prefixes it realistically names on
+    ///   macOS (`/opt/homebrew`, `/usr/local`) are in the list above already.
+    /// - a project-level `./.npmrc` is meaningless for a GUI app whose working
+    ///   directory the user never chose.
+    static func npmPrefixBin(home: String = NSHomeDirectory(),
+                             fileManager: FileManager = .default) -> String? {
+        let npmrc = (home as NSString).appendingPathComponent(".npmrc")
+        guard let data = fileManager.contents(atPath: npmrc),
+              let text = String(data: data, encoding: .utf8),
+              let value = npmrcPrefixValue(in: text) else { return nil }
+        let expanded = expandingHome(value, home: home)
+        // Blank, relative, commented-out or otherwise unusable values degrade
+        // to "no extra directory" rather than a nonsense path to probe.
+        guard expanded.hasPrefix("/") else {
+            if !expanded.isEmpty {
+                llmRunnerLog.debug("""
+                    llm npm prefix ignored (not an absolute path) \
+                    npmrc=\(npmrc, privacy: .public)
+                    """)
+            }
+            return nil
+        }
+        return (expanded as NSString).appendingPathComponent("bin")
+    }
+
+    /// The effective `prefix` value in an npmrc body, following the `ini`
+    /// parser npm itself uses: `;` and `#` start a comment, a quoted value is
+    /// taken verbatim, an unquoted one ends at an inline comment, and a later
+    /// assignment overwrites an earlier one. `nil` when the key is absent —
+    /// an empty string when it is present but blank, which the caller rejects
+    /// along with every other unusable value.
+    private static func npmrcPrefixValue(in text: String) -> String? {
+        var found: String?
+        // `isNewline` rather than splitting on "\n": Swift treats CRLF as a
+        // single Character, so a file saved with Windows line endings would
+        // otherwise parse as one giant line.
+        for rawLine in text.split(whereSeparator: { $0.isNewline }) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix(";") || line.hasPrefix("#") { continue }
+            guard let equals = line.firstIndex(of: "=") else { continue }
+            let key = line[line.startIndex..<equals]
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased()
+            guard key == "prefix" else { continue }
+            var value = line[line.index(after: equals)...]
+                .trimmingCharacters(in: .whitespaces)
+            if value.count >= 2,
+               let quote = value.first, quote == "\"" || quote == "'",
+               value.last == quote {
+                value = String(value.dropFirst().dropLast())
+            } else if let comment = value.firstIndex(where: { $0 == ";" || $0 == "#" }) {
+                value = String(value[value.startIndex..<comment])
+                    .trimmingCharacters(in: .whitespaces)
+            }
+            found = value
+        }
+        return found
+    }
+
+    /// Expands a leading `~`, `$HOME` or `${HOME}` against the given home.
+    /// Anything else (`~someoneelse`, `$OTHER`) is returned untouched so it
+    /// fails `npmPrefixBin`'s absolute-path check instead of being
+    /// half-expanded into a directory that cannot exist.
+    private static func expandingHome(_ value: String, home: String) -> String {
+        for token in ["${HOME}", "$HOME", "~"] {
+            if value == token { return home }
+            if value.hasPrefix(token + "/") {
+                let rest = String(value.dropFirst(token.count + 1))
+                return (home as NSString).appendingPathComponent(rest)
+            }
+        }
+        return value
     }
 }
 

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1412,7 +1412,10 @@ enum LLMRunner {
         // Homebrew's is /usr/local, so a configured value routinely collides
         // with an entry already in the list (or already on PATH), and probing
         // the same directory twice per lookup buys nothing.
-        var seen = Set(dirs)
+        // De-dupe the inherited PATH too, not just the fallbacks: a PATH with
+        // the same directory twice would otherwise be probed twice.
+        var seen = Set<String>()
+        dirs = dirs.filter { seen.insert($0).inserted }
         dirs += fallbacks.filter { seen.insert($0).inserted }
         return dirs
     }
@@ -1468,12 +1471,21 @@ enum LLMRunner {
     /// along with every other unusable value.
     private static func npmrcPrefixValue(in text: String) -> String? {
         var found: String?
+        var inSection = false
         // `isNewline` rather than splitting on "\n": Swift treats CRLF as a
         // single Character, so a file saved with Windows line endings would
         // otherwise parse as one giant line.
         for rawLine in text.split(whereSeparator: { $0.isNewline }) {
             let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
             if line.isEmpty || line.hasPrefix(";") || line.hasPrefix("#") { continue }
+            // `[section]` scopes everything under it. npm does not use a
+            // section-scoped `prefix` as the global prefix, so neither may we --
+            // probing its `bin` would add a directory npm never installs into.
+            if line.hasPrefix("[") && line.hasSuffix("]") {
+                inSection = true
+                continue
+            }
+            guard !inSection else { continue }
             guard let equals = line.firstIndex(of: "=") else { continue }
             let key = line[line.startIndex..<equals]
                 .trimmingCharacters(in: .whitespaces)
@@ -1504,23 +1516,31 @@ enum LLMRunner {
     /// it -- it is an escape, not part of the path.
     private static func truncatingAtUnescapedComment(_ value: String) -> String {
         var out = ""
-        var escaped = false
+        var pendingBackslash = false
         for character in value {
-            if escaped {
-                out.append(character)
-                escaped = false
+            if pendingBackslash {
+                // npm escapes only these three. Before anything else the
+                // backslash is an ordinary character and both survive --
+                // `prefix=/opt/npm\\tools` is a path with a backslash in it, not
+                // `/opt/npmtools`.
+                if character == "\\" || character == ";" || character == "#" {
+                    out.append(character)
+                } else {
+                    out.append("\\")
+                    out.append(character)
+                }
+                pendingBackslash = false
                 continue
             }
             if character == "\\" {
-                escaped = true
+                pendingBackslash = true
                 continue
             }
             if character == ";" || character == "#" { break }
             out.append(character)
         }
-        // A trailing lone backslash was an escape with nothing after it; npm
-        // treats it as a literal, so keep it rather than silently dropping it.
-        if escaped { out.append("\\") }
+        // A trailing lone backslash escaped nothing; npm keeps it as a literal.
+        if pendingBackslash { out.append("\\") }
         return out.trimmingCharacters(in: .whitespaces)
     }
 

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1485,13 +1485,43 @@ enum LLMRunner {
                let quote = value.first, quote == "\"" || quote == "'",
                value.last == quote {
                 value = String(value.dropFirst().dropLast())
-            } else if let comment = value.firstIndex(where: { $0 == ";" || $0 == "#" }) {
-                value = String(value[value.startIndex..<comment])
-                    .trimmingCharacters(in: .whitespaces)
+            } else {
+                value = truncatingAtUnescapedComment(value)
             }
             found = value
         }
         return found
+    }
+
+    /// Cuts an unquoted value at its first *unescaped* `;` or `#`.
+    ///
+    /// npm keeps `\\#` and `\\;` as literal characters in an unquoted value, so
+    /// a naive scan for the bare delimiter turns `prefix=/opt/npm\\#tools` into
+    /// `/opt/npm\\` and probes a directory that does not exist. Verified
+    /// against `npm config get prefix --userconfig`.
+    ///
+    /// The backslash is dropped as it is consumed, which is what npm does with
+    /// it -- it is an escape, not part of the path.
+    private static func truncatingAtUnescapedComment(_ value: String) -> String {
+        var out = ""
+        var escaped = false
+        for character in value {
+            if escaped {
+                out.append(character)
+                escaped = false
+                continue
+            }
+            if character == "\\" {
+                escaped = true
+                continue
+            }
+            if character == ";" || character == "#" { break }
+            out.append(character)
+        }
+        // A trailing lone backslash was an escape with nothing after it; npm
+        // treats it as a literal, so keep it rather than silently dropping it.
+        if escaped { out.append("\\") }
+        return out.trimmingCharacters(in: .whitespaces)
     }
 
     /// Expands a leading `~`, `$HOME` or `${HOME}` against the given home.

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1500,11 +1500,18 @@ enum LLMRunner {
                 // npm's ini reader JSON-parses a double-quoted value, so every
                 // JSON escape applies -- not just `\\\\` and `\\"` but `\\u006e` too.
                 // Hand-rolling that decoding got it wrong twice on this branch,
-                // so delegate to a real JSON parser and keep the raw value when
-                // it isn't valid JSON (the absolute-path check then rejects it).
-                // Single-quoted values are literal in npm; no decoding there.
+                // so delegate to a real JSON parser rather than enumerating the
+                // escapes. Single-quoted values are literal in npm; no decoding.
+                //
+                // A double-quoted value that isn't valid JSON is **discarded**,
+                // not salvaged by dropping the quotes: npm cannot read it
+                // either, so it has no prefix from this file, and stripping the
+                // quotes off `"/opt/bad\\q"` yields `/opt/bad\\q`, which is
+                // absolute and would be probed -- a directory npm would never
+                // install into. Better to have no candidate than a wrong one.
                 if quote == "\"" {
-                    value = jsonDecodedString(String(value)) ?? inner
+                    guard let decoded = jsonDecodedString(String(value)) else { continue }
+                    value = decoded
                 } else {
                     value = inner
                 }

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1497,11 +1497,17 @@ enum LLMRunner {
                let quote = value.first, quote == "\"" || quote == "'",
                value.last == quote {
                 let inner = String(value.dropFirst().dropLast())
-                // npm decodes escapes inside DOUBLE quotes only -- it runs the
-                // value through a JSON-style unescape -- so
-                // `prefix="/opt/npm\\\\tools"` resolves to `/opt/npm\\tools`.
-                // Single-quoted values are literal.
-                value = quote == "\"" ? decodingDoubleQuotedEscapes(inner) : inner
+                // npm's ini reader JSON-parses a double-quoted value, so every
+                // JSON escape applies -- not just `\\\\` and `\\"` but `\\u006e` too.
+                // Hand-rolling that decoding got it wrong twice on this branch,
+                // so delegate to a real JSON parser and keep the raw value when
+                // it isn't valid JSON (the absolute-path check then rejects it).
+                // Single-quoted values are literal in npm; no decoding there.
+                if quote == "\"" {
+                    value = jsonDecodedString(String(value)) ?? inner
+                } else {
+                    value = inner
+                }
             } else {
                 value = truncatingAtUnescapedComment(value)
             }
@@ -1510,29 +1516,13 @@ enum LLMRunner {
         return found
     }
 
-    /// Undoes the escaping npm applies inside a double-quoted `.npmrc` value:
-    /// `\\\\` is a literal backslash and `\\"` a literal quote. Anything else is
-    /// left as written -- npm's own reader is JSON-ish here, but inventing
-    /// further escapes would corrupt paths that merely contain a backslash.
-    private static func decodingDoubleQuotedEscapes(_ value: String) -> String {
-        var out = ""
-        var pending = false
-        for character in value {
-            if pending {
-                if character == "\\" || character == "\"" {
-                    out.append(character)
-                } else {
-                    out.append("\\")
-                    out.append(character)
-                }
-                pending = false
-                continue
-            }
-            if character == "\\" { pending = true; continue }
-            out.append(character)
-        }
-        if pending { out.append("\\") }
-        return out
+    /// Decodes a JSON string literal (quotes included), or nil when the text
+    /// isn't valid JSON. `npm/ini` uses JSON parsing for double-quoted values,
+    /// so this matches it exactly instead of approximating a subset of the
+    /// escapes by hand.
+    private static func jsonDecodedString(_ quoted: String) -> String? {
+        guard let data = quoted.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(String.self, from: data)
     }
 
     /// Cuts an unquoted value at its first *unescaped* `;` or `#`.

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1464,9 +1464,11 @@ enum LLMRunner {
     }
 
     /// The effective `prefix` value in an npmrc body, following the `ini`
-    /// parser npm itself uses: `;` and `#` start a comment, a quoted value is
-    /// taken verbatim, an unquoted one ends at an inline comment, and a later
-    /// assignment overwrites an earlier one. `nil` when the key is absent —
+    /// parser npm itself uses: `;` and `#` start a comment, a double-quoted
+    /// value is JSON-decoded and a single-quoted one is literal, an unquoted
+    /// one ends at an inline comment, and a later assignment overwrites an
+    /// earlier one — *including* a later one npm cannot parse, which lands as
+    /// its own raw text and so leaves no usable prefix. `nil` when the key is absent —
     /// an empty string when it is present but blank, which the caller rejects
     /// along with every other unusable value.
     private static func npmrcPrefixValue(in text: String) -> String? {
@@ -1503,15 +1505,24 @@ enum LLMRunner {
                 // so delegate to a real JSON parser rather than enumerating the
                 // escapes. Single-quoted values are literal in npm; no decoding.
                 //
-                // A double-quoted value that isn't valid JSON is **discarded**,
-                // not salvaged by dropping the quotes: npm cannot read it
-                // either, so it has no prefix from this file, and stripping the
-                // quotes off `"/opt/bad\\q"` yields `/opt/bad\\q`, which is
-                // absolute and would be probed -- a directory npm would never
-                // install into. Better to have no candidate than a wrong one.
+                // A double-quoted value that isn't valid JSON is kept **raw,
+                // quotes and all** -- which is precisely what `npm/ini` does:
+                // its `JSON.parse` sits inside a `try/catch` whose handler
+                // leaves the value untouched, and the parse loop then assigns
+                // it like any other. That buys two things at once. The leading
+                // `"` fails `npmPrefixBin`'s absolute-path check, so a value
+                // npm cannot read still yields no directory to probe -- unlike
+                // dropping the quotes, which would turn `"/opt/bad\\q"` into
+                // the absolute-looking `/opt/bad\\q` and probe a directory npm
+                // would never install into. And because the line is *assigned*
+                // rather than skipped, it overwrites an earlier `prefix`,
+                // keeping last-assignment-wins true even when the last
+                // assignment is malformed. Skipping it would leave a stale
+                // earlier value in force and send Mila hunting for a CLI in a
+                // directory npm no longer points at -- a wrong answer where
+                // npm gives none.
                 if quote == "\"" {
-                    guard let decoded = jsonDecodedString(String(value)) else { continue }
-                    value = decoded
+                    value = jsonDecodedString(value) ?? value
                 } else {
                     value = inner
                 }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1100,7 +1100,7 @@ private struct AIProviderSettingsTab: View {
     private var cliFields: some View {
         VStack(alignment: .leading, spacing: 6) {
             fieldRow("Executable",
-                     help: "Set this when `claude` / `cursor-agent` / `gemini` lives somewhere a GUI app won't see by default — ~/.local/bin, an asdf shim, a Homebrew prefix that isn't on the system PATH.") {
+                     help: "Only needed when Mila can't find the CLI itself — it already searches $PATH, Homebrew, ~/.local/bin, your configured npm prefix and the node version managers (nvm, Volta, asdf).") {
                 TextField("(use $PATH)", text: $settings.executablePath)
                     .textFieldStyle(.roundedBorder)
                     .autocorrectionDisabled()

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -785,6 +785,48 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertEqual(LLMRunner.npmPrefixBin(home: both.path), "/opt/a#b/bin")
     }
 
+    /// npm treats a backslash as an escape only before `\\`, `;` or `#`. Before an
+    /// ordinary character both survive, so `prefix=/opt/npm\\tools` is a path
+    /// containing a backslash -- an earlier fix for escaped comment markers
+    /// stripped every backslash and turned it into `/opt/npmtools`.
+    func test_npmPrefixBin_keeps_a_backslash_before_an_ordinary_character() throws {
+        let home = try makeHome(npmrc: "prefix=/opt/npm\\tools\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/npm\\tools/bin")
+    }
+
+    /// An escaped backslash collapses to one, as npm does.
+    func test_npmPrefixBin_collapses_an_escaped_backslash() throws {
+        let home = try makeHome(npmrc: "prefix=/opt/npm\\\\tools\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/npm\\tools/bin")
+    }
+
+    /// `[section]` scopes what follows it. npm does not use a section-scoped
+    /// `prefix` as the global prefix, so probing its `bin` would add a
+    /// directory npm never installs into.
+    func test_npmPrefixBin_ignores_a_section_scoped_prefix() throws {
+        let scoped = try makeHome(npmrc: "[tool]\nprefix=/tmp/tool\n")
+        defer { try? FileManager.default.removeItem(at: scoped) }
+        XCTAssertNil(LLMRunner.npmPrefixBin(home: scoped.path))
+
+        // A top-level value before a section still counts.
+        let mixed = try makeHome(npmrc: "prefix=/opt/real\n[tool]\nprefix=/tmp/tool\n")
+        defer { try? FileManager.default.removeItem(at: mixed) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: mixed.path), "/opt/real/bin")
+    }
+
+    /// The search list must not probe the same directory twice, including when
+    /// the inherited PATH itself repeats one.
+    func test_searchDirectories_deduplicates_repeated_path_entries() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let dirs = LLMRunner.searchDirectories(home: home.path,
+                                               pathEnv: "/usr/local/bin:/usr/local/bin")
+        XCTAssertEqual(dirs.filter { $0 == "/usr/local/bin" }.count, 1,
+                       "a repeated PATH entry was probed twice: \(dirs)")
+    }
+
     func test_npmPrefixBin_is_nil_without_an_npmrc() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -653,6 +653,128 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertFalse(dirs.contains { $0.contains("/.nvm/versions/node/") })
     }
 
+    // MARK: - Configured npm prefix (~/.npmrc)
+
+    /// A throwaway home directory, optionally carrying an `.npmrc`. Local to
+    /// these tests — nothing else needs a fake home.
+    private func makeHome(npmrc: String? = nil) throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mila-npmrc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home,
+                                                withIntermediateDirectories: true)
+        if let npmrc {
+            try npmrc.write(to: home.appendingPathComponent(".npmrc"),
+                            atomically: true, encoding: .utf8)
+        }
+        return home
+    }
+
+    func test_searchDirectories_honours_a_configured_npm_prefix() throws {
+        // The whole point of the feature: a prefix that is *not* the
+        // ~/.npm-global convention still gets searched.
+        let home = try makeHome(npmrc: """
+            registry=https://registry.npmjs.org/
+            prefix=/opt/npm-elsewhere
+            """)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let dirs = LLMRunner.searchDirectories(home: home.path, pathEnv: nil)
+        XCTAssertTrue(dirs.contains("/opt/npm-elsewhere/bin"), "\(dirs)")
+        // Configured beats guessed: it must be probed before the conventions.
+        let configured = try XCTUnwrap(dirs.firstIndex(of: "/opt/npm-elsewhere/bin"))
+        let convention = try XCTUnwrap(dirs.firstIndex(of: "\(home.path)/.npm-global/bin"))
+        XCTAssertLessThan(configured, convention, "\(dirs)")
+    }
+
+    func test_searchDirectories_expands_home_in_a_configured_npm_prefix() throws {
+        // npmrc files are written by hand, so all three spellings of "my home
+        // directory" show up in the wild. A literal "~" would be a directory
+        // that cannot exist.
+        for spelling in ["~/npm-here", "$HOME/npm-here", "${HOME}/npm-here"] {
+            let home = try makeHome(npmrc: "prefix=\(spelling)\n")
+            defer { try? FileManager.default.removeItem(at: home) }
+
+            let dirs = LLMRunner.searchDirectories(home: home.path, pathEnv: nil)
+            XCTAssertTrue(dirs.contains("\(home.path)/npm-here/bin"),
+                          "\(spelling) was not expanded: \(dirs)")
+        }
+    }
+
+    func test_searchDirectories_ignores_unusable_npm_prefix_values() throws {
+        // A malformed, blank, relative or commented-out value must degrade to
+        // "no extra directory" — never to a nonsense path we then probe.
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let npmrc = home.appendingPathComponent(".npmrc")
+        let baseline = LLMRunner.searchDirectories(home: home.path, pathEnv: nil)
+
+        for content in [
+            "prefix=\n",                          // blank
+            "prefix=   \n",                       // whitespace only
+            "prefix=relative/dir\n",              // not absolute
+            "; prefix=/opt/commented\n",          // ini comment
+            "#prefix=/opt/commented\n",           // the other comment marker
+            "prefix=~someoneelse/npm\n",          // another user's home
+            "prefix\n",                           // no '=' at all
+            "registry=https://example.com/\n",    // no prefix key
+            "[scope]\nnothing-here=1\n"          // no prefix key, with a section
+        ] {
+            try content.write(to: npmrc, atomically: true, encoding: .utf8)
+            XCTAssertEqual(LLMRunner.searchDirectories(home: home.path, pathEnv: nil),
+                           baseline,
+                           "unusable value must add nothing: \(content.debugDescription)")
+        }
+    }
+
+    func test_npmPrefixBin_strips_quotes_and_inline_comments() throws {
+        // npm parses npmrc with the `ini` package: a quoted value is verbatim,
+        // an unquoted one ends at the first ; or #.
+        let quoted = try makeHome(npmrc: "prefix = \"/opt/quoted npm\"\n")
+        defer { try? FileManager.default.removeItem(at: quoted) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: quoted.path),
+                       "/opt/quoted npm/bin")
+
+        let commented = try makeHome(npmrc: "prefix=/opt/trailing # set by hand\n")
+        defer { try? FileManager.default.removeItem(at: commented) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: commented.path),
+                       "/opt/trailing/bin")
+    }
+
+    func test_npmPrefixBin_takes_the_last_assignment_and_normalises_slashes() throws {
+        // Later wins, matching ini semantics; a trailing slash must not
+        // produce "/opt/second//bin".
+        let home = try makeHome(npmrc: """
+            prefix=/opt/first
+            prefix=/opt/second/
+            """)
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/second/bin")
+    }
+
+    func test_npmPrefixBin_handles_windows_line_endings() throws {
+        // Swift treats CRLF as a single Character, so splitting on "\n" would
+        // swallow the whole file into one line and the prefix would be lost.
+        let home = try makeHome(npmrc: "registry=https://example.com/\r\nprefix=/opt/crlf\r\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/crlf/bin")
+    }
+
+    func test_npmPrefixBin_is_nil_without_an_npmrc() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertNil(LLMRunner.npmPrefixBin(home: home.path))
+    }
+
+    func test_searchDirectories_does_not_duplicate_a_default_npm_prefix() throws {
+        // /usr/local is npm's own default prefix, so the configured value
+        // routinely collides with an entry that is already in the list.
+        let home = try makeHome(npmrc: "prefix=/usr/local\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let dirs = LLMRunner.searchDirectories(home: home.path, pathEnv: "/usr/local/bin")
+        XCTAssertEqual(dirs.filter { $0 == "/usr/local/bin" }.count, 1, "\(dirs)")
+    }
+
     func test_gemini_cli_returns_a_title_for_a_sample_transcript() async throws {
         guard let geminiPath = resolve("gemini") else {
             throw XCTSkip("gemini CLI not installed on this machine")

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -827,6 +827,23 @@ final class LLMRunnerTests: XCTestCase {
                        "a repeated PATH entry was probed twice: \(dirs)")
     }
 
+    /// npm decodes escapes inside a DOUBLE-quoted value, so
+    /// `prefix="/opt/npm\\\\tools"` resolves to `/opt/npm\\tools`. Stripping the
+    /// quotes without decoding left both backslashes and probed a path that
+    /// cannot exist. Verified against `npm config get prefix --userconfig`.
+    func test_npmPrefixBin_decodes_escapes_in_a_double_quoted_value() throws {
+        let home = try makeHome(npmrc: "prefix=\"/opt/npm\\\\tools\"\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/npm\\tools/bin")
+    }
+
+    /// Single quotes are literal in npm -- no decoding there.
+    func test_npmPrefixBin_leaves_single_quoted_values_literal() throws {
+        let home = try makeHome(npmrc: "prefix='/opt/npm\\\\tools'\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/npm\\\\tools/bin")
+    }
+
     func test_npmPrefixBin_is_nil_without_an_npmrc() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -759,6 +759,32 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/crlf/bin")
     }
 
+    /// npm keeps an escaped `\\#` / `\\;` as a literal character in an unquoted
+    /// value, so scanning for the bare delimiter cut `/opt/npm\\#tools` down to
+    /// `/opt/npm\\` and probed a directory that does not exist. Verified against
+    /// `npm config get prefix --userconfig` when this was found.
+    func test_npmPrefixBin_preserves_escaped_comment_characters() throws {
+        let hash = try makeHome(npmrc: "prefix=/opt/npm\\#tools\n")
+        defer { try? FileManager.default.removeItem(at: hash) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: hash.path), "/opt/npm#tools/bin")
+
+        let semi = try makeHome(npmrc: "prefix=/opt/npm\\;tools\n")
+        defer { try? FileManager.default.removeItem(at: semi) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: semi.path), "/opt/npm;tools/bin")
+    }
+
+    /// The escape handling must not stop a genuine inline comment being cut.
+    func test_npmPrefixBin_still_strips_a_real_inline_comment() throws {
+        let hash = try makeHome(npmrc: "prefix=/opt/plain #a trailing note\n")
+        defer { try? FileManager.default.removeItem(at: hash) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: hash.path), "/opt/plain/bin")
+
+        // Escaped first, then a real one: keep the literal, drop the comment.
+        let both = try makeHome(npmrc: "prefix=/opt/a\\#b #note\n")
+        defer { try? FileManager.default.removeItem(at: both) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: both.path), "/opt/a#b/bin")
+    }
+
     func test_npmPrefixBin_is_nil_without_an_npmrc() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -837,6 +837,24 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/npm\\tools/bin")
     }
 
+    /// `npm/ini` JSON-parses a double-quoted value, so every JSON escape
+    /// applies -- `prefix="/opt/\\u006eode"` is `/opt/node` to npm. Decoding only
+    /// `\\\\` and `\\"` by hand missed this, which is why the implementation now
+    /// delegates to `JSONDecoder` rather than approximating the escape set.
+    func test_npmPrefixBin_decodes_a_unicode_escape_in_a_double_quoted_value() throws {
+        let home = try makeHome(npmrc: "prefix=\"/opt/\\u006eode\"\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/node/bin")
+    }
+
+    /// An invalid escape makes the value un-decodable; keep it raw so the
+    /// absolute-path check rejects it rather than inventing a path.
+    func test_npmPrefixBin_keeps_an_undecodable_quoted_value_raw() throws {
+        let home = try makeHome(npmrc: "prefix=\"/opt/bad\\q\"\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/bad\\q/bin")
+    }
+
     /// Single quotes are literal in npm -- no decoding there.
     func test_npmPrefixBin_leaves_single_quoted_values_literal() throws {
         let home = try makeHome(npmrc: "prefix='/opt/npm\\\\tools'\n")

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -858,12 +858,33 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertNil(LLMRunner.npmPrefixBin(home: home.path))
     }
 
-    /// ...but an earlier valid top-level `prefix` still wins, since a later
-    /// unparseable line must not erase a good value.
-    func test_npmPrefixBin_keeps_an_earlier_valid_prefix_when_a_later_one_is_undecodable() throws {
-        let home = try makeHome(npmrc: "prefix=/opt/good\nprefix=\"/opt/bad\\q\"\n")
-        defer { try? FileManager.default.removeItem(at: home) }
-        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/good/bin")
+    /// ...and it erases an earlier good one, because last-assignment-wins
+    /// holds even when the last assignment is malformed.
+    ///
+    /// `npm/ini` does not skip the unparseable line: its `JSON.parse` sits in
+    /// a `try/catch` whose handler leaves the raw quoted text in place, and
+    /// the parse loop assigns that like any other value. npm's effective
+    /// `prefix` here is therefore the literal `"/opt/bad\\q"` -- quotes
+    /// included, so not an absolute path, so no prefix at all. Retaining
+    /// `/opt/good` instead would have Mila probe a directory the user's npm
+    /// config no longer names and launch a CLI npm does not install into,
+    /// where npm itself simply finds nothing.
+    func test_npmPrefixBin_drops_an_earlier_prefix_when_a_later_one_is_undecodable() throws {
+        // Control: the same first line on its own really does resolve, so the
+        // nil below is the override taking effect -- not a fixture that failed
+        // to write or a parser that choked on the whole file. Without this the
+        // assertion would pass just as happily against a `makeHome` that wrote
+        // nothing at all.
+        let good = try makeHome(npmrc: "prefix=/opt/good\n")
+        defer { try? FileManager.default.removeItem(at: good) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: good.path), "/opt/good/bin")
+
+        let overridden = try makeHome(npmrc: "prefix=/opt/good\nprefix=\"/opt/bad\\q\"\n")
+        defer { try? FileManager.default.removeItem(at: overridden) }
+        let resolved = LLMRunner.npmPrefixBin(home: overridden.path)
+        XCTAssertNotEqual(resolved, "/opt/good/bin",
+                          "the superseded prefix survived a malformed override")
+        XCTAssertNil(resolved)
     }
 
     /// Single quotes are literal in npm -- no decoding there.

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -847,12 +847,23 @@ final class LLMRunnerTests: XCTestCase {
         XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/node/bin")
     }
 
-    /// An invalid escape makes the value un-decodable; keep it raw so the
-    /// absolute-path check rejects it rather than inventing a path.
-    func test_npmPrefixBin_keeps_an_undecodable_quoted_value_raw() throws {
+    /// A double-quoted value npm itself cannot parse yields **no** prefix.
+    ///
+    /// Stripping the quotes instead would leave `/opt/bad\\q` -- absolute, so
+    /// it passes the path check and gets probed, even though npm has no prefix
+    /// from that file at all. A missing candidate is better than a wrong one.
+    func test_npmPrefixBin_discards_an_undecodable_quoted_value() throws {
         let home = try makeHome(npmrc: "prefix=\"/opt/bad\\q\"\n")
         defer { try? FileManager.default.removeItem(at: home) }
-        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/bad\\q/bin")
+        XCTAssertNil(LLMRunner.npmPrefixBin(home: home.path))
+    }
+
+    /// ...but an earlier valid top-level `prefix` still wins, since a later
+    /// unparseable line must not erase a good value.
+    func test_npmPrefixBin_keeps_an_earlier_valid_prefix_when_a_later_one_is_undecodable() throws {
+        let home = try makeHome(npmrc: "prefix=/opt/good\nprefix=\"/opt/bad\\q\"\n")
+        defer { try? FileManager.default.removeItem(at: home) }
+        XCTAssertEqual(LLMRunner.npmPrefixBin(home: home.path), "/opt/good/bin")
     }
 
     /// Single quotes are literal in npm -- no decoding there.


### PR DESCRIPTION
Closes #158

## What & why

Both halves of #158, verified against the code first — both claims held.

**1. Honour the *configured* npm prefix.** `LLMRunner.searchDirectories()` did
hardcode `~/.npm-global/bin` (commented "custom npm prefix") and read no npm
config at all, so a user with `prefix=/somewhere/else` in `~/.npmrc` got no
auto-discovery from a GUI-launched Mila — launchd hands the app a stripped
`PATH` — and had to paste an absolute path into Settings → AI Provider →
Executable.

New `LLMRunner.npmPrefixBin(home:fileManager:)` reads `~/.npmrc`, takes the
`prefix` value, expands a leading `~` / `$HOME` / `${HOME}`, and appends
`/bin`. Subprocess-free on purpose, as the issue asks: `npm config get prefix`
needs `npm` on `PATH`, which is exactly what is missing, and would cost a
spawn per lookup. The parse follows the `ini` semantics npm itself uses:

- `;` and `#` comment lines are skipped, and an unquoted value ends at an
  inline `;`/`#`;
- a quoted value is taken verbatim (paths with spaces survive);
- the last assignment wins;
- CRLF files parse (Swift treats `\r\n` as a single `Character`, so splitting
  on `"\n"` would have read a Windows-saved npmrc as one giant line — caught
  while checking the parser, see below);
- blank / relative / `~someoneelse` / no-`=` values degrade to "no extra
  directory", with a `debug` log line when a *non-empty* value is rejected so a
  typo'd prefix isn't silent.

The configured prefix leads the fallback dirs — it is the only one derived from
real config rather than a guess — and the candidate list is now de-duped
(order kept). That de-dupe isn't decoration: `/usr/local` is npm's own default
prefix, so a configured value routinely equals an entry that is already in the
list or already on `PATH`, and probing the same directory twice per lookup buys
nothing.

**Boundary on npm config sources — `~/.npmrc` only**, reasoned rather than
assumed (documented in the doc comment):

- `NPM_CONFIG_PREFIX` / `npm_config_prefix` / `NPM_CONFIG_USERCONFIG` live in
  the environment, which the launchd launch strips exactly as it strips `PATH`
  — so they are absent in the broken case; and when Mila *is* started from a
  shell, that prefix's `bin` is already on the inherited `PATH` we search
  first. Honouring them would be dead code in one case and redundant in the
  other.
- the global `$PREFIX/etc/npmrc` can only be located once you know the prefix
  (circular), and the two prefixes it realistically names on macOS
  (`/opt/homebrew`, `/usr/local`) are hardcoded in the list already.
- a project-level `./.npmrc` is meaningless for a GUI app whose working
  directory the user never chose.

**2. Tooltip.** Confirmed stale: every example the `help:` gave — `~/.local/bin`,
an asdf shim, a Homebrew prefix — is already searched by `searchDirectories()`,
and it enumerated the three tool names #145 is moving away from. Reworded to the
issue's shorter, tool-agnostic text, plus "your configured npm prefix" now that
it is true. The visible caption below the field
(`Leave blank to look the binary up on $PATH.`) is untouched, as the issue asks.

No new log line for "executable not found" — #192's `logSetupFailure` already
records that at `error` level with the user-facing message, which covers the
#175 case. The only newly-possible failure is "npmrc names a prefix we can't
use", and that gets the `debug` line above.

## How it was tested

- `make build` → **BUILD SUCCEEDED**, no new warnings in either changed file.
- `xcodebuild … build-for-testing` → **TEST BUILD SUCCEEDED**, so the new tests
  compile.
- The parser's semantics were exercised outside the test host: the three new
  helpers were copied verbatim into a standalone `swift` script and run over 20
  npmrc bodies (all the cases below plus `prefix=~`, `prefix=/opt/first` then
  `prefix=`) — all pass. That is how the CRLF bug was found and fixed before
  commit.

**Tests written but not executed here (9 new cases):**
`test_searchDirectories_honours_a_configured_npm_prefix`,
`…_expands_home_in_a_configured_npm_prefix` (`~`, `$HOME`, `${HOME}`),
`…_ignores_unusable_npm_prefix_values` (blank, whitespace-only, relative, both
comment markers, `~someoneelse`, no `=`, no `prefix` key, a `[section]` header),
`…_does_not_duplicate_a_default_npm_prefix`,
`test_npmPrefixBin_strips_quotes_and_inline_comments`,
`…_takes_the_last_assignment_and_normalises_slashes`,
`…_handles_windows_line_endings`, `…_is_nil_without_an_npmrc`.

They were not run locally because every one lives in `MilaTests`, which is
app-hosted: each `xcodebuild test` run launches a freshly ad-hoc-signed
`Mila.app`, and several `MilaTests` files read the login keychain, which pops a
password dialog at the machine's owner. `LLMRunnerTests` additionally holds
smoke tests that invoke the real `claude` / `cursor-agent` / `gemini` binaries.
All nine are pure functions over an injected temp `home` — no network, no
keychain, no subprocess — so **CI is the right place to run them**, and it has:
`unit-and-ui-tests` runs the whole `MilaTests` target (`-only-testing:MilaTests`
in `.github/workflows/ios-tests.yml`) and is green on this head, as is
`build-and-test`.

## Checklist

- [x] Builds locally (`make build`); the new tests were run by CI's
      `unit-and-ui-tests` (green), not locally, for the reason above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — not applicable (no version bump; behaviour change is
      "auto-discovery works for more users")

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mila now detects CLI tools in npm’s configured prefix and other common installation locations.
  * Duplicate executable locations are removed from automatic searches.
  * CLI discovery handles common `.npmrc` formatting variations, including home-directory paths, quoted values, escaped characters, and line endings.

* **Documentation**
  * Updated the AI Provider “Executable” help text to explain automatic search locations and when manual configuration is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->