### PR TITLE
fix(llm): restore action items on the one-shot summary

### DIFF
--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -373,8 +373,15 @@ final class RecordingSummarizer: ObservableObject {
                 return "Hebrew"
             }
         }()
-        let prompt = liveAISettings.summaryPrompt
+        let basePrompt = liveAISettings.summaryPrompt
             .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName)
+        // Wrap the user's plain-text summary prompt so the one-shot call
+        // also returns action items. Restores the summary + action-items
+        // pair the pre-#87 inline final Live-AI tick used to produce. See
+        // `promptWithActionItems`: the summary stays PLAIN TEXT and only a
+        // compact item array is JSON, so a long multi-line Hebrew summary
+        // full of quotes can't corrupt the parse.
+        let prompt = Self.promptWithActionItems(base: basePrompt)
         let transcript = recording.fullText
         let timeout = timeoutSeconds
         // OpenAI-compatible config captured up front so the detached call
@@ -425,8 +432,15 @@ final class RecordingSummarizer: ObservableObject {
                     false,
                     nil
                 )
-                let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !cleaned.isEmpty else {
+                // Split the CLI output into the plain-text summary and the
+                // action-items list. `parseSummaryAndItems` handles the
+                // sentinel format the prompt asks for, tolerates a model
+                // that returned a JSON envelope instead, and — crucially —
+                // never surfaces a raw `{...}` blob as the summary when the
+                // model emits malformed JSON (unescaped quotes / newlines in
+                // a long summary value, which broke the object decode).
+                let (summaryText, parsedItems) = Self.parseSummaryAndItems(from: raw)
+                guard !summaryText.isEmpty else {
                     summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
                     // No summary landed — let a pending export fall back to
                     // the transcript rather than waiting forever. Skip the
@@ -454,10 +468,18 @@ final class RecordingSummarizer: ObservableObject {
                     self.onSummaryFinished?(current)
                     return
                 }
-                current.summary = cleaned
+                current.summary = summaryText
+                // Replace the recording's action items with the fresh
+                // full-transcript set whenever the model returned any. An
+                // empty list is treated as "keep what's there" so a glitchy
+                // empty response can't wipe the rolling live snapshot a
+                // Live-AI recording already captured at stop.
+                if !parsedItems.isEmpty {
+                    current.actionItems = parsedItems
+                }
                 self.store.update(current)
                 let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(cleaned.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
+                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(summaryText.count, privacy: .public) items=\(parsedItems.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
                 self.onSummaryFinished?(current)
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -502,6 +524,106 @@ final class RecordingSummarizer: ObservableObject {
 
     private func shortID(_ id: UUID) -> String {
         String(id.uuidString.prefix(8))
+    }
+
+    /// Marker the one-shot prompt asks the model to place between the
+    /// plain-text summary and the JSON action-items array. Keeping the
+    /// summary OUTSIDE any JSON is deliberate: LLMs routinely emit long,
+    /// multi-line summaries with unescaped quotes/newlines, which makes an
+    /// enclosing JSON object un-decodable. Only the compact item array — far
+    /// less prone to stray quotes — needs to be valid JSON.
+    static let actionItemsSentinel = "###ACTION_ITEMS###"
+
+    /// Wrap the user's plain-text summary prompt so the one-shot call also
+    /// returns action items, WITHOUT embedding the summary in JSON. The
+    /// user's `summaryPrompt` still drives the summary's content and style
+    /// (including its `{{LANGUAGE}}` directive); this only appends the
+    /// output-format + action-item contract. Building the request here rather
+    /// than baking it into the persisted `summaryPrompt` means a user's
+    /// customised prompt keeps working and no persisted-default migration is
+    /// needed.
+    static func promptWithActionItems(base: String) -> String {
+        """
+        \(base)
+
+        After the summary, list the action items. Format your ENTIRE response \
+        exactly like this — the plain-text summary first, then the marker on \
+        its own line, then a JSON array:
+
+        <the summary as plain text>
+        \(actionItemsSentinel)
+        [{"id": "stable-slug", "text": "...", "source": "inferred"}]
+
+        Write the summary as plain text — do NOT wrap it in JSON or quotes. \
+        Output the marker \(actionItemsSentinel) verbatim on its own line, then \
+        ONLY the JSON array and nothing after it. An action item is a concrete \
+        task someone committed to do (with or without a deadline) or an \
+        explicit follow-up or request. If there are none, output an empty \
+        array: []
+        """
+    }
+
+    /// Split raw CLI output into `(summary, items)`.
+    ///
+    /// Resolution order, most-trusted first:
+    ///   1. Sentinel format (what `promptWithActionItems` asks for): plain
+    ///      summary before `actionItemsSentinel`, JSON array after it.
+    ///   2. A JSON envelope `{"summary":...,"items":[...]}` the model may have
+    ///      returned out of habit — decoded via `LiveAISession.parseEnvelope`.
+    ///   3. Malformed JSON that LOOKS like an envelope (the failure the user
+    ///      hit: unescaped quotes broke the object decode). Salvage the
+    ///      summary text so a raw `{...}` blob is never shown, and keep any
+    ///      items the lenient array parse recovered.
+    ///   4. Plain prose — the whole output is the summary, no items.
+    static func parseSummaryAndItems(from raw: String) -> (summary: String, items: [ActionItem]) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let sentinel = trimmed.range(of: actionItemsSentinel) {
+            let summary = String(trimmed[..<sentinel.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let items = LiveAISession.parseActionItems(from: String(trimmed[sentinel.upperBound...]))
+            return (summary, items)
+        }
+        // No sentinel — the model returned a JSON envelope (or prose).
+        let parsed = LiveAISession.parseEnvelope(from: trimmed)
+        if !parsed.summary.isEmpty {
+            return (parsed.summary, parsed.items)
+        }
+        // Object decode produced no summary. If it still looks like an
+        // envelope, salvage the summary value rather than surfacing the blob.
+        if trimmed.hasPrefix("{"), trimmed.range(of: "\"summary\"") != nil {
+            return (Self.salvageSummaryValue(from: trimmed), parsed.items)
+        }
+        return (trimmed, [])
+    }
+
+    /// Best-effort extraction of the `"summary"` value from a JSON string the
+    /// decoder rejected (typically because the value itself contains
+    /// unescaped `"`). Anchors on the structural `"items"` key that follows
+    /// the summary value, so quotes INSIDE the summary don't cut it short,
+    /// then un-escapes the common JSON escapes so `\n` renders as newlines.
+    static func salvageSummaryValue(from json: String) -> String {
+        guard let keyRange = json.range(of: "\"summary\"") else { return "" }
+        let afterKey = json[keyRange.upperBound...]
+        guard let colon = afterKey.firstIndex(of: ":") else { return "" }
+        let afterColon = afterKey[afterKey.index(after: colon)...]
+        guard let openQuote = afterColon.firstIndex(of: "\"") else { return "" }
+        let valueStart = afterColon.index(after: openQuote)
+        let rest = afterColon[valueStart...]
+        let endIdx: Substring.Index
+        if let itemsAnchor = rest.range(of: "\", \"items\"")
+            ?? rest.range(of: "\",\"items\"") {
+            endIdx = itemsAnchor.lowerBound
+        } else if let lastQuote = rest.lastIndex(of: "\"") {
+            endIdx = lastQuote
+        } else {
+            endIdx = rest.endIndex
+        }
+        let value = String(rest[..<endIdx])
+            .replacingOccurrences(of: "\\n", with: "\n")
+            .replacingOccurrences(of: "\\t", with: "\t")
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\/", with: "/")
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// The freshest copy of a recording from the store, or `fallback` when

--- a/Mila/Models/LiveAISettings.swift
+++ b/Mila/Models/LiveAISettings.swift
@@ -273,7 +273,18 @@ final class LiveAISettings: ObservableObject {
         self.prompt = defaults.string(forKey: Keys.prompt) ?? Self.defaultPrompt
         let langRaw = defaults.string(forKey: Keys.outputLanguage) ?? OutputLanguage.auto.rawValue
         self.outputLanguage = OutputLanguage(rawValue: langRaw) ?? .auto
-        self.summaryPrompt = defaults.string(forKey: Keys.summaryPrompt) ?? Self.defaultSummaryPrompt
+        // Migrate users still on the pre-1.8.x concise default up to the
+        // richer `defaultSummaryPrompt`. A nil value (never set) or an exact
+        // match of the old default both adopt the new default; any other
+        // value is a user customisation and is preserved as-is. Idempotent:
+        // the migration is a pure read (we don't write the default back), so
+        // a later prompt revision can migrate the same way.
+        let storedSummaryPrompt = defaults.string(forKey: Keys.summaryPrompt)
+        if let stored = storedSummaryPrompt, stored != Self.legacySummaryPromptV1 {
+            self.summaryPrompt = stored
+        } else {
+            self.summaryPrompt = Self.defaultSummaryPrompt
+        }
     }
 
     /// Default model. Currently `claude-sonnet-4-6` — better
@@ -326,13 +337,40 @@ If the call has just started and there is no transcript yet, output \
 {"summary": "", "items": []}.
 """
 
-    /// Default one-shot summary prompt. Plain-text, meeting-style — no
-    /// JSON envelope, no action items, no "you've been called repeatedly"
-    /// framing. This runs ONCE against the full transcript after a
-    /// recording finishes, so the prompt can assume the model has the
-    /// complete picture and just needs to produce a concise human-readable
-    /// summary. `{{LANGUAGE}}` is substituted at send time.
+    /// Default one-shot summary prompt. Plain-text, meeting-style — this
+    /// runs ONCE against the full transcript after a recording finishes, so
+    /// the prompt can assume the model has the complete picture. The one-shot
+    /// caller (`RecordingSummarizer`) appends the action-items contract at
+    /// send time, so this prompt only governs the SUMMARY content/style.
+    /// `{{LANGUAGE}}` is substituted at send time.
+    ///
+    /// Depth deliberately matches the pre-#87 live summary: an overview, the
+    /// main topics with their key points, decisions made, and — when the
+    /// conversation centres on specific people / projects / items — a
+    /// per-item breakdown so each one's situation and next steps are clear.
     static let defaultSummaryPrompt = """
+You are summarizing a meeting transcript. Output everything in {{LANGUAGE}}.
+
+Write a thorough summary for someone who did not attend. Cover:
+  • A short overview of what the meeting was about.
+  • The main topics discussed, with the key points for each.
+  • Any decisions that were made.
+  • When the conversation centres on specific people, projects, or items,
+    break the summary down per person / topic so each one's situation and
+    the next steps for it are clear.
+
+Use short paragraphs or bullet points, and **bold** the key names and
+topics so the summary is easy to skim. Be comprehensive but do not repeat
+yourself. Do NOT include a preamble like "Here is the summary"; start
+directly with the content.
+"""
+
+    /// The pre-1.8.x concise default. Kept verbatim so `init` can migrate a
+    /// user still on the old default up to `defaultSummaryPrompt` without
+    /// clobbering a genuinely customised prompt. Do not edit — changing it
+    /// would break the migration match. (Retire once enough releases have
+    /// passed that no one is on the old default.)
+    static let legacySummaryPromptV1 = """
 You are summarizing a meeting transcript. Output everything in {{LANGUAGE}}.
 
 Read the transcript below and produce a concise summary suitable for

--- a/MilaTests/LiveAISettingsMigrationTests.swift
+++ b/MilaTests/LiveAISettingsMigrationTests.swift
@@ -100,4 +100,36 @@ final class LiveAISettingsMigrationTests: XCTestCase {
         let settings = LiveAISettings(defaults: defaults)
         XCTAssertEqual(settings.speakerSimilarityThreshold, 0.55, accuracy: 0.0001)
     }
+
+    // MARK: - summaryPrompt
+
+    func test_summaryPrompt_unset_uses_new_default() {
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt)
+    }
+
+    /// A user still carrying the pre-1.8.x concise default must be migrated
+    /// up to the richer default so the summary regains its pre-#87 depth.
+    func test_summaryPrompt_legacy_default_migrates_to_new_default() {
+        defaults.set(LiveAISettings.legacySummaryPromptV1, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt,
+                       "The legacy concise default must be migrated to the richer default")
+    }
+
+    /// A genuinely customised prompt must never be clobbered by the migration.
+    func test_summaryPrompt_custom_value_is_preserved() {
+        let custom = "Summarise in exactly three bullet points."
+        defaults.set(custom, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, custom,
+                       "A user's customised summary prompt must survive the migration")
+    }
+
+    /// A user already on the new default keeps it (no spurious reset).
+    func test_summaryPrompt_new_default_is_preserved() {
+        defaults.set(LiveAISettings.defaultSummaryPrompt, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt)
+    }
 }

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -506,6 +506,197 @@ final class RecordingSummarizerTests: XCTestCase {
                        "The OpenAI summary path must send openAIModelName, not the Live AI model")
     }
 
+    // MARK: - JSON envelope (summary + action items)
+
+    /// The one-shot summarizer now asks for a JSON envelope so it can
+    /// populate BOTH the summary and the action-items list from the full
+    /// transcript — restoring the pair the pre-#87 inline final Live-AI
+    /// tick used to produce. A well-formed envelope must land both halves.
+    func test_summarize_parses_envelope_and_stores_summary_and_action_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            #"{"summary": "We agreed to ship next week.", "items": [{"id": "ship", "text": "Ship the beta", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}, {"id": "deck", "text": "Dana sends the deck", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}]}"#
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Envelope")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Envelope",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "we discussed the roadmap and agreed to ship next week"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "We agreed to ship next week.")
+        let items = try XCTUnwrap(updated.actionItems)
+        XCTAssertEqual(items.map(\.text), ["Ship the beta", "Dana sends the deck"])
+    }
+
+    /// Back-compat: a model that ignores the JSON instruction and returns
+    /// plain prose must still have its whole output stored as the summary,
+    /// with no action items — exactly the pre-change behaviour.
+    func test_summarize_plain_text_output_still_stored_as_summary_without_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "Just a plain prose summary." }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Prose")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Prose",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "transcript text"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Just a plain prose summary.")
+        XCTAssertNil(updated.actionItems,
+                     "plain-text output must not fabricate an action-items list")
+    }
+
+    /// `regenerate` (the Live-AI finalize path + manual affordance) must
+    /// REPLACE stale action items with the fresh full-transcript set, the
+    /// same way it already replaces the summary.
+    func test_regenerate_replaces_action_items_from_full_transcript() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            #"{"summary": "Fresh summary.", "items": [{"id": "new", "text": "New follow-up", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}]}"#
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "RegenItems")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "RegenItems",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.summary = "stale summary"
+        rec.actionItems = [ActionItem(id: "old", text: "Stale item", speaker: nil,
+                                      timestampSeconds: 0, source: .llmInferred,
+                                      addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Fresh summary.")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["New follow-up"],
+                       "regenerate must replace the stale action items")
+    }
+
+    /// An empty (or absent) items list must NOT wipe action items the
+    /// recording already has — e.g. a Live-AI recording's rolling snapshot.
+    /// A glitchy prose response shouldn't cost the user their items.
+    func test_regenerate_empty_items_preserves_existing_action_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "Only a prose summary, no JSON." }
+
+        let audioURL = store.freshAudioURL(suggestedName: "KeepItems")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "KeepItems",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.summary = "stale summary"
+        rec.actionItems = [ActionItem(id: "keep", text: "Keep me", speaker: nil,
+                                      timestampSeconds: 0, source: .llmInferred,
+                                      addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Only a prose summary, no JSON.")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["Keep me"],
+                       "an empty items response must not wipe existing action items")
+    }
+
+    /// The prompt's preferred shape: a plain-text summary, the sentinel on
+    /// its own line, then a JSON array. The summary stays plain text (no JSON
+    /// wrapping) and the items are parsed from the trailing array.
+    func test_summarize_parses_sentinel_format() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            """
+            We agreed to ship next week and Dana owns the deck.
+            \(RecordingSummarizer.actionItemsSentinel)
+            [{"id": "ship", "text": "Ship the beta", "source": "inferred"}, {"id": "deck", "text": "Dana sends the deck", "source": "inferred"}]
+            """
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Sentinel")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Sentinel",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "we discussed the roadmap"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "We agreed to ship next week and Dana owns the deck.")
+        XCTAssertFalse(updated.summary?.contains(RecordingSummarizer.actionItemsSentinel) ?? true,
+                       "the sentinel marker must not leak into the summary")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["Ship the beta", "Dana sends the deck"])
+    }
+
+    /// Regression for the reported bug: the model returned a JSON envelope
+    /// whose summary value had UNESCAPED quotes and newlines (Hebrew review),
+    /// so the object decode failed. The summarizer must NOT dump the raw
+    /// `{...}` blob into the summary — it salvages the summary text and still
+    /// recovers the (independently valid) items array.
+    func test_summarize_salvages_summary_from_malformed_json_envelope() async throws {
+        llm.tool = .claude
+        // Note the unescaped inner quotes around על חלל and the literal \n —
+        // exactly what broke JSONDecoder in production.
+        let malformed = #"{"summary": "השיחה עסקה בניהול צוות.\n\n• בייליס מתנהג כאילו הוא "על חלל" ואינו לוקח אחריות.", "items": [{"id": "a", "text": "להחזיר לבייליס ביקורת ישירה", "source": "inferred"}, {"id": "b", "text": "לנטרל את גוליאן משיחות פרודקט", "source": "inferred"}]}"#
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in malformed }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Malformed")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Malformed",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        let summary = try XCTUnwrap(updated.summary)
+        XCTAssertFalse(summary.hasPrefix("{"),
+                       "a raw JSON blob must never be shown as the summary")
+        XCTAssertFalse(summary.contains("\"items\""),
+                       "the items scaffolding must not leak into the summary")
+        XCTAssertTrue(summary.contains("השיחה עסקה בניהול צוות"),
+                      "the real summary text must be salvaged")
+        XCTAssertTrue(summary.contains("\n"),
+                      "escaped newlines must be restored so it renders as lines")
+        XCTAssertEqual(updated.actionItems?.count, 2,
+                       "the valid items array must still be recovered")
+    }
+
     // MARK: - Helpers
 
     /// Rebuild `summarizer` with a deterministic `runLLM` stub so the


