### PR TITLE
feat(settings): replace the tab strip with a sidebar, and prove it renders in CI

### DIFF
--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -108,6 +108,14 @@ jobs:
               - 'scripts/fixtures/**'
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
+              # DetailLayoutUITests screenshots the main window AND the
+              # Settings window, so a change to either container has to be
+              # able to trigger this job. #194 shipped an empty Settings
+              # window past a green CI precisely because nothing here looked
+              # at Settings; leaving the view out of the filter would put the
+              # new coverage back out of reach.
+              - 'Mila/Views/SettingsView.swift'
+              - 'Mila/Views/ContentView.swift'
               - 'MilaUITests/DetailLayoutUITests.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
       - name: Install xcodegen

--- a/.github/workflows/llm-live-ai-e2e.yml
+++ b/.github/workflows/llm-live-ai-e2e.yml
@@ -109,13 +109,29 @@ jobs:
               - 'Mila/Models/LiveAISettings.swift'
               - 'Mila/Actions/LiveAISession.swift'
               # DetailLayoutUITests screenshots the main window AND the
-              # Settings window, so a change to either container has to be
-              # able to trigger this job. #194 shipped an empty Settings
-              # window past a green CI precisely because nothing here looked
-              # at Settings; leaving the view out of the filter would put the
-              # new coverage back out of reach.
-              - 'Mila/Views/SettingsView.swift'
-              - 'Mila/Views/ContentView.swift'
+              # Settings window, so a change to any view this job renders —
+              # or to any accessibility identifier or launch seam it queries
+              # — has to be able to trigger it.
+              #
+              # A glob rather than a hand-kept list of files, deliberately.
+              # #194 shipped an empty Settings window past a green CI
+              # precisely because nothing here looked at Settings, and an
+              # incomplete filter reproduces that failure exactly: the job
+              # never runs, so the coverage exists on paper only. Enumerating
+              # files re-opens that hole every time a view moves, gets split,
+              # or a new destination lands in a new file — three ways for
+              # this list to rot silently. Naming the whole directory cannot
+              # rot. The identifiers these tests match on are spread across
+              # SidebarView (sidebar.settings.link, sidebar.folder.default,
+              # sidebar.recording.*), RecordingDetailView
+              # (detail.title.label), SettingsView (settings.section.* plus
+              # most destination probes), StorageSettingsTab and
+              # VoiceMemosSettingsTab (their probes) — all under Mila/Views.
+              - 'Mila/Views/**'
+              # The --ui-test-clean-store / --ui-test-seed-recording launch
+              # seams and the Settings scene's windowResizability live here,
+              # and the tests' launch-state contract depends on both.
+              - 'Mila/App/MilaApp.swift'
               - 'MilaUITests/DetailLayoutUITests.swift'
               - '.github/workflows/llm-live-ai-e2e.yml'
       - name: Install xcodegen

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -783,6 +783,13 @@ struct MilaApp: App {
                 .environmentObject(obsidianVaultSettings)
                 .environmentObject(obsidianExporter)
         }
+        // Settings used to be pinned to 700×560 by a rigid `.frame` inside
+        // `SettingsView`; since #177 it is a resizable sidebar window whose
+        // content declares min/ideal/max instead. `.contentSize` is what
+        // turns those declarations into the window's own resize limits —
+        // without it the window would not honour the minimum and could be
+        // dragged narrower than the destinations can lay out in.
+        .windowResizability(.contentSize)
     }
 
     /// Build a diagnostic zip and let the user pick where to save it.

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2,85 +2,321 @@ import SwiftUI
 import AppKit
 import Carbon.HIToolbox
 
-enum SettingsTab: Int, Hashable {
+/// One destination in Settings.
+///
+/// Still called `SettingsTab` even though Settings is no longer a `TabView`
+/// (#177 replaced the strip with a sidebar). The name is deliberately kept:
+/// it is the key of the deep-link contract (`SettingsNavigation.pendingTab`),
+/// its raw values are pinned by `AISettingsKeyCompatibilityTests`, and the
+/// per-destination views are all still named `…SettingsTab`. Renaming the type
+/// would churn all three for no behavioural gain.
+///
+/// `allCases` order IS the sidebar order, top to bottom. Adding a case adds a
+/// row; it costs vertical space in a scrollable list, so — unlike the old tab
+/// strip — there is no width budget to re-measure.
+enum SettingsTab: Int, Hashable, CaseIterable, Identifiable {
     /// `aiProvider` + `aiFeatures` replace the former separate `llm` and
     /// `liveAI` tabs. The split is by *how often you touch it*: the provider
     /// is technical and set once (often via a `.milaconfig` import), while the
     /// feature switches are what people come back for. Keeping them on one
     /// screen forced every feature below the fold behind a disclosure arrow.
-    ///
-    /// Net tab count is unchanged from before the AI work (two AI tabs
-    /// replacing two AI tabs), which matters: the strip has to stay inside
-    /// the run measured in `SettingsView.body` below.
     case general, audio, models, aiProvider, aiFeatures, speakers, meetings, voiceMemos, storage
+
+    var id: Int { rawValue }
+
+    /// Sidebar row label, and the Settings window title while selected.
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .audio: return "Audio"
+        case .models: return "Models"
+        case .aiProvider: return "AI Provider"
+        case .aiFeatures: return "AI Features"
+        case .speakers: return "Speakers"
+        case .meetings: return "Meetings"
+        case .voiceMemos: return "Voice Memos"
+        case .storage: return "Storage"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape"
+        case .audio: return "mic"
+        case .models: return "cube.box"
+        case .aiProvider: return "sparkles"
+        case .aiFeatures: return "wand.and.stars"
+        case .speakers: return "person.2"
+        case .meetings: return "video.fill"
+        case .voiceMemos: return "waveform"
+        case .storage: return "externaldrive"
+        }
+    }
+
+    /// Stable per-row accessibility identifier, so GUI tests can select a
+    /// destination without matching on the (localisable) visible label.
+    /// `MilaUITests` hardcodes these strings — the UI-test target cannot
+    /// import the app's types — and `AISettingsKeyCompatibilityTests` pins
+    /// them.
+    var accessibilityID: String {
+        switch self {
+        case .general: return "settings.section.general"
+        case .audio: return "settings.section.audio"
+        case .models: return "settings.section.models"
+        case .aiProvider: return "settings.section.aiProvider"
+        case .aiFeatures: return "settings.section.aiFeatures"
+        case .speakers: return "settings.section.speakers"
+        case .meetings: return "settings.section.meetings"
+        case .voiceMemos: return "settings.section.voiceMemos"
+        case .storage: return "settings.section.storage"
+        }
+    }
+
+    /// True when the destination's own root view is already a `ScrollView`.
+    ///
+    /// Load-bearing, not cosmetic. The detail column must never report a
+    /// height larger than the window proposes it — that overflow is exactly
+    /// what made the first attempt at this change render an empty window (see
+    /// `SettingsView`). A `ScrollView` is the structural guarantee: it
+    /// accepts whatever height it is offered and scrolls the rest. Sections
+    /// that don't bring their own get wrapped in one by
+    /// `SettingsView.detailPane`; double-wrapping the ones that do would nest
+    /// two vertical scrollers, which fight each other.
+    var providesOwnScrollView: Bool {
+        switch self {
+        case .models, .aiProvider, .aiFeatures, .meetings, .storage:
+            return true
+        case .general, .audio, .speakers, .voiceMemos:
+            return false
+        }
+    }
 }
 
 @Observable
 final class SettingsNavigation {
     @MainActor static let shared = SettingsNavigation()
+
+    /// Set this to jump Settings to a destination. Consumed (reset to nil) by
+    /// `SettingsView` as soon as it applies. Cross-references inside Settings
+    /// use it to become real navigation instead of prose — see
+    /// `AIFeaturesSettingsTab.notConfiguredBanner`.
     var pendingTab: SettingsTab?
 }
 
