### PR TITLE
feat(llm): reference the transcript by file path for the Send action

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -114,6 +114,111 @@ struct LLMTestResult: Equatable {
     var didLaunch: Bool { exitCode != nil || httpStatus != nil }
 }
 
+/// The on-disk artifacts a recording already has, for the *reference*
+/// transcript delivery (issue #179). Nothing here is produced for the LLM's
+/// benefit: these are the `.srt` / `.txt` / audio files `TranscriptionService`
+/// and `RecordingStore` write next to every completed recording anyway, so
+/// referencing them puts no new copy of the user's content on disk.
+///
+/// Every field is optional because none of them is guaranteed to exist at the
+/// moment a run starts: the `.srt` is written after the transcription pass and
+/// is skipped entirely for a recording with no segments, and the `.txt` is
+/// removed when the transcript comes up empty. Use `existing(...)` rather than
+/// the memberwise init so a path that is not actually on disk can never reach a
+/// prompt — a reference the CLI can't open is worse than no reference at all,
+/// because the model then answers from the prompt's framing instead of from
+/// anything that was said.
+struct TranscriptFiles: Equatable {
+    /// The `.srt` sidecar: SubRip cues carrying `00:00:07,000 --> 00:00:14,000`
+    /// timings and, when diarization ran, a `SPEAKER_00: ` prefix per cue. The
+    /// only artifact Mila writes that has timestamps at all.
+    var subtitles: URL?
+    /// The `.txt` sidecar. This is `Recording.fullText` — the plain join, with
+    /// **no** speaker labels (unlike the inlined body, which goes through
+    /// `TranscriptFormatter.plainText`). Offered as the easy-to-read whole-file
+    /// option, and it is the only reference available for a recording that has
+    /// no segments; `subtitles` is the richer one whenever it exists.
+    var plainText: URL?
+    /// The recording's audio. Referenced, never suggested for reading — an LLM
+    /// CLI can't decode it, but an agentic action ("file this recording in
+    /// $SYSTEM") needs to know where it is.
+    var audio: URL?
+
+    /// True when there is nothing to point the model at, which is the signal
+    /// for `LLMRunner.effectiveDelivery` to fall back to inlining.
+    var isEmpty: Bool { subtitles == nil && plainText == nil && audio == nil }
+
+    /// Which references survived, as a stable `+`-joined log token
+    /// (`srt+txt+audio`). Extensions only — a *filename* is derived from the
+    /// recording's title, which Mila generates from the meeting, so it is
+    /// content and does not belong in the unified log. See `redactedCommand`.
+    var logToken: String {
+        var parts: [String] = []
+        if subtitles != nil { parts.append("srt") }
+        if plainText != nil { parts.append("txt") }
+        if audio != nil { parts.append("audio") }
+        return parts.isEmpty ? "none" : parts.joined(separator: "+")
+    }
+
+    /// Keep only the paths that exist on disk *and* have bytes in them. The
+    /// zero-length check matters: `RecordingStore` deletes an emptied sidecar,
+    /// but an interrupted atomic write can still leave a 0-byte file behind,
+    /// and "read this empty file" reads to a model as "nothing was said".
+    static func existing(subtitles: URL? = nil,
+                         plainText: URL? = nil,
+                         audio: URL? = nil,
+                         fileManager: FileManager = .default) -> TranscriptFiles {
+        func usable(_ url: URL?) -> URL? {
+            guard let url else { return nil }
+            guard let size = (try? fileManager.attributesOfItem(atPath: url.path))?[.size] as? NSNumber,
+                  size.int64Value > 0 else { return nil }
+            return url
+        }
+        return TranscriptFiles(subtitles: usable(subtitles),
+                               plainText: usable(plainText),
+                               audio: usable(audio))
+    }
+}
+
+/// How the transcript reaches the model (issue #179).
+///
+/// `inline` is the historical behaviour and stays the default everywhere: the
+/// transcript body is pasted into the prompt argument. It is the only shape
+/// that works for a provider with no filesystem — notably the
+/// OpenAI-compatible HTTP endpoint.
+///
+/// `reference` swaps the body for the paths of files Mila already wrote. It
+/// exists because inlining is lossy in a way that is invisible from inside the
+/// prompt: `TranscriptFormatter.plainText` keeps speaker labels but drops every
+/// timestamp, while the `.srt` sitting next to the audio has both. It also
+/// turns a one-shot paste into something an agent can re-read, seek within and
+/// quote exact times out of — which is the point of the Send-to-LLM action.
+///
+/// A caller only ever *requests* a delivery; what actually happens is decided
+/// by `LLMRunner.effectiveDelivery(_:tool:)`, which downgrades to `inline` for
+/// a tool that cannot read files and for an empty reference set.
+enum TranscriptDelivery: Equatable {
+    case inline
+    case reference(TranscriptFiles)
+
+    /// `delivery=` log token.
+    var logToken: String {
+        switch self {
+        case .inline:    return "inline"
+        case .reference: return "reference"
+        }
+    }
+
+    /// `refs=` log token. `none` for inline, so the pair always reads
+    /// consistently.
+    var refsToken: String {
+        switch self {
+        case .inline:               return "none"
+        case .reference(let files): return files.logToken
+        }
+    }
+}
+
 /// Spawns the configured `claude` or `cursor-agent` binary with the user's
 /// prompt + transcript and returns whatever the CLI prints to stdout.
 ///