### PR DESCRIPTION
Closes #199

## What

The post-recording one-shot summarizer again produces **summary + action items** from the full transcript, and no longer stores a raw `{...}` blob when the model emits broken JSON.

## Why

#87 moved the final summary to a one-shot CLI call that only stored plain text. That dropped the action-items half of the old Live-AI stop tick, and when a model still returned a JSON envelope with unescaped quotes/newlines (typical in long Hebrew summaries) the UI showed the malformed object as the summary.

## How

- `RecordingSummarizer` wraps the user's summary prompt with an output contract: plain-text summary, then `###ACTION_ITEMS###`, then a JSON array. Custom prompts keep working because the extra contract is not persisted.
- Parse order: sentinel → valid envelope → salvage a broken envelope (extract `"summary"` without decoding the object) → prose fallback.
- Fresh items replace the recording's list; an empty list **keeps** existing Live-AI items so a glitchy response cannot wipe them.
- Default summary prompt is richer again (pre-#87 depth). Exact match of the old concise default is migrated; any other stored value is treated as a customisation.

## Tests

`RecordingSummarizerTests` + `LiveAISettingsMigrationTests`: **36/36 passed** (sentinel, envelope, prose, regenerate replace/preserve items, Hebrew salvage, prompt migration).

Made with [Cursor](https://cursor.com)