-/// Standard `Settings` scene. Opened via `Cmd+,` from the menu bar.
+/// Standard `Settings` scene. Opened via `Cmd+,` from the menu bar, and via
+/// `SettingsLink` in the sidebar footer.
+///
+/// ## Why a sidebar and not a tab strip (#177)
+///
+/// This used to be a `TabView`, and the window width was load-bearing because
+/// of it: AppKit's `NSTabView` collapses whatever does not fit the strip into
+/// a `>>` overflow menu, which reads as a stray "expand button" and makes the
+/// collapsed tabs look disabled. That was reported as #131 and worked around
+/// in #137 by pinning the window to 700×560 (740 pt of strip room) to hold
+/// the measured 599 pt run of nine tab items. #144 then concluded the
+/// obvious: nine fits, "with no room for a tenth". Both remaining moves —
+/// widen again, or merge tabs — were spent, so new settings were being parked
+/// inside the Storage section for want of a slot.
+///
+/// A sidebar list removes the ceiling instead of raising it: destinations cost
+/// vertical space, which scrolls, rather than horizontal strip width, which
+/// does not. There is no `NSTabView` in the tree, so #131's `>>` chevron
+/// cannot come back at any destination count, and the window no longer needs
+/// a hardcoded size — it is resizable, which also settles #177's "a dense tab
+/// can't be given more room".
+///
+/// Settings stays its own `Settings` scene rather than becoming a page inside
+/// the main window (which is what #177 literally proposed): that keeps
+/// `Cmd+,`, `SettingsLink` and the App-menu item working with no code at all,
+/// keeps the macOS-native idiom, and — being a real window — can be placed
+/// side by side with the main window, which an in-app page that takes over
+/// the content area cannot. It also keeps the documented convention that
+/// app-wide settings objects are injected into both scenes (`CLAUDE.md`) true
+/// as written.
+///
+/// ## Why the layout is hand-rolled and not a `NavigationSplitView`
+///
+/// The first attempt at this change (#194, commit `60218f1`) used
+/// `NavigationSplitView` and shipped a completely empty window: no sidebar
+/// rows, no controls. It was reverted in `6b64e8b`.
+///
+/// The cause, from the accessibility tree of the running app: inside the
+/// 900×472 Settings window, the split view laid out at
+/// `{{62, -2671}, {900, 6115}}` — 6115 pt tall, vertically centred, so it
+/// began 2671 pt *above* the window. Every sidebar row landed at y ≈ -2600
+/// and `updates.autoCheck.toggle` at y = 3314, i.e. thousands of points
+/// outside the visible content area. Nothing was missing; everything was
+/// off-screen. The window title still tracked the section, which is why the
+/// window read as "chrome but no content".
+///
+/// What let that happen: the old `.frame(width: 700, height: 560)` was a
+/// *rigid* frame, and it had been the only thing pinning the content to the
+/// window. #194 replaced it with `.frame(minWidth:idealWidth:minHeight:
+/// idealHeight:)` — no `max` in either axis. A flexible frame reports
+/// `clamp(childSize, min, max)`, so with no upper bound it adopted the split
+/// view's content-driven 6115 pt instead of the 472 pt the window offered.
+///
+/// So the rule this layout follows: **every child of the window-sized frame
+/// must be bounded** — it may never report a size larger than it is
+/// proposed. A `ScrollView` satisfies that by construction (it takes the
+/// height offered and scrolls the overflow), and so does a fixed-width
+/// column. That is the whole reason `SettingsTab.providesOwnScrollView`
+/// exists and the reason this is a plain `HStack` of two bounded columns
+/// rather than an AppKit-bridged split container whose sizing behaviour is
+/// not ours to reason about. It is also the same failure mode
+/// `DetailLayoutUITests` was originally written for, one window over.
 struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .general
 