@@ -122,6 +227,8 @@ struct LLMTestResult: Equatable {
 /// `cursor-agent -p` only looks at argv and silently asks "what transcript?"
 /// when stdin is closed. Putting the transcript in the prompt is the
 /// portable shape that works for both CLIs without the user having to know.
+/// (`TranscriptDelivery.reference` narrows *what* travels in that argument —
+/// paths instead of the body — but not the mechanism: it is still argv.)
 ///
 /// We deliberately don't try to manage authentication, model selection, or
 /// streaming — both CLIs handle that themselves. Our job is "give the user's
@@ -146,12 +253,33 @@ enum LLMRunner {
     /// transcript. Empty / whitespace-only `summary` is omitted entirely
     /// (we don't want "Summary: (empty)" confusing the model when Live AI
     /// wasn't configured for this recording).
+    ///
+    /// `delivery` selects between pasting the transcript body in (the default,
+    /// unchanged) and naming the on-disk sidecars instead (issue #179). Pass the
+    /// value `effectiveDelivery(_:tool:)` returned, not the caller's raw request
+    /// — this function trusts that the paths it is handed exist and that the
+    /// tool can open them. It stays the ONE place either wire format is built,
+    /// so the format tests cover both modes.
     static func composedPrompt(_ userPrompt: String,
                                transcript: String,
-                               summary: String = "") -> String {
+                               summary: String = "",
+                               delivery: TranscriptDelivery = .inline) -> String {
         let prompt = userPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        let body = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         let gist = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if case .reference(let files) = delivery, !files.isEmpty {
+            // Reference mode: the body is deliberately dropped. The summary is
+            // NOT — it is a few hundred characters, it is the gist the model
+            // should read before deciding which file to open, and it may exist
+            // for a recording whose sidecars don't (a Send fired mid-meeting).
+            // Same envelope as inline mode — one `---` under the user's prompt,
+            // blank-line-separated sections after it — so a user who switches
+            // modes doesn't have to re-tune a prompt that says "below".
+            var sections: [String] = []
+            if !gist.isEmpty { sections.append("Summary:\n\(gist)") }
+            sections.append(referenceBlock(files))
+            return "\(prompt)\n\n---\n" + sections.joined(separator: "\n\n")
+        }
+        let body = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         if body.isEmpty && gist.isEmpty { return prompt }
         if gist.isEmpty {
             return "\(prompt)\n\n---\nTranscript:\n\(body)"
@@ -160,6 +288,59 @@ enum LLMRunner {
             return "\(prompt)\n\n---\nSummary:\n\(gist)"
         }
         return "\(prompt)\n\n---\nSummary:\n\(gist)\n\nFull transcript:\n\(body)"
+    }
+
+    /// The path-list half of the reference wire format.
+    ///
+    /// Labels describe the **format**, not the content: "with timestamps" is
+    /// true of every `.srt` Mila writes, whereas "diarized" would be a lie for
+    /// a recording transcribed with diarization off, and the URL alone can't
+    /// tell us which happened. `.srt` is listed first because it is a superset
+    /// of the `.txt` whenever both exist.
+    ///
+    /// The read instruction covers only the transcripts. The audio line sits
+    /// below it, unmentioned, so an agent doesn't spend a tool call trying to
+    /// read an `.m4a` it cannot decode — but an action that has to attach or
+    /// move the recording still knows where it is.
+    static func referenceBlock(_ files: TranscriptFiles) -> String {
+        var lines: [String] = []
+        if let srt = files.subtitles {
+            lines.append("Transcript (SubRip subtitles, with timestamps): \(srt.path)")
+        }
+        if let txt = files.plainText {
+            lines.append("Transcript (plain text): \(txt.path)")
+        }
+        if !lines.isEmpty {
+            lines.append("Read the transcript file(s) above before answering.")
+        }
+        if let audio = files.audio {
+            lines.append("Audio: \(audio.path)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// What `delivery` will actually do for `tool`, applied once in `run` so
+    /// the prompt builder and the log line can never disagree about it.
+    ///
+    /// Two downgrades to `inline`, both of them "the reference would be a lie":
+    ///
+    /// 1. **A tool with no filesystem.** `.openaiCompatible` is a remote HTTP
+    ///    endpoint; handing it `/Users/…/Foo.srt` sends a path it cannot open
+    ///    and gets back an answer about a meeting it never saw. The Settings UI
+    ///    doesn't offer the mode for that provider — this is the defence in
+    ///    depth behind it, exactly like `run`'s own re-check of the base URL.
+    /// 2. **No usable references.** `TranscriptFiles.existing` filtered every
+    ///    candidate out (transcription hasn't finished, or produced no
+    ///    segments and no text). Inlining whatever body we do have beats
+    ///    sending a prompt that points nowhere.
+    ///
+    /// Both degrade rather than throw: a Send that silently loses timestamps is
+    /// a worse answer, but a Send that fails outright is a lost one.
+    static func effectiveDelivery(_ delivery: TranscriptDelivery,
+                                 tool: LLMTool) -> TranscriptDelivery {
+        guard case .reference(let files) = delivery else { return .inline }
+        guard tool.readsLocalFiles, !files.isEmpty else { return .inline }
+        return delivery
     }
 
     /// Run `tool` with `prompt` + `transcript`. Returns stdout, trimmed.
@@ -173,6 +354,13 @@ enum LLMRunner {
     /// Pass empty string when there is no summary (e.g. Live AI not
     /// configured) — the wire format collapses to the old transcript-only
     /// shape in that case.
+    ///
+    /// `delivery` chooses whether the transcript body is inlined into the
+    /// prompt argument (the default, and the historical behaviour) or replaced
+    /// by the paths of the recording's own sidecars (issue #179). Always pass
+    /// the transcript text as well, even in `.reference` mode: it is what
+    /// `effectiveDelivery`'s fallback inlines when the tool can't read files or
+    /// no sidecar turned out to exist.
     ///
     /// `extraArgs` are appended verbatim after the tool's standard arguments
     /// — the user's persisted "Extra args" from Settings → AI Provider (e.g.
@@ -190,6 +378,7 @@ enum LLMRunner {
                     prompt: String,
                     transcript: String,
                     summary: String = "",
+                    delivery: TranscriptDelivery = .inline,
                     executablePathOverride: String?,
                     model: String? = nil,
                     session: LLMSession = .none,
@@ -217,7 +406,11 @@ enum LLMRunner {
 
         // OpenAI-compatible HTTP path — handled before any CLI resolution, so
         // `executablePathOverride` / `session` / `extraArgs` (CLI-only) are
-        // irrelevant here. Defense in depth: `run` has no `LLMSettings`, so it
+        // irrelevant here. `delivery` is deliberately NOT forwarded either: a
+        // remote endpoint cannot open `/Users/…/Foo.srt`, so this path always
+        // sends the transcript inline (issue #179). `effectiveDelivery` encodes
+        // the same rule for anyone composing a prompt without going through
+        // here. Defense in depth: `run` has no `LLMSettings`, so it
         // re-checks the base-URL readiness gate the Settings UI also enforces
         // via `isConfigured` — a nil/empty base URL can't send anything.
         if tool == .openaiCompatible {
@@ -253,7 +446,14 @@ enum LLMRunner {
             logSetupFailure(feature: feature, tool: tool, error: error)
             throw error
         }
-        let fullPrompt = composedPrompt(prompt, transcript: transcript, summary: summary)
+        // Resolve the delivery ONCE, here: the prompt below and the log line
+        // after it must describe the same run, and the downgrade rules live in
+        // `effectiveDelivery` rather than being re-derived at each use.
+        let resolvedDelivery = effectiveDelivery(delivery, tool: tool)
+        let fullPrompt = composedPrompt(prompt,
+                                        transcript: transcript,
+                                        summary: summary,
+                                        delivery: resolvedDelivery)
         let arguments = tool.arguments(prompt: fullPrompt,
                                        model: model,
                                        session: session) + extraArgs
@@ -272,6 +472,7 @@ enum LLMRunner {
                     summaryChars: summary.count,
                     transcriptChars: transcript.count,
                     composedChars: fullPrompt.count,
+                    delivery: resolvedDelivery,
                     timeout: timeout,
                     command: command)
         // ProcessHandle bridges Swift task cancellation to the underlying
@@ -548,6 +749,11 @@ enum LLMRunner {
                     summaryChars: summary.count,
                     transcriptChars: transcript.count,
                     composedChars: fullPrompt.count,
+                    // The Settings test panel runs against its own editable
+                    // sample transcript, not a recording, so there are no
+                    // sidecars to reference — this path is inline by
+                    // construction rather than by choice.
+                    delivery: .inline,
                     timeout: timeout,
                     command: loggedCommand)
         // Bridge Task cancellation to the child process, same as `run` — if
@@ -815,7 +1021,18 @@ enum LLMRunner {
     /// payload keeps the shape diagnosable without publishing the payload.
     /// Two things get redacted:
     ///
-    /// 1. **The composed prompt**, which is the meeting transcript.
+    /// 1. **The composed prompt.** Under the default `inline` delivery this is
+    ///    the meeting transcript, verbatim. Under `reference` delivery (issue
+    ///    #179) the body is gone — but the argument is *not* thereby neutral,
+    ///    which is the trap: it still carries the Live-AI summary, and it
+    ///    carries the sidecar paths, whose filenames Mila derives from the
+    ///    recording's title, which the LLM generated from the meeting. A run
+    ///    log full of `…/Q3 layoffs — legal review.srt` leaks the same thing
+    ///    the transcript would, one line at a time. So the placeholder holds in
+    ///    both modes, and the thing the reference mode actually made
+    ///    un-diagnosable — "did it send paths or the body, and which files?" —
+    ///    is answered by the `delivery=` / `refs=` tokens on the start line,
+    ///    which name extensions and never filenames.
     /// 2. **The values of the user's own "Extra args"** (the trailing
     ///    `extraArgsCount` tokens). These are free text from Settings → AI
     ///    Provider and people do put credentials in them — `--api-key sk-…`,
@@ -918,6 +1135,15 @@ enum LLMRunner {
     /// to catch, and the path is useless when redacted. It can contain the
     /// account's short name — the same exposure the pre-existing sandbox-path
     /// line already accepts.
+    ///
+    /// `delivery=` / `refs=` are the counterpart for issue #179. The
+    /// transcript's *path* can't be logged (it embeds the recording title — see
+    /// `redactedCommand`), so these say the shape instead: `delivery=reference
+    /// refs=srt+txt+audio` versus `delivery=inline refs=none`. That is enough
+    /// to tell the two failures apart — "the mode is on but silently fell back
+    /// to inlining because the `.srt` wasn't written yet" reads as
+    /// `delivery=inline` with a non-zero `transcript=`, while a genuine
+    /// reference run shows `transcript=` bytes that never left the machine.
     static func logRunStart(feature: LLMFeature,
                             tool: LLMTool,
                             executable: URL,
@@ -928,6 +1154,7 @@ enum LLMRunner {
                             summaryChars: Int,
                             transcriptChars: Int,
                             composedChars: Int,
+                            delivery: TranscriptDelivery,
                             timeout: TimeInterval,
                             command: String) {
         llmRunnerLog.notice("""
@@ -941,6 +1168,8 @@ enum LLMRunner {
             summary=\(summaryChars, privacy: .public)c \
             transcript=\(transcriptChars, privacy: .public)c \
             composed=\(composedChars, privacy: .public)c \
+            delivery=\(delivery.logToken, privacy: .public) \
+            refs=\(delivery.refsToken, privacy: .public) \
             timeout=\(Int(timeout.rounded(.up)), privacy: .public)s
             """)
         // The redacted argv is `debug`: it repeats what the start line already

--- a/Mila/Actions/LLMSettings.swift
+++ b/Mila/Actions/LLMSettings.swift
@@ -89,6 +89,28 @@ enum LLMTool: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Whether this tool runs on the user's machine and can therefore open a
+    /// file we name in the prompt. Gates `TranscriptDelivery.reference`
+    /// (issue #179).
+    ///
+    /// True for all three CLIs: each is an agentic coding tool whose whole
+    /// premise is reading the local filesystem, and each is launched with
+    /// workspace trust already granted (`cursor-agent -f`, `gemini
+    /// --skip-trust`) so a read in the sandbox cwd's world doesn't stall on a
+    /// prompt Mila would never see.
+    ///
+    /// False for `.openaiCompatible` — a remote HTTP endpoint has no filesystem
+    /// — and for `.none`, which runs nothing. This is the "must never apply to
+    /// the OpenAI-compatible provider" constraint from #179, expressed once
+    /// here so the Settings UI and `LLMRunner.effectiveDelivery` cannot drift
+    /// apart on it.
+    var readsLocalFiles: Bool {
+        switch self {
+        case .claude, .cursor, .gemini: return true
+        case .none, .openaiCompatible:  return false
+        }
+    }
+
     /// Default executable name (looked up via the user's `$PATH`). Empty for
     /// `.openaiCompatible` — the HTTP branch in `LLMRunner.run` returns before
     /// `resolveExecutable` is ever reached for this case.
@@ -226,6 +248,44 @@ final class LLMSettings: ObservableObject {
 
     @Published var postActionPrompt: String {
         didSet { defaults.set(postActionPrompt, forKey: Keys.actionPrompt) }
+    }
+
+    /// Send-to-LLM action only: hand the CLI the recording's sidecar **paths**
+    /// instead of pasting the transcript into the prompt (issue #179).
+    ///
+    /// Off by default, deliberately. Inlining is the shape that works
+    /// everywhere, and reference delivery trades that for fidelity: the `.srt`
+    /// it points at is the only artifact carrying timestamps, and the CLI can
+    /// re-read and seek within a file it opened itself. The cost is a
+    /// dependency on the CLI actually performing the read — which is why this
+    /// governs the *action* and not title generation or the automatic summary.
+    /// Those two run unattended on every recording, so a tool that declines to
+    /// read the file would degrade them silently and permanently; the action is
+    /// user-triggered and its result is shown in a banner, where "it didn't
+    /// read the transcript" is immediately visible.
+    ///
+    /// Scoped per-feature rather than global for the same reason. See
+    /// `actionDeliversTranscriptByPath` for the readiness gate that pairs with
+    /// this switch (`.claude/rules/feature-gates.md`).
+    @Published var actionTranscriptByPath: Bool {
+        didSet {
+            guard actionTranscriptByPath != oldValue else { return }
+            defaults.set(actionTranscriptByPath, forKey: Keys.actionTranscriptByPath)
+        }
+    }
+
+    /// "Enabled AND usable": the user asked for path delivery *and* the
+    /// selected tool can actually read a local file. Per
+    /// `.claude/rules/feature-gates.md` the persisted switch on its own is not
+    /// a readiness signal — a user who turns this on and later switches to the
+    /// OpenAI-compatible endpoint must not start shipping paths to a remote
+    /// endpoint that cannot open them. Callers ask this, never
+    /// `actionTranscriptByPath`.
+    ///
+    /// The stored preference is left untouched by the gate so switching back to
+    /// a CLI restores the user's choice rather than silently losing it.
+    var actionDeliversTranscriptByPath: Bool {
+        actionTranscriptByPath && tool.readsLocalFiles
     }
 
     /// Value `cliTimeout` falls back to when nothing is persisted, and the
@@ -506,6 +566,10 @@ final class LLMSettings: ObservableObject {
         self.namePrompt = defaults.string(forKey: Keys.namePrompt) ?? Self.defaultNamePrompt
         self.postActionEnabled = defaults.bool(forKey: Keys.actionEnabled)
         self.postActionPrompt = defaults.string(forKey: Keys.actionPrompt) ?? Self.defaultActionPrompt
+        // Default-OFF, so a plain `bool` read is the right one here (unlike
+        // `summaryEnabled` below): "key absent" and "user said no" mean the
+        // same thing, and inlining must stay the behaviour nobody opted into.
+        self.actionTranscriptByPath = defaults.bool(forKey: Keys.actionTranscriptByPath)
         // Default-on: a bare `defaults.bool` would read false for users who
         // have never seen this key, silently disabling summaries for
         // everyone on upgrade. Treat "key absent" as true.
@@ -571,6 +635,7 @@ final class LLMSettings: ObservableObject {
         static let namePrompt = "llm.name.prompt"
         static let actionEnabled = "llm.action.enabled"
         static let actionPrompt = "llm.action.prompt"
+        static let actionTranscriptByPath = "llm.action.transcriptByPath"
         static let summaryEnabled = "llm.summary.enabled"
         static let cliTimeout = "llm.cli.timeout"
         static let extraArgs = "llm.extraArgs"

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -52,7 +52,11 @@ final class PostRecordingCoordinator: ObservableObject {
         // Which surface this call is for — the auto-title path and the Send
         // path share this one seam, so the label has to come from the call
         // site or the log can't tell them apart (issue #175).
-        _ feature: LLMFeature
+        _ feature: LLMFeature,
+        // Inline the transcript body, or name the recording's sidecars and let
+        // the CLI read them (issue #179). Only the Send path ever asks for
+        // `.reference`; the auto-title path passes `.inline`.
+        _ delivery: TranscriptDelivery
     ) async throws -> String
     private let runLLM: RunLLM
 
@@ -87,12 +91,13 @@ final class PostRecordingCoordinator: ObservableObject {
     init(store: RecordingStore,
          transcription: TranscriptionService,
          llm: LLMSettings,
-         runLLM: @escaping RunLLM = { tool, prompt, transcript, summary, executablePathOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport, feature in
+         runLLM: @escaping RunLLM = { tool, prompt, transcript, summary, executablePathOverride, model, extraArgs, timeout, openAIBaseURL, openAIAPIKey, jsonMode, transport, feature, delivery in
         try await LLMRunner.run(
             tool: tool,
             prompt: prompt,
             transcript: transcript,
             summary: summary,
+            delivery: delivery,
             executablePathOverride: executablePathOverride,
             model: model,
             extraArgs: extraArgs,
@@ -194,7 +199,13 @@ final class PostRecordingCoordinator: ObservableObject {
                     openAIAPIKey,
                     false,
                     nil,
-                    .name)
+                    .name,
+                    // Titles stay inlined. Path delivery is scoped to the
+                    // Send action (issue #179): this path runs unattended on
+                    // every recording, so a CLI that skipped the read would
+                    // quietly title everything from a prompt with no
+                    // transcript in it, and nobody would notice.
+                    .inline)
                 if Task.isCancelled { return }
                 let title = Self.cleanedTitle(from: suggestion)
                 guard !title.isEmpty else { return }
@@ -289,6 +300,12 @@ final class PostRecordingCoordinator: ObservableObject {
     /// Idempotent per id: a second send for the same recording cancels and
     /// replaces the first (no use case for two competing CLI calls writing
     /// the same banner). The task clears its own handle on completion.
+    ///
+    /// When `LLMSettings.actionDeliversTranscriptByPath` is on, the composed
+    /// prompt names the recording's `.srt` / `.txt` / audio files instead of
+    /// carrying the transcript body (issue #179). `transcript` is still
+    /// resolved and passed either way — it is the fallback when no sidecar
+    /// exists yet.
     func sendToLLM(recordingID: UUID,
                    tool: LLMTool,
                    prompt: String,
@@ -314,6 +331,13 @@ final class PostRecordingCoordinator: ObservableObject {
         let openAIBaseURL = llm.openAIBaseURL
         let openAIAPIKey = llm.openAIAPIKey
         let openAIModelName = llm.openAIModelName
+        // Whether to reference the transcript by path (issue #179) is a
+        // click-time snapshot for the same reason the endpoint fields are: the
+        // Task below can sit in `awaitTranscript` for minutes, and a Settings
+        // edit landing in that window must not repaint this send. The *paths*
+        // are resolved later, inside the Task — they only exist once
+        // transcription has written them.
+        let byPath = llm.actionDeliversTranscriptByPath
         let task = Task { @MainActor [weak self] in
             defer {
                 // Only relinquish the slot if we finished on our own. If we
@@ -359,7 +383,12 @@ final class PostRecordingCoordinator: ObservableObject {
                     openAIAPIKey,
                     false,
                     nil,
-                    .action)
+                    .action,
+                    // Resolved here, after the transcript wait: the `.srt` is
+                    // written at the end of the transcription pass, so asking
+                    // any earlier would find nothing and fall back to inline
+                    // for every send fired mid-recording.
+                    byPath ? self.transcriptReferences(for: recordingID) : .inline)
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")
                     .prefix(80)
@@ -376,6 +405,29 @@ final class PostRecordingCoordinator: ObservableObject {
             }
         }
         sendTasks[recordingID] = task
+    }
+
+    /// The recording's own sidecars, as a `.reference` delivery (issue #179).
+    ///
+    /// Nothing is written here: `.srt`, `.txt` and the audio are files
+    /// `TranscriptionService` / `RecordingStore` already maintain next to each
+    /// other in the recordings directory, and `TranscriptFiles.existing` drops
+    /// any of them that isn't on disk with bytes in it. So the mode adds no new
+    /// copy of the user's transcript anywhere — in particular not into the
+    /// shared `llm-sandbox` cwd (#187), which every later invocation is also
+    /// chdir'd into and would therefore be able to read (the concern open in
+    /// #190).
+    ///
+    /// Returns `.reference` with an empty set when nothing exists yet;
+    /// `LLMRunner.effectiveDelivery` turns that back into `.inline`, so the
+    /// worst case is today's behaviour rather than a prompt pointing nowhere.
+    private func transcriptReferences(for recordingID: UUID) -> TranscriptDelivery {
+        guard let rec = store.recordings.first(where: { $0.id == recordingID }) else {
+            return .inline
+        }
+        return .reference(.existing(subtitles: store.subtitleURL(for: rec),
+                                    plainText: store.transcriptURL(for: rec),
+                                    audio: store.audioURL(for: rec)))
     }
 
     /// Poll the store until `recordingID` has a non-empty transcript and

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1377,6 +1377,7 @@ private struct AIFeaturesSettingsTab: View {
                         ExamplesView(title: "Examples", items: LLMSettings.actionExamples) {
                             settings.postActionPrompt = $0
                         }
+                        transcriptByPathToggle
                     }
                 }
                 Divider()
@@ -1403,6 +1404,48 @@ private struct AIFeaturesSettingsTab: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)
         }
+    }
+
+    /// Transcript delivery for the Send-to-LLM action (issue #179): paste the
+    /// transcript into the prompt, or name the recording's files and let the CLI
+    /// read them.
+    ///
+    /// Lives inside the action row rather than next to the provider picker
+    /// because it governs that one feature — title generation and the automatic
+    /// summary stay inlined on purpose (see
+    /// `LLMSettings.actionTranscriptByPath`).
+    ///
+    /// Greyed rather than hidden for a provider that can't read files, matching
+    /// how the Live AI row treats its own gates: a control that vanishes reads
+    /// as "this app can't do that", and the caption says which gate is closed.
+    private var transcriptByPathToggle: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Toggle("Send the transcript as a file path",
+                   isOn: $settings.actionTranscriptByPath)
+                .font(.callout)
+                .toggleStyle(.switch)
+                .disabled(!settings.postActionEnabled || !settings.tool.readsLocalFiles)
+                .accessibilityIdentifier("llm.action.transcriptByPath.toggle")
+            Text(transcriptByPathCaption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+        }
+        .help("Instead of pasting the transcript into the prompt, Mila names the "
+              + "recording's subtitle (.srt), transcript (.txt) and audio files and "
+              + "asks the tool to read them. The .srt keeps the timestamps the pasted "
+              + "text drops, and the tool can re-read or seek within the file instead "
+              + "of getting one pass over a blob. Needs a tool that reads local files.")
+    }
+
+    /// Say which gate is closed rather than leaving a dead switch unexplained —
+    /// same principle as `liveAICaption`.
+    private var transcriptByPathCaption: String {
+        if !settings.tool.readsLocalFiles {
+            return "Needs a local CLI — the OpenAI-compatible endpoint can't read your files."
+        }
+        return "Point the tool at the recording's .srt / .txt / audio instead of pasting the text. Keeps timestamps."
     }
 
     /// Live AI has two independent gates on top of the user's own switch, and

--- a/MilaTests/LLMRunnerObservabilityTests.swift
+++ b/MilaTests/LLMRunnerObservabilityTests.swift
@@ -37,6 +37,11 @@ final class LLMRunnerObservabilityTests: XCTestCase {
 
     /// The privacy invariant stated directly, so a future refactor that stops
     /// redacting fails here rather than in a user's log.
+    ///
+    /// This is the *inline* delivery — the transcript is literally inside the
+    /// prompt argument. See
+    /// `test_redacted_command_never_contains_referenced_sidecar_paths` for why
+    /// the redaction still has to hold once #179 takes the body back out.
     func test_redacted_command_never_contains_transcript_text() {
         let secret = "Acme is acquiring Globex for $4.2M"
         let prompt = LLMRunner.composedPrompt("Name this call.", transcript: secret)
@@ -56,6 +61,59 @@ final class LLMRunnerObservabilityTests: XCTestCase {
         // …while the diagnostically useful parts are all still there.
         XCTAssertTrue(command.contains("--resume \(session.uuidString)"))
         XCTAssertTrue(command.contains("/usr/local/bin/claude"))
+    }
+
+    /// Issue #179 moves the transcript body out of argv and puts sidecar
+    /// **paths** there instead. The tempting conclusion is that the prompt
+    /// argument no longer needs redacting; it is wrong, and this test is the
+    /// statement of why.
+    ///
+    /// A recording's filename is derived from its title, and Mila generates
+    /// that title from the meeting with an LLM. So `…/Q3 layoffs — legal
+    /// review.srt` in a log line leaks the same class of thing the transcript
+    /// would, one line at a time, into a store that persists for days and is
+    /// readable by anything with the right entitlement. The prompt argument
+    /// also still carries the Live-AI summary in this mode.
+    ///
+    /// What replaces the lost detail is the `delivery=` / `refs=` pair on the
+    /// start line, which names extensions and never filenames.
+    func test_redacted_command_never_contains_referenced_sidecar_paths() {
+        let title = "Q3 layoffs — legal review"
+        let dir = "/Users/someone/Recordings"
+        let files = TranscriptFiles(subtitles: URL(fileURLWithPath: "\(dir)/\(title).srt"),
+                                    plainText: URL(fileURLWithPath: "\(dir)/\(title).txt"),
+                                    audio: URL(fileURLWithPath: "\(dir)/\(title).m4a"))
+        let prompt = LLMRunner.composedPrompt("File this.",
+                                              transcript: "the body",
+                                              summary: "We agreed to ship on Friday.",
+                                              delivery: .reference(files))
+        let args = LLMTool.claude.arguments(prompt: prompt)
+        let command = LLMRunner.redactedCommand(
+            executable: URL(fileURLWithPath: "/usr/local/bin/claude"),
+            arguments: args,
+            prompt: prompt)
+
+        XCTAssertEqual(command, "/usr/local/bin/claude -p <prompt:\(prompt.count)c>")
+        XCTAssertFalse(command.contains(title),
+                       "a recording title leaked into the logged command via its path: \(command)")
+        XCTAssertFalse(command.contains(".srt"),
+                       "a referenced sidecar path leaked into the logged command: \(command)")
+        XCTAssertFalse(command.contains("ship on Friday"),
+                       "the summary leaked into the logged command: \(command)")
+    }
+
+    /// The tokens that replace what reference delivery took away. Pinned as
+    /// literals because they are grep targets in the unified log, exactly like
+    /// the `feature=` tokens below.
+    func test_delivery_log_tokens_are_stable() {
+        XCTAssertEqual(TranscriptDelivery.inline.logToken, "inline")
+        XCTAssertEqual(TranscriptDelivery.inline.refsToken, "none")
+
+        let files = TranscriptFiles(subtitles: URL(fileURLWithPath: "/r/a.srt"),
+                                    plainText: URL(fileURLWithPath: "/r/a.txt"),
+                                    audio: URL(fileURLWithPath: "/r/a.m4a"))
+        XCTAssertEqual(TranscriptDelivery.reference(files).logToken, "reference")
+        XCTAssertEqual(TranscriptDelivery.reference(files).refsToken, "srt+txt+audio")
     }
 
     /// An empty prompt must not turn into a wildcard that redacts every empty

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -272,7 +272,7 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         var callCount = 0
         let openAICoordinator = PostRecordingCoordinator(
             store: store, transcription: service, llm: llm,
-            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _ in
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _, _ in
                 capturedModel = model
                 callCount += 1
                 return "OPENAI ANSWER"
@@ -304,7 +304,7 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         var callCount = 0
         let cliCoordinator = PostRecordingCoordinator(
             store: store, transcription: service, llm: llm,
-            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _ in
+            runLLM: { _, _, _, _, _, model, _, _, _, _, _, _, _, _ in
                 capturedModel = model
                 callCount += 1
                 return "CLI ANSWER"
@@ -320,6 +320,143 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         try await waitFor(callCount > 0)
         XCTAssertNil(capturedModel,
                      "The CLI path must leave model nil (the CLI chooses its own)")
+    }
+
+    // MARK: - Transcript delivery (issue #179)
+
+    /// With the setting on, the send must hand the runner the recording's own
+    /// sidecars rather than the transcript body. The paths have to come from the
+    /// store — the sheets that call `sendToLLM` only ever pass text, so if the
+    /// coordinator didn't derive them nothing would.
+    func test_sendToLLM_references_the_recordings_sidecars_when_enabled() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.byPath.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.byPath.\(#function)")
+        let llm = LLMSettings(defaults: suite,
+                              apiKeyKeychainKey: "PostRecordingCoordinatorSendTests.byPath.\(#function)")
+        llm.tool = .claude
+        llm.actionTranscriptByPath = true
+
+        var captured: TranscriptDelivery?
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, delivery in
+                captured = delivery
+                callCount += 1
+                return "ANSWER"
+            })
+
+        let rec = addCompletedRecording(text: "the transcript text")
+        // `store.add` writes the `.txt`; the `.srt` is written by the
+        // transcription pass, which the stub engine never runs here.
+        let srt = store.subtitleURL(for: rec)
+        try "1\n00:00:01,000 --> 00:00:04,000\nSPEAKER_00: hello\n\n"
+            .write(to: srt, atomically: true, encoding: .utf8)
+
+        coordinator.sendToLLM(recordingID: rec.id,
+                              tool: .claude,
+                              prompt: "File this",
+                              transcript: "the transcript text",
+                              summary: "",
+                              executableOverride: nil)
+        try await waitFor(callCount > 0)
+
+        guard case .reference(let files) = captured else {
+            return XCTFail("expected a reference delivery, got \(String(describing: captured))")
+        }
+        XCTAssertEqual(files.subtitles, srt)
+        XCTAssertEqual(files.plainText, store.transcriptURL(for: rec))
+        XCTAssertEqual(files.audio, store.audioURL(for: rec))
+    }
+
+    /// Off by default (#179's first constraint), so an untouched install keeps
+    /// inlining exactly as it did before.
+    func test_sendToLLM_inlines_by_default() async throws {
+        var captured: TranscriptDelivery?
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service,
+            llm: LLMSettings(defaults: UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.inline.\(#function)")!,
+                             apiKeyKeychainKey: "PostRecordingCoordinatorSendTests.inline.\(#function)"),
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, delivery in
+                captured = delivery
+                callCount += 1
+                return "ANSWER"
+            })
+
+        let rec = addCompletedRecording(text: "the transcript text")
+        coordinator.sendToLLM(recordingID: rec.id,
+                              tool: .claude,
+                              prompt: "Summarize",
+                              transcript: "the transcript text",
+                              summary: "",
+                              executableOverride: nil)
+        try await waitFor(callCount > 0)
+
+        XCTAssertEqual(captured, .inline)
+    }
+
+    /// The recording was discarded while the send was waiting for its
+    /// transcript, so there is nothing left to reference. Inline is the safe
+    /// answer — it is what the runner would fall back to anyway.
+    func test_sendToLLM_inlines_when_the_recording_is_gone() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.gone.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.gone.\(#function)")
+        let llm = LLMSettings(defaults: suite,
+                              apiKeyKeychainKey: "PostRecordingCoordinatorSendTests.gone.\(#function)")
+        llm.tool = .claude
+        llm.actionTranscriptByPath = true
+
+        var captured: TranscriptDelivery?
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, delivery in
+                captured = delivery
+                callCount += 1
+                return "ANSWER"
+            })
+
+        coordinator.sendToLLM(recordingID: UUID(),
+                              tool: .claude,
+                              prompt: "Summarize",
+                              // Non-empty, so the send doesn't stall in
+                              // `awaitTranscript` looking for a recording that
+                              // was never in the store.
+                              transcript: "the transcript text",
+                              summary: "",
+                              executableOverride: nil)
+        try await waitFor(callCount > 0)
+
+        XCTAssertEqual(captured, .inline)
+    }
+
+    /// The title path is deliberately excluded from path delivery: it runs
+    /// unattended on every recording, so a CLI that skipped the read would
+    /// quietly title everything from a prompt with no transcript in it.
+    func test_auto_title_always_inlines() async throws {
+        let suite = UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.title.\(#function)")!
+        suite.removePersistentDomain(forName: "PostRecordingCoordinatorSendTests.title.\(#function)")
+        let llm = LLMSettings(defaults: suite,
+                              apiKeyKeychainKey: "PostRecordingCoordinatorSendTests.title.\(#function)")
+        llm.tool = .claude
+        llm.nameGenerationEnabled = true
+        llm.actionTranscriptByPath = true
+
+        var captured: TranscriptDelivery?
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, _, _, _, _, _, _, _, _, _, _, _, delivery in
+                captured = delivery
+                callCount += 1
+                return "A Tidy Title"
+            })
+
+        coordinator.present(addCompletedRecording(text: "the transcript text"))
+        try await waitFor(callCount > 0)
+
+        XCTAssertEqual(captured, .inline)
     }
 
     // MARK: - Helpers

--- a/MilaTests/TranscriptDeliveryTests.swift
+++ b/MilaTests/TranscriptDeliveryTests.swift
@@ -1,0 +1,387 @@
+import XCTest
+@testable import Mila
+
+/// Issue #179 — "reference the transcript by file path instead of inlining it
+/// in argv".
+///
+/// The transcript really does travel inside the prompt argument today
+/// (`LLMRunnerTests.test_runner_passes_prompt_in_argv_and_closes_stdin` proves
+/// it by spawning a script that echoes its last argv token), and inlining it
+/// there is lossy in a way nothing in the prompt reveals:
+/// `TranscriptFormatter.plainText` keeps speaker labels but drops every
+/// timestamp, while the `.srt` sidecar written next to the same audio has both.
+/// `TranscriptDelivery.reference` names those files instead of pasting the body.
+///
+/// What is pinned here is the whole decision surface, and all of it is pure:
+/// which references survive the existence filter, when the mode downgrades back
+/// to inlining, and the two wire formats `composedPrompt` can emit.
+///
+/// Deliberately its own file rather than an addition to `LLMRunnerTests`: that
+/// class also holds smoke tests that invoke the real `claude` / `cursor-agent` /
+/// `gemini` binaries, so it cannot be run casually. Nothing here spawns a
+/// process or touches the network; the only I/O is temp files this class writes
+/// and removes itself.
+final class TranscriptDeliveryTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptDeliveryTests.\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot,
+                                                withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        try super.tearDownWithError()
+    }
+
+    /// Write `contents` to `name` under the temp root and return its URL.
+    /// Passing `""` creates the zero-byte case on purpose.
+    private func makeFile(_ name: String, contents: String = "x") throws -> URL {
+        let url = tempRoot.appendingPathComponent(name)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// A path under the temp root that deliberately has no file behind it.
+    private func missing(_ name: String) -> URL {
+        tempRoot.appendingPathComponent(name)
+    }
+
+    // MARK: - TranscriptFiles.existing
+
+    /// The reason `existing` exists at all: none of the three artifacts is
+    /// guaranteed to be on disk when a send fires. A path that can't be opened
+    /// is worse than no path, because the model then answers from the prompt's
+    /// framing ("the transcript is in that file") rather than from anything
+    /// that was actually said.
+    func test_existing_drops_paths_with_no_file_behind_them() throws {
+        let srt = try makeFile("Standup.srt", contents: "1\n00:00:01,000 --> 00:00:02,000\nhi\n\n")
+        let files = TranscriptFiles.existing(subtitles: srt,
+                                             plainText: missing("Standup.txt"),
+                                             audio: missing("Standup.m4a"))
+
+        XCTAssertEqual(files.subtitles, srt)
+        XCTAssertNil(files.plainText)
+        XCTAssertNil(files.audio)
+        XCTAssertFalse(files.isEmpty)
+    }
+
+    /// `RecordingStore` deletes an emptied sidecar rather than truncating it,
+    /// but an interrupted atomic write can still leave 0 bytes behind — and
+    /// "read this empty file" reads to a model as "nothing was said", which is
+    /// a confidently wrong answer rather than a missing one.
+    func test_existing_drops_zero_byte_files() throws {
+        let empty = try makeFile("Silent.srt", contents: "")
+        let text = try makeFile("Silent.txt", contents: "we did speak")
+
+        let files = TranscriptFiles.existing(subtitles: empty, plainText: text)
+
+        XCTAssertNil(files.subtitles, "a 0-byte sidecar must not be referenced")
+        XCTAssertEqual(files.plainText, text)
+    }
+
+    func test_existing_with_nothing_on_disk_is_empty() {
+        let files = TranscriptFiles.existing(subtitles: missing("a.srt"),
+                                             plainText: missing("a.txt"),
+                                             audio: missing("a.m4a"))
+        XCTAssertTrue(files.isEmpty)
+    }
+
+    // MARK: - log tokens
+
+    /// `refs=` is the only thing in the log that says which artifacts a run
+    /// referenced — the paths themselves can't be logged (see
+    /// `redactedCommand`), so this token carries the whole diagnosis.
+    /// Extensions, never filenames.
+    func test_log_token_lists_the_surviving_references() throws {
+        let srt = try makeFile("a.srt")
+        let txt = try makeFile("a.txt")
+        let m4a = try makeFile("a.m4a")
+
+        XCTAssertEqual(TranscriptFiles(subtitles: srt, plainText: txt, audio: m4a).logToken,
+                       "srt+txt+audio")
+        XCTAssertEqual(TranscriptFiles(subtitles: srt, plainText: nil, audio: m4a).logToken,
+                       "srt+audio")
+        XCTAssertEqual(TranscriptFiles(plainText: txt).logToken, "txt")
+        XCTAssertEqual(TranscriptFiles().logToken, "none")
+    }
+
+    /// The pair of tokens has to read consistently for an inline run too, or a
+    /// log scan for `refs=` silently skips half the invocations.
+    func test_delivery_tokens_render_both_modes() throws {
+        let srt = try makeFile("a.srt")
+        XCTAssertEqual(TranscriptDelivery.inline.logToken, "inline")
+        XCTAssertEqual(TranscriptDelivery.inline.refsToken, "none")
+
+        let reference = TranscriptDelivery.reference(TranscriptFiles(subtitles: srt))
+        XCTAssertEqual(reference.logToken, "reference")
+        XCTAssertEqual(reference.refsToken, "srt")
+    }
+
+    // MARK: - readsLocalFiles (the provider gate)
+
+    /// #179's hard constraint: reference delivery must never apply to the
+    /// OpenAI-compatible endpoint, which has no access to the local filesystem.
+    /// Stated once on `LLMTool` so the Settings UI and
+    /// `LLMRunner.effectiveDelivery` can't drift apart on it.
+    func test_only_local_CLIs_read_local_files() {
+        XCTAssertTrue(LLMTool.claude.readsLocalFiles)
+        XCTAssertTrue(LLMTool.cursor.readsLocalFiles)
+        XCTAssertTrue(LLMTool.gemini.readsLocalFiles)
+        XCTAssertFalse(LLMTool.openaiCompatible.readsLocalFiles,
+                       "a remote HTTP endpoint cannot open a path we name")
+        XCTAssertFalse(LLMTool.none.readsLocalFiles)
+    }
+
+    // MARK: - effectiveDelivery
+
+    func test_effective_delivery_keeps_reference_for_a_local_cli() throws {
+        let srt = try makeFile("a.srt")
+        let requested = TranscriptDelivery.reference(TranscriptFiles(subtitles: srt))
+
+        for tool in [LLMTool.claude, .cursor, .gemini] {
+            XCTAssertEqual(LLMRunner.effectiveDelivery(requested, tool: tool), requested,
+                           "\(tool) can read files — the reference must survive")
+        }
+    }
+
+    /// Defense in depth behind the Settings gate. `run` returns down the HTTP
+    /// branch before it ever composes a CLI prompt, but anything that composes
+    /// one directly gets the same answer here.
+    func test_effective_delivery_downgrades_for_a_provider_with_no_filesystem() throws {
+        let srt = try makeFile("a.srt")
+        let requested = TranscriptDelivery.reference(TranscriptFiles(subtitles: srt))
+
+        XCTAssertEqual(LLMRunner.effectiveDelivery(requested, tool: .openaiCompatible),
+                       .inline)
+        XCTAssertEqual(LLMRunner.effectiveDelivery(requested, tool: .none), .inline)
+    }
+
+    /// The transcription pass writes the `.srt` last, so a send fired before it
+    /// finishes finds nothing. Inlining whatever body we do have beats sending a
+    /// prompt that points nowhere — the worst case of the new mode is exactly
+    /// today's behaviour.
+    func test_effective_delivery_downgrades_when_no_reference_exists() {
+        XCTAssertEqual(
+            LLMRunner.effectiveDelivery(.reference(TranscriptFiles()), tool: .claude),
+            .inline)
+    }
+
+    func test_effective_delivery_leaves_inline_alone() {
+        XCTAssertEqual(LLMRunner.effectiveDelivery(.inline, tool: .claude), .inline)
+    }
+
+    // MARK: - composedPrompt, reference mode
+
+    /// The wire format from the issue. `.srt` is listed first because it is a
+    /// superset of the `.txt` whenever both exist, and the read instruction
+    /// covers only the transcripts — the audio line sits *below* it so an agent
+    /// doesn't burn a tool call trying to read an `.m4a` it can't decode.
+    func test_composed_prompt_reference_lists_srt_then_txt_then_audio() throws {
+        let srt = try makeFile("Q3 review.srt")
+        let txt = try makeFile("Q3 review.txt")
+        let m4a = try makeFile("Q3 review.m4a")
+
+        let composed = LLMRunner.composedPrompt(
+            "File this in the tracker.",
+            transcript: "unused in reference mode",
+            delivery: .reference(TranscriptFiles(subtitles: srt, plainText: txt, audio: m4a)))
+
+        XCTAssertEqual(composed, """
+            File this in the tracker.
+
+            ---
+            Transcript (SubRip subtitles, with timestamps): \(srt.path)
+            Transcript (plain text): \(txt.path)
+            Read the transcript file(s) above before answering.
+            Audio: \(m4a.path)
+            """)
+    }
+
+    /// The point of the whole change, asserted directly: in reference mode the
+    /// transcript body does not appear in the composed prompt, so it never
+    /// reaches argv.
+    func test_composed_prompt_reference_omits_the_transcript_body() throws {
+        let srt = try makeFile("a.srt")
+        let body = "Acme is acquiring Globex for $4.2M"
+
+        let composed = LLMRunner.composedPrompt(
+            "Summarize.",
+            transcript: body,
+            delivery: .reference(TranscriptFiles(subtitles: srt)))
+
+        XCTAssertFalse(composed.contains(body),
+                       "reference delivery must not inline the transcript: \(composed)")
+        XCTAssertTrue(composed.contains(srt.path))
+    }
+
+    /// The summary is NOT dropped with the body. It is a few hundred characters,
+    /// it is the gist the model should have before it picks a file to open, and
+    /// it can exist for a recording whose sidecars don't (a send fired
+    /// mid-meeting). Same `Summary:` label and same position as inline mode, so
+    /// a user switching modes doesn't have to re-tune a prompt.
+    func test_composed_prompt_reference_keeps_the_summary_above_the_paths() throws {
+        let srt = try makeFile("a.srt")
+
+        let composed = LLMRunner.composedPrompt(
+            "Draft the follow-up.",
+            transcript: "the body",
+            summary: "We agreed to ship on Friday.",
+            delivery: .reference(TranscriptFiles(subtitles: srt)))
+
+        XCTAssertEqual(composed, """
+            Draft the follow-up.
+
+            ---
+            Summary:
+            We agreed to ship on Friday.
+
+            Transcript (SubRip subtitles, with timestamps): \(srt.path)
+            Read the transcript file(s) above before answering.
+            """)
+    }
+
+    /// A recording with no segments gets no `.srt` at all, and its `.txt` is the
+    /// only transcript there is. The label stays honest — it never claims
+    /// timestamps for a plain-text file.
+    func test_composed_prompt_reference_with_only_plain_text() throws {
+        let txt = try makeFile("a.txt")
+
+        let composed = LLMRunner.composedPrompt(
+            "Summarize.",
+            transcript: "the body",
+            delivery: .reference(TranscriptFiles(plainText: txt)))
+
+        XCTAssertEqual(composed, """
+            Summarize.
+
+            ---
+            Transcript (plain text): \(txt.path)
+            Read the transcript file(s) above before answering.
+            """)
+    }
+
+    /// Audio but no transcript: there is nothing to read, so the read
+    /// instruction must not appear — telling a model to read "the file(s) above"
+    /// when the only one is an undecodable `.m4a` is an instruction to fail.
+    func test_composed_prompt_reference_with_audio_only_omits_the_read_instruction() throws {
+        let m4a = try makeFile("a.m4a")
+
+        let composed = LLMRunner.composedPrompt(
+            "File this.",
+            transcript: "the body",
+            delivery: .reference(TranscriptFiles(audio: m4a)))
+
+        XCTAssertEqual(composed, """
+            File this.
+
+            ---
+            Audio: \(m4a.path)
+            """)
+        XCTAssertFalse(composed.contains("Read the transcript"))
+    }
+
+    /// An empty reference set collapses to the inline format even if
+    /// `composedPrompt` is called with `.reference` directly — belt and braces
+    /// alongside `effectiveDelivery`, since a prompt whose only content is a
+    /// `---` separator is the one output that helps nobody.
+    func test_composed_prompt_reference_with_no_files_falls_back_to_inline() {
+        let composed = LLMRunner.composedPrompt(
+            "Summarize.",
+            transcript: "Hello world.",
+            delivery: .reference(TranscriptFiles()))
+
+        XCTAssertEqual(composed, "Summarize.\n\n---\nTranscript:\nHello world.")
+    }
+
+    // MARK: - composedPrompt, inline mode is untouched
+
+    /// Inlining is the default and every existing caller must keep producing
+    /// the byte-identical prompt it produced before #179 — this is the
+    /// back-compat guarantee for the OpenAI path, title generation, the
+    /// automatic summary, Live AI and the Settings test panel, none of which
+    /// pass a delivery at all.
+    func test_default_delivery_is_inline_and_unchanged() {
+        XCTAssertEqual(
+            LLMRunner.composedPrompt("Summarize this.", transcript: "Hello world."),
+            "Summarize this.\n\n---\nTranscript:\nHello world.")
+        XCTAssertEqual(
+            LLMRunner.composedPrompt("Make a tweet.",
+                                     transcript: "Hello world.",
+                                     summary: "We discussed the new schema."),
+            "Make a tweet.\n\n---\nSummary:\nWe discussed the new schema.\n\nFull transcript:\nHello world.")
+    }
+
+    // MARK: - LLMSettings gate
+
+    /// Inlining stays the default (#179's first constraint): a fresh install,
+    /// and an upgrading user who has never seen this switch, must both keep
+    /// pasting the transcript.
+    @MainActor
+    func test_setting_defaults_to_inline() {
+        let suite = "TranscriptDeliveryTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let llm = LLMSettings(defaults: defaults,
+                              apiKeyKeychainKey: "TranscriptDeliveryTests.\(UUID())")
+        llm.tool = .claude
+
+        XCTAssertFalse(llm.actionTranscriptByPath)
+        XCTAssertFalse(llm.actionDeliversTranscriptByPath)
+    }
+
+    /// The key is the persistence contract — renaming it silently resets the
+    /// user's choice, which is what `AISettingsKeyCompatibilityTests` exists to
+    /// prevent for the rest of this model.
+    @MainActor
+    func test_setting_round_trips_through_its_namespaced_key() {
+        let suite = "TranscriptDeliveryTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let keychainKey = "TranscriptDeliveryTests.\(UUID())"
+
+        defaults.set(true, forKey: "llm.action.transcriptByPath")
+        let restored = LLMSettings(defaults: defaults, apiKeyKeychainKey: keychainKey)
+        restored.tool = .claude
+        XCTAssertTrue(restored.actionTranscriptByPath,
+                      "a stored preference must be adopted at init")
+        XCTAssertTrue(restored.actionDeliversTranscriptByPath)
+
+        restored.actionTranscriptByPath = false
+        XCTAssertFalse(defaults.bool(forKey: "llm.action.transcriptByPath"))
+    }
+
+    /// `.claude/rules/feature-gates.md`: the switch alone is not readiness.
+    /// A user who turns this on and later moves to the OpenAI-compatible
+    /// endpoint must not start shipping paths to something that cannot open
+    /// them — and the stored preference must survive the trip so switching back
+    /// to a CLI restores it rather than silently losing it.
+    @MainActor
+    func test_setting_is_gated_off_for_a_provider_that_cannot_read_files() {
+        let suite = "TranscriptDeliveryTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let llm = LLMSettings(defaults: defaults,
+                              apiKeyKeychainKey: "TranscriptDeliveryTests.\(UUID())")
+        llm.tool = .claude
+        llm.actionTranscriptByPath = true
+        XCTAssertTrue(llm.actionDeliversTranscriptByPath)
+
+        llm.tool = .openaiCompatible
+        XCTAssertFalse(llm.actionDeliversTranscriptByPath,
+                       "path delivery must be inert for the HTTP provider")
+        XCTAssertTrue(llm.actionTranscriptByPath,
+                      "the user's stored choice must survive the gate")
+
+        llm.tool = .cursor
+        XCTAssertTrue(llm.actionDeliversTranscriptByPath,
+                      "switching back to a CLI restores the preference")
+    }
+}


### PR DESCRIPTION
Closes #179

## What & why

The Send-to-LLM action can now hand the CLI the recording's own sidecar **paths** instead of pasting the transcript into the prompt argument. Off by default; inlining is unchanged for everything else.

**The premise checks out, with one correction.** The transcript really is in argv today — `composedPrompt` puts it in the `-p` argument, and `LLMRunnerTests.test_runner_passes_prompt_in_argv_and_closes_stdin` already proves it by echoing the last argv token. And the fidelity loss is real: `TranscriptFormatter.plainText` keeps speaker labels but carries no times, while the `.srt` written next to the same audio has both.

Two things in the issue don't hold as written, and the implementation reflects the corrected version:

- The accessor is `Recording.subtitleFileName` / `RecordingStore.subtitleURL(for:)`, not `srtFileName`.
- **The `.txt` sidecar is *poorer* than what we inline today, not richer.** It holds `Recording.fullText` — the plain join, with no speaker labels — whereas the inlined body goes through `TranscriptFormatter.plainText`. Only the `.srt` is a strict superset. So `.srt` is listed first, `.txt` is offered as the whole-file plain option (and is the only reference that exists for a recording with no segments), and the labels describe the *format* rather than claiming diarization the URL can't attest to.

The issue is also explicit that this is **not** about argv size limits, and that holds: ~65 KB largest transcript against a 1 MB `ARG_MAX`, and #192 already keeps the body out of the log. Nothing here is justified by a size or quoting problem — it's fidelity and agent capability.

### What changed

- **`TranscriptFiles` / `TranscriptDelivery`** in `LLMRunner.swift`. `TranscriptFiles.existing(...)` filters to paths that are on disk *with bytes in them* — a 0-byte sidecar reads to a model as "nothing was said", which is a confidently wrong answer rather than a missing one.
- **`composedPrompt(_:transcript:summary:delivery:)`** stays the single place either wire format is built, so the existing format tests cover both modes. Reference mode emits the issue's shape, keeping the same `---` envelope so a prompt that says "below" still reads correctly. The read instruction covers only the transcripts; the audio line sits below it, unmentioned, so an agent doesn't burn a tool call on an `.m4a` it can't decode.
- **`LLMRunner.effectiveDelivery(_:tool:)`** — the gate, applied once in `run` so the prompt and the log line can't disagree. Two downgrades back to `inline`, both "the reference would be a lie": a tool with no filesystem (`.openaiCompatible`, `.none` — the issue's hard constraint, expressed once on `LLMTool.readsLocalFiles` so the UI and the runner can't drift), and a reference set that came back empty. Both degrade rather than throw: **the worst case of the new mode is exactly today's behaviour.**
- **`LLMSettings.actionTranscriptByPath`** (`llm.action.transcriptByPath`, default off) plus `actionDeliversTranscriptByPath`, the readiness gate per `.claude/rules/feature-gates.md`. The stored preference survives switching to a provider that can't read files, so switching back restores it.
- **Settings → AI Features → Send-to-LLM action** gains one switch, greyed with an explanatory caption when the provider can't read files (same treatment the Live AI row gives its gates). No other UI change.
- **`PostRecordingCoordinator`** derives the paths from the store, so neither sheet that calls `sendToLLM` needed touching. The `byPath` decision is a click-time snapshot (a Settings edit mid-send must not repaint it); the *paths* are resolved after the transcript wait, because the `.srt` is written at the end of the transcription pass and asking earlier would find nothing for every send fired mid-recording.

### Where the transcript file lives: nowhere new

**No temp file is written.** The `.srt`, `.txt` and audio are files `TranscriptionService` and `RecordingStore` already maintain next to each other in the recordings directory — the proposal is to *reference* what is written today, so the feature adds no copy of the user's content anywhere.

That side-steps #190 entirely rather than mitigating it: nothing of the user's is placed in the shared `llm-sandbox` cwd from #187, which every later invocation is also chdir'd into and could therefore read. There is also nothing to clean up and nothing to accumulate.

### Timestamps: reference the `.srt`, don't inline it

Referencing the `.srt` is where the value is — it's the only artifact with times. But inline mode is deliberately **not** changed to carry timestamps:

- SRT roughly triples the payload (sequence number + paired timecodes per cue) for content the model mostly doesn't need.
- Whisper's cues are ~5–10s fragments. That fragmentation reads *worse* to a summarizer than the speaker-collapsed paragraphs `TranscriptFormatter.plainText` already produces.

So the timestamped rendering is available to any agent that wants it, at the cost of a file read, and the default one-shot path keeps the shape that summarizes well. The issue never actually asked for inlined timestamps, and I don't think it should.

### #192's redaction rationale: updated, not relaxed

The tempting conclusion is that once the body leaves argv the prompt argument no longer needs redacting. It's wrong, and the doc comment and a new test both say why: the argument still carries the Live-AI summary, and it carries the sidecar paths — whose filenames Mila derives from the recording title, which Mila generated from the meeting with an LLM. A run log full of `…/Q3 layoffs — legal review.srt` leaks the same class of thing the transcript would, one line at a time, into a store that persists for days.

So `<prompt:Nc>` holds in both modes. What replaces the detail reference mode *did* make un-diagnosable ("did it send paths or the body, and which files?") is a new `delivery=` / `refs=` pair on the start line, naming extensions and never filenames. A silent fallback now reads as `delivery=inline` with a non-zero `transcript=`; a genuine reference run shows `transcript=` bytes that never left the machine.

`LLMRunnerObservabilityTests`' invariant test is unchanged and still passes (it pins inline mode); it gained a cross-reference plus a sibling, `test_redacted_command_never_contains_referenced_sidecar_paths`, asserting the title, the `.srt` path and the summary are all absent from the logged command in reference mode.

## How it was tested

**Built, not run.** `make build` → `** BUILD SUCCEEDED **`, and `xcodebuild … build-for-testing` → `** TEST BUILD SUCCEEDED **` after `make project` picked up the new test file (so every test below compiles).

**I did not execute any test.** App-hosted tests launch a freshly ad-hoc-signed `Mila.app` and several `MilaTests` files read the real login keychain, which pops a password dialog at the machine's owner; `LLMRunnerTests` additionally holds smoke tests that invoke the real `claude` / `cursor-agent` / `gemini` binaries. CI runs them.

Tests written and committed but **not executed**:

- `MilaTests/TranscriptDeliveryTests.swift` (new, 18 tests, pure + temp files only, no process/network): `TranscriptFiles.existing` dropping missing and 0-byte paths; `logToken` / `refsToken` renderings; `readsLocalFiles` per tool; all four `effectiveDelivery` branches; the reference wire format for srt+txt+audio, srt-only, txt-only, audio-only (no read instruction) and summary-above-paths; that reference mode omits the body; that an empty reference set falls back to the inline format; that the default delivery is byte-identical to pre-#179 inline output; and the `LLMSettings` default-off, key round-trip, and provider gate.
- `MilaTests/LLMRunnerObservabilityTests.swift`: `test_redacted_command_never_contains_referenced_sidecar_paths`, `test_delivery_log_tokens_are_stable`.
- `MilaTests/PostRecordingCoordinatorSendTests.swift`: the seam receives `.reference` with all three store-derived paths when enabled; `.inline` by default; `.inline` when the recording is gone; and the auto-title path always inlines. Two existing stub closures gained a `_` for the new seam parameter.

## Left out, deliberately

- **Executable discovery** — #158 owns it and touches this same file.
- **Title generation, the automatic summary, Live AI and the Settings test panel all stay inlined.** The first two run unattended on every recording, so a CLI that declined the read would degrade them silently and permanently; Live AI has no sidecar yet (the recording is still running); the test panel has no recording at all, only its editable sample.
- **The OpenAI-compatible HTTP path** gets no `delivery` forwarded, by construction.
- No `RELEASE_NOTES/` entry — that belongs to whichever version ships this.

## Checklist

- [x] Builds locally (`make build`); tests written and compiled but **not run** — see above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — not touched; flag if wanted

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to send transcripts as local file references instead of inline text.
  * Supports subtitle, plain-text transcript, and audio files when available.
  * Added settings guidance and automatic fallback to inline delivery when file access isn’t supported.
  * Transcript references are available for compatible local tools.

* **Bug Fixes**
  * Auto-generated titles continue to use inline transcript delivery.

* **Tests**
  * Added coverage for delivery modes, settings persistence, file availability, fallback behavior, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->