+    /// Sidebar column width. Fixed rather than draggable: nine short labels
+    /// need no user-tunable column, and a fixed column is one fewer thing
+    /// that can be dragged into an unusable state.
+    private static let sidebarWidth: CGFloat = 188
+
+    /// The old `TabView` was wrapped in `.padding(20)`, so every
+    /// destination's content is written assuming a 20 pt outer inset. Keep
+    /// it, so the per-destination layouts are untouched by this change.
+    private static let detailInset: CGFloat = 20
+
+    /// Narrowest the destination *content* may get. Every destination lays
+    /// out flexibly (`maxWidth:`); the widest rigid run in any of them is a
+    /// 110 pt label beside a 160 pt hotkey field, so 560 has real slack. It
+    /// exists to stop the window being dragged into nonsense, and it is what
+    /// `minWindowWidth` is derived from.
+    private static let minDetailWidth: CGFloat = 560
+
+    /// The old window was 740 pt wide with 700 pt of content. Keep 700 pt of
+    /// content at the ideal size so first launch is not a downgrade.
+    private static let idealDetailWidth: CGFloat = 700
+
+    static let minWindowWidth = sidebarWidth + minDetailWidth + 2 * detailInset
+    static let idealWindowWidth = sidebarWidth + idealDetailWidth + 2 * detailInset
+
+    /// The old window was 600 pt tall (560 pt of content). Never offer less
+    /// vertical room than the fixed window did; growing past it is the point.
+    private static let minWindowHeight: CGFloat = 600
+    private static let idealWindowHeight: CGFloat = 700
+
     var body: some View {
-        TabView(selection: $selectedTab) {
-            GeneralSettingsTab()
-                .tabItem { Label("General", systemImage: "gearshape") }
-                .tag(SettingsTab.general)
-            AudioSettingsTab()
-                .tabItem { Label("Audio", systemImage: "mic") }
-                .tag(SettingsTab.audio)
-            ModelsSettingsTab()
-                .tabItem { Label("Models", systemImage: "cube.box") }
-                .tag(SettingsTab.models)
-            AIProviderSettingsTab()
-                .tabItem { Label("AI Provider", systemImage: "sparkles") }
-                .tag(SettingsTab.aiProvider)
-            AIFeaturesSettingsTab()
-                .tabItem { Label("AI Features", systemImage: "wand.and.stars") }
-                .tag(SettingsTab.aiFeatures)
-            DiarizationSettingsTab()
-                .tabItem { Label("Speakers", systemImage: "person.2") }
-                .tag(SettingsTab.speakers)
-            MeetingsSettingsTab()
-                .tabItem { Label("Meetings", systemImage: "video.fill") }
-                .tag(SettingsTab.meetings)
-            VoiceMemosSettingsTab()
-                .tabItem { Label("Voice Memos", systemImage: "waveform") }
-                .tag(SettingsTab.voiceMemos)
-            StorageSettingsTab()
-                .tabItem { Label("Storage", systemImage: "externaldrive") }
-                .tag(SettingsTab.storage)
+        HStack(spacing: 0) {
+            sectionList
+            Divider()
+            detailPane
         }
-        // The width is load-bearing: it has to hold the whole tab strip.
-        // AppKit's NSTabView collapses whatever doesn't fit into a `>>`
-        // overflow menu, which reads as a stray "expand button" and makes
-        // the collapsed tabs look disabled (reported in #131, fixed here
-        // per #137).
-        //
-        // Measured on macOS 26 at the default system font: the ten tab
-        // items occupy a 599 pt run (widest single item — "Voice Memos" —
-        // is 82 pt).
-        //
-        // The strip is NOT laid out inside this 700 pt frame. `.padding(20)`
-        // below sizes the Settings window to 740 pt, and AppKit draws the
-        // tab strip edge-to-edge across the whole window, so the run has the
-        // full 740 pt to sit in — measured item origins are 70 pt from the
-        // left window edge and 71 pt from the right. That is why 560 failed:
-        // it gave the strip 600 pt for a 599 pt run.
-        //
-        // If you add a tab, re-check Settings for the `>>` chevron rather
-        // than assuming it still fits.
-        .frame(width: 700, height: 560)
-        .padding(20)
+        // Bounded in both axes, unlike #194's frame. `maxWidth`/`maxHeight`
+        // of `.infinity` make this greedy — it fills the window instead of
+        // sizing to its content — and `windowResizability(.contentSize)` on
+        // the `Settings` scene in `MilaApp` maps min/max onto the window's
+        // own resize limits.
+        .frame(minWidth: Self.minWindowWidth,
+               idealWidth: Self.idealWindowWidth,
+               maxWidth: .infinity,
+               minHeight: Self.minWindowHeight,
+               idealHeight: Self.idealWindowHeight,
+               maxHeight: .infinity)
+        .background(
+            SettingsWindowTitle(title: selectedTab.title)
+                .frame(width: 0, height: 0)
+        )
         .onChange(of: SettingsNavigation.shared.pendingTab, initial: true) { _, newTab in
             if let tab = newTab {
                 selectedTab = tab
                 SettingsNavigation.shared.pendingTab = nil
             }
+        }
+    }
+
+    // MARK: Sidebar
+
+    private var sectionList: some View {
+        List(SettingsTab.allCases, selection: sidebarSelection) { tab in
+            Label(tab.title, systemImage: tab.systemImage)
+                .accessibilityIdentifier(tab.accessibilityID)
+                .tag(tab)
+        }
+        .listStyle(.sidebar)
+        // A `List` is bounded by construction — it takes the height it is
+        // offered and scrolls the rest — so a tenth, twentieth or fiftieth
+        // destination changes nothing about the window's geometry.
+        .frame(width: Self.sidebarWidth)
+        .frame(maxHeight: .infinity)
+    }
+
+    /// `List`'s selection binding is `Optional` — Escape, or a click on empty
+    /// sidebar space, clears it, which would blank the detail pane.
+    /// Swallowing the nil keeps a destination always selected.
+    private var sidebarSelection: Binding<SettingsTab?> {
+        Binding(
+            get: { selectedTab },
+            set: { if let new = $0 { selectedTab = new } }
+        )
+    }
+
+    // MARK: Detail
+
+    private var detailPane: some View {
+        Group {
+            if selectedTab.providesOwnScrollView {
+                destination
+                    .padding(Self.detailInset)
+            } else {
+                ScrollView(.vertical) {
+                    destination
+                        .padding(Self.detailInset)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // A fresh identity per destination. Two things hang off it: the
+        // scroll offset resets per section (a leftover offset from a long
+        // section reads as a mis-rendered short one), and SwiftUI is
+        // guaranteed to tear the previous destination down — so
+        // `AudioSettingsTab`'s `.onDisappear` really does stop the VU meter
+        // when you leave Audio, and its `.task` really does restart it when
+        // you come back. The old `TabView` gave that teardown for free.
+        .id(selectedTab)
+    }
+
+    @ViewBuilder
+    private var destination: some View {
+        switch selectedTab {
+        case .general: GeneralSettingsTab()
+        case .audio: AudioSettingsTab()
+        case .models: ModelsSettingsTab()
+        case .aiProvider: AIProviderSettingsTab()
+        case .aiFeatures: AIFeaturesSettingsTab()
+        case .speakers: DiarizationSettingsTab()
+        case .meetings: MeetingsSettingsTab()
+        case .voiceMemos: VoiceMemosSettingsTab()
+        case .storage: StorageSettingsTab()
+        }
+    }
+}
+
+/// Puts the selected destination's name in the Settings window's title bar.
+///
+/// The old `TabView` got this for free: AppKit titles an `NSTabView`-backed
+/// Settings window after the selected tab item. With the strip gone nothing
+/// sets it, and `.navigationTitle` needs a navigation container to hang off —
+/// there isn't one here — so set it on the hosting `NSWindow` directly. This
+/// is the only window this view is ever installed in, so there is no risk of
+/// retitling someone else's.
+private struct SettingsWindowTitle: NSViewRepresentable {
+    let title: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.setAccessibilityElement(false)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        let title = self.title
+        // `nsView.window` is nil while the view is still being installed, so
+        // the very first update would drop the title. Defer a runloop turn.
+        DispatchQueue.main.async {
+            nsView.window?.title = title
         }
     }
 }
@@ -122,6 +358,10 @@ private struct AudioSettingsTab: View {
             }
             .pickerStyle(.menu)
             .frame(maxWidth: 360)
+            // Audio's per-section probe for `DetailLayoutUITests`: a control
+            // that is present unconditionally, so "this destination rendered"
+            // is checkable without depending on device state.
+            .accessibilityIdentifier("audio.input.picker")
 
             Button("Refresh device list") { refresh() }
                 .buttonStyle(.borderless)
@@ -144,6 +384,14 @@ private struct AudioSettingsTab: View {
                     Text(meterStatusText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        // Lets a GUI test see that the VU meter's lifecycle
+                        // still runs when Settings switches destinations
+                        // (`.task` / `.onDisappear` now fire on selection
+                        // change rather than tab change — see
+                        // `SettingsView.detailPane`). Deliberately not
+                        // asserted to read "Live" in CI: the hosted runners
+                        // have no input device.
+                        .accessibilityIdentifier("audio.meter.status")
                 }
                 LevelMeterView(level: monitor.level,
                                isLive: monitor.isRunning && !actions.isRecording)
@@ -232,6 +480,11 @@ private struct AudioSettingsTab: View {
 /// didn't justify a tenth tab — and the tab strip had already overflowed into
 /// AppKit's ">>" overflow chevron at that width, which is what made the
 /// Updates tab look "disabled" (see PR discussion).
+///
+/// The strip is gone as of #177, so the width half of that argument no longer
+/// applies. The other half — a single toggle and a version string don't
+/// deserve their own destination — still does, which is why this stays folded
+/// in.
 private struct GeneralSettingsTab: View {
     @EnvironmentObject private var hotkeys: HotkeySettings
 
@@ -568,6 +821,10 @@ private struct ModelsSettingsTab: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                // Models' per-section probe for `DetailLayoutUITests` — the
+                // one control on this destination that is present whichever
+                // backend is selected.
+                .accessibilityIdentifier("models.backend.picker")
 
                 switch remote.backend {
                 case .local:
@@ -1606,10 +1863,23 @@ private struct AIFeaturesSettingsTab: View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-            Text("No AI provider yet — set one up in Settings → AI Provider.")
+            VStack(alignment: .leading, spacing: 2) {
+                Text("No AI provider yet.")
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+                // A button, not prose: with the sidebar (#177) a
+                // cross-reference inside Settings can actually navigate, so
+                // it does. This is also the only producer of
+                // `SettingsNavigation.pendingTab` inside Settings, which
+                // until now had consumers but no caller.
+                Button("Set one up in AI Provider") {
+                    SettingsNavigation.shared.pendingTab = .aiProvider
+                }
+                .buttonStyle(.link)
                 .font(.caption)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: aiCaptionWidth, alignment: .leading)
+                .accessibilityIdentifier("ai.features.notConfigured.link")
+            }
+            .frame(maxWidth: aiCaptionWidth, alignment: .leading)
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -2306,6 +2576,8 @@ private struct MeetingsSettingsTab: View {
                 }
                 .toggleStyle(.switch)
                 .controlSize(.regular)
+                // Meetings' per-section probe for `DetailLayoutUITests`.
+                .accessibilityIdentifier("meetings.enable.toggle")
 
                 Divider()
 

--- a/Mila/Views/SidebarView.swift
+++ b/Mila/Views/SidebarView.swift
@@ -448,6 +448,11 @@ private struct SidebarFooter: View {
                 .padding(.horizontal, 6)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            // GUI tests open Settings through this row rather than through
+            // `Cmd+,`: a synthesised menu-key event needs the app to be
+            // frontmost and is unreliable on the hosted macOS runners, a
+            // click on a real element is not.
+            .accessibilityIdentifier("sidebar.settings.link")
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
 

--- a/Mila/Views/StorageSettingsTab.swift
+++ b/Mila/Views/StorageSettingsTab.swift
@@ -46,10 +46,17 @@ struct StorageSettingsTab: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 // Obsidian vault destination lives under Storage rather than
-                // in a top-level tab (keeps the tab bar from overflowing), and
-                // renders as one more card in this stack rather than a titled
-                // section — off by default, it's a single toggle. It expands
-                // itself once enabled; see `ObsidianSettingsSection`.
+                // in a top-level tab (originally to keep the tab bar from
+                // overflowing), and renders as one more card in this stack
+                // rather than a titled section — off by default, it's a
+                // single toggle. It expands itself once enabled; see
+                // `ObsidianSettingsSection`.
+                //
+                // #177 removed the overflow constraint, so the original
+                // reason for parking it here is gone and promoting it to its
+                // own sidebar destination is now possible. Deliberately NOT
+                // done here (this is a container change only) — it's a
+                // separate, reviewable UX call.
                 ObsidianSettingsSection()
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Mila/Views/VoiceMemosSettingsTab.swift
+++ b/Mila/Views/VoiceMemosSettingsTab.swift
@@ -67,6 +67,9 @@ struct VoiceMemosSettingsTab: View {
             // control left to turn the integration back off.
             Toggle("Sync recordings from iPhone Voice Memos", isOn: $settings.isEnabled)
                 .toggleStyle(.switch)
+                // Voice Memos' per-section probe for `DetailLayoutUITests`
+                // — unconditional, per the comment above.
+                .accessibilityIdentifier("voiceMemos.enable.toggle")
 
             if settings.isEnabled {
                 switch library.availability {

--- a/MilaTests/AISettingsKeyCompatibilityTests.swift
+++ b/MilaTests/AISettingsKeyCompatibilityTests.swift
@@ -187,9 +187,10 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
         // is in-memory only, which is why this PR could renumber freely), so
         // this is a tripwire for whoever first writes one to disk or a URL.
         //
-        // The list is also the authoritative tab inventory: nine tabs, which
-        // is what the measured tab-strip run in `SettingsView` assumes. Adding
-        // a tenth needs that measurement redone, not just a line here.
+        // The list is also the authoritative destination inventory. Since
+        // #177 it is no longer capped: destinations are sidebar rows, so a
+        // tenth costs scrollable vertical space rather than a re-measured tab
+        // strip. Adding one here plus a case is the whole job.
         XCTAssertEqual(SettingsTab.general.rawValue, 0)
         XCTAssertEqual(SettingsTab.audio.rawValue, 1)
         XCTAssertEqual(SettingsTab.models.rawValue, 2)
@@ -199,6 +200,72 @@ final class AISettingsKeyCompatibilityTests: XCTestCase {
         XCTAssertEqual(SettingsTab.meetings.rawValue, 6)
         XCTAssertEqual(SettingsTab.voiceMemos.rawValue, 7)
         XCTAssertEqual(SettingsTab.storage.rawValue, 8)
+    }
+
+    // MARK: - Sidebar destination inventory (#177)
+
+    func test_every_settings_destination_is_presentable_in_the_sidebar() {
+        // `SettingsView` builds the sidebar from `allCases` and switches the
+        // detail pane on the same enum, so a case with no `switch` arm is a
+        // compile error and a case missing from `allCases` is impossible.
+        // What CAN silently break is the presentation: a destination with a
+        // blank title is an unclickable-looking empty row, and a duplicate
+        // title or identifier makes deep links and GUI tests ambiguous.
+        let all = SettingsTab.allCases
+        XCTAssertEqual(all.count, 9, "Destination count changed — intended?")
+
+        for tab in all {
+            XCTAssertFalse(tab.title.isEmpty, "\(tab) has no sidebar title")
+            XCTAssertFalse(tab.systemImage.isEmpty, "\(tab) has no sidebar icon")
+            XCTAssertTrue(tab.accessibilityID.hasPrefix("settings.section."),
+                          "\(tab) identifier must stay namespaced — GUI tests match on it")
+        }
+
+        XCTAssertEqual(Set(all.map(\.title)).count, all.count,
+                       "Two destinations share a sidebar title")
+        XCTAssertEqual(Set(all.map(\.accessibilityID)).count, all.count,
+                       "Two destinations share an accessibility identifier")
+        XCTAssertEqual(Set(all.map(\.id)).count, all.count,
+                       "Two destinations share a List identity")
+
+        // Sidebar order is `allCases` order, which is declaration order,
+        // which is raw-value order. The old left-to-right tab order is
+        // preserved top-to-bottom.
+        XCTAssertEqual(all.map(\.rawValue), Array(0..<all.count))
+    }
+
+    /// `MilaUITests` hardcode these strings — the UI-test target cannot
+    /// import the app's types, so this is the only thing keeping the two
+    /// sides in sync. `DetailLayoutUITests.settingsSections` drives every
+    /// Settings assertion off them, and `SpeakerSelfHealUITests` clicks
+    /// `settings.section.speakers` by name.
+    func test_destination_identifiers_match_the_strings_the_gui_tests_use() {
+        XCTAssertEqual(SettingsTab.general.accessibilityID, "settings.section.general")
+        XCTAssertEqual(SettingsTab.audio.accessibilityID, "settings.section.audio")
+        XCTAssertEqual(SettingsTab.models.accessibilityID, "settings.section.models")
+        XCTAssertEqual(SettingsTab.aiProvider.accessibilityID, "settings.section.aiProvider")
+        XCTAssertEqual(SettingsTab.aiFeatures.accessibilityID, "settings.section.aiFeatures")
+        XCTAssertEqual(SettingsTab.speakers.accessibilityID, "settings.section.speakers")
+        XCTAssertEqual(SettingsTab.meetings.accessibilityID, "settings.section.meetings")
+        XCTAssertEqual(SettingsTab.voiceMemos.accessibilityID, "settings.section.voiceMemos")
+        XCTAssertEqual(SettingsTab.storage.accessibilityID, "settings.section.storage")
+    }
+
+    /// The Settings window floor has to leave the destinations a workable
+    /// content width. #194's post-mortem called this out specifically
+    /// (Models and AI Provider are the widest), and a future tweak to the
+    /// sidebar width or the inset could quietly eat into it.
+    func test_settings_window_floor_leaves_room_for_the_widest_destination() {
+        // 188 pt sidebar + 560 pt of content + 2 × 20 pt inset. Pinned as
+        // literals on purpose: this is a tripwire, so shrinking the content
+        // budget has to be a deliberate edit here rather than a side effect
+        // of widening the sidebar.
+        XCTAssertEqual(SettingsView.minWindowWidth, 788,
+                       "Settings' narrowest window no longer leaves 560 pt of destination content")
+        // 188 pt sidebar + the old fixed window's 700 pt of content + inset,
+        // so first launch is not a downgrade from the tab strip.
+        XCTAssertEqual(SettingsView.idealWindowWidth, 928,
+                       "Settings' default window no longer offers the 700 pt of content the fixed window had")
     }
 
     // MARK: - Controls the two-tab split moved between screens

--- a/MilaUITests/DetailLayoutUITests.swift
+++ b/MilaUITests/DetailLayoutUITests.swift
@@ -216,7 +216,16 @@ final class DetailLayoutUITests: XCTestCase {
         let probe = element(app, section.probe)
         if !probe.waitForExistence(timeout: 8) {
             let cell = app.cells.containing(.any, identifier: section.row).firstMatch
-            if cell.exists { cell.click() }
+            if cell.exists {
+                cell.click()
+                // Wait again, exactly as the primary path does. Returning
+                // straight after the fallback click would have the caller
+                // evaluate `probe.exists` before the destination has had a
+                // chance to render — turning a recoverable click miss into a
+                // flaky failure, which is worse than no assertion because it
+                // teaches people to rerun instead of read.
+                _ = probe.waitForExistence(timeout: 8)
+            }
         }
         return probe
     }

--- a/MilaUITests/DetailLayoutUITests.swift
+++ b/MilaUITests/DetailLayoutUITests.swift
@@ -136,6 +136,246 @@ final class DetailLayoutUITests: XCTestCase {
         )
     }
 
+    // MARK: - Settings window (#177)
+
+    /// The nine Settings destinations, in sidebar order: row identifier,
+    /// window title, and one control that is present *unconditionally* on
+    /// that destination.
+    ///
+    /// Mirrors `SettingsTab` — the UI-test target cannot import the app's
+    /// types, so `AISettingsKeyCompatibilityTests` pins the row identifiers
+    /// on the app side to keep the two in sync.
+    ///
+    /// The probe controls are the point of this table. The first attempt at
+    /// the sidebar (#194, reverted in `6b64e8b`) rendered an empty window —
+    /// the split view laid out 6115 pt tall inside a 472 pt window, so every
+    /// row and every control sat thousands of points off-screen — and passed
+    /// this workflow green, because nothing here looked at whether Settings
+    /// contained anything. Asserting a real control per destination, inside
+    /// the window's bounds, is what makes that failure loud.
+    private static let settingsSections: [(row: String, title: String, probe: String)] = [
+        ("settings.section.general",    "General",     "updates.autoCheck.toggle"),
+        ("settings.section.audio",      "Audio",       "audio.input.picker"),
+        ("settings.section.models",     "Models",      "models.backend.picker"),
+        ("settings.section.aiProvider", "AI Provider", "ai.provider.tool"),
+        ("settings.section.aiFeatures", "AI Features", "ai.features.outputLanguage"),
+        ("settings.section.speakers",   "Speakers",    "speakers.enable.toggle"),
+        ("settings.section.meetings",   "Meetings",    "meetings.enable.toggle"),
+        ("settings.section.voiceMemos", "Voice Memos", "voiceMemos.enable.toggle"),
+        ("settings.section.storage",    "Storage",     "storage.chooseFolder.button"),
+    ]
+
+    private func element(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    /// Attach + write a screenshot of one specific element (a window, here)
+    /// rather than `app.windows.firstMatch`, which is the *main* window once
+    /// Settings is open.
+    ///
+    /// `forVisionCheck: false` attaches the shot to the test result but keeps
+    /// it out of `$MILA_UI_SCREENSHOTS_DIR`, i.e. out of
+    /// `scripts/llm-verify-screenshots.py`'s input. Used for shots taken in a
+    /// deliberately unusual state (a window dragged to its size floor) that a
+    /// "does this look right?" judge would reasonably flag.
+    private func attachScreenshot(of element: XCUIElement,
+                                  name: String,
+                                  forVisionCheck: Bool = true) {
+        let shot = element.screenshot()
+        let att = XCTAttachment(screenshot: shot)
+        att.name = name
+        att.lifetime = .keepAlways
+        add(att)
+
+        guard forVisionCheck else { return }
+        let dir = ProcessInfo.processInfo.environment["MILA_UI_SCREENSHOTS_DIR"]
+            ?? "/tmp/mila-ui-screenshots"
+        try? FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let safe = name.replacingOccurrences(of: "/", with: "_")
+        let url = URL(fileURLWithPath: "\(dir)/\(self.name)-\(safe).png")
+        try? shot.pngRepresentation.write(to: url)
+    }
+
+    /// Click a sidebar row and return that destination's probe control.
+    ///
+    /// The identifier lands on the row's `Label`, which macOS exposes as a
+    /// `StaticText` inside the list's cell. Clicking the label normally
+    /// selects the row; if the probe doesn't turn up, retry on the enclosing
+    /// cell before giving up, so a routing quirk reads as a click that needs
+    /// retrying rather than as a destination that rendered nothing.
+    private func selectSection(
+        _ app: XCUIApplication,
+        _ section: (row: String, title: String, probe: String)
+    ) -> XCUIElement {
+        let row = element(app, section.row)
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "Sidebar row \(section.row) (\(section.title)) is missing from Settings")
+        row.click()
+
+        let probe = element(app, section.probe)
+        if !probe.waitForExistence(timeout: 8) {
+            let cell = app.cells.containing(.any, identifier: section.row).firstMatch
+            if cell.exists { cell.click() }
+        }
+        return probe
+    }
+
+    /// Poll the window title. `SettingsWindowTitle` applies it one runloop
+    /// turn after the selection changes, so a bare read can lose the race.
+    /// Returns the last value seen, for the failure message.
+    private func waitForWindowTitle(_ window: XCUIElement,
+                                    _ expected: String,
+                                    timeout: TimeInterval = 5) -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        var seen = window.title
+        while Date() < deadline {
+            seen = window.title
+            if seen == expected { return seen }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return seen
+    }
+
+    /// Open Settings by clicking the sidebar footer's `SettingsLink` and
+    /// return the Settings window element.
+    ///
+    /// Clicked rather than `Cmd+,`'d on purpose: a synthesised menu-key event
+    /// needs the app frontmost and is unreliable on the hosted runners.
+    private func openSettings(_ app: XCUIApplication) -> XCUIElement {
+        let link = element(app, "sidebar.settings.link")
+        XCTAssertTrue(link.waitForExistence(timeout: 15),
+                      "Sidebar's Settings row (sidebar.settings.link) not found — cannot open Settings")
+        link.click()
+
+        // Wait on a sidebar row rather than on the window: the window exists
+        // the moment it is ordered in, whether or not anything rendered
+        // inside it, which is exactly the state #194 shipped.
+        let firstRow = element(app, Self.settingsSections[0].row)
+        XCTAssertTrue(
+            firstRow.waitForExistence(timeout: 20),
+            "Settings opened but no section row ever appeared in the accessibility tree — the sidebar list did not render.")
+
+        let window = app.windows
+            .containing(.any, identifier: Self.settingsSections[0].row)
+            .firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5),
+                      "Could not identify the Settings window from its section rows")
+        return window
+    }
+
+    /// The section list is populated: all nine rows exist, are hittable, and
+    /// sit inside the window's bounds.
+    ///
+    /// The bounds assertion is the one that matters. `exists` was true for all
+    /// nine rows in the broken build too — they were just at y ≈ -2600, above
+    /// the top of a window whose own frame started at y = 134.
+    func test_settings_sidebar_lists_every_section() {
+        let app = launchApp()
+        let window = openSettings(app)
+        attachScreenshot(of: window, name: "settings-general")
+
+        let windowFrame = window.frame
+        XCTAssertGreaterThan(windowFrame.width, 0, "Settings window has no width")
+
+        for section in Self.settingsSections {
+            let row = element(app, section.row)
+            XCTAssertTrue(row.waitForExistence(timeout: 5),
+                          "Sidebar row \(section.row) (\(section.title)) is missing from Settings")
+            XCTAssertTrue(
+                windowFrame.contains(row.frame),
+                "Sidebar row \(section.row) is at \(row.frame), OUTSIDE the Settings window \(windowFrame). This is the #194 regression: the content was laid out far taller than the window and centred, pushing every row off-screen."
+            )
+            XCTAssertTrue(row.isHittable,
+                          "Sidebar row \(section.row) exists and is inside the window but is not hittable — something is covering it.")
+        }
+    }
+
+    /// Selecting a section shows that section's content, and the window title
+    /// follows the selection.
+    ///
+    /// Also covers the destination-teardown contract `AudioSettingsTab`'s VU
+    /// meter depends on: with the old `TabView`, `.task` / `.onDisappear`
+    /// fired on tab change; they now have to fire on *selection* change. The
+    /// previous section's probe having disappeared by the time the next one
+    /// appears is what proves the old destination was torn down rather than
+    /// left alive (and, for Audio, that the monitor was stopped).
+    func test_settings_each_section_renders_its_content_and_retitles_the_window() {
+        let app = launchApp()
+        let window = openSettings(app)
+
+        var previous: (title: String, probe: XCUIElement)?
+        for section in Self.settingsSections {
+            let probe = selectSection(app, section)
+            XCTAssertTrue(
+                probe.exists,
+                "Selected \(section.title) but its \(section.probe) control never appeared — the destination rendered nothing."
+            )
+            XCTAssertTrue(
+                window.frame.contains(probe.frame),
+                "\(section.title)'s \(section.probe) is at \(probe.frame), OUTSIDE the Settings window \(window.frame) — the destination is overflowing or clipped."
+            )
+
+            let title = waitForWindowTitle(window, section.title)
+            XCTAssertEqual(
+                title, section.title,
+                "Settings window title is '\(title)' after selecting \(section.title) — the title is not tracking the selected section."
+            )
+
+            if let stale = previous {
+                XCTAssertFalse(
+                    stale.probe.exists,
+                    "\(stale.title)'s control is still in the tree after switching to \(section.title) — the destination was not torn down, so `.onDisappear` (e.g. Audio's VU-meter stop) never fired."
+                )
+            }
+            previous = (section.title, probe)
+
+            let shortName = section.row
+                .replacingOccurrences(of: "settings.section.", with: "")
+            attachScreenshot(of: window, name: "settings-\(shortName)")
+        }
+    }
+
+    /// Requirement from the #194 post-mortem: shrinking the window to its
+    /// floor must not clip a destination. Models and AI Provider are the
+    /// widest, so check those two.
+    ///
+    /// Resizing is done by dragging the bottom-right corner well past the
+    /// declared minimum; `windowResizability(.contentSize)` clamps it there.
+    /// If the runner does not land the corner drag the window frame is
+    /// unchanged, which says nothing about clipping — skip rather than fail
+    /// in that case, since the default-size bounds checks in the two tests
+    /// above still run on every build.
+    func test_settings_content_is_not_clipped_at_the_window_floor() throws {
+        let app = launchApp()
+        let window = openSettings(app)
+
+        let before = window.frame
+        let corner = window.coordinate(withNormalizedOffset: CGVector(dx: 0.999, dy: 0.999))
+        let target = window.coordinate(withNormalizedOffset: CGVector(dx: -0.6, dy: -0.6))
+        corner.press(forDuration: 0.3, thenDragTo: target)
+
+        let after = window.frame
+        try XCTSkipIf(
+            abs(after.width - before.width) < 2 && abs(after.height - before.height) < 2,
+            "Corner drag did not resize the Settings window (\(before) -> \(after)) — cannot exercise the floor on this runner."
+        )
+
+        for section in Self.settingsSections where section.title == "Models" || section.title == "AI Provider" {
+            let probe = selectSection(app, section)
+            XCTAssertTrue(probe.exists,
+                          "\(section.title) rendered nothing at the window floor \(after)")
+            XCTAssertTrue(
+                window.frame.contains(probe.frame),
+                "At the window floor \(window.frame), \(section.title)'s \(section.probe) is at \(probe.frame) — clipped."
+            )
+            let shortName = section.title.replacingOccurrences(of: " ", with: "")
+            attachScreenshot(of: window,
+                             name: "settings-floor-\(shortName)",
+                             forVisionCheck: false)
+        }
+    }
+
     /// Regression test for the Hebrew live-transcript alignment bug
     /// where, with the sidebar open, the live transcript text was
     /// shifted away from the right edge of the pane by a gap equal

--- a/MilaUITests/SpeakerSelfHealUITests.swift
+++ b/MilaUITests/SpeakerSelfHealUITests.swift
@@ -63,14 +63,23 @@ final class SpeakerSelfHealUITests: XCTestCase {
         let settingsApp = XCUIApplication()
         settingsApp.typeKey(",", modifierFlags: .command)
 
-        // The SettingsView is a TabView. macOS exposes each tab as a
-        // toolbar button; "Speakers" is the label.
-        let speakersTab = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label == 'Speakers'"))
+        // SettingsView is a sidebar since #177: destinations are rows in a
+        // list, each carrying a stable identifier. Mirrors
+        // `SettingsTab.speakers.accessibilityID` — the UI-test target can't
+        // import the app's types, so `AISettingsKeyCompatibilityTests` pins
+        // the string on the app side. Falls back to the visible label if the
+        // identifier ever stops reaching the accessibility tree.
+        var speakersSection = app.descendants(matching: .any)
+            .matching(identifier: "settings.section.speakers")
             .firstMatch
-        XCTAssertTrue(speakersTab.waitForExistence(timeout: 10),
-                      "Speakers settings tab not found")
-        speakersTab.click()
+        if !speakersSection.waitForExistence(timeout: 10) {
+            speakersSection = app.descendants(matching: .any)
+                .matching(NSPredicate(format: "label == 'Speakers'"))
+                .firstMatch
+        }
+        XCTAssertTrue(speakersSection.waitForExistence(timeout: 10),
+                      "Speakers settings destination not found")
+        speakersSection.click()
 
         // Toggle "Enable speaker diarization" on.
         let toggle = app.checkBoxes["speakers.enable.toggle"]

--- a/scripts/llm-verify-screenshots.py
+++ b/scripts/llm-verify-screenshots.py
@@ -26,6 +26,12 @@ For LIST shots (filename contains "transcriptions" or "list"):
   * Sidebar list visible.
   * Main pane shows a list header + at least one recording row.
 
+For SETTINGS shots (filename contains "settings"):
+  * Left sidebar lists the nine section rows (General … Storage), one
+    selected.
+  * Right pane shows that section's real controls, not a blank card.
+  * No tab strip and no ">>" overflow chevron.
+
 The script exits non-zero if Claude reports ANY of: sidebar items
 missing, main pane visibly empty, content overflowing or cut off,
 extreme misalignment that suggests a layout bug.
@@ -73,6 +79,11 @@ def classify(name: str) -> str:
     if bracket_end >= 0:
         suffix = name[bracket_end + 2:]
     lower = suffix.lower()
+    # Checked first: a Settings shot is a different window with a different
+    # expected layout, and without its own profile it would fall through to
+    # "home" and be failed for missing a Record button.
+    if "settings" in lower:
+        return "settings"
     if "detail" in lower:
         return "detail"
     if "transcription" in lower or "list" in lower:
@@ -101,6 +112,25 @@ EXPECTATIONS = {
         "least one recording row beneath it. The main pane should NOT be "
         "empty when there is a seeded recording.\n"
         "  - Layout should not be overflowing or misaligned."
+    ),
+    "settings": (
+        "This should be Mila's SETTINGS window (a separate, smaller window "
+        "from the main one). Expected layout:\n"
+        "  - LEFT SIDEBAR is a list of section rows, each an icon plus a "
+        "label, reading top to bottom: General, Audio, Models, AI Provider, "
+        "AI Features, Speakers, Meetings, Voice Memos, Storage. One row is "
+        "highlighted as selected. The sidebar MUST NOT be empty — an empty "
+        "sidebar is the exact regression this check exists for.\n"
+        "  - RIGHT PANE shows the selected section's controls: a heading and "
+        "real controls (checkboxes, switches, pop-up menus, segmented "
+        "controls, text fields, buttons). It MUST NOT be blank or show only "
+        "empty boxes. A short section — a heading, a line of description and "
+        "a single switch, with empty space below — is normal and correct; "
+        "only a pane with NO heading and NO controls is a defect.\n"
+        "  - The window's title bar names the selected section.\n"
+        "  - Nothing should be pushed off-screen or cut off at an edge.\n"
+        "  - There must be NO tab strip along the top and no '>>' overflow "
+        "chevron — Settings is a sidebar, not tabs."
     ),
     "detail": (
         "This should be Mila's RECORDING DETAIL view. Expected layout:\n"


### PR DESCRIPTION
Closes #177

Second attempt at #177. The first (#194, `60218f1`) was merged on green CI and reverted a day later in `6b64e8b` because Settings rendered completely empty.

## Why the first attempt was empty

Diagnosed, not guessed. I re-applied `60218f1` on a throwaway branch with a capture-only UI test that dumps the Settings window's accessibility tree from CI. Inside the 900×472 Settings window:

```
Window, {{62,134},{900,472}}, identifier: 'com_apple_SwiftUI_Settings_window', title: 'General'
  Group,      {{62,134},{900,472}}
    SplitGroup, {{62,-2671},{900,6115}}, identifier: '…SidebarNavigationSplitView'
      …
        StaticText, {{92,-2621},{72,16}}, identifier: 'settings.section.general'
        StaticText, {{94,-2589},{57,16}}, identifier: 'settings.section.audio'
        …
        CheckBox,   {{230,3314},{216,17}}, identifier: 'updates.autoCheck.toggle'
```

The split view laid out **6115 pt tall inside a 472 pt window**, vertically centred, so it began 2671 pt *above* the window. Every sidebar row landed at y ≈ −2600 and General's controls at y ≈ +3314 — thousands of points outside the visible content area. Nothing was missing; everything was off-screen. The window title still tracked the section, which is precisely why the window read as "chrome, but no content", and why the post-mortem saw only the traffic lights and the title.

**The mechanism.** The old `.frame(width: 700, height: 560)` was a *rigid* frame, and it had been the only thing pinning the content to the window. #194 replaced it with `.frame(minWidth:idealWidth:minHeight:idealHeight:)` — no `max` in either axis. A flexible frame reports `clamp(childSize, min, max)`, so with no upper bound it adopted the split view's content-driven 6115 pt instead of the 472 pt the window offered. This is the same failure mode `DetailLayoutUITests` was originally written for, one window over.

## What & why

The design reasoning from #194 is unchanged and still holds. What changes is the layout mechanism.

A plain `HStack` of two **bounded** columns — a fixed-width `List` sidebar and a detail column that can never report more height than it is proposed. `SettingsTab.providesOwnScrollView` records which destinations already root a `ScrollView`; the four that don't (General, Audio, Speakers, Voice Memos) get wrapped in one, so the invariant "every child of the window-sized frame is bounded" holds for all nine. Double-wrapping the other five would nest two vertical scrollers, which fight.

The window frame declares min/ideal/max in **both** axes, and `windowResizability(.contentSize)` on the `Settings` scene maps those onto the window's own resize limits:

| | width | height |
|---|---|---|
| floor | 788 (188 sidebar + 560 content + 2×20 inset) | 600 (the old window's height) |
| default | 928 (the old window's 700 pt of content) | 700 |
| ceiling | none | none |

Everything else carries over from #194:

* **The ceiling is removed, not raised.** Destinations cost scrollable vertical space instead of horizontal strip width, so #144's "nine fits, with no room for a tenth" stops being a constraint. Adding a case plus a `switch` arm is the whole job.
* **#131 cannot regress.** There is no `NSTabView` in the tree, so AppKit's `>>` overflow chevron has nowhere to come from at any destination count.
* **`Cmd+,` and `SettingsLink` keep working with zero code**, because Settings stays its own `Settings` scene rather than becoming a page in the main window. That also keeps the `.environmentObject`-on-both-scenes convention in `CLAUDE.md` true as written, and — being a real window — it can sit side by side with the main window, which an in-app page taking over the content area cannot.
* **Container change only.** Section order, titles, icons, every persisted `UserDefaults` key and the Keychain items are untouched (`AISettingsKeyCompatibilityTests` still pins them).

One behavioural addition, because a cross-reference inside one window can now actually navigate: AI Features' "no AI provider yet" banner becomes a link to AI Provider. It is the first producer of `SettingsNavigation.pendingTab`, which until now had consumers but no caller.

## How it was tested

`make build` and `xcodebuild build-for-testing` both succeed locally. **The app was not launched or screenshotted on the author's machine** — visual confirmation comes from CI, which is the point of the rest of this section.

#194 passed every check, `UI layout tests` included, because nothing in CI ever looked inside the Settings window. Three tests in `DetailLayoutUITests` — the class `.github/workflows/llm-live-ai-e2e.yml` runs — now do:

1. `test_settings_sidebar_lists_every_section` — all nine rows exist, are hittable, **and their frames are inside the window's frame**. That last clause is what fails on #194's build, where `exists` was true for all nine rows at y ≈ −2600.
2. `test_settings_each_section_renders_its_content_and_retitles_the_window` — selects each of the nine in turn and asserts a control unique to that destination appears inside the window bounds, that the window title becomes the section name, and that the *previous* destination's control has disappeared. That last assertion is also the VU-meter check the post-mortem asked for: it proves the old destination is torn down on selection change, which is what makes `AudioSettingsTab`'s `.onDisappear` stop the monitor and its `.task` restart it (the `TabView` used to give that for free; `.id(selectedTab)` on the detail pane guarantees it now).
3. `test_settings_content_is_not_clipped_at_the_window_floor` — drags the window to its size floor and asserts Models and AI Provider (the widest) are not clipped. It skips rather than fails if the runner doesn't land the corner drag, since a missed drag says nothing about clipping.

Each writes a PNG of the Settings window into `$MILA_UI_SCREENSHOTS_DIR`, so `scripts/llm-verify-screenshots.py` judges them too. That script gains a `settings` profile that fails an empty sidebar, a blank pane, or a reappearing tab strip; the floor shots are attached to the test result but kept out of the vision input, since a window at its minimum size is exactly what a "does this look right?" judge would flag.

`Mila/Views/SettingsView.swift` and `Mila/Views/ContentView.swift` join the workflow's paths filter — without them a future change to either container could not trigger the job that screenshots it.

Also added: an app-side inventory test asserting every destination has a non-empty title, icon and namespaced identifier, no duplicates, and `allCases` order equal to raw-value order; plus a tripwire on the two window-width constants so the 560 pt content floor can't be eaten by a wider sidebar.

## What the CI run on this head actually showed

`UI layout tests (+ optional vision)` green in 4m47s. The Settings window came up 900×632 on the runner (its ideal is 928×700; the runner's screen clamps it, and 900 is comfortably above the 788 floor). I downloaded the `ui-screenshots` artifact and looked at all ten Settings shots: sidebar populated with the nine rows in order, the selected row highlighted, each destination's real controls rendered inside the window, and the title bar naming the section. Storage — the tallest — shows all four of its cards with nothing cut off; Models shows the backend picker plus both model rows with their download bars out to x ≈ 880; AI Features shows the new "Set one up in AI Provider" link.

Two caveats, both visible in the artifact:

* **`test_settings_content_is_not_clipped_at_the_window_floor` skipped.** The corner drag did not move the window (`(62,54,900,632) -> (62,54,900,632)`), so the floor was never exercised. The bounds assertions at the default size still ran on all nine destinations. If someone wants the floor genuinely covered, the honest fix is an app-side test seam that sets the window to its declared minimum, rather than a synthetic drag.
* **The Claude-vision step skipped** — `ANTHROPIC_API_KEY` is not available to this run, so the new `settings` profile in `llm-verify-screenshots.py` has not executed against a real image. Its classifier mapping is unit-checked against the actual artifact filenames, and the profile text is the only untested part.
* Several shots contain macOS's own "Mila would like to access the Microphone" sheet floating over the pane. That is the runner's TCC prompt, not a layout defect.

## Checklist

- [x] Builds locally (`make build`) and the test target builds (`xcodebuild build-for-testing`)
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — leaving to the release that ships it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Settings with a sidebar for navigating sections and a dedicated detail pane.
  * Added clearer Settings window titles and improved content sizing and resizing behavior.
  * Added a “Set one up in AI Provider” action to the “No AI provider” message.
  * Improved support for navigating and displaying all Settings sections without tab overflow.

* **Bug Fixes**
  * Prevented Settings content from being clipped when the window is resized smaller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->