### PR TITLE
feat(speakers): cross-recording voice recognition, opt-in and off by default (relay of #198)

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -148,6 +148,20 @@ final class QuickActionsController: ObservableObject {
     /// `stopRecording`.
     @Published var isFinalizingRecording: Bool = false
 
+    /// Late-bound by MilaApp. Called once per finished recording, **with
+    /// that recording's id**, from inside the finalize drain: after
+    /// `liveDiarizer.awaitPending()` (so `intervals` are final), after the
+    /// recording's final state is written to the store, and before
+    /// `liveDiarizer.stop()` — i.e. inside the window where the live
+    /// diarizer's pool is still guaranteed to belong to this recording.
+    ///
+    /// Cross-recording voice recognition hangs off this. It has to be told
+    /// the id: observing `isRecording` flipping false carries none, and
+    /// recovering one from `store.recordings.first` is unreliable because
+    /// `add` inserts at index 0 with no re-sort, so any recording added in
+    /// between (a Voice Memos import, say) becomes `first`.
+    var onRecordingFinalized: ((UUID) -> Void)?
+
     /// Late-bound by MilaApp. When the live-transcript path saves a
     /// recording directly (skipping `transcription.enqueue` because the
     /// VAD path already produced segments), TranscriptionService's
@@ -837,6 +851,22 @@ final class QuickActionsController: ObservableObject {
         updated.actionItems = finalItems.isEmpty ? nil : finalItems
         updated.status = liveTranscriptIsAuthoritative ? .completed : .pending
         store.update(updated)
+
+        // Cross-recording voice recognition gets its one shot here, with the
+        // id of the recording that actually just finished. This is the only
+        // point where reading the live diarizer for *this* recording is
+        // sound: `awaitPending()` above means `intervals` are final, the
+        // `isFinalizingRecording` window below hasn't closed so no new
+        // recording can have `reset()` the pool, and `updated` is already
+        // written so the speaker names it assigns won't be clobbered by the
+        // snapshot above.
+        //
+        // Deliberately a callback with the id rather than something MilaApp
+        // observes: it used to run off `.onChange(of: actions.isRecording)`,
+        // which carries no id and had to guess with `store.recordings.first`
+        // — and `add` inserts at index 0, so a Voice Memos import landing in
+        // between made the memo "the recording that just stopped".
+        onRecordingFinalized?(recording.id)
 
         // ---- END OF THE LIVE-PIPELINE-OWNING PHASE.
         //

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -589,17 +589,23 @@ struct MilaApp: App {
         let profileStoreRef = SpeakerProfileStore(settings: voiceSettings)
         _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
         // Save a voice profile when a speaker is named — if the live
-        // diarizer has a centroid for that speaker, persist it. The store
-        // refuses writes while the feature is off; the guard here means an
-        // opted-out user's centroid isn't so much as read out of the pool.
+        // diarizer observed that speaker, persist it. The store refuses
+        // writes while the feature is off; the guard here means an opted-out
+        // user's voice isn't so much as read out of the pool.
+        //
+        // `currentProfiles()` reports what was observed in *this* recording,
+        // not the pool's matching centroid — for a seeded speaker the latter
+        // carries weight that is already stored on disk, and folding it back
+        // in counts it twice. This is the only place voice profiles are
+        // written, so a recognised speaker merges exactly once per recording.
         let diarizerRef = liveDiar
         store.onSpeakerNamed = { _, rawID, name in
             guard voiceSettings.isConfigured else { return }
             if let entry = diarizerRef.currentProfiles().first(where: { $0.id == rawID }) {
                 profileStoreRef.updateProfile(
                     name: name,
-                    embedding: entry.centroid,
-                    sampleCount: entry.sampleCount
+                    embedding: entry.observedCentroid,
+                    sampleCount: entry.observedCount
                 )
             }
         }
@@ -903,11 +909,18 @@ struct MilaApp: App {
         guard voiceRecognitionSettings.isConfigured else { return }
         guard let rec = store.recordings.first else { return }
         let poolEntries = liveSpeakerDiarizer.currentProfiles()
-        // Only assign names for pool entries that were seeded AND
-        // actually matched utterances (sampleCount > the seed cap of 3).
+        // Only assign names for pool entries that were seeded (they carry a
+        // profileName) AND actually spoke. Both halves matter: a seeded
+        // speaker who never said anything must not be labelled onto the
+        // recording just because their voice was in the pool.
         for entry in poolEntries {
             guard let profileName = entry.profileName else { continue }
-            // Check this speaker actually spoke (has intervals).
+            // Check this speaker actually spoke (has intervals). Now that
+            // seeded weight is kept out of the persisted delta,
+            // `entry.observedCount > 0` says much the same thing — but
+            // `intervals` is the stronger signal, since it means the speaker
+            // reached the transcript rather than merely matching an
+            // embedding.
             let spoke = liveSpeakerDiarizer.intervals.contains { $0.speaker == entry.id }
             guard spoke else { continue }
             store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -361,6 +361,7 @@ struct MilaApp: App {
     /// Applies double-clicked `.milaconfig` files (with a confirmation sheet).
     @StateObject private var configImporter: MilaConfigImporter
     @StateObject private var updater = UpdaterViewModel()
+    @StateObject private var speakerProfileStore: SpeakerProfileStore
 
     init() {
         // RecordingStore's no-arg init handles the legacy migration and
@@ -570,6 +571,21 @@ struct MilaApp: App {
                 summarizer?.summarizeIfNeeded(rec)
             }
         }
+        // Save voice profile when a speaker is named — if the live
+        // diarizer has a centroid for that speaker, persist it.
+        let profileStoreRef = SpeakerProfileStore()
+        _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
+        let diarizerRef = liveDiar
+        store.onSpeakerNamed = { _, rawID, name in
+            if let entry = diarizerRef.currentProfiles().first(where: { $0.id == rawID }) {
+                profileStoreRef.updateProfile(
+                    name: name,
+                    embedding: entry.centroid,
+                    sampleCount: entry.sampleCount
+                )
+            }
+        }
+
         // Auto-drop accidental short+empty captures (issue #61). A recording
         // that finishes transcription with no text AND under the user's
         // minimum-duration threshold (Settings ▸ Storage, default 5s, 0 = keep
@@ -691,11 +707,20 @@ struct MilaApp: App {
                 .task { await runFinalizeRegressionIfRequested() }
                 .task { recordingSummarizer.backfillIfNeeded() }
                 .task { voiceMemosImporter.start() }
+                .onChange(of: actions.isRecording) { wasRecording, isRecording in
+                    if wasRecording, !isRecording {
+                        // Recording just stopped — auto-assign names from
+                        // recognised voice profiles for seeded pool entries
+                        // that actually matched utterances.
+                        autoAssignRecognisedSpeakers()
+                    }
+                }
                 .environmentObject(recordingSummarizer)
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(speakerProfileStore)
                 .environmentObject(configImporter)
                 .sheet(item: Binding(
                     get: { configImporter.pending },
@@ -774,6 +799,7 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(speakerProfileStore)
                 .environmentObject(configImporter)
                 // Settings ▸ General shows the Sparkle-backed
                 // "Automatically check for updates" toggle, so the Settings
@@ -831,6 +857,29 @@ struct MilaApp: App {
     /// user's enabled toggle. Called once from the main `WindowGroup`
     /// `.task` so the work is tied to the app's lifetime rather than
     /// to any single view.
+    /// After recording stops, check the live diarizer pool for speakers
+    /// that were seeded from voice profiles and actually matched real
+    /// utterances. Auto-assign their names to the most recent recording
+    /// and update their voice profiles with fresh centroid data.
+    private func autoAssignRecognisedSpeakers() {
+        guard let rec = store.recordings.first else { return }
+        let poolEntries = liveSpeakerDiarizer.currentProfiles()
+        // Only assign names for pool entries that were seeded AND
+        // actually matched utterances (sampleCount > the seed cap of 3).
+        for entry in poolEntries {
+            guard let profileName = entry.profileName else { continue }
+            // Check this speaker actually spoke (has intervals).
+            let spoke = liveSpeakerDiarizer.intervals.contains { $0.speaker == entry.id }
+            guard spoke else { continue }
+            store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
+            speakerProfileStore.updateProfile(
+                name: profileName,
+                embedding: entry.centroid,
+                sampleCount: entry.sampleCount
+            )
+        }
+    }
+
     private func startMeetingDetectionIfNeeded() {
         meetingPrompt.start()
         meetingPrompt.bindEnabledChanges()
@@ -1373,6 +1422,7 @@ struct MilaApp: App {
                 // By the time this runs, the session has already been freshly
                 // started for this recording.
                 diarizer.reset()
+                diarizer.seedPool(with: speakerProfileStore.seedEntries())
                 diarizer.similarityThreshold = aiSettings.speakerSimilarityThreshold
                 // Detach the diarizer start so a quick stop-after-start
                 // doesn't block the state observer on pyannote cold-init.

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -590,6 +590,24 @@ struct MilaApp: App {
         _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
         let voiceSnapshots = ObservedVoiceSnapshots()
         voiceSnapshots.clearOnOptOut(of: voiceSettings)
+        // …and the third holder of copied voice data: the live pool. The two
+        // lines above unload the profiles (`SpeakerProfileStore`'s own
+        // observer) and drop the snapshots, but `seedPool` handed the
+        // diarizer its own copy of every centroid at record-start, so an
+        // opt-out mid-recording otherwise leaves `assign` matching against
+        // stored voices for the rest of it. The write gates stop the result
+        // being persisted; they do not stop it being *read*, and the user
+        // still watches their transcript auto-fill with names from a feature
+        // they just switched off.
+        //
+        // Exactly the deletion path's problem, so it gets the deletion
+        // path's remedy — see `addDeletionObserver` below. Opt-out is the
+        // broader of the two, so it forgets every seeded entry rather than
+        // named ones.
+        voiceSettings.addEnabledObserver { [weak liveDiar] nowEnabled in
+            guard !nowEnabled else { return }
+            liveDiar?.forgetSeededProfiles()
+        }
         // Auto-naming + the per-recording snapshot, driven by the finalize
         // drain rather than by observing `isRecording`. The drain hands over
         // the id of the recording that actually finished, and calls

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -361,6 +361,10 @@ struct MilaApp: App {
     /// Applies double-clicked `.milaconfig` files (with a confirmation sheet).
     @StateObject private var configImporter: MilaConfigImporter
     @StateObject private var updater = UpdaterViewModel()
+    /// Opt-in switch for cross-recording voice recognition (off by default).
+    @StateObject private var voiceRecognitionSettings: VoiceRecognitionSettings
+    /// Persisted voice fingerprints behind that feature. Inert — nothing
+    /// read, nothing written — until the setting above is turned on.
     @StateObject private var speakerProfileStore: SpeakerProfileStore
 
     init() {
@@ -547,7 +551,7 @@ struct MilaApp: App {
         // summary referring to the previous transcript; we force-
         // regenerate so the user doesn't end up with a stale summary
         // that disagrees with what the segments now say.
-        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian, weak store, weak diarSettings] rec, wasRetranscription in
+        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian] rec, wasRetranscription in
             // Obsidian export is driven off the summarizer's completion hook.
             // Mark this fresh completion pending so the hook knows to write it
             // (backfilled recordings are never marked, hence never re-filed).
@@ -571,12 +575,26 @@ struct MilaApp: App {
                 summarizer?.summarizeIfNeeded(rec)
             }
         }
-        // Save voice profile when a speaker is named — if the live
-        // diarizer has a centroid for that speaker, persist it.
-        let profileStoreRef = SpeakerProfileStore()
+        // Cross-recording voice recognition. Opt-in and off by default:
+        // `voiceSettings.isConfigured` is the single gate, and it means
+        // "the user turned it on AND diarization can actually produce
+        // embeddings" — see `.claude/rules/feature-gates.md`. Readiness is
+        // injected as a closure so the settings object can read the
+        // diarization gate without being able to mutate it.
+        let voiceSettings = VoiceRecognitionSettings()
+        voiceSettings.diarizationReady = { [weak diarSettings] in
+            diarSettings?.isConfigured ?? false
+        }
+        _voiceRecognitionSettings = StateObject(wrappedValue: voiceSettings)
+        let profileStoreRef = SpeakerProfileStore(settings: voiceSettings)
         _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
+        // Save a voice profile when a speaker is named — if the live
+        // diarizer has a centroid for that speaker, persist it. The store
+        // refuses writes while the feature is off; the guard here means an
+        // opted-out user's centroid isn't so much as read out of the pool.
         let diarizerRef = liveDiar
         store.onSpeakerNamed = { _, rawID, name in
+            guard voiceSettings.isConfigured else { return }
             if let entry = diarizerRef.currentProfiles().first(where: { $0.id == rawID }) {
                 profileStoreRef.updateProfile(
                     name: name,
@@ -720,6 +738,7 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(voiceRecognitionSettings)
                 .environmentObject(speakerProfileStore)
                 .environmentObject(configImporter)
                 .sheet(item: Binding(
@@ -799,6 +818,7 @@ struct MilaApp: App {
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
                 .environmentObject(speakerDirectory)
+                .environmentObject(voiceRecognitionSettings)
                 .environmentObject(speakerProfileStore)
                 .environmentObject(configImporter)
                 // Settings ▸ General shows the Sparkle-backed
@@ -861,7 +881,12 @@ struct MilaApp: App {
     /// that were seeded from voice profiles and actually matched real
     /// utterances. Auto-assign their names to the most recent recording
     /// and update their voice profiles with fresh centroid data.
+    ///
+    /// No-ops entirely while voice recognition is off. The pool would carry
+    /// no `profileName` anyway (nothing was seeded), but an explicit gate
+    /// keeps the guarantee readable rather than emergent.
     private func autoAssignRecognisedSpeakers() {
+        guard voiceRecognitionSettings.isConfigured else { return }
         guard let rec = store.recordings.first else { return }
         let poolEntries = liveSpeakerDiarizer.currentProfiles()
         // Only assign names for pool entries that were seeded AND
@@ -1422,7 +1447,14 @@ struct MilaApp: App {
                 // By the time this runs, the session has already been freshly
                 // started for this recording.
                 diarizer.reset()
-                diarizer.seedPool(with: speakerProfileStore.seedEntries())
+                // Seed the embedding pool with known voices only when the
+                // user opted in. `seedEntries()` refuses on its own too, and
+                // while off it has nothing to hand over regardless (the
+                // profiles file is never parsed) — three independent reasons
+                // an opted-out recording starts from a blank pool.
+                if voiceRecognitionSettings.isConfigured {
+                    diarizer.seedPool(with: speakerProfileStore.seedEntries())
+                }
                 diarizer.similarityThreshold = aiSettings.speakerSimilarityThreshold
                 // Detach the diarizer start so a quick stop-after-start
                 // doesn't block the state observer on pyannote cold-init.

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -879,12 +879,26 @@ struct MilaApp: App {
     /// to any single view.
     /// After recording stops, check the live diarizer pool for speakers
     /// that were seeded from voice profiles and actually matched real
-    /// utterances. Auto-assign their names to the most recent recording
-    /// and update their voice profiles with fresh centroid data.
+    /// utterances. Auto-assign their names to the most recent recording.
     ///
     /// No-ops entirely while voice recognition is off. The pool would carry
     /// no `profileName` anyway (nothing was seeded), but an explicit gate
     /// keeps the guarantee readable rather than emergent.
+    ///
+    /// **Persistence is `setSpeakerName`'s job, not this loop's — one
+    /// recognition must fold into the stored centroid exactly once.**
+    /// `setSpeakerName` synchronously fires `store.onSpeakerNamed`, which
+    /// `MilaApp.init` wires to `SpeakerProfileStore.updateProfile`; this used
+    /// to *also* call `updateProfile` directly with the same entry, so every
+    /// recognised speaker was merged twice per recording. The centroid value
+    /// survives that (a weighted average of x with x is x) but `sampleCount`
+    /// doubles, and since the merge weights by sample count the profile goes
+    /// progressively rigid and quietly stops adapting — recognition decays
+    /// with no visible failure. Do not re-add a second persistence call
+    /// here: the single call below is deliberately the only one, and it is
+    /// what makes re-running this for the same recording idempotent (the
+    /// name already matches, so `setSpeakerName` returns without firing the
+    /// hook).
     private func autoAssignRecognisedSpeakers() {
         guard voiceRecognitionSettings.isConfigured else { return }
         guard let rec = store.recordings.first else { return }
@@ -897,11 +911,6 @@ struct MilaApp: App {
             let spoke = liveSpeakerDiarizer.intervals.contains { $0.speaker == entry.id }
             guard spoke else { continue }
             store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
-            speakerProfileStore.updateProfile(
-                name: profileName,
-                embedding: entry.centroid,
-                sampleCount: entry.sampleCount
-            )
         }
     }
 

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -598,7 +598,23 @@ struct MilaApp: App {
         let assigner = RecognisedSpeakerAssigner(store: store,
                                                 diarizer: liveDiar,
                                                 snapshots: voiceSnapshots,
-                                                settings: voiceSettings)
+                                                settings: voiceSettings,
+                                                profileStillStored: { name in
+                                                    profileStoreRef.profileExists(name: name)
+                                                })
+        // Deleting voice profiles has to reach the recording that is already
+        // running, not just memory and the file. The pool was seeded from
+        // these profiles at record-start and keeps its own copy of every
+        // centroid, so without this the rest of the recording goes on
+        // matching the erased voice and `assigner.finish` writes it back at
+        // stop — the deleted file reappears, holding the same person's
+        // fingerprint. Same immediacy as the opt-out path above.
+        profileStoreRef.addDeletionObserver { [weak liveDiar] deletion in
+            switch deletion {
+            case .all: liveDiar?.forgetSeededProfiles()
+            case .named(let names): liveDiar?.forgetSeededProfiles(named: names)
+            }
+        }
         actions.onRecordingFinalized = { [assigner] recordingID in
             assigner.finish(recording: recordingID)
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -366,6 +366,11 @@ struct MilaApp: App {
     /// Persisted voice fingerprints behind that feature. Inert — nothing
     /// read, nothing written — until the setting above is turned on.
     @StateObject private var speakerProfileStore: SpeakerProfileStore
+    /// Per-recording snapshots of the diarizer pool, so naming a speaker
+    /// persists that recording's voice rather than the live pool's. Not
+    /// observable by any view, hence a plain reference rather than a
+    /// `@StateObject`.
+    private let observedVoices: ObservedVoiceSnapshots
 
     init() {
         // RecordingStore's no-arg init handles the legacy migration and
@@ -588,26 +593,36 @@ struct MilaApp: App {
         _voiceRecognitionSettings = StateObject(wrappedValue: voiceSettings)
         let profileStoreRef = SpeakerProfileStore(settings: voiceSettings)
         _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
+        let voiceSnapshots = ObservedVoiceSnapshots()
+        voiceSnapshots.clearOnOptOut(of: voiceSettings)
+        observedVoices = voiceSnapshots
         // Save a voice profile when a speaker is named — if the live
-        // diarizer observed that speaker, persist it. The store refuses
-        // writes while the feature is off; the guard here means an opted-out
-        // user's voice isn't so much as read out of the pool.
+        // diarizer observed that speaker *in that recording*, persist it.
+        // The store refuses writes while the feature is off; the guard here
+        // means an opted-out user's voice isn't so much as looked up.
         //
-        // `currentProfiles()` reports what was observed in *this* recording,
-        // not the pool's matching centroid — for a seeded speaker the latter
-        // carries weight that is already stored on disk, and folding it back
-        // in counts it twice. This is the only place voice profiles are
-        // written, so a recognised speaker merges exactly once per recording.
-        let diarizerRef = liveDiar
-        store.onSpeakerNamed = { _, rawID, name in
+        // Resolved through `observedVoices` keyed on `recordingID`, never
+        // against the live pool. `SPEAKER_00` restarts from zero on every
+        // `reset()`, so a live-pool lookup silently returned the *current*
+        // recording's speaker for a name applied to an older one — writing a
+        // stranger's voice into the named profile. A recording with no
+        // snapshot resolves to nil and persists nothing, which is the honest
+        // answer: its pool is gone.
+        //
+        // The snapshot holds what was observed in that recording, not the
+        // pool's matching centroid — for a seeded speaker the latter carries
+        // weight already stored on disk, and folding it back counts it twice.
+        // This is the only place voice profiles are written, so a recognised
+        // speaker merges exactly once per recording.
+        store.onSpeakerNamed = { recordingID, rawID, name in
             guard voiceSettings.isConfigured else { return }
-            if let entry = diarizerRef.currentProfiles().first(where: { $0.id == rawID }) {
-                profileStoreRef.updateProfile(
-                    name: name,
-                    embedding: entry.observedCentroid,
-                    sampleCount: entry.observedCount
-                )
-            }
+            guard let observed = voiceSnapshots.observation(forSpeaker: rawID,
+                                                           in: recordingID) else { return }
+            profileStoreRef.updateProfile(
+                name: name,
+                embedding: observed.observedCentroid,
+                sampleCount: observed.observedCount
+            )
         }
 
         // Auto-drop accidental short+empty captures (issue #61). A recording
@@ -909,18 +924,31 @@ struct MilaApp: App {
         guard voiceRecognitionSettings.isConfigured else { return }
         guard let rec = store.recordings.first else { return }
         let poolEntries = liveSpeakerDiarizer.currentProfiles()
-        // Only assign names for pool entries that were seeded (they carry a
-        // profileName) AND actually spoke. Both halves matter: a seeded
-        // speaker who never said anything must not be labelled onto the
-        // recording just because their voice was in the pool.
+        // Snapshot the pool against this recording's id BEFORE naming
+        // anything: `setSpeakerName` fires `onSpeakerNamed` synchronously,
+        // and that hook resolves the voice through this snapshot. Every pool
+        // entry is kept, not just the seeded ones, because a speaker the user
+        // names by hand later needs the same lookup.
+        observedVoices.record(poolEntries, for: rec.id)
+        // Assign a name only where all three hold.
         for entry in poolEntries {
+            // 1. Seeded from a stored profile — there is a name to assign.
             guard let profileName = entry.profileName else { continue }
-            // Check this speaker actually spoke (has intervals). Now that
-            // seeded weight is kept out of the persisted delta,
-            // `entry.observedCount > 0` says much the same thing — but
-            // `intervals` is the stronger signal, since it means the speaker
-            // reached the transcript rather than merely matching an
-            // embedding.
+            // 2. Confidently matched this recording. `assign` deliberately
+            //    attaches *borderline* utterances (and anything under a
+            //    second) to the nearest existing speaker without folding
+            //    them into the centroid — so such an utterance produces an
+            //    interval while leaving `observedCount` at zero. Gating on
+            //    intervals alone therefore stamped a stored profile's name
+            //    onto a speaker that never confidently matched it: a
+            //    misattributed transcript, and the wrong person's name shown
+            //    against their words. `observedCount` is precisely the
+            //    "confidently observed this recording" signal.
+            guard entry.observedCount > 0 else { continue }
+            // 3. Reached the transcript. Kept alongside the count check
+            //    rather than replaced by it: intervals prove the speaker
+            //    actually surfaced in the saved transcript, which is a
+            //    stronger claim than having matched an embedding.
             let spoke = liveSpeakerDiarizer.intervals.contains { $0.speaker == entry.id }
             guard spoke else { continue }
             store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -366,11 +366,6 @@ struct MilaApp: App {
     /// Persisted voice fingerprints behind that feature. Inert — nothing
     /// read, nothing written — until the setting above is turned on.
     @StateObject private var speakerProfileStore: SpeakerProfileStore
-    /// Per-recording snapshots of the diarizer pool, so naming a speaker
-    /// persists that recording's voice rather than the live pool's. Not
-    /// observable by any view, hence a plain reference rather than a
-    /// `@StateObject`.
-    private let observedVoices: ObservedVoiceSnapshots
 
     init() {
         // RecordingStore's no-arg init handles the legacy migration and
@@ -595,14 +590,25 @@ struct MilaApp: App {
         _speakerProfileStore = StateObject(wrappedValue: profileStoreRef)
         let voiceSnapshots = ObservedVoiceSnapshots()
         voiceSnapshots.clearOnOptOut(of: voiceSettings)
-        observedVoices = voiceSnapshots
+        // Auto-naming + the per-recording snapshot, driven by the finalize
+        // drain rather than by observing `isRecording`. The drain hands over
+        // the id of the recording that actually finished, and calls
+        // synchronously inside the window where the diarizer pool still
+        // belongs to it — see `RecognisedSpeakerAssigner`.
+        let assigner = RecognisedSpeakerAssigner(store: store,
+                                                diarizer: liveDiar,
+                                                snapshots: voiceSnapshots,
+                                                settings: voiceSettings)
+        actions.onRecordingFinalized = { [assigner] recordingID in
+            assigner.finish(recording: recordingID)
+        }
         // Save a voice profile when a speaker is named — if the live
         // diarizer observed that speaker *in that recording*, persist it.
         // The store refuses writes while the feature is off; the guard here
         // means an opted-out user's voice isn't so much as looked up.
         //
-        // Resolved through `observedVoices` keyed on `recordingID`, never
-        // against the live pool. `SPEAKER_00` restarts from zero on every
+        // Resolved through the per-recording snapshot keyed on
+        // `recordingID`, never against the live pool. `SPEAKER_00` restarts from zero on every
         // `reset()`, so a live-pool lookup silently returned the *current*
         // recording's speaker for a name applied to an older one — writing a
         // stranger's voice into the named profile. A recording with no
@@ -746,14 +752,6 @@ struct MilaApp: App {
                 .task { await runFinalizeRegressionIfRequested() }
                 .task { recordingSummarizer.backfillIfNeeded() }
                 .task { voiceMemosImporter.start() }
-                .onChange(of: actions.isRecording) { wasRecording, isRecording in
-                    if wasRecording, !isRecording {
-                        // Recording just stopped — auto-assign names from
-                        // recognised voice profiles for seeded pool entries
-                        // that actually matched utterances.
-                        autoAssignRecognisedSpeakers()
-                    }
-                }
                 .environmentObject(recordingSummarizer)
                 .environmentObject(meetingDetectionSettings)
                 .environmentObject(voiceMemosSettings)
@@ -898,63 +896,6 @@ struct MilaApp: App {
     /// user's enabled toggle. Called once from the main `WindowGroup`
     /// `.task` so the work is tied to the app's lifetime rather than
     /// to any single view.
-    /// After recording stops, check the live diarizer pool for speakers
-    /// that were seeded from voice profiles and actually matched real
-    /// utterances. Auto-assign their names to the most recent recording.
-    ///
-    /// No-ops entirely while voice recognition is off. The pool would carry
-    /// no `profileName` anyway (nothing was seeded), but an explicit gate
-    /// keeps the guarantee readable rather than emergent.
-    ///
-    /// **Persistence is `setSpeakerName`'s job, not this loop's — one
-    /// recognition must fold into the stored centroid exactly once.**
-    /// `setSpeakerName` synchronously fires `store.onSpeakerNamed`, which
-    /// `MilaApp.init` wires to `SpeakerProfileStore.updateProfile`; this used
-    /// to *also* call `updateProfile` directly with the same entry, so every
-    /// recognised speaker was merged twice per recording. The centroid value
-    /// survives that (a weighted average of x with x is x) but `sampleCount`
-    /// doubles, and since the merge weights by sample count the profile goes
-    /// progressively rigid and quietly stops adapting — recognition decays
-    /// with no visible failure. Do not re-add a second persistence call
-    /// here: the single call below is deliberately the only one, and it is
-    /// what makes re-running this for the same recording idempotent (the
-    /// name already matches, so `setSpeakerName` returns without firing the
-    /// hook).
-    private func autoAssignRecognisedSpeakers() {
-        guard voiceRecognitionSettings.isConfigured else { return }
-        guard let rec = store.recordings.first else { return }
-        let poolEntries = liveSpeakerDiarizer.currentProfiles()
-        // Snapshot the pool against this recording's id BEFORE naming
-        // anything: `setSpeakerName` fires `onSpeakerNamed` synchronously,
-        // and that hook resolves the voice through this snapshot. Every pool
-        // entry is kept, not just the seeded ones, because a speaker the user
-        // names by hand later needs the same lookup.
-        observedVoices.record(poolEntries, for: rec.id)
-        // Assign a name only where all three hold.
-        for entry in poolEntries {
-            // 1. Seeded from a stored profile — there is a name to assign.
-            guard let profileName = entry.profileName else { continue }
-            // 2. Confidently matched this recording. `assign` deliberately
-            //    attaches *borderline* utterances (and anything under a
-            //    second) to the nearest existing speaker without folding
-            //    them into the centroid — so such an utterance produces an
-            //    interval while leaving `observedCount` at zero. Gating on
-            //    intervals alone therefore stamped a stored profile's name
-            //    onto a speaker that never confidently matched it: a
-            //    misattributed transcript, and the wrong person's name shown
-            //    against their words. `observedCount` is precisely the
-            //    "confidently observed this recording" signal.
-            guard entry.observedCount > 0 else { continue }
-            // 3. Reached the transcript. Kept alongside the count check
-            //    rather than replaced by it: intervals prove the speaker
-            //    actually surfaced in the saved transcript, which is a
-            //    stronger claim than having matched an embedding.
-            let spoke = liveSpeakerDiarizer.intervals.contains { $0.speaker == entry.id }
-            guard spoke else { continue }
-            store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
-        }
-    }
-
     private func startMeetingDetectionIfNeeded() {
         meetingPrompt.start()
         meetingPrompt.bindEnabledChanges()

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -547,7 +547,7 @@ struct MilaApp: App {
         // summary referring to the previous transcript; we force-
         // regenerate so the user doesn't end up with a stale summary
         // that disagrees with what the segments now say.
-        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian] rec, wasRetranscription in
+        svc.onTranscriptionCompleted = { [weak summarizer, weak llm, weak obsidianSettings, weak obsidian, weak store, weak diarSettings] rec, wasRetranscription in
             // Obsidian export is driven off the summarizer's completion hook.
             // Mark this fresh completion pending so the hook knows to write it
             // (backfilled recordings are never marked, hence never re-filed).

--- a/Mila/Models/ObservedVoiceSnapshots.swift
+++ b/Mila/Models/ObservedVoiceSnapshots.swift
@@ -1,0 +1,109 @@
+import Foundation
+import os
+
+private let snapshotLog = Logger(
+    subsystem: "io.island.whisper.IslandWhisper", category: "ObservedVoiceSnapshots")
+
+/// Per-recording snapshots of what `LiveSpeakerDiarizer` observed, so that
+/// naming a speaker persists **that recording's** voice and never a later
+/// recording's.
+///
+/// Speaker ids (`SPEAKER_00`, `SPEAKER_01`, …) are positional and restart
+/// from zero after every `LiveSpeakerDiarizer.reset()` — once per recording.
+/// The persistence hook used to resolve a name against the *live* pool by raw
+/// id, which is only correct while the recording being named happens to be
+/// the one the pool belongs to. Name a speaker in an earlier recording after
+/// a later one has started — an entirely ordinary thing to do from the
+/// sidebar — and `SPEAKER_00` resolved to whoever was `SPEAKER_00` in the
+/// *newer* recording, writing a different person's voice into the named
+/// profile. Nothing surfaced the mistake: the profile was silently poisoned
+/// with a stranger's embedding.
+///
+/// Keying the lookup by recording id makes that confusion impossible. A
+/// recording with no snapshot resolves to `nil` and persists nothing, which
+/// is the honest answer: its pool is gone, so there is no embedding to learn
+/// from.
+///
+/// Only ever populated from behind the `VoiceRecognitionSettings.isConfigured`
+/// gate, and it drops everything on opt-out — an opted-out user has no voice
+/// data held here either.
+@MainActor
+final class ObservedVoiceSnapshots {
+
+    /// What one speaker contributed in one recording. Mirrors the
+    /// `observedCentroid` / `observedCount` pair from
+    /// `LiveSpeakerDiarizer.SpeakerProfile` — the delta for this recording
+    /// alone, never the matching centroid.
+    struct Observation: Equatable {
+        let observedCentroid: [Float]
+        let observedCount: Int
+        let profileName: String?
+    }
+
+    /// How many recordings' snapshots to keep. Naming happens right after a
+    /// recording in the overwhelming majority of cases; a handful of slots
+    /// covers "record a few back-to-back, then go back and label them"
+    /// without letting embeddings accumulate for the life of the process.
+    private let limit: Int
+
+    private var byRecording: [UUID: [String: Observation]] = [:]
+    /// Insertion order, oldest first — the eviction queue.
+    private var order: [UUID] = []
+
+    init(limit: Int = 8) {
+        self.limit = max(1, limit)
+    }
+
+    /// Observe a settings object so an opt-out discards everything held.
+    func clearOnOptOut(of settings: VoiceRecognitionSettings) {
+        settings.addEnabledObserver { [weak self] nowEnabled in
+            guard !nowEnabled else { return }
+            self?.removeAll()
+        }
+    }
+
+    /// Snapshot a recording's pool. Call once, at stop, **before** anything
+    /// can trigger `RecordingStore.onSpeakerNamed` for this recording.
+    ///
+    /// Every pool entry is kept, not just seeded ones: a brand-new speaker
+    /// the user names by hand is the primary way profiles get created in the
+    /// first place, and that path needs the same lookup.
+    ///
+    /// Re-snapshotting the same recording replaces its entry and keeps its
+    /// original position in the eviction queue.
+    func record(
+        _ entries: [(id: String, observedCentroid: [Float], observedCount: Int, profileName: String?)],
+        for recordingID: UUID
+    ) {
+        var observations: [String: Observation] = [:]
+        for entry in entries {
+            observations[entry.id] = Observation(observedCentroid: entry.observedCentroid,
+                                                 observedCount: entry.observedCount,
+                                                 profileName: entry.profileName)
+        }
+        if byRecording.updateValue(observations, forKey: recordingID) == nil {
+            order.append(recordingID)
+        }
+        while order.count > limit {
+            let evicted = order.removeFirst()
+            byRecording.removeValue(forKey: evicted)
+        }
+        snapshotLog.log("snapshot: \(observations.count, privacy: .public) speakers for a recording (holding \(self.order.count, privacy: .public))")
+    }
+
+    /// The observation for `rawID` **in that specific recording**, or nil
+    /// when this recording was never snapshotted (or has been evicted) — in
+    /// which case the caller must persist nothing rather than fall back to
+    /// the live pool.
+    func observation(forSpeaker rawID: String, in recordingID: UUID) -> Observation? {
+        byRecording[recordingID]?[rawID]
+    }
+
+    func removeAll() {
+        byRecording.removeAll()
+        order.removeAll()
+    }
+
+    /// Number of recordings currently held. For tests and diagnostics.
+    var heldRecordingCount: Int { order.count }
+}

--- a/Mila/Models/RecognisedSpeakerAssigner.swift
+++ b/Mila/Models/RecognisedSpeakerAssigner.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Applies stored voice-profile names to the speakers a finished recording
+/// actually recognised, and snapshots that recording's observations so a
+/// later rename can persist the right voice.
+///
+/// Extracted from `MilaApp` for one reason above all: **it must be told which
+/// recording finished, never infer it.** The previous version ran off
+/// `.onChange(of: actions.isRecording)` — which carries no id — and recovered
+/// one with `store.recordings.first`. That is wrong twice over:
+///
+///   * `RecordingStore.add` does `recordings.insert(_, at: 0)` with no
+///     re-sort, so *any* recording added afterwards becomes `first`. The
+///     Voice Memos importer calls `add` from its own async flow, so a memo
+///     landing between the meeting's `add` and SwiftUI delivering the
+///     `.onChange` made the memo "the recording that just stopped".
+///   * `load()` and `recoverOrphanRecordings()` sort by `createdAt`
+///     descending, and imported memos carry their *own* dates, so ordering
+///     is not a reliable proxy for recency of *finishing* either.
+///
+/// Misidentifying the recording degraded safely — an unknown id resolves to
+/// no snapshot, so the profile silently fails to learn rather than merging a
+/// stranger's voice — and that fail-closed property is deliberate and worth
+/// keeping. But failing safely is not the same as being right, so the id is
+/// now carried: `QuickActionsController` invokes `finish(recording:)` from
+/// inside its finalize drain, where it holds the exact id.
+///
+/// That call site is also the only moment when reading the live diarizer is
+/// sound. It sits after `awaitPending()` (so `intervals` are final) and
+/// before `liveDiarizer?.stop()`, inside the window `isFinalizingRecording`
+/// holds the next recording off — so the pool is guaranteed to still be this
+/// recording's. The old deferred `.onChange` had no such guarantee: a user
+/// hitting Record again promptly could `reset()` the pool first.
+@MainActor
+final class RecognisedSpeakerAssigner {
+
+    private let store: RecordingStore
+    private let diarizer: LiveSpeakerDiarizer
+    private let snapshots: ObservedVoiceSnapshots
+    private let settings: VoiceRecognitionSettings
+
+    init(store: RecordingStore,
+         diarizer: LiveSpeakerDiarizer,
+         snapshots: ObservedVoiceSnapshots,
+         settings: VoiceRecognitionSettings) {
+        self.store = store
+        self.diarizer = diarizer
+        self.snapshots = snapshots
+        self.settings = settings
+    }
+
+    /// Call once per finished recording, with that recording's id.
+    ///
+    /// No-ops entirely while voice recognition is off — the pool would carry
+    /// no `profileName` anyway (nothing was seeded), but an explicit gate
+    /// keeps the guarantee readable rather than emergent, and it also stops
+    /// the snapshot below from holding embeddings for an opted-out user.
+    ///
+    /// **On the removed `intervals` check.** This loop used to also require
+    /// `diarizer.intervals.contains { $0.speaker == entry.id }`, justified as
+    /// proving the speaker "reached the transcript". That justification was
+    /// wrong on both halves. `intervals` holds *diarizer utterance*
+    /// intervals, appended in `process` before anything is matched against
+    /// transcript segments (`applySpeakerLabels` does that later), so it
+    /// never evidenced transcript presence. And it was redundant:
+    /// `observedCount` is only ever incremented by `assign`, whose sole
+    /// production caller is `process`, which appends an interval for exactly
+    /// the id `assign` returned — so `observedCount > 0` already implies an
+    /// interval for that speaker. `reset()` clears pool and intervals
+    /// together, so they cannot drift apart either. Do not re-add it
+    /// expecting extra safety; it adds none, and it made this method
+    /// unreachable from a unit test (`intervals` is `private(set)` and only
+    /// fills via the daemon).
+    func finish(recording recordingID: UUID) {
+        guard settings.isConfigured else { return }
+        let poolEntries = diarizer.currentProfiles()
+
+        // Snapshot against this recording's id BEFORE naming anything:
+        // `setSpeakerName` fires `onSpeakerNamed` synchronously, and that
+        // hook resolves the voice through this snapshot. Every pool entry is
+        // kept, not just seeded ones, because a speaker the user names by
+        // hand later needs the same lookup.
+        snapshots.record(poolEntries, for: recordingID)
+
+        // Persistence is `setSpeakerName`'s job, not this loop's — one
+        // recognition must fold into the stored centroid exactly once.
+        // `setSpeakerName` synchronously fires `store.onSpeakerNamed`, which
+        // `MilaApp.init` wires to `SpeakerProfileStore.updateProfile`. This
+        // used to *also* call `updateProfile` directly with the same entry,
+        // so every recognised speaker merged twice per recording: the
+        // centroid value survives that (a weighted average of x with x is x)
+        // but `sampleCount` doubles, and since the merge weights by sample
+        // count the profile goes progressively rigid and quietly stops
+        // adapting — recognition decays with no visible failure. Do not
+        // re-add a second persistence call here. The single call below is
+        // deliberately the only one, and it is what makes re-running this
+        // for the same recording idempotent: the name already matches, so
+        // `setSpeakerName` returns without firing the hook.
+        for entry in poolEntries {
+            // 1. Seeded from a stored profile — there is a name to assign.
+            guard let profileName = entry.profileName else { continue }
+            // 2. Confidently matched this recording. `assign` deliberately
+            //    attaches *borderline* utterances (and anything under a
+            //    second) to the nearest existing speaker without folding
+            //    them into the centroid — so such an utterance produces an
+            //    interval while leaving `observedCount` at zero. Gating on
+            //    intervals alone therefore stamped a stored profile's name
+            //    onto a speaker that never confidently matched it: a
+            //    misattributed transcript, and the wrong person's name shown
+            //    against their words. `observedCount` is precisely the
+            //    "confidently observed this recording" signal.
+            guard entry.observedCount > 0 else { continue }
+            store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: recordingID)
+        }
+    }
+}

--- a/Mila/Models/RecognisedSpeakerAssigner.swift
+++ b/Mila/Models/RecognisedSpeakerAssigner.swift
@@ -38,15 +38,25 @@ final class RecognisedSpeakerAssigner {
     private let diarizer: LiveSpeakerDiarizer
     private let snapshots: ObservedVoiceSnapshots
     private let settings: VoiceRecognitionSettings
+    private let profileStillStored: (String) -> Bool
 
+    /// `profileStillStored` answers "is there still a stored profile under
+    /// this name?", read at stop rather than at record-start. A closure
+    /// rather than a `SpeakerProfileStore` reference, following
+    /// `VoiceRecognitionSettings.diarizationReady`: this object has no
+    /// business mutating the store, and the gate is trivially testable. It
+    /// has no default — a defaulted `{ true }` would fail open, which is the
+    /// bug it exists to prevent.
     init(store: RecordingStore,
          diarizer: LiveSpeakerDiarizer,
          snapshots: ObservedVoiceSnapshots,
-         settings: VoiceRecognitionSettings) {
+         settings: VoiceRecognitionSettings,
+         profileStillStored: @escaping (String) -> Bool) {
         self.store = store
         self.diarizer = diarizer
         self.snapshots = snapshots
         self.settings = settings
+        self.profileStillStored = profileStillStored
     }
 
     /// Call once per finished recording, with that recording's id.
@@ -110,6 +120,29 @@ final class RecognisedSpeakerAssigner {
             //    against their words. `observedCount` is precisely the
             //    "confidently observed this recording" signal.
             guard entry.observedCount > 0 else { continue }
+            // 3. The profile is still stored. The pool was seeded at
+            //    record-start and holds its own copy of the centroid, so a
+            //    profile can disappear underneath it while the recording
+            //    runs — the user deleting their voice profiles from Settings
+            //    is the case that matters, and merging or renaming one has
+            //    the same shape. Naming a speaker here fires
+            //    `RecordingStore.onSpeakerNamed`, which persists; and
+            //    `updateProfile` *creates* when the name is absent, because
+            //    that is how a hand-named speaker gets a profile at all. So
+            //    an ungated auto-name recreates exactly what the user just
+            //    erased, file and all, with this recording's centroid — a
+            //    fingerprint that matches the deleted one to better than
+            //    0.999 cosine.
+            //
+            //    `SpeakerProfileStore`'s deletion observer already strips
+            //    `profileName` out of the pool, so deletion normally never
+            //    reaches this line. This is the second lock: it keeps the
+            //    guarantee local to the write path, covers the routes that
+            //    do not notify (a rename, or the absorbed half of a merge),
+            //    and does not depend on a caller having wired the observer
+            //    up. Note it can only *suppress* an auto-name — naming a
+            //    speaker by hand still creates a profile, as it must.
+            guard profileStillStored(profileName) else { continue }
             store.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: recordingID)
         }
     }

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -22,6 +22,11 @@ final class RecordingStore: ObservableObject {
     /// up in the sidebar and survives moving its last recording elsewhere.
     @Published private(set) var folders: [String] = []
 
+    /// Called when a speaker name is assigned (via setSpeakerName).
+    /// Provides the recording ID, raw speaker ID, and the name.
+    /// Used by voice recognition to save voice profiles.
+    var onSpeakerNamed: ((_ recordingID: UUID, _ rawID: String, _ name: String) -> Void)?
+
     private let fileManager = FileManager.default
     /// `storeURL` and `foldersURL` move with `recordingsDirectory` on
     /// every `relocateRecordings` call. On the default path they live
@@ -385,6 +390,7 @@ final class RecordingStore: ObservableObject {
         if let trimmed, !trimmed.isEmpty {
             guard recordings[idx].speakerNames[rawID] != trimmed else { return }
             recordings[idx].speakerNames[rawID] = trimmed
+            onSpeakerNamed?(recordingID, rawID, trimmed)
         } else {
             guard recordings[idx].speakerNames[rawID] != nil else { return }
             recordings[idx].speakerNames.removeValue(forKey: rawID)

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -32,10 +32,20 @@ struct VoiceProfile: Codable, Identifiable, Hashable {
 final class SpeakerProfileStore: ObservableObject {
     @Published private(set) var profiles: [VoiceProfile] = []
 
+    /// Master opt-in for voice recognition. When off, no voice profiles
+    /// are created or matched — speaker naming still works (via
+    /// SpeakerDirectory) but without cross-recording auto-identification.
+    /// Off by default: the user must consciously opt in to storing voice
+    /// biometric data.
+    @Published var enabled: Bool {
+        didSet { UserDefaults.standard.set(enabled, forKey: "voiceRecognition.enabled") }
+    }
+
     private let fileManager = FileManager.default
     private let storeURL: URL
 
     init() {
+        self.enabled = UserDefaults.standard.bool(forKey: "voiceRecognition.enabled")
         let appSupport = try! fileManager.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,
@@ -50,6 +60,7 @@ final class SpeakerProfileStore: ObservableObject {
 
     /// Injectable init for tests.
     init(directory: URL) {
+        self.enabled = true
         self.storeURL = directory.appendingPathComponent("speaker-profiles.json")
         load()
     }
@@ -62,6 +73,7 @@ final class SpeakerProfileStore: ObservableObject {
     /// exists, merge the new embedding into its centroid via weighted
     /// average. Otherwise create a new profile.
     func updateProfile(name: String, embedding: [Float], sampleCount: Int) {
+        guard enabled else { return }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !embedding.isEmpty else { return }
 
@@ -104,6 +116,13 @@ final class SpeakerProfileStore: ObservableObject {
 
     func deleteProfile(name: String) {
         profiles.removeAll { $0.name == name }
+        save()
+    }
+
+    /// Remove all stored voice profiles. Used by the "Wipe All Voice
+    /// Data" button in Settings.
+    func deleteAllProfiles() {
+        profiles.removeAll()
         save()
     }
 
@@ -154,6 +173,7 @@ final class SpeakerProfileStore: ObservableObject {
     /// Match an embedding against all stored profiles. Returns the best
     /// match above the threshold, or nil.
     func match(embedding: [Float], threshold: Double = 0.55) -> VoiceProfile? {
+        guard enabled else { return nil }
         var best: (profile: VoiceProfile, sim: Double)?
         for profile in profiles {
             let sim = cosineSimilarity(embedding, profile.embedding)
@@ -166,7 +186,8 @@ final class SpeakerProfileStore: ObservableObject {
 
     /// Entries suitable for seeding the live diarizer pool.
     func seedEntries() -> [(id: String, name: String, centroid: [Float], sampleCount: Int)] {
-        profiles.map { p in
+        guard enabled else { return [] }
+        return profiles.map { p in
             (id: p.name, name: p.name, centroid: p.embedding, sampleCount: p.sampleCount)
         }
     }

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -24,45 +24,86 @@ struct VoiceProfile: Codable, Identifiable, Hashable {
 }
 
 /// Manages persistent speaker voice profiles for cross-recording
-/// recognition. Profiles are created when a user names a speaker
-/// that has an embedding available (from the live diarizer pool or
-/// batch extraction). Builds on top of the existing SpeakerDirectory
-/// (which manages the name list) by adding voice embeddings.
+/// recognition, in `speaker-profiles.json` at the Application Support/Mila
+/// root. Profiles are created when a user names a speaker that has an
+/// embedding available (from the live diarizer pool). Builds on top of the
+/// existing `SpeakerDirectory` (which manages the name list) by adding
+/// voice embeddings.
+///
+/// **Entirely gated on `VoiceRecognitionSettings.isConfigured`, which is
+/// off by default.** With the feature off this object is inert: the JSON
+/// file is never parsed, `profiles` stays empty, no embedding is written,
+/// and `seedEntries()` hands the diarizer nothing. A user who never opts in
+/// has no voice data stored — the guarantee is "never written", not
+/// "written and ignored".
+///
+/// The one thing that still works while off is deletion
+/// (`deleteAllProfiles`), because off is precisely when somebody wants
+/// their voice data gone. Opting out is otherwise non-destructive: profiles
+/// stay on disk so re-enabling restores them, and Settings keeps an
+/// explicit delete button visible for as long as the file exists.
 @MainActor
 final class SpeakerProfileStore: ObservableObject {
+    /// Profiles held in memory. **Empty whenever the feature is off** — the
+    /// file is not even parsed until the user opts in, so an opted-out
+    /// process holds no voice data at all, not merely unused voice data.
     @Published private(set) var profiles: [VoiceProfile] = []
 
-    /// Master opt-in for voice recognition. When off, no voice profiles
-    /// are created or matched — speaker naming still works (via
-    /// SpeakerDirectory) but without cross-recording auto-identification.
-    /// Off by default: the user must consciously opt in to storing voice
-    /// biometric data.
-    @Published var enabled: Bool {
-        didSet { UserDefaults.standard.set(enabled, forKey: "voiceRecognition.enabled") }
-    }
+    /// True when `speaker-profiles.json` exists on disk, whether or not it
+    /// has been parsed. Lets Settings tell an opted-out user that voice
+    /// profiles from an earlier opt-in are still stored, and offer to
+    /// delete them, without reading a single embedding back into memory.
+    @Published private(set) var hasStoredProfilesOnDisk: Bool = false
+
+    /// The opt-in gate. Every persist / seed / match path below is guarded
+    /// on `settings.isConfigured` (enabled **and** the diarization pipeline
+    /// able to produce embeddings), never on `settings.isEnabled` alone.
+    let settings: VoiceRecognitionSettings
 
     private let fileManager = FileManager.default
     private let storeURL: URL
 
-    init() {
-        self.enabled = UserDefaults.standard.bool(forKey: "voiceRecognition.enabled")
-        let appSupport = try! fileManager.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        self.storeURL = appSupport
-            .appendingPathComponent("Mila", isDirectory: true)
-            .appendingPathComponent("speaker-profiles.json")
-        load()
+    /// `directory` is the folder that holds `speaker-profiles.json`.
+    /// Injectable so tests can point at a temp directory.
+    init(directory: URL, settings: VoiceRecognitionSettings) {
+        self.settings = settings
+        self.storeURL = directory.appendingPathComponent("speaker-profiles.json")
+        self.hasStoredProfilesOnDisk = fileManager.fileExists(atPath: storeURL.path)
+        // Only read the file when the user has opted in. Off means off: no
+        // embedding reaches memory, so nothing can be seeded or matched
+        // even by a caller that forgot its own guard.
+        if settings.isEnabled { load() }
+        // Toggling mid-session has to take effect without a relaunch:
+        // opting in loads what was stored, opting out drops it again.
+        settings.onEnabledChange = { [weak self] nowEnabled in
+            guard let self else { return }
+            if nowEnabled {
+                self.load()
+            } else {
+                self.profiles.removeAll()
+            }
+        }
     }
 
-    /// Injectable init for tests.
-    init(directory: URL) {
-        self.enabled = true
-        self.storeURL = directory.appendingPathComponent("speaker-profiles.json")
-        load()
+    /// Production init: the same Application Support/Mila root
+    /// `RecordingStore` and `SpeakerDirectory` resolve.
+    convenience init(settings: VoiceRecognitionSettings) {
+        // Mirror SpeakerDirectory: UI tests must never read or write the
+        // user's real voice profiles.
+        if CommandLine.arguments.contains("--ui-test-clean-store") {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("Mila-UITest-VoiceProfiles-\(UUID())", isDirectory: true)
+            self.init(directory: tmp, settings: settings)
+            return
+        }
+        // Non-throwing lookup + temp-dir fallback, matching SpeakerDirectory:
+        // a missing Application Support directory must not crash the app at
+        // launch (the previous `try!` here would have).
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        self.init(directory: appSupport.appendingPathComponent("Mila", isDirectory: true),
+                  settings: settings)
     }
 
     deinit {}
@@ -73,7 +114,10 @@ final class SpeakerProfileStore: ObservableObject {
     /// exists, merge the new embedding into its centroid via weighted
     /// average. Otherwise create a new profile.
     func updateProfile(name: String, embedding: [Float], sampleCount: Int) {
-        guard enabled else { return }
+        // The write gate. Callers guard too (so an opted-out user's centroid
+        // is never even read out of the diarizer pool), but the refusal that
+        // actually matters is here: nothing reaches `save()` while off.
+        guard settings.isConfigured else { return }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !embedding.isEmpty, sampleCount > 0 else { return }
 
@@ -119,11 +163,24 @@ final class SpeakerProfileStore: ObservableObject {
         save()
     }
 
-    /// Remove all stored voice profiles. Used by the "Wipe All Voice
-    /// Data" button in Settings.
+    /// Remove every stored voice profile — the "Delete voice profiles"
+    /// button in Settings.
+    ///
+    /// Deliberately **not** gated: deletion has to work when the feature is
+    /// off, because off is exactly when a user wants their voice data gone.
+    /// It deletes the file rather than writing an empty array over it, so
+    /// after opting out and deleting there is no `speaker-profiles.json`
+    /// left behind at all.
     func deleteAllProfiles() {
         profiles.removeAll()
-        save()
+        do {
+            if fileManager.fileExists(atPath: storeURL.path) {
+                try fileManager.removeItem(at: storeURL)
+            }
+        } catch {
+            profileLog.log("deleteAll error: \(error.localizedDescription, privacy: .public)")
+        }
+        hasStoredProfilesOnDisk = fileManager.fileExists(atPath: storeURL.path)
     }
 
     func profileExists(name: String) -> Bool {
@@ -182,7 +239,7 @@ final class SpeakerProfileStore: ObservableObject {
     /// Match an embedding against all stored profiles. Returns the best
     /// match above the threshold, or nil.
     func match(embedding: [Float], threshold: Double = 0.55) -> VoiceProfile? {
-        guard enabled else { return nil }
+        guard settings.isConfigured else { return nil }
         var best: (profile: VoiceProfile, sim: Double)?
         for profile in profiles {
             let sim = cosineSimilarity(embedding, profile.embedding)
@@ -194,8 +251,11 @@ final class SpeakerProfileStore: ObservableObject {
     }
 
     /// Entries suitable for seeding the live diarizer pool.
+    ///
+    /// The seed gate. Returns nothing while the feature is off — and while
+    /// off `profiles` is empty anyway, since the file was never parsed.
     func seedEntries() -> [(id: String, name: String, centroid: [Float], sampleCount: Int)] {
-        guard enabled else { return [] }
+        guard settings.isConfigured else { return [] }
         return profiles.map { p in
             (id: p.name, name: p.name, centroid: p.embedding, sampleCount: p.sampleCount)
         }
@@ -203,7 +263,27 @@ final class SpeakerProfileStore: ObservableObject {
 
     // MARK: - Persistence
 
+    /// Writes `profiles` to disk.
+    ///
+    /// **Refuses while the feature is off**, and that refusal does double
+    /// duty. It is the last line of the "nothing is written unless the user
+    /// opted in" guarantee, and it stops the opposite failure too: while off
+    /// `profiles` is empty, so a stray `save()` would overwrite a
+    /// previously-stored file with `[]` and destroy voice profiles the user
+    /// is entitled to get back by re-enabling.
+    ///
+    /// This one guard reads `isEnabled` rather than `isConfigured` on
+    /// purpose. `isConfigured` gates everything that *creates* voice data
+    /// (`updateProfile`) or *uses* it (`seedEntries`, `match`), so no new
+    /// embedding can reach here without it; what's left is the user's own
+    /// housekeeping — a rename or a single delete from Settings — and that
+    /// must still persist when the diarization pipeline happens to be
+    /// unverified, or their edit would silently revert on relaunch.
     private func save() {
+        guard settings.isEnabled else {
+            profileLog.log("save skipped — voice recognition is off")
+            return
+        }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -215,12 +295,18 @@ final class SpeakerProfileStore: ObservableObject {
             }
             let data = try encoder.encode(profiles)
             try data.write(to: storeURL, options: .atomic)
+            hasStoredProfilesOnDisk = true
         } catch {
             profileLog.log("save error: \(error.localizedDescription, privacy: .public)")
         }
     }
 
+    /// Parses `speaker-profiles.json` into memory. Called from `init` only
+    /// when the user has already opted in, and from the opt-in transition —
+    /// the guard is belt and braces so a future caller can't read voice data
+    /// back in behind an opted-out user's back.
     private func load() {
+        guard settings.isEnabled else { return }
         guard fileManager.fileExists(atPath: storeURL.path) else { return }
         do {
             let data = try Data(contentsOf: storeURL)

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -27,7 +27,29 @@ struct VoiceProfile: Codable, Identifiable, Hashable {
     /// valid counts can be added without trapping**, which both
     /// `updateProfile` and `mergeProfiles` do. Those two also clamp their sums
     /// to it, so the store can never produce a value its own validator would
-    /// later reject.
+    /// later reject. `Int.max / 2 + Int.max / 2 == Int.max - 1`: exactly one
+    /// unit of headroom, which is all that is needed.
+    ///
+    /// **The clamp applies to the stored count only, never to the divisor of
+    /// the weighted mean.** Both folds weight their numerator by the *true*
+    /// counts, so dividing by the clamped total would not produce a mean at
+    /// all — it would scale the whole centroid by `rawTotal / maxSampleCount`,
+    /// up to 2× at the ceiling. Verified: folding two ceiling-count profiles
+    /// `[1, 0]` and `[0, 1]` that way yields `[1, 1]` where the mean is
+    /// `[0.5, 0.5]`.
+    ///
+    /// The count therefore **saturates** while the centroid stays exact, and
+    /// the two disagree from that point on: a profile that has really seen
+    /// `rawTotal` samples reports `maxSampleCount`, so the *next* fold
+    /// under-weights it and lets the incoming sample pull the centroid
+    /// harder than it should — by at most 2×, since no single valid count
+    /// exceeds the ceiling either. That is a deliberate trade. The
+    /// alternatives are worse: storing `rawTotal` unclamped re-arms the
+    /// overflow trap this ceiling exists to prevent, and refusing the fold
+    /// would silently stop a speaker from ever being updated again. It is
+    /// also unreachable in practice — at one utterance per second, reaching
+    /// the ceiling takes on the order of 10¹¹ years — so the residual
+    /// imprecision is bounded, documented and never paid.
     static let maxSampleCount = Int.max / 2
 
     /// Why this profile cannot be used, or nil when it is sound.
@@ -204,19 +226,23 @@ final class SpeakerProfileStore: ObservableObject {
             // incoming one by the guard above, the stored one because every
             // route into `profiles` (this method, or `load`'s validation)
             // enforces it. Swift traps on `Int` overflow, and a decoded
-            // `Int.max` here would otherwise crash the app outright. The
-            // clamp keeps the result inside the same bound, so what is
-            // written back is always something `load` will accept.
-            let totalCount = min(existing.sampleCount + sampleCount, VoiceProfile.maxSampleCount)
+            // `Int.max` here would otherwise crash the app outright.
+            let rawTotal = existing.sampleCount + sampleCount
+            // Clamped so what is written back is always something `load` will
+            // accept. **Only the stored count is clamped** — the fold below
+            // divides by `rawTotal`, because its numerator is weighted by the
+            // true counts and a clamped divisor would scale the centroid
+            // instead of averaging it. See `VoiceProfile.maxSampleCount`.
+            let storedCount = min(rawTotal, VoiceProfile.maxSampleCount)
             var merged = [Float](repeating: 0, count: embedding.count)
             for i in 0..<merged.count {
                 merged[i] = (existing.embedding[i] * Float(existing.sampleCount)
-                           + embedding[i] * Float(sampleCount)) / Float(totalCount)
+                           + embedding[i] * Float(sampleCount)) / Float(rawTotal)
             }
             profiles[idx].embedding = merged
-            profiles[idx].sampleCount = totalCount
+            profiles[idx].sampleCount = storedCount
             profiles[idx].lastSeenAt = Date()
-            profileLog.log("updateProfile: merged into \(trimmed, privacy: .private) (now \(totalCount) samples)")
+            profileLog.log("updateProfile: merged into \(trimmed, privacy: .private) (now \(storedCount) samples)")
             save()
         } else {
             let profile = VoiceProfile(
@@ -301,15 +327,19 @@ final class SpeakerProfileStore: ObservableObject {
         }
         let dim = keep.embedding.count
         guard dim > 0 else { return nil }
-        // Bounded and clamped for the same reason as `updateProfile`'s sum.
-        let totalCount = min(keep.sampleCount + absorb.sampleCount, VoiceProfile.maxSampleCount)
+        // Bounded and clamped exactly as in `updateProfile`, and for the same
+        // reasons: the sum cannot trap because both stored counts are at most
+        // `maxSampleCount`, and only the *stored* count is clamped — the fold
+        // divides by the true `rawTotal` so it stays a weighted mean.
+        let rawTotal = keep.sampleCount + absorb.sampleCount
+        let storedCount = min(rawTotal, VoiceProfile.maxSampleCount)
         var merged = [Float](repeating: 0, count: dim)
         for i in 0..<dim {
             merged[i] = (keep.embedding[i] * Float(keep.sampleCount)
-                       + absorb.embedding[i] * Float(absorb.sampleCount)) / Float(totalCount)
+                       + absorb.embedding[i] * Float(absorb.sampleCount)) / Float(rawTotal)
         }
         profiles[keepIdx].embedding = merged
-        profiles[keepIdx].sampleCount = totalCount
+        profiles[keepIdx].sampleCount = storedCount
         profiles[keepIdx].lastSeenAt = max(keep.lastSeenAt, absorb.lastSeenAt)
         profiles.removeAll { $0.id == absorb.id }
         profileLog.log("mergeProfiles: merged \(absorbName, privacy: .private) into \(keepName, privacy: .private)")

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -1,0 +1,200 @@
+import Foundation
+import os
+
+private let profileLog = Logger(
+    subsystem: "io.island.whisper.IslandWhisper", category: "SpeakerProfileStore")
+
+/// Persistent voice profile for cross-recording speaker recognition.
+/// Stores the speaker's name alongside a centroid embedding (256-dim
+/// vector from wespeaker ECAPA-TDNN via pyannote). The centroid is a
+/// running mean of all embeddings observed for this speaker — the more
+/// recordings, the tighter the distribution.
+struct VoiceProfile: Codable, Identifiable, Hashable {
+    var id: UUID
+    var name: String
+    /// 256-dimensional centroid embedding (running mean).
+    var embedding: [Float]
+    /// Number of utterances folded into the centroid.
+    var sampleCount: Int
+    var createdAt: Date
+    var lastSeenAt: Date
+
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: VoiceProfile, rhs: VoiceProfile) -> Bool { lhs.id == rhs.id }
+}
+
+/// Manages persistent speaker voice profiles for cross-recording
+/// recognition. Profiles are created when a user names a speaker
+/// that has an embedding available (from the live diarizer pool or
+/// batch extraction). Builds on top of the existing SpeakerDirectory
+/// (which manages the name list) by adding voice embeddings.
+@MainActor
+final class SpeakerProfileStore: ObservableObject {
+    @Published private(set) var profiles: [VoiceProfile] = []
+
+    private let fileManager = FileManager.default
+    private let storeURL: URL
+
+    init() {
+        let appSupport = try! fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        self.storeURL = appSupport
+            .appendingPathComponent("Mila", isDirectory: true)
+            .appendingPathComponent("speaker-profiles.json")
+        load()
+    }
+
+    /// Injectable init for tests.
+    init(directory: URL) {
+        self.storeURL = directory.appendingPathComponent("speaker-profiles.json")
+        load()
+    }
+
+    deinit {}
+
+    // MARK: - CRUD
+
+    /// Upsert a speaker profile by name. If a profile with the same name
+    /// exists, merge the new embedding into its centroid via weighted
+    /// average. Otherwise create a new profile.
+    func updateProfile(name: String, embedding: [Float], sampleCount: Int) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !embedding.isEmpty else { return }
+
+        if let idx = profiles.firstIndex(where: { $0.name == trimmed }) {
+            let existing = profiles[idx]
+            guard existing.embedding.count == embedding.count else {
+                profileLog.log("updateProfile: dimension mismatch (\(existing.embedding.count) vs \(embedding.count)) for \(trimmed, privacy: .private)")
+                return
+            }
+            let totalCount = existing.sampleCount + sampleCount
+            var merged = [Float](repeating: 0, count: embedding.count)
+            for i in 0..<merged.count {
+                merged[i] = (existing.embedding[i] * Float(existing.sampleCount)
+                           + embedding[i] * Float(sampleCount)) / Float(totalCount)
+            }
+            profiles[idx].embedding = merged
+            profiles[idx].sampleCount = totalCount
+            profiles[idx].lastSeenAt = Date()
+            profileLog.log("updateProfile: merged into \(trimmed, privacy: .private) (now \(totalCount) samples)")
+            save()
+        } else {
+            let profile = VoiceProfile(
+                id: UUID(),
+                name: trimmed,
+                embedding: embedding,
+                sampleCount: sampleCount,
+                createdAt: Date(),
+                lastSeenAt: Date()
+            )
+            profiles.append(profile)
+            profileLog.log("updateProfile: created \(trimmed, privacy: .private) (\(sampleCount) samples)")
+            save()
+        }
+    }
+
+    func deleteProfile(id: UUID) {
+        profiles.removeAll { $0.id == id }
+        save()
+    }
+
+    func deleteProfile(name: String) {
+        profiles.removeAll { $0.name == name }
+        save()
+    }
+
+    func profileExists(name: String) -> Bool {
+        profiles.contains { $0.name == name }
+    }
+
+    func profile(named: String) -> VoiceProfile? {
+        profiles.first { $0.name == named }
+    }
+
+    /// Rename a profile.
+    func renameProfile(from oldName: String, to newName: String) {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != oldName else { return }
+        if let idx = profiles.firstIndex(where: { $0.name == oldName }) {
+            profiles[idx].name = trimmed
+            save()
+        }
+    }
+
+    /// Merge two profiles: weighted-average centroids, delete absorbed.
+    @discardableResult
+    func mergeProfiles(keep keepName: String, absorb absorbName: String) -> VoiceProfile? {
+        guard let keepIdx = profiles.firstIndex(where: { $0.name == keepName }),
+              let absorbIdx = profiles.firstIndex(where: { $0.name == absorbName }),
+              keepIdx != absorbIdx else { return nil }
+
+        let keep = profiles[keepIdx]
+        let absorb = profiles[absorbIdx]
+        let dim = min(keep.embedding.count, absorb.embedding.count)
+        guard dim > 0 else { return nil }
+        let totalCount = keep.sampleCount + absorb.sampleCount
+        var merged = [Float](repeating: 0, count: dim)
+        for i in 0..<dim {
+            merged[i] = (keep.embedding[i] * Float(keep.sampleCount)
+                       + absorb.embedding[i] * Float(absorb.sampleCount)) / Float(totalCount)
+        }
+        profiles[keepIdx].embedding = merged
+        profiles[keepIdx].sampleCount = totalCount
+        profiles[keepIdx].lastSeenAt = max(keep.lastSeenAt, absorb.lastSeenAt)
+        profiles.removeAll { $0.id == absorb.id }
+        profileLog.log("mergeProfiles: merged \(absorbName, privacy: .private) into \(keepName, privacy: .private)")
+        save()
+        return profiles.first { $0.id == keep.id }
+    }
+
+    /// Match an embedding against all stored profiles. Returns the best
+    /// match above the threshold, or nil.
+    func match(embedding: [Float], threshold: Double = 0.55) -> VoiceProfile? {
+        var best: (profile: VoiceProfile, sim: Double)?
+        for profile in profiles {
+            let sim = cosineSimilarity(embedding, profile.embedding)
+            if sim >= threshold, best == nil || sim > best!.sim {
+                best = (profile, sim)
+            }
+        }
+        return best?.profile
+    }
+
+    /// Entries suitable for seeding the live diarizer pool.
+    func seedEntries() -> [(id: String, name: String, centroid: [Float], sampleCount: Int)] {
+        profiles.map { p in
+            (id: p.name, name: p.name, centroid: p.embedding, sampleCount: p.sampleCount)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(profiles)
+            try data.write(to: storeURL, options: .atomic)
+        } catch {
+            profileLog.log("save error: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func load() {
+        guard fileManager.fileExists(atPath: storeURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: storeURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            profiles = try decoder.decode([VoiceProfile].self, from: data)
+            profileLog.log("loaded \(self.profiles.count) voice profiles")
+        } catch {
+            profileLog.log("load error: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -75,7 +75,7 @@ final class SpeakerProfileStore: ObservableObject {
     func updateProfile(name: String, embedding: [Float], sampleCount: Int) {
         guard enabled else { return }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !embedding.isEmpty else { return }
+        guard !trimmed.isEmpty, !embedding.isEmpty, sampleCount > 0 else { return }
 
         if let idx = profiles.firstIndex(where: { $0.name == trimmed }) {
             let existing = profiles[idx]
@@ -138,6 +138,11 @@ final class SpeakerProfileStore: ObservableObject {
     func renameProfile(from oldName: String, to newName: String) {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed != oldName else { return }
+        // Reject if the target name is already taken by another profile.
+        guard !profiles.contains(where: { $0.name == trimmed }) else {
+            profileLog.log("renameProfile: target name already exists: \(trimmed, privacy: .private)")
+            return
+        }
         if let idx = profiles.firstIndex(where: { $0.name == oldName }) {
             profiles[idx].name = trimmed
             save()
@@ -153,7 +158,11 @@ final class SpeakerProfileStore: ObservableObject {
 
         let keep = profiles[keepIdx]
         let absorb = profiles[absorbIdx]
-        let dim = min(keep.embedding.count, absorb.embedding.count)
+        guard keep.embedding.count == absorb.embedding.count else {
+            profileLog.log("mergeProfiles: dimension mismatch (\(keep.embedding.count) vs \(absorb.embedding.count))")
+            return nil
+        }
+        let dim = keep.embedding.count
         guard dim > 0 else { return nil }
         let totalCount = keep.sampleCount + absorb.sampleCount
         var merged = [Float](repeating: 0, count: dim)
@@ -199,6 +208,11 @@ final class SpeakerProfileStore: ObservableObject {
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
+            // Ensure the parent directory exists (first launch on a clean install).
+            let dir = storeURL.deletingLastPathComponent()
+            if !fileManager.fileExists(atPath: dir.path) {
+                try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+            }
             let data = try encoder.encode(profiles)
             try data.write(to: storeURL, options: .atomic)
         } catch {

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -75,7 +75,7 @@ final class SpeakerProfileStore: ObservableObject {
         if settings.isEnabled { load() }
         // Toggling mid-session has to take effect without a relaunch:
         // opting in loads what was stored, opting out drops it again.
-        settings.onEnabledChange = { [weak self] nowEnabled in
+        settings.addEnabledObserver { [weak self] nowEnabled in
             guard let self else { return }
             if nowEnabled {
                 self.load()

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -148,6 +148,45 @@ final class SpeakerProfileStore: ObservableObject {
     private let fileManager = FileManager.default
     private let storeURL: URL
 
+    /// What a deletion removed, handed to the observers below.
+    enum Deletion: Equatable {
+        /// Every profile — `deleteAllProfiles`. Carries no names on purpose:
+        /// while the feature is off `profiles` is empty (the file is never
+        /// parsed), so the store genuinely does not know what it just
+        /// deleted. "All" is the honest answer and the safe one.
+        case all
+        /// One profile, by name.
+        case named(Set<String>)
+    }
+
+    private var deletionObservers: [(Deletion) -> Void] = []
+
+    /// Register a handler for profile deletions, called synchronously after
+    /// the profiles are gone.
+    ///
+    /// **This is what stops a recording that is already in flight from
+    /// putting a deleted profile back.** Deleting is a privacy action, but
+    /// it only reaches this object and the file: `LiveSpeakerDiarizer`'s pool
+    /// was seeded with those centroids at record-start and keeps its own
+    /// copy, so without this the rest of the recording goes on matching
+    /// against the erased voice, and `RecognisedSpeakerAssigner.finish`
+    /// writes it straight back at stop — under a new id, with this
+    /// recording's centroid, which is the same person's fingerprint to
+    /// within rounding. `MilaApp` wires this to
+    /// `LiveSpeakerDiarizer.forgetSeededProfiles`, so the deletion takes
+    /// effect immediately and everywhere, exactly as opting out does through
+    /// `VoiceRecognitionSettings.addEnabledObserver`.
+    ///
+    /// A list rather than one slot, for the same reason `addEnabledObserver`
+    /// is: a second registrant must not silently unhook the first.
+    func addDeletionObserver(_ observer: @escaping (Deletion) -> Void) {
+        deletionObservers.append(observer)
+    }
+
+    private func notifyDeleted(_ deletion: Deletion) {
+        for observer in deletionObservers { observer(deletion) }
+    }
+
     /// `directory` is the folder that holds `speaker-profiles.json`.
     /// Injectable so tests can point at a temp directory.
     init(directory: URL, settings: VoiceRecognitionSettings) {
@@ -260,13 +299,21 @@ final class SpeakerProfileStore: ObservableObject {
     }
 
     func deleteProfile(id: UUID) {
+        let removed = Set(profiles.filter { $0.id == id }.map(\.name))
         profiles.removeAll { $0.id == id }
         save()
+        // Same reason as `deleteAllProfiles`: a live diarizer seeded with
+        // this profile would otherwise keep matching it and write it back at
+        // stop. Skipped when nothing matched the id, so a no-op delete does
+        // not disturb an in-flight recording.
+        if !removed.isEmpty { notifyDeleted(.named(removed)) }
     }
 
     func deleteProfile(name: String) {
+        let removed = Set(profiles.filter { $0.name == name }.map(\.name))
         profiles.removeAll { $0.name == name }
         save()
+        if !removed.isEmpty { notifyDeleted(.named(removed)) }
     }
 
     /// Remove every stored voice profile — the "Delete voice profiles"
@@ -277,6 +324,16 @@ final class SpeakerProfileStore: ObservableObject {
     /// It deletes the file rather than writing an empty array over it, so
     /// after opting out and deleting there is no `speaker-profiles.json`
     /// left behind at all.
+    ///
+    /// **Deleting in memory and on disk is not the whole job.** A recording
+    /// in flight was seeded from these profiles at record-start and holds
+    /// its own copy of every centroid in `LiveSpeakerDiarizer`'s pool, so
+    /// until the observers below are told, the deletion is only two thirds
+    /// done: the rest of the recording keeps matching the erased voice, and
+    /// `RecognisedSpeakerAssigner` writes the profile back at stop — the
+    /// file the user deleted reappears, holding a fingerprint that matches
+    /// the deleted one to better than 0.999 cosine. That is CWE-459, and the
+    /// notification is what completes the cleanup.
     func deleteAllProfiles() {
         profiles.removeAll()
         do {
@@ -287,6 +344,12 @@ final class SpeakerProfileStore: ObservableObject {
             profileLog.log("deleteAll error: \(error.localizedDescription, privacy: .public)")
         }
         hasStoredProfilesOnDisk = fileManager.fileExists(atPath: storeURL.path)
+        // Unconditional, and after the file is gone: this must fire even
+        // when `profiles` was already empty in memory (the feature is off,
+        // so the file was never parsed) — that is precisely the case where
+        // the store cannot name what it deleted but a seeded pool may still
+        // be holding it.
+        notifyDeleted(.all)
     }
 
     func profileExists(name: String) -> Bool {

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -21,6 +21,69 @@ struct VoiceProfile: Codable, Identifiable, Hashable {
 
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
     static func == (lhs: VoiceProfile, rhs: VoiceProfile) -> Bool { lhs.id == rhs.id }
+
+    /// Ceiling on `sampleCount`. Not a capacity limit in any meaningful sense
+    /// — it is roughly 4.6 × 10¹⁸ utterances — but a guarantee that **any two
+    /// valid counts can be added without trapping**, which both
+    /// `updateProfile` and `mergeProfiles` do. Those two also clamp their sums
+    /// to it, so the store can never produce a value its own validator would
+    /// later reject.
+    static let maxSampleCount = Int.max / 2
+
+    /// Why this profile cannot be used, or nil when it is sound.
+    ///
+    /// `speaker-profiles.json` is a plain file in Application Support that
+    /// anything can edit, and a syntactically valid one can still hold values
+    /// no code path here tolerates. These are exactly the invariants
+    /// `SpeakerProfileStore.updateProfile` enforces on the way *in*, so the
+    /// same check on the way back out means the store cannot read something
+    /// it would have refused to write. Each clause is load-bearing:
+    ///
+    /// * **`sampleCount <= 0`** — `seedPool` carries the stored count into
+    ///   the live pool (`min(count, 3)`, which leaves a negative one
+    ///   negative), and the confident-match fold in `LiveSpeakerDiarizer.assign`
+    ///   computes `(centroid[i] * Float(n) + embedding[i]) / Float(n + 1)`.
+    ///   At `n == -1` that divides by zero. It is `Float` division, not
+    ///   `Int`: **nothing traps**. The centroid silently becomes ±inf/NaN,
+    ///   every later fold keeps it NaN, and `cosineSimilarity` then returns
+    ///   NaN for that entry forever. Worse, `assign` picks its best match
+    ///   with `sim > best.sim`, which is *false* for NaN — so a poisoned
+    ///   entry ahead of the real ones captures `best`, clears no threshold,
+    ///   and every utterance mints a fresh speaker instead of matching. The
+    ///   symptom is silent misrecognition, not a crash. The weighted folds in
+    ///   `updateProfile` and `mergeProfiles` land on the same `Float(0)`
+    ///   divisor when a stored `-1` meets a single new sample, and there the
+    ///   NaN is worse still: `JSONEncoder` refuses to encode it, so `save()`
+    ///   throws and the store quietly stops persisting anything at all.
+    /// * **`sampleCount > maxSampleCount`** — the one variant that *is*
+    ///   fatal: `updateProfile` evaluates `existing.sampleCount +
+    ///   sampleCount`, and Swift traps on `Int` overflow, so a stored
+    ///   `Int.max` crashes the app the moment that speaker is named again.
+    /// * **a non-finite component** — the same NaN poisoning, with no fold
+    ///   needed to trigger it. Belt and braces rather than a live hole:
+    ///   `JSONDecoder` cannot hand one back today, because JSON has no NaN or
+    ///   Infinity literal and a number too large for `Float` (`1e39` upwards)
+    ///   makes the *whole file* fail to parse. The clause states the
+    ///   invariant the arithmetic actually rests on, so it survives a change
+    ///   of encoding or of where embeddings come from.
+    /// * **an empty name or embedding** — nothing to label with, nothing to
+    ///   match against.
+    ///
+    /// Deliberately *not* checked: the embedding's width. Nothing here
+    /// assumes it — `updateProfile`, `mergeProfiles` and `assign` each carry
+    /// an explicit dimension-mismatch guard, so a profile written by some
+    /// other embedding model is inert rather than dangerous. Pinning it to
+    /// 256 here and nowhere else would also make the store refuse to read
+    /// back exactly what `updateProfile` accepts, and quietly drop a user's
+    /// profiles on any future model change.
+    var unusableReason: String? {
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "empty name" }
+        if embedding.isEmpty { return "empty embedding" }
+        if embedding.contains(where: { !$0.isFinite }) { return "non-finite embedding value" }
+        if sampleCount <= 0 { return "non-positive sampleCount (\(sampleCount))" }
+        if sampleCount > Self.maxSampleCount { return "sampleCount out of range (\(sampleCount))" }
+        return nil
+    }
 }
 
 /// Manages persistent speaker voice profiles for cross-recording
@@ -119,7 +182,17 @@ final class SpeakerProfileStore: ObservableObject {
         // actually matters is here: nothing reaches `save()` while off.
         guard settings.isConfigured else { return }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !embedding.isEmpty, sampleCount > 0 else { return }
+        // The same invariants `VoiceProfile.unusableReason` re-checks on the
+        // way back off disk — kept identical on purpose, so the store never
+        // accepts something it would later refuse to load, or vice versa. The
+        // finiteness and upper-bound clauses matter here too: a NaN reaching
+        // the centroid poisons it permanently, and an unbounded count makes
+        // the addition below trap.
+        guard !trimmed.isEmpty,
+              !embedding.isEmpty,
+              embedding.allSatisfy({ $0.isFinite }),
+              sampleCount > 0,
+              sampleCount <= VoiceProfile.maxSampleCount else { return }
 
         if let idx = profiles.firstIndex(where: { $0.name == trimmed }) {
             let existing = profiles[idx]
@@ -127,7 +200,14 @@ final class SpeakerProfileStore: ObservableObject {
                 profileLog.log("updateProfile: dimension mismatch (\(existing.embedding.count) vs \(embedding.count)) for \(trimmed, privacy: .private)")
                 return
             }
-            let totalCount = existing.sampleCount + sampleCount
+            // Safe to add: both operands are at most `maxSampleCount` — the
+            // incoming one by the guard above, the stored one because every
+            // route into `profiles` (this method, or `load`'s validation)
+            // enforces it. Swift traps on `Int` overflow, and a decoded
+            // `Int.max` here would otherwise crash the app outright. The
+            // clamp keeps the result inside the same bound, so what is
+            // written back is always something `load` will accept.
+            let totalCount = min(existing.sampleCount + sampleCount, VoiceProfile.maxSampleCount)
             var merged = [Float](repeating: 0, count: embedding.count)
             for i in 0..<merged.count {
                 merged[i] = (existing.embedding[i] * Float(existing.sampleCount)
@@ -221,7 +301,8 @@ final class SpeakerProfileStore: ObservableObject {
         }
         let dim = keep.embedding.count
         guard dim > 0 else { return nil }
-        let totalCount = keep.sampleCount + absorb.sampleCount
+        // Bounded and clamped for the same reason as `updateProfile`'s sum.
+        let totalCount = min(keep.sampleCount + absorb.sampleCount, VoiceProfile.maxSampleCount)
         var merged = [Float](repeating: 0, count: dim)
         for i in 0..<dim {
             merged[i] = (keep.embedding[i] * Float(keep.sampleCount)
@@ -305,6 +386,24 @@ final class SpeakerProfileStore: ObservableObject {
     /// when the user has already opted in, and from the opt-in transition —
     /// the guard is belt and braces so a future caller can't read voice data
     /// back in behind an opted-out user's back.
+    ///
+    /// Decoding is only half the job: a file that parses can still describe a
+    /// profile no arithmetic here survives, so each decoded entry is checked
+    /// against `VoiceProfile.unusableReason` before it is installed.
+    ///
+    /// **An unusable entry is dropped individually and logged**, rather than
+    /// the whole file being rejected. One hand-edited or truncated profile
+    /// must not cost the user every other voice they have trained, and the
+    /// entry is unusable by definition — there is nothing to salvage, and
+    /// leaving it in memory is what does the damage. The drop is in-memory;
+    /// the file is not rewritten here, so the bad entry survives on disk
+    /// until the next legitimate `save()` and can still be repaired by hand
+    /// until then.
+    ///
+    /// Per-entry granularity is only available for *semantic* invalidity.
+    /// Malformed JSON, or a number too large for its Swift type, fails inside
+    /// `decode` before any entry exists, so those stay all-or-nothing — the
+    /// catch below leaves `profiles` as it was and logs.
     private func load() {
         guard settings.isEnabled else { return }
         guard fileManager.fileExists(atPath: storeURL.path) else { return }
@@ -312,8 +411,18 @@ final class SpeakerProfileStore: ObservableObject {
             let data = try Data(contentsOf: storeURL)
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            profiles = try decoder.decode([VoiceProfile].self, from: data)
-            profileLog.log("loaded \(self.profiles.count) voice profiles")
+            let decoded = try decoder.decode([VoiceProfile].self, from: data)
+            var accepted: [VoiceProfile] = []
+            accepted.reserveCapacity(decoded.count)
+            for profile in decoded {
+                if let reason = profile.unusableReason {
+                    profileLog.log("load: dropped \(profile.name, privacy: .private) — \(reason, privacy: .public)")
+                    continue
+                }
+                accepted.append(profile)
+            }
+            profiles = accepted
+            profileLog.log("loaded \(accepted.count) of \(decoded.count) voice profiles")
         } catch {
             profileLog.log("load error: \(error.localizedDescription, privacy: .public)")
         }

--- a/Mila/Models/VoiceRecognitionSettings.swift
+++ b/Mila/Models/VoiceRecognitionSettings.swift
@@ -50,12 +50,21 @@ final class VoiceRecognitionSettings: ObservableObject {
     /// Register a handler for actual changes to `isEnabled`, called
     /// synchronously with the new value.
     ///
-    /// `SpeakerProfileStore` uses it to load stored profiles on opt-in and
-    /// drop them from memory on opt-out; `ObservedVoiceSnapshots` uses it to
-    /// discard the observations it is holding. A list rather than one
-    /// assignable slot on purpose: with a single slot the second registrant
-    /// silently unhooked the first, so whichever object was constructed last
-    /// would have been the only one to ever hear about an opt-out.
+    /// Three registrants, one per place a copied embedding can be sitting
+    /// when the user flips the switch: `SpeakerProfileStore` loads stored
+    /// profiles on opt-in and drops them from memory on opt-out;
+    /// `ObservedVoiceSnapshots` discards the observations it is holding; and
+    /// `MilaApp` calls `LiveSpeakerDiarizer.forgetSeededProfiles()` so the
+    /// pool of a recording that is *already running* stops matching against
+    /// centroids `seedPool` copied out of the store at record-start. Miss
+    /// that last one and opting out stops the writes but not the reads —
+    /// the transcript goes on being auto-labelled from stored voices until
+    /// the recording ends.
+    ///
+    /// A list rather than one assignable slot on purpose: with a single slot
+    /// the second registrant silently unhooked the first, so whichever
+    /// object was constructed last would have been the only one to ever hear
+    /// about an opt-out.
     func addEnabledObserver(_ observer: @escaping (Bool) -> Void) {
         enabledObservers.append(observer)
     }

--- a/Mila/Models/VoiceRecognitionSettings.swift
+++ b/Mila/Models/VoiceRecognitionSettings.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Combine
+
+/// User settings for cross-recording voice recognition — the feature that
+/// remembers a named speaker's voice so the same person is labelled
+/// automatically in later recordings.
+///
+/// Follows the same shape as `DiarizationSettings` / `VoiceMemosSettings`:
+/// `@Published` properties writing through to namespaced `UserDefaults`
+/// keys, with an injectable `defaults` suite so tests never touch the
+/// user's real preferences.
+///
+/// **Why this is its own opt-in rather than part of diarization.** A voice
+/// fingerprint is a 256-dimensional embedding of somebody's voice — one of
+/// the few things Mila could store that identifies a *person* rather than a
+/// recording, and it is captured for everyone in the room, not just the
+/// person driving the app. Diarization only separates voices within a
+/// single recording and keeps nothing afterwards; this feature keeps a
+/// durable, matchable record. That difference in kind is why it gets its
+/// own switch, defaults off, and does nothing whatsoever until the user
+/// turns it on.
+@MainActor
+final class VoiceRecognitionSettings: ObservableObject {
+
+    enum Keys {
+        static let enabled = "speakers.voiceRecognition.enabled"
+    }
+
+    /// Master switch. **Off by default** and deliberately not inferred from
+    /// anything else: with this off Mila writes no voice fingerprint to
+    /// disk, reads none back, and seeds no recognition — a user who never
+    /// opts in has no voice data stored at all.
+    @Published var isEnabled: Bool {
+        didSet {
+            guard isEnabled != oldValue else { return }
+            defaults.set(isEnabled, forKey: Keys.enabled)
+            // Synchronous, on the main actor, and after the property has
+            // been written — so the observer (SpeakerProfileStore) sees the
+            // new value. This is the repo's existing callback idiom
+            // (`RecordingStore.onSpeakerNamed`, `svc.onTranscriptionCompleted`)
+            // rather than a Combine sink, because `@Published` delivers on
+            // *willSet*: a sink would fire while `isEnabled` still read the
+            // old value, and the store's own guards read it.
+            onEnabledChange?(isEnabled)
+        }
+    }
+
+    /// Called on every actual change to `isEnabled`, with the new value.
+    /// `SpeakerProfileStore` installs this to load stored profiles on
+    /// opt-in and to drop them out of memory again on opt-out.
+    var onEnabledChange: ((Bool) -> Void)?
+
+    /// Answers "can the embedding pipeline this feature rides on actually
+    /// produce embeddings right now?". Injected by `MilaApp` as a read of
+    /// `DiarizationSettings.isConfigured`; a closure rather than a stored
+    /// reference so this object can never mutate diarization settings, and
+    /// so the gate is trivially testable.
+    ///
+    /// Defaults to `false` — an unwired instance is never "ready", so a
+    /// forgotten injection fails closed (nothing stored) rather than open.
+    var diarizationReady: (() -> Bool)?
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.isEnabled = defaults.bool(forKey: Keys.enabled)
+    }
+
+    /// **The gate.** True iff voice recognition is switched on *and* able to
+    /// work — per `.claude/rules/feature-gates.md`, "enabled" alone is not
+    /// enough.
+    ///
+    /// The readiness half is `diarizationReady`. Voice recognition owns no
+    /// embedding pipeline of its own: every centroid it stores or matches
+    /// comes out of `LiveSpeakerDiarizer`'s pool, which is only populated
+    /// while diarization is enabled *and* its local Python pipeline is
+    /// verified (`DiarizationSettings.isConfigured`). With diarization off
+    /// there is nothing to persist and nothing to match against, so acting
+    /// on the toggle alone would mean seeding an empty pool and writing
+    /// profiles that can never be recognised.
+    ///
+    /// Every persist, seed and match path is guarded on this — not on
+    /// `isEnabled`.
+    var isConfigured: Bool {
+        guard isEnabled else { return false }
+        return diarizationReady?() ?? false
+    }
+}

--- a/Mila/Models/VoiceRecognitionSettings.swift
+++ b/Mila/Models/VoiceRecognitionSettings.swift
@@ -35,20 +35,30 @@ final class VoiceRecognitionSettings: ObservableObject {
             guard isEnabled != oldValue else { return }
             defaults.set(isEnabled, forKey: Keys.enabled)
             // Synchronous, on the main actor, and after the property has
-            // been written — so the observer (SpeakerProfileStore) sees the
-            // new value. This is the repo's existing callback idiom
-            // (`RecordingStore.onSpeakerNamed`, `svc.onTranscriptionCompleted`)
-            // rather than a Combine sink, because `@Published` delivers on
-            // *willSet*: a sink would fire while `isEnabled` still read the
-            // old value, and the store's own guards read it.
-            onEnabledChange?(isEnabled)
+            // been written — so observers see the new value. This is the
+            // repo's existing callback idiom (`RecordingStore.onSpeakerNamed`,
+            // `svc.onTranscriptionCompleted`) rather than a Combine sink,
+            // because `@Published` delivers on *willSet*: a sink would fire
+            // while `isEnabled` still read the old value, and the observers'
+            // own guards read it.
+            for observer in enabledObservers { observer(isEnabled) }
         }
     }
 
-    /// Called on every actual change to `isEnabled`, with the new value.
-    /// `SpeakerProfileStore` installs this to load stored profiles on
-    /// opt-in and to drop them out of memory again on opt-out.
-    var onEnabledChange: ((Bool) -> Void)?
+    private var enabledObservers: [(Bool) -> Void] = []
+
+    /// Register a handler for actual changes to `isEnabled`, called
+    /// synchronously with the new value.
+    ///
+    /// `SpeakerProfileStore` uses it to load stored profiles on opt-in and
+    /// drop them from memory on opt-out; `ObservedVoiceSnapshots` uses it to
+    /// discard the observations it is holding. A list rather than one
+    /// assignable slot on purpose: with a single slot the second registrant
+    /// silently unhooked the first, so whichever object was constructed last
+    /// would have been the only one to ever hear about an opt-out.
+    func addEnabledObserver(_ observer: @escaping (Bool) -> Void) {
+        enabledObservers.append(observer)
+    }
 
     /// Answers "can the embedding pipeline this feature rides on actually
     /// produce embeddings right now?". Injected by `MilaApp` as a read of

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -61,8 +61,28 @@ final class LiveSpeakerDiarizer: ObservableObject {
 
     struct SpeakerProfile {
         var id: String
+        /// Matching centroid: a running mean over the seeded weight (if any)
+        /// plus every embedding that matched this entry during the recording.
+        /// A seeded entry starts at the persisted centroid so the first
+        /// utterance can't blow it away.
         var centroid: [Float]
+        /// The weight behind `centroid`. Seeded entries start at a capped
+        /// share of the persisted count — see `seedPool`.
         var sampleCount: Int
+        /// Running mean over **only** the embeddings observed in *this*
+        /// recording, and how many there were. Empty / zero for a seeded
+        /// entry until it first matches.
+        ///
+        /// This pair exists because `centroid` / `sampleCount` cannot be
+        /// persisted: both already contain the seeded profile's own weight,
+        /// which is *already on disk*. Folding them back into the stored
+        /// profile counts that weight twice — a seeded entry with three
+        /// carried samples and one live match persisted as four new samples,
+        /// so the stored count grew ~4x per recording and the centroid froze.
+        /// `currentProfiles()` therefore reports this delta, never the
+        /// matching pair.
+        var observedCentroid: [Float]
+        var observedCount: Int
         /// Name from a stored voice profile if this pool entry was seeded.
         var profileName: String?
     }
@@ -218,6 +238,13 @@ final class LiveSpeakerDiarizer: ObservableObject {
     /// recording start. Each entry gets a fresh `SPEAKER_NN` ID and a
     /// capped `sampleCount` so the centroid can adapt to current-session
     /// acoustics on the first few matches.
+    ///
+    /// The seeded weight goes into `sampleCount` only — the matching side.
+    /// `observedCount` starts at zero because nothing has been observed in
+    /// *this* recording yet, and that is the number the persistence path
+    /// reads. A seeded entry that never speaks therefore contributes
+    /// nothing to its stored profile, and one that speaks once contributes
+    /// exactly one sample.
     func seedPool(with entries: [(id: String, name: String, centroid: [Float], sampleCount: Int)]) {
         for entry in entries {
             let id = String(format: "SPEAKER_%02d", pool.count)
@@ -225,16 +252,29 @@ final class LiveSpeakerDiarizer: ObservableObject {
                 id: id,
                 centroid: entry.centroid,
                 sampleCount: min(entry.sampleCount, 3),
+                observedCentroid: [],
+                observedCount: 0,
                 profileName: entry.name
             ))
         }
     }
 
-    /// Snapshot the current pool for persistence. Returns entries for
-    /// each speaker with their final centroid, sample count, and the
-    /// voice-profile name they were seeded from (if any).
-    func currentProfiles() -> [(id: String, centroid: [Float], sampleCount: Int, profileName: String?)] {
-        pool.map { ($0.id, $0.centroid, $0.sampleCount, $0.profileName) }
+    /// Snapshot the pool for **persistence**: for each speaker, the mean of
+    /// what was observed in this recording, how many observations that was,
+    /// and the voice-profile name it was seeded from (if any).
+    ///
+    /// Deliberately reports `observedCentroid` / `observedCount` rather than
+    /// the matching `centroid` / `sampleCount`. For a seeded entry the
+    /// matching pair carries weight that is already stored on disk, and
+    /// folding it back in counts it twice — see `SpeakerProfile`. For a
+    /// speaker minted during this recording the two pairs are identical, so
+    /// nothing changes for the common case.
+    ///
+    /// A seeded speaker who never matched reports `observedCount == 0`;
+    /// `SpeakerProfileStore.updateProfile` refuses a zero count, so it can
+    /// never write a spurious update.
+    func currentProfiles() -> [(id: String, observedCentroid: [Float], observedCount: Int, profileName: String?)] {
+        pool.map { ($0.id, $0.observedCentroid, $0.observedCount, $0.profileName) }
     }
 
     /// Fire-and-track variant of `process(...)`. Chains the call onto
@@ -335,7 +375,11 @@ final class LiveSpeakerDiarizer: ObservableObject {
         let longEnoughForNewSpeaker = utteranceDuration >= 1.0
         diarLog.log("assign: poolSize=\(self.pool.count, privacy: .public) bestMatch=\(bestId, privacy: .public) bestSim=\(bestSim, privacy: .public) threshold=\(self.similarityThreshold, privacy: .public) createThreshold=\(createThreshold, privacy: .public) dur=\(utteranceDuration, privacy: .public)")
         if let chosen = best, chosen.sim >= similarityThreshold {
-            // Confident match → fold into the centroid (running mean).
+            // Confident match → fold into the matching centroid (running
+            // mean). `centroid.count` is safe to index `embedding` with:
+            // `cosineSimilarity` returns 0 on a dimension mismatch, so a
+            // seeded profile from a different embedding model can never be
+            // `best` above the threshold and never reaches this fold.
             let n = pool[chosen.idx].sampleCount
             var centroid = pool[chosen.idx].centroid
             for i in 0..<centroid.count {
@@ -343,6 +387,23 @@ final class LiveSpeakerDiarizer: ObservableObject {
             }
             pool[chosen.idx].centroid = centroid
             pool[chosen.idx].sampleCount = n + 1
+            // The same fold over this recording's observations alone — the
+            // pair that gets persisted. A seeded entry starts empty, so its
+            // first match takes the embedding directly rather than averaging
+            // into nothing.
+            let observedSoFar = pool[chosen.idx].observedCount
+            if observedSoFar == 0 {
+                pool[chosen.idx].observedCentroid = embedding
+                pool[chosen.idx].observedCount = 1
+            } else {
+                var observed = pool[chosen.idx].observedCentroid
+                for i in 0..<observed.count {
+                    observed[i] = (observed[i] * Float(observedSoFar) + embedding[i])
+                        / Float(observedSoFar + 1)
+                }
+                pool[chosen.idx].observedCentroid = observed
+                pool[chosen.idx].observedCount = observedSoFar + 1
+            }
             return pool[chosen.idx].id
         }
         // Borderline, or too short to trust as a new voice → attach to the
@@ -350,8 +411,15 @@ final class LiveSpeakerDiarizer: ObservableObject {
         if let chosen = best, chosen.sim >= createThreshold || !longEnoughForNewSpeaker {
             return pool[chosen.idx].id
         }
+        // A speaker minted during this recording has no seeded weight, so
+        // the matching pair and the persisted pair are the same thing.
         let nextID = String(format: "SPEAKER_%02d", pool.count)
-        pool.append(SpeakerProfile(id: nextID, centroid: embedding, sampleCount: 1, profileName: nil))
+        pool.append(SpeakerProfile(id: nextID,
+                                   centroid: embedding,
+                                   sampleCount: 1,
+                                   observedCentroid: embedding,
+                                   observedCount: 1,
+                                   profileName: nil))
         return nextID
     }
 

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -263,6 +263,16 @@ final class LiveSpeakerDiarizer: ObservableObject {
     /// the user has just deleted (`names`), or for every seeded entry when
     /// `names` is nil.
     ///
+    /// Two callers, both wired in `MilaApp.init`, both answering the same
+    /// question — "the user just revoked something; does the recording that
+    /// is already running honour it?":
+    ///
+    ///   * `SpeakerProfileStore`'s deletion observer, passing the deleted
+    ///     `names` (or nil for "delete everything");
+    ///   * `VoiceRecognitionSettings`' enabled observer on opt-out, passing
+    ///     nil — switching the feature off revokes every seeded voice at
+    ///     once, not a named subset.
+    ///
     /// Deleting voice profiles is a privacy action, and `seedPool` gave this
     /// object its own copy of the centroids at record-start. Deleting the
     /// file therefore does not, by itself, delete the voice from a recording

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -259,6 +259,50 @@ final class LiveSpeakerDiarizer: ObservableObject {
         }
     }
 
+    /// Drop everything the pool holds that came off disk, for the profiles
+    /// the user has just deleted (`names`), or for every seeded entry when
+    /// `names` is nil.
+    ///
+    /// Deleting voice profiles is a privacy action, and `seedPool` gave this
+    /// object its own copy of the centroids at record-start. Deleting the
+    /// file therefore does not, by itself, delete the voice from a recording
+    /// that is already running: the pool goes on matching against the erased
+    /// centroid for the rest of it, and `RecognisedSpeakerAssigner.finish`
+    /// then names the speaker and writes the profile straight back at stop —
+    /// under a fresh id and this recording's own centroid, which is the same
+    /// person's fingerprint to within rounding. The user is told their voice
+    /// data is gone while it quietly returns. `SpeakerProfileStore`'s
+    /// deletion observer calls this so the deletion lands everywhere at
+    /// once, the way opting out already does.
+    ///
+    /// Entries are neutralised, never removed: ids are minted positionally
+    /// (`SPEAKER_%02d` from `pool.count`), so removing one would make the
+    /// next minted speaker collide with an existing id, and any interval
+    /// already labelled with the removed id would dangle. What each entry
+    /// keeps is exactly what *this recording* heard:
+    ///
+    ///   * `profileName` is cleared, so nothing downstream can auto-apply
+    ///     the deleted name or persist under it;
+    ///   * the matching pair falls back to the observed pair, dropping the
+    ///     seeded weight — the deleted centroid stops steering the match
+    ///     while the speaker stays coherent for the rest of the recording
+    ///     from utterances the recording itself produced.
+    ///
+    /// A seeded entry that never matched has no observations, so it is left
+    /// with an empty centroid: inert, and skipped by `assign`'s scan.
+    /// In-recording diarization is not what was deleted — the stored profile
+    /// is — so this deliberately keeps the former and destroys only the
+    /// latter.
+    func forgetSeededProfiles(named names: Set<String>? = nil) {
+        for idx in pool.indices {
+            guard let name = pool[idx].profileName else { continue }
+            if let names, !names.contains(name) { continue }
+            pool[idx].profileName = nil
+            pool[idx].centroid = pool[idx].observedCentroid
+            pool[idx].sampleCount = pool[idx].observedCount
+        }
+    }
+
     /// Snapshot the pool for **persistence**: for each speaker, the mean of
     /// what was observed in this recording, how many observations that was,
     /// and the voice-profile name it was seeded from (if any).
@@ -359,6 +403,17 @@ final class LiveSpeakerDiarizer: ObservableObject {
     func assign(embedding: [Float], utteranceDuration: Double = 2.0) -> String {
         var best: (idx: Int, sim: Double)?
         for (idx, profile) in pool.enumerated() {
+            // An entry with no centroid has nothing to compare against, so
+            // it cannot be anyone's best match. `cosineSimilarity` already
+            // returns 0 for it, which keeps it out of the confident-match
+            // branch — but not out of the borderline/short-utterance
+            // *attach* branch below, which takes the best entry whatever its
+            // similarity. Without this skip, a seeded entry emptied by
+            // `forgetSeededProfiles` could still capture utterances into a
+            // speaker whose voice the user just deleted. Unreachable
+            // otherwise: `process` refuses an empty embedding, so nothing
+            // else ever puts an empty centroid in the pool.
+            guard !profile.centroid.isEmpty else { continue }
             let sim = cosineSimilarity(embedding, profile.centroid)
             if best == nil || sim > best!.sim {
                 best = (idx, sim)

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -60,9 +60,11 @@ final class LiveSpeakerDiarizer: ObservableObject {
     private var processQueue: Task<Void, Never>?
 
     struct SpeakerProfile {
-        let id: String
+        var id: String
         var centroid: [Float]
         var sampleCount: Int
+        /// Name from a stored voice profile if this pool entry was seeded.
+        var profileName: String?
     }
 
     private struct EmbedResponse: Decodable {
@@ -211,6 +213,30 @@ final class LiveSpeakerDiarizer: ObservableObject {
         intervals.removeAll()
     }
 
+    /// Pre-populate the pool with known speaker voice profiles so
+    /// returning speakers are auto-recognised. Call after `reset()` at
+    /// recording start. Each entry gets a fresh `SPEAKER_NN` ID and a
+    /// capped `sampleCount` so the centroid can adapt to current-session
+    /// acoustics on the first few matches.
+    func seedPool(with entries: [(id: String, name: String, centroid: [Float], sampleCount: Int)]) {
+        for entry in entries {
+            let id = String(format: "SPEAKER_%02d", pool.count)
+            pool.append(SpeakerProfile(
+                id: id,
+                centroid: entry.centroid,
+                sampleCount: min(entry.sampleCount, 3),
+                profileName: entry.name
+            ))
+        }
+    }
+
+    /// Snapshot the current pool for persistence. Returns entries for
+    /// each speaker with their final centroid, sample count, and the
+    /// voice-profile name they were seeded from (if any).
+    func currentProfiles() -> [(id: String, centroid: [Float], sampleCount: Int, profileName: String?)] {
+        pool.map { ($0.id, $0.centroid, $0.sampleCount, $0.profileName) }
+    }
+
     /// Fire-and-track variant of `process(...)`. Chains the call onto
     /// `processQueue` so the FIFO order matches the daemon's, and
     /// `awaitPending()` can join the tail. Use this from the live-
@@ -325,7 +351,7 @@ final class LiveSpeakerDiarizer: ObservableObject {
             return pool[chosen.idx].id
         }
         let nextID = String(format: "SPEAKER_%02d", pool.count)
-        pool.append(SpeakerProfile(id: nextID, centroid: embedding, sampleCount: 1))
+        pool.append(SpeakerProfile(id: nextID, centroid: embedding, sampleCount: 1, profileName: nil))
         return nextID
     }
 

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -374,12 +374,26 @@ final class LiveSpeakerDiarizer: ObservableObject {
         // speaker when we already have a pool to attach to.
         let longEnoughForNewSpeaker = utteranceDuration >= 1.0
         diarLog.log("assign: poolSize=\(self.pool.count, privacy: .public) bestMatch=\(bestId, privacy: .public) bestSim=\(bestSim, privacy: .public) threshold=\(self.similarityThreshold, privacy: .public) createThreshold=\(createThreshold, privacy: .public) dur=\(utteranceDuration, privacy: .public)")
-        if let chosen = best, chosen.sim >= similarityThreshold {
+        // A confident match must agree in *dimension* as well as in angle.
+        // `cosineSimilarity` returns 0 on a count mismatch, so while the
+        // threshold is positive a differently-sized centroid can never clear
+        // it — but `similarityThreshold` is a plain `var` with no invariant
+        // of its own (Settings clamps its slider to 0.5...0.95; nothing binds
+        // a direct caller), and at a non-positive threshold that 0 would pass
+        // and the fold below would index `embedding` out of bounds. The
+        // mismatch itself is real, not hypothetical: `seedPool` takes
+        // centroids straight off disk, so a profile written by a different
+        // embedding model arrives at whatever length it was stored at.
+        // Checking here keeps the fold's memory safety local instead of
+        // resting on a distant clamp, and enforces exactly the outcome the
+        // threshold was assumed to produce — such an entry is not a
+        // confident match, so it falls through to attach-or-mint below.
+        if let chosen = best,
+           chosen.sim >= similarityThreshold,
+           pool[chosen.idx].centroid.count == embedding.count {
             // Confident match → fold into the matching centroid (running
-            // mean). `centroid.count` is safe to index `embedding` with:
-            // `cosineSimilarity` returns 0 on a dimension mismatch, so a
-            // seeded profile from a different embedding model can never be
-            // `best` above the threshold and never reaches this fold.
+            // mean). The guard above makes `centroid.count` safe to index
+            // `embedding` with.
             let n = pool[chosen.idx].sampleCount
             var centroid = pool[chosen.idx].centroid
             for i in 0..<centroid.count {
@@ -390,7 +404,9 @@ final class LiveSpeakerDiarizer: ObservableObject {
             // The same fold over this recording's observations alone — the
             // pair that gets persisted. A seeded entry starts empty, so its
             // first match takes the embedding directly rather than averaging
-            // into nothing.
+            // into nothing. A non-empty `observedCentroid` was itself built
+            // from embeddings that passed the dimension check above, so it is
+            // the same length as `embedding` and safe to index in step.
             let observedSoFar = pool[chosen.idx].observedCount
             if observedSoFar == 0 {
                 pool[chosen.idx].observedCentroid = embedding

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2086,7 +2086,7 @@ private struct DiarizationSettingsTabContent: View {
 
             Divider()
 
-            VoiceRecognitionSection()
+            VoiceRecognitionSection(diarization: diarization)
 
             Spacer()
         }
@@ -2285,65 +2285,91 @@ private struct KnownSpeakersSection: View {
     }
 }
 
-/// Voice recognition opt-in toggle + profile management. Shown in the
-/// Speakers settings section below the known-speakers list.
+/// Settings → Speakers → voice recognition: the opt-in switch for
+/// cross-recording recognition, plus the delete path for whatever it has
+/// already stored. Sits below the known-speakers list.
+///
+/// The off-state footprint is deliberately one toggle and one caption — the
+/// shape `ObsidianSettingsSection.enableCard` uses, in the flat,
+/// divider-separated style the rest of this tab uses rather than a card —
+/// with one addition that only appears when it has to. While profiles from
+/// an earlier opt-in are still on disk, the delete button stays visible
+/// *even with the feature off*: opting out stops all reading and writing but
+/// does not destroy the user's work, so deleting is a separate, explicit
+/// decision, and it would be dishonest for the opt-out to be the only hint
+/// that voice data is still at rest.
+///
+/// The caption is the full disclosure in both states rather than a teaser
+/// that expands once you've already switched it on. What gets stored, where
+/// it goes, and the fact that it never leaves the Mac are things you need
+/// *before* deciding, not after.
 private struct VoiceRecognitionSection: View {
+    /// The diarization settings this tab is already showing. Voice
+    /// recognition rides on the diarizer's embedding pool, so the section
+    /// observes it to explain why an enabled toggle might not be doing
+    /// anything yet.
+    @ObservedObject var diarization: DiarizationSettings
+    @EnvironmentObject private var settings: VoiceRecognitionSettings
     @EnvironmentObject private var profileStore: SpeakerProfileStore
-    @State private var showWipeConfirmation = false
+    @State private var showDeleteConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Voice recognition")
                 .font(.callout.weight(.semibold))
 
-            Toggle(isOn: $profileStore.enabled) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Learn speaker voices across recordings")
-                        .font(.body)
-                    Text("When enabled, Mila stores a voice fingerprint (256-dimensional embedding) for each speaker you name. This data is used to auto-identify returning speakers in future recordings. Voice data is stored locally and never sent to any server.")
+            Toggle("Recognise returning speakers by voice", isOn: $settings.isEnabled)
+                .accessibilityIdentifier("speakers.voiceRecognition.toggle")
+
+            Text("Naming a speaker also saves a voice fingerprint for them: 256 numbers describing how the voice sounds, written to speaker-profiles.json in Mila's Application Support folder. The audio is not part of it and a fingerprint can't be played back — but it is enough to pick the same person out of a later recording, which is the point of it. Nothing is uploaded: the fingerprints stay on this Mac and are left out of diagnostic reports. They describe everyone whose name you fill in, not only you, so turn this on only where that is yours to decide.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // An enabled toggle does nothing until the diarizer can hand it
+            // embeddings, so say so rather than letting it look broken.
+            if settings.isEnabled, !diarization.isConfigured {
+                Text("Waiting on speaker diarization above — until that reports Ready there are no voices to learn from, and nothing is stored.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("speakers.voiceRecognition.waiting")
+            }
+
+            if profileStore.hasStoredProfilesOnDisk {
+                Divider()
+                HStack(alignment: .firstTextBaseline) {
+                    Text(storedProfilesLabel)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .toggleStyle(.switch)
-            .controlSize(.regular)
-            .accessibilityIdentifier("speakers.voiceRecognition.toggle")
-
-            if profileStore.enabled {
-                HStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text("Voice fingerprints are biometric data. Other participants in your meetings may not know their voice is being stored. Use responsibly.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .padding(8)
-                .background(.orange.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
-            }
-
-            if !profileStore.profiles.isEmpty {
-                HStack {
-                    Text("\(profileStore.profiles.count) voice profile\(profileStore.profiles.count == 1 ? "" : "s") stored")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Button("Delete All Voice Data", role: .destructive) {
-                        showWipeConfirmation = true
+                    Spacer(minLength: 12)
+                    Button("Delete Voice Profiles", role: .destructive) {
+                        showDeleteConfirmation = true
                     }
                     .font(.caption)
+                    .accessibilityIdentifier("speakers.voiceRecognition.delete")
                 }
-                .alert("Delete all voice profiles?", isPresented: $showWipeConfirmation) {
-                    Button("Delete All", role: .destructive) {
+                .alert("Delete stored voice profiles?", isPresented: $showDeleteConfirmation) {
+                    Button("Delete", role: .destructive) {
                         profileStore.deleteAllProfiles()
                     }
                     Button("Cancel", role: .cancel) {}
                 } message: {
-                    Text("This permanently removes all stored voice fingerprints. Speakers will no longer be auto-recognized in new recordings. This cannot be undone.")
+                    Text("This deletes speaker-profiles.json and every voice fingerprint in it. Speaker names already on your recordings are untouched, but nobody will be recognised in new ones. This can't be undone.")
                 }
             }
         }
+    }
+
+    /// While the feature is off the profiles file is deliberately never
+    /// parsed, so there is no count to show — only the fact that it exists.
+    private var storedProfilesLabel: String {
+        guard settings.isEnabled else {
+            return "Voice profiles from an earlier session are still stored on this Mac. Turning the switch back on picks up where you left off; they are only removed if you remove them."
+        }
+        let n = profileStore.profiles.count
+        return n == 1 ? "1 voice profile stored." : "\(n) voice profiles stored."
     }
 }
 

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2084,6 +2084,10 @@ private struct DiarizationSettingsTabContent: View {
 
             KnownSpeakersSection()
 
+            Divider()
+
+            VoiceRecognitionSection()
+
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -2277,6 +2281,67 @@ private struct KnownSpeakersSection: View {
     private func addName() {
         if directory.add(newName) != nil {
             newName = ""
+        }
+    }
+}
+
+/// Voice recognition opt-in toggle + profile management. Shown in the
+/// Speakers settings section below the known-speakers list.
+private struct VoiceRecognitionSection: View {
+    @EnvironmentObject private var profileStore: SpeakerProfileStore
+    @State private var showWipeConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Voice recognition")
+                .font(.callout.weight(.semibold))
+
+            Toggle(isOn: $profileStore.enabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Learn speaker voices across recordings")
+                        .font(.body)
+                    Text("When enabled, Mila stores a voice fingerprint (256-dimensional embedding) for each speaker you name. This data is used to auto-identify returning speakers in future recordings. Voice data is stored locally and never sent to any server.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toggleStyle(.switch)
+            .controlSize(.regular)
+
+            if profileStore.enabled {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text("Voice fingerprints are biometric data. Other participants in your meetings may not know their voice is being stored. Use responsibly.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(8)
+                .background(.orange.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+            }
+
+            if !profileStore.profiles.isEmpty {
+                HStack {
+                    Text("\(profileStore.profiles.count) voice profile\(profileStore.profiles.count == 1 ? "" : "s") stored")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Delete All Voice Data", role: .destructive) {
+                        showWipeConfirmation = true
+                    }
+                    .font(.caption)
+                }
+                .alert("Delete all voice profiles?", isPresented: $showWipeConfirmation) {
+                    Button("Delete All", role: .destructive) {
+                        profileStore.deleteAllProfiles()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This permanently removes all stored voice fingerprints. Speakers will no longer be auto-recognized in new recordings. This cannot be undone.")
+                }
+            }
         }
     }
 }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2308,6 +2308,7 @@ private struct VoiceRecognitionSection: View {
             }
             .toggleStyle(.switch)
             .controlSize(.regular)
+            .accessibilityIdentifier("speakers.voiceRecognition.toggle")
 
             if profileStore.enabled {
                 HStack(spacing: 8) {

--- a/MilaTests/CrossRecordingVoiceIsolationTests.swift
+++ b/MilaTests/CrossRecordingVoiceIsolationTests.swift
@@ -1,0 +1,321 @@
+import XCTest
+@testable import Mila
+
+/// Two invariants on the voice-profile write path, both about *which* voice
+/// gets written.
+///
+/// 1. **A name applied to recording A persists A's voice, never a later
+///    recording's.** `SPEAKER_00` is positional and restarts from zero on
+///    every `LiveSpeakerDiarizer.reset()`, so resolving a name against the
+///    *live* pool by raw id silently returned whoever was `SPEAKER_00` in the
+///    newest recording. Naming an older recording from the sidebar — an
+///    entirely ordinary thing to do — poisoned the named profile with a
+///    stranger's embedding, with nothing to show it had happened.
+/// 2. **Automatic naming requires a confident match, not merely an
+///    interval.** `assign` attaches borderline utterances (and anything under
+///    a second) to the nearest existing speaker *without* folding them into
+///    the centroid, so such an utterance yields an interval while leaving
+///    `observedCount` at zero. Gating on intervals alone stamped a stored
+///    profile's name onto a speaker that never confidently matched it.
+///
+/// Real `LiveSpeakerDiarizer`, real `ObservedVoiceSnapshots`, real
+/// `RecordingStore`, real `SpeakerProfileStore`. Only the three-line
+/// `onSpeakerNamed` closure is replicated from `MilaApp.init` — that is
+/// unreachable from a unit test — and it is written verbatim below. Each
+/// invariant has a negative control reproducing the old shape, so the
+/// assertions are provably discriminating.
+@MainActor
+final class CrossRecordingVoiceIsolationTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    /// Alice, as stored on disk before any of this.
+    private let aliceStored: [Float] = [1, 0, 0, 0]
+    /// Close enough to Alice to be a confident match at threshold 0.7.
+    private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+    /// Nothing like Alice — a different person entirely.
+    private let strangerSpeaking: [Float] = [0, 1, 0, 0]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "CrossRecordingVoiceIsolationTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    private func makeSettings() -> VoiceRecognitionSettings {
+        let name = "CrossRecordingVoiceIsolationTests.\(UUID())"
+        suiteNames.append(name)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        settings.diarizationReady = { true }
+        settings.isEnabled = true
+        return settings
+    }
+
+    private func makeDiarizer() -> LiveSpeakerDiarizer {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        return d
+    }
+
+    @discardableResult
+    private func addRecording(_ title: String, to store: RecordingStore) -> Recording {
+        let rec = Recording(title: title,
+                            duration: 60,
+                            source: .microphone,
+                            audioFileName: "\(title).wav")
+        store.add(rec)
+        return rec
+    }
+
+    /// Verbatim shape of `MilaApp.init`'s wiring.
+    private func wireHook(_ recordings: RecordingStore,
+                          _ snapshots: ObservedVoiceSnapshots,
+                          _ profiles: SpeakerProfileStore,
+                          _ settings: VoiceRecognitionSettings) {
+        recordings.onSpeakerNamed = { recordingID, rawID, name in
+            guard settings.isConfigured else { return }
+            guard let observed = snapshots.observation(forSpeaker: rawID,
+                                                      in: recordingID) else { return }
+            profiles.updateProfile(name: name,
+                                   embedding: observed.observedCentroid,
+                                   sampleCount: observed.observedCount)
+        }
+    }
+
+    private func alice(_ profiles: SpeakerProfileStore) -> VoiceProfile? {
+        profiles.profile(named: "Alice")
+    }
+
+    /// Alice on disk; recording A where Alice actually spoke and was
+    /// snapshotted; then recording B where a *stranger* took the
+    /// `SPEAKER_00` slot and was snapshotted too. That is the collision.
+    private func makeTwoRecordingWorld() -> (recordings: RecordingStore,
+                                            profiles: SpeakerProfileStore,
+                                            snapshots: ObservedVoiceSnapshots,
+                                            diarizer: LiveSpeakerDiarizer,
+                                            recA: Recording,
+                                            recB: Recording) {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let snapshots = ObservedVoiceSnapshots()
+        wireHook(recordings, snapshots, profiles, settings)
+
+        let diarizer = makeDiarizer()
+
+        // --- Recording A: Alice speaks, matching her seeded profile.
+        let recA = addRecording("A", to: recordings)
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        snapshots.record(diarizer.currentProfiles(), for: recA.id)
+
+        // --- Recording B: not seeded, and someone else entirely speaks, so
+        // the stranger takes the SPEAKER_00 slot.
+        let recB = addRecording("B", to: recordings)
+        diarizer.reset()
+        XCTAssertEqual(diarizer.assign(embedding: strangerSpeaking), "SPEAKER_00",
+                       "the stranger must land on the same raw id — that is the collision")
+        snapshots.record(diarizer.currentProfiles(), for: recB.id)
+
+        return (recordings, profiles, snapshots, diarizer, recA, recB)
+    }
+
+    // MARK: - 1. A name on an older recording uses that recording's voice
+
+    func test_naming_an_older_recording_persists_its_own_voice_not_a_later_ones() {
+        let w = makeTwoRecordingWorld()
+
+        // The user goes back to recording A in the sidebar and names
+        // SPEAKER_00 "Alice" — after B has already reset the pool.
+        w.recordings.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: w.recA.id)
+
+        XCTAssertEqual(alice(w.profiles)?.sampleCount, 41, "40 stored + A's 1 observation")
+        // Alice's centroid must still point at Alice. The stranger is
+        // [0, 1, 0, 0], so a leak shows up as component 1 moving off zero.
+        let embedding = alice(w.profiles)?.embedding ?? []
+        XCTAssertGreaterThan(embedding[0], 0.98, "still Alice")
+        XCTAssertLessThan(embedding[1], 0.02, "the stranger's voice must not have leaked in")
+        XCTAssertGreaterThan(cosineSimilarity(embedding, aliceStored), 0.99)
+    }
+
+    /// Negative control: resolve the name the old way — against the *live*
+    /// pool by raw id — and confirm it does write the stranger into Alice.
+    /// Without this the assertions above could pass for the wrong reason.
+    func test_the_live_pool_lookup_would_have_leaked_the_stranger() {
+        let w = makeTwoRecordingWorld()
+
+        // The removed shape: ignore recordingID, read the current pool.
+        let leaked = w.diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(leaked?.observedCount, 1)
+        w.profiles.updateProfile(name: "Alice",
+                                 embedding: leaked?.observedCentroid ?? [],
+                                 sampleCount: leaked?.observedCount ?? 0)
+
+        let embedding = alice(w.profiles)?.embedding ?? []
+        XCTAssertGreaterThan(embedding[1], 0.02,
+                             "the old lookup leaks the stranger — this is what the fix prevents")
+    }
+
+    /// Naming a recording that was never snapshotted persists nothing at all
+    /// rather than falling back to whatever the pool currently holds. Its
+    /// pool is gone; there is no embedding to learn from, and saying so is
+    /// better than guessing.
+    func test_naming_a_recording_with_no_snapshot_persists_nothing() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let snapshots = ObservedVoiceSnapshots()
+        wireHook(recordings, snapshots, profiles, settings)
+
+        let old = addRecording("Ancient", to: recordings)
+        recordings.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: old.id)
+
+        XCTAssertEqual(alice(profiles)?.sampleCount, 40, "untouched")
+        XCTAssertEqual(alice(profiles)?.embedding, aliceStored, "untouched")
+        // The label itself still applies — naming keeps working, it just
+        // doesn't learn a voice it never heard.
+        XCTAssertEqual(recordings.recordings.first(where: { $0.id == old.id })?
+                        .speakerNames["SPEAKER_00"], "Alice")
+    }
+
+    /// Naming the newest recording still works — the fix must not break the
+    /// common case of labelling the recording you just made.
+    func test_naming_the_newest_recording_still_persists_its_voice() {
+        let w = makeTwoRecordingWorld()
+
+        w.recordings.setSpeakerName("Stranger", forSpeaker: "SPEAKER_00", recordingID: w.recB.id)
+
+        let stranger = w.profiles.profile(named: "Stranger")
+        XCTAssertEqual(stranger?.sampleCount, 1)
+        XCTAssertGreaterThan(cosineSimilarity(stranger?.embedding ?? [], strangerSpeaking), 0.99)
+        XCTAssertEqual(alice(w.profiles)?.sampleCount, 40, "Alice untouched")
+    }
+
+    // MARK: - 2. Automatic naming requires a confident match
+
+    /// A borderline attachment leaves `observedCount` at zero: `assign`
+    /// returns the existing speaker without folding the embedding in. This is
+    /// the fact the auto-naming gate rests on.
+    func test_a_borderline_attachment_does_not_count_as_an_observation() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        // cos([0.6, 0.8, 0, 0], [1, 0, 0, 0]) == 0.6 — above the 0.55 create
+        // floor so it attaches, below the 0.7 match threshold so it is never
+        // folded in.
+        let borderline: [Float] = [0.6, 0.8, 0, 0]
+        XCTAssertEqual(cosineSimilarity(borderline, aliceStored), 0.6, accuracy: 0.0001,
+                       "fixture must actually be borderline")
+        XCTAssertEqual(diarizer.assign(embedding: borderline), "SPEAKER_00",
+                       "borderline utterances attach rather than fork")
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 0, "attached, but never confidently matched")
+        XCTAssertEqual(entry?.profileName, "Alice", "still a seeded entry")
+    }
+
+    /// The gate itself, over real diarizer state: a seeded speaker with only
+    /// a borderline attachment must not be auto-named, even though it has a
+    /// `profileName` and would have produced an interval.
+    ///
+    /// The three-part guard is replicated from `autoAssignRecognisedSpeakers`
+    /// (a private method); `spoke` is forced true to isolate the count check,
+    /// which is exactly the condition the intervals-only gate lacked.
+    func test_a_borderline_only_speaker_is_not_auto_named() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let rec = addRecording("Borderline", to: recordings)
+
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+        _ = diarizer.assign(embedding: [0.6, 0.8, 0, 0])
+
+        // Stand-in for `liveSpeakerDiarizer.intervals`, which is
+        // `private(set)` and only fills via the daemon. Deliberately
+        // *contains* the speaker, so the count check is the only thing that
+        // can refuse — which is precisely what the old gate lacked.
+        let speakersWithIntervals: Set<String> = ["SPEAKER_00"]
+
+        var namedCount = 0
+        for entry in diarizer.currentProfiles() {
+            guard let profileName = entry.profileName else { continue }
+            guard entry.observedCount > 0 else { continue }   // the added gate
+            guard speakersWithIntervals.contains(entry.id) else { continue }
+            recordings.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
+            namedCount += 1
+        }
+
+        XCTAssertEqual(namedCount, 0, "a borderline-only speaker must not be auto-named")
+        XCTAssertNil(recordings.recordings.first(where: { $0.id == rec.id })?
+                        .speakerNames["SPEAKER_00"])
+    }
+
+    /// Negative control for the gate: with the intervals-only condition the
+    /// old code used, the same borderline-only speaker *is* named — so the
+    /// assertion above is discriminating.
+    func test_the_intervals_only_gate_would_have_named_a_borderline_speaker() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let rec = addRecording("Borderline", to: recordings)
+
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+        _ = diarizer.assign(embedding: [0.6, 0.8, 0, 0])
+
+        let speakersWithIntervals: Set<String> = ["SPEAKER_00"]
+
+        var namedCount = 0
+        for entry in diarizer.currentProfiles() {
+            guard let profileName = entry.profileName else { continue }
+            // Intervals only — no observedCount check, as the old gate had.
+            guard speakersWithIntervals.contains(entry.id) else { continue }
+            recordings.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
+            namedCount += 1
+        }
+
+        XCTAssertEqual(namedCount, 1,
+                       "the old gate names it — that misattribution is what the fix removes")
+    }
+
+    /// And a genuinely confident match still passes the gate, so the added
+    /// condition hasn't simply switched auto-naming off.
+    func test_a_confident_match_still_passes_the_gate() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+        _ = diarizer.assign(embedding: aliceSpeaking)
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 1)
+        XCTAssertEqual(entry?.profileName, "Alice")
+    }
+}

--- a/MilaTests/CrossRecordingVoiceIsolationTests.swift
+++ b/MilaTests/CrossRecordingVoiceIsolationTests.swift
@@ -233,48 +233,11 @@ final class CrossRecordingVoiceIsolationTests: XCTestCase {
         XCTAssertEqual(entry?.profileName, "Alice", "still a seeded entry")
     }
 
-    /// The gate itself, over real diarizer state: a seeded speaker with only
-    /// a borderline attachment must not be auto-named, even though it has a
-    /// `profileName` and would have produced an interval.
-    ///
-    /// The three-part guard is replicated from `autoAssignRecognisedSpeakers`
-    /// (a private method); `spoke` is forced true to isolate the count check,
-    /// which is exactly the condition the intervals-only gate lacked.
-    func test_a_borderline_only_speaker_is_not_auto_named() {
-        let settings = makeSettings()
-        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
-        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
-        let recordings = RecordingStore(rootDirectory: tempRoot)
-        let rec = addRecording("Borderline", to: recordings)
-
-        let diarizer = makeDiarizer()
-        diarizer.reset()
-        diarizer.seedPool(with: profiles.seedEntries())
-        _ = diarizer.assign(embedding: [0.6, 0.8, 0, 0])
-
-        // Stand-in for `liveSpeakerDiarizer.intervals`, which is
-        // `private(set)` and only fills via the daemon. Deliberately
-        // *contains* the speaker, so the count check is the only thing that
-        // can refuse — which is precisely what the old gate lacked.
-        let speakersWithIntervals: Set<String> = ["SPEAKER_00"]
-
-        var namedCount = 0
-        for entry in diarizer.currentProfiles() {
-            guard let profileName = entry.profileName else { continue }
-            guard entry.observedCount > 0 else { continue }   // the added gate
-            guard speakersWithIntervals.contains(entry.id) else { continue }
-            recordings.setSpeakerName(profileName, forSpeaker: entry.id, recordingID: rec.id)
-            namedCount += 1
-        }
-
-        XCTAssertEqual(namedCount, 0, "a borderline-only speaker must not be auto-named")
-        XCTAssertNil(recordings.recordings.first(where: { $0.id == rec.id })?
-                        .speakerNames["SPEAKER_00"])
-    }
-
     /// Negative control for the gate: with the intervals-only condition the
-    /// old code used, the same borderline-only speaker *is* named — so the
-    /// assertion above is discriminating.
+    /// old code used, the same borderline-only speaker *is* named — which is
+    /// what makes `RecognisedSpeakerAssignerTests`'
+    /// `test_a_borderline_only_speaker_is_not_auto_named` discriminating.
+    /// Necessarily a replica: the condition it reproduces no longer exists.
     func test_the_intervals_only_gate_would_have_named_a_borderline_speaker() {
         let settings = makeSettings()
         let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)

--- a/MilaTests/CrossRecordingVoiceIsolationTests.swift
+++ b/MilaTests/CrossRecordingVoiceIsolationTests.swift
@@ -145,7 +145,15 @@ final class CrossRecordingVoiceIsolationTests: XCTestCase {
         XCTAssertEqual(alice(w.profiles)?.sampleCount, 41, "40 stored + A's 1 observation")
         // Alice's centroid must still point at Alice. The stranger is
         // [0, 1, 0, 0], so a leak shows up as component 1 moving off zero.
-        let embedding = alice(w.profiles)?.embedding ?? []
+        //
+        // Unwrapped rather than defaulted to `[]`: if the write path ever
+        // regresses and nothing is stored, an empty fallback would trap on the
+        // subscript below and abort the whole runner, hiding *which* invariant
+        // broke. Failing here names it instead.
+        guard let embedding = alice(w.profiles)?.embedding, embedding.count >= 2 else {
+            XCTFail("Alice was never written, or her embedding is too short to check for a leak")
+            return
+        }
         XCTAssertGreaterThan(embedding[0], 0.98, "still Alice")
         XCTAssertLessThan(embedding[1], 0.02, "the stranger's voice must not have leaked in")
         XCTAssertGreaterThan(cosineSimilarity(embedding, aliceStored), 0.99)
@@ -164,7 +172,13 @@ final class CrossRecordingVoiceIsolationTests: XCTestCase {
                                  embedding: leaked?.observedCentroid ?? [],
                                  sampleCount: leaked?.observedCount ?? 0)
 
-        let embedding = alice(w.profiles)?.embedding ?? []
+        // Same unwrap-don't-default reasoning as above: this control is only
+        // meaningful if Alice was actually written, so say so rather than
+        // trapping on an empty array.
+        guard let embedding = alice(w.profiles)?.embedding, embedding.count >= 2 else {
+            XCTFail("the control did not write Alice at all, so it cannot demonstrate the leak")
+            return
+        }
         XCTAssertGreaterThan(embedding[1], 0.02,
                              "the old lookup leaks the stranger — this is what the fix prevents")
     }

--- a/MilaTests/LiveSpeakerDiarizerPoolTests.swift
+++ b/MilaTests/LiveSpeakerDiarizerPoolTests.swift
@@ -243,6 +243,107 @@ final class LiveSpeakerDiarizerPoolTests: XCTestCase {
         XCTAssertEqual(profile?.observedCentroid.count, 4)
     }
 
+    // MARK: - forgetSeededProfiles (deleting voice profiles mid-recording)
+
+    /// A seeded entry that has not been heard yet holds nothing but the
+    /// deleted profile, so after `forgetSeededProfiles` its owner is a
+    /// stranger: she mints a fresh, nameless speaker instead of being
+    /// recognised. The emptied entry is kept rather than removed — ids are
+    /// minted positionally from `pool.count`, so removing it would collide
+    /// the next mint with an id already in `intervals`.
+    func test_forgetSeededProfiles_stops_an_unheard_voice_being_recognised() {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        d.seedPool(with: [(id: "Alice", name: "Alice", centroid: [1, 0, 0, 0], sampleCount: 40)])
+
+        d.forgetSeededProfiles()
+
+        XCTAssertEqual(d.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_01",
+                       "the erased centroid must not match her any more")
+        let pool = d.currentProfiles()
+        XCTAssertEqual(pool.count, 2, "the emptied entry stays so ids cannot collide")
+        XCTAssertEqual(pool.map(\.id), ["SPEAKER_00", "SPEAKER_01"])
+        XCTAssertTrue(pool.allSatisfy { $0.profileName == nil }, "and carries no name")
+    }
+
+    /// Control for the same fixture without the deletion: she *is*
+    /// recognised, on her seeded entry, under her name.
+    func test_an_unforgotten_seeded_voice_is_still_recognised() {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        d.seedPool(with: [(id: "Alice", name: "Alice", centroid: [1, 0, 0, 0], sampleCount: 40)])
+
+        XCTAssertEqual(d.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_00")
+        XCTAssertEqual(d.currentProfiles().first?.profileName, "Alice")
+    }
+
+    /// An emptied entry must not collect utterances through the *attach*
+    /// branch either. `cosineSimilarity` scores it 0, which keeps it out of
+    /// the confident-match branch — but the borderline / too-short-to-mint
+    /// branch takes the best entry whatever its score, so without the
+    /// empty-centroid skip in `assign` a short utterance would land on a
+    /// speaker whose voice the user just deleted.
+    func test_a_short_utterance_does_not_attach_to_a_forgotten_entry() {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        d.seedPool(with: [(id: "Alice", name: "Alice", centroid: [1, 0, 0, 0], sampleCount: 40)])
+        d.forgetSeededProfiles()
+
+        XCTAssertEqual(d.assign(embedding: [0, 0, 1, 0], utteranceDuration: 0.4), "SPEAKER_01",
+                       "too short to mint, but there is no longer anything to attach to")
+    }
+
+    /// What a heard-from entry keeps is exactly what *this recording*
+    /// produced: the seeded weight is dropped and the matching centroid falls
+    /// back to the observed one, so the deleted numbers stop steering
+    /// matching while the speaker stays coherent for the rest of the
+    /// recording.
+    ///
+    /// Discriminating by construction. `U` folds into the seeded entry
+    /// (cos 0.75 to the stored centroid), leaving a matching centroid of
+    /// `[0.9375, 0.165, 0, 0]` — three parts stored, one part heard. The
+    /// probe `P` sits at cos 0.37 to that blend but cos 0.80 to `U` alone,
+    /// so it mints a new speaker while the seeded weight is there and
+    /// matches `SPEAKER_00` once it is gone.
+    func test_forgetSeededProfiles_drops_the_seeded_weight_and_keeps_the_heard_one() {
+        let stored: [Float] = [1, 0, 0, 0]
+        let U: [Float] = [0.75, 0.66, 0, 0]
+        let P: [Float] = [0.2, 0.98, 0, 0]
+
+        let control = LiveSpeakerDiarizer()
+        control.similarityThreshold = 0.7
+        control.seedPool(with: [(id: "Alice", name: "Alice", centroid: stored, sampleCount: 40)])
+        XCTAssertEqual(control.assign(embedding: U), "SPEAKER_00")
+        XCTAssertEqual(control.assign(embedding: P), "SPEAKER_01",
+                       "with the seeded weight in place, P is a different speaker")
+
+        let forgotten = LiveSpeakerDiarizer()
+        forgotten.similarityThreshold = 0.7
+        forgotten.seedPool(with: [(id: "Alice", name: "Alice", centroid: stored, sampleCount: 40)])
+        XCTAssertEqual(forgotten.assign(embedding: U), "SPEAKER_00")
+        forgotten.forgetSeededProfiles()
+        XCTAssertEqual(forgotten.assign(embedding: P), "SPEAKER_00",
+                       "matching now runs off what this recording heard, not off disk")
+        let entry = forgotten.currentProfiles().first
+        XCTAssertNil(entry?.profileName)
+        XCTAssertEqual(entry?.observedCount, 2, "the recording's own observations are kept")
+    }
+
+    /// Deleting one profile leaves the others seeded and recognisable.
+    func test_forgetSeededProfiles_by_name_leaves_the_others_alone() {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        d.seedPool(with: [(id: "Alice", name: "Alice", centroid: [1, 0, 0, 0], sampleCount: 40),
+                          (id: "Bob", name: "Bob", centroid: [0, 1, 0, 0], sampleCount: 40)])
+
+        d.forgetSeededProfiles(named: ["Alice"])
+
+        XCTAssertEqual(d.assign(embedding: [0.02, 0.99, 0, 0]), "SPEAKER_01", "Bob is untouched")
+        XCTAssertEqual(d.currentProfiles().first { $0.id == "SPEAKER_01" }?.profileName, "Bob")
+        XCTAssertEqual(d.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_02", "Alice is a stranger")
+        XCTAssertNil(d.currentProfiles().first { $0.id == "SPEAKER_00" }?.profileName)
+    }
+
     func test_higher_threshold_makes_pool_more_conservative() {
         let d = LiveSpeakerDiarizer()
         d.similarityThreshold = 0.99

--- a/MilaTests/LiveSpeakerDiarizerPoolTests.swift
+++ b/MilaTests/LiveSpeakerDiarizerPoolTests.swift
@@ -188,6 +188,61 @@ final class LiveSpeakerDiarizerPoolTests: XCTestCase {
             "A same-speaker similarity dip into the [0.40,0.55) band must attach, not fork")
     }
 
+    /// The confident-match fold walks `centroid.count` and indexes
+    /// `embedding` in step, so an entry whose centroid has a *different*
+    /// dimension must never reach it. `cosineSimilarity` returns 0 on a count
+    /// mismatch, which keeps such an entry out only while the threshold is
+    /// positive — and `similarityThreshold` is a plain `var` (Settings clamps
+    /// its slider to 0.5...0.95, but nothing binds a direct caller). At a
+    /// non-positive threshold that 0 clears the bar, and without the explicit
+    /// dimension check in `assign` the fold would read off the end of the
+    /// shorter vector. The mismatch has a real source: `seedPool` takes
+    /// centroids straight off disk, so a profile written by a different
+    /// embedding model arrives at whatever length it was stored at.
+    func test_non_positive_threshold_cannot_fold_a_mismatched_dimension_profile() {
+        for threshold in [0.0, -1.0] {
+            let d = LiveSpeakerDiarizer()
+            d.similarityThreshold = threshold
+            // Seeded from disk with an 8-dim centroid; this "daemon" emits
+            // 4-dim embeddings.
+            d.seedPool(with: [(id: "Ada", name: "Ada",
+                               centroid: [Float](repeating: 1, count: 8),
+                               sampleCount: 3)])
+
+            // Long enough to mint: the mismatched entry is not a confident
+            // match, so it forks instead of folding.
+            let minted = d.assign(embedding: [1, 0, 0, 0], utteranceDuration: 2.0)
+            XCTAssertEqual(minted, "SPEAKER_01",
+                "A dimension-mismatched entry must not count as a confident match (threshold \(threshold))")
+
+            // Too short to mint: attaches to the closest entry — which is the
+            // mismatched one — still without folding into it.
+            let attached = d.assign(embedding: [0, 1, 0, 0], utteranceDuration: 0.5)
+            XCTAssertEqual(attached, "SPEAKER_00",
+                "A short utterance attaches to the closest entry (threshold \(threshold))")
+
+            let seeded = d.currentProfiles().first { $0.profileName == "Ada" }
+            XCTAssertEqual(seeded?.observedCount, 0,
+                "The mismatched seeded profile must record no observations (threshold \(threshold))")
+            XCTAssertEqual(seeded?.observedCentroid.count, 0,
+                "The mismatched seeded profile must not take on this recording's embeddings")
+        }
+    }
+
+    /// Positive control for the dimension check: it rejects mismatched entries
+    /// only. At the same non-positive threshold a same-dimension entry still
+    /// folds exactly as before.
+    func test_non_positive_threshold_still_folds_matching_dimensions() {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.0
+        XCTAssertEqual(d.assign(embedding: [1, 0, 0, 0]), "SPEAKER_00")
+        XCTAssertEqual(d.assign(embedding: [0, 1, 0, 0]), "SPEAKER_00",
+            "sim 0 clears a 0 threshold, so a same-dimension entry is still a confident match")
+        let profile = d.currentProfiles().first
+        XCTAssertEqual(profile?.observedCount, 2, "Both embeddings must have folded in")
+        XCTAssertEqual(profile?.observedCentroid.count, 4)
+    }
+
     func test_higher_threshold_makes_pool_more_conservative() {
         let d = LiveSpeakerDiarizer()
         d.similarityThreshold = 0.99

--- a/MilaTests/ObservedVoiceSnapshotsTests.swift
+++ b/MilaTests/ObservedVoiceSnapshotsTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Mila
+
+/// Unit tests for the per-recording snapshot store that keeps one recording's
+/// voices from being written into another's profile.
+@MainActor
+final class ObservedVoiceSnapshotsTests: XCTestCase {
+
+    private var suiteNames: [String] = []
+
+    override func tearDown() async throws {
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    private func makeSettings(enabled: Bool = true) -> VoiceRecognitionSettings {
+        let name = "ObservedVoiceSnapshotsTests.\(UUID())"
+        suiteNames.append(name)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        settings.diarizationReady = { true }
+        settings.isEnabled = enabled
+        return settings
+    }
+
+    private func entries(_ pairs: [(String, [Float], Int, String?)])
+        -> [(id: String, observedCentroid: [Float], observedCount: Int, profileName: String?)] {
+        pairs.map { (id: $0.0, observedCentroid: $0.1, observedCount: $0.2, profileName: $0.3) }
+    }
+
+    // MARK: - Per-recording isolation
+
+    /// The same raw speaker id in two recordings resolves to two different
+    /// voices. This is the whole point: `SPEAKER_00` is positional and means
+    /// nothing across recordings.
+    func test_the_same_raw_id_in_two_recordings_resolves_separately() {
+        let snapshots = ObservedVoiceSnapshots()
+        let recA = UUID(), recB = UUID()
+
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 2, "Alice")]), for: recA)
+        snapshots.record(entries([("SPEAKER_00", [0, 1], 5, nil)]), for: recB)
+
+        XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_00", in: recA),
+                       .init(observedCentroid: [1, 0], observedCount: 2, profileName: "Alice"))
+        XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_00", in: recB),
+                       .init(observedCentroid: [0, 1], observedCount: 5, profileName: nil))
+    }
+
+    func test_an_unknown_recording_or_speaker_resolves_to_nil() {
+        let snapshots = ObservedVoiceSnapshots()
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 2, nil)]), for: rec)
+
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_01", in: rec),
+                     "unknown speaker in a known recording")
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: UUID()),
+                     "known speaker id in an unknown recording — must not fall through")
+    }
+
+    /// Every pool entry is retained, seeded or not: a speaker the user names
+    /// by hand is how profiles get created in the first place.
+    func test_unseeded_entries_are_retained_too() {
+        let snapshots = ObservedVoiceSnapshots()
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 1, nil),
+                                  ("SPEAKER_01", [0, 1], 3, "Bob")]), for: rec)
+
+        XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_00", in: rec)?.observedCount, 1)
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: rec)?.profileName)
+        XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_01", in: rec)?.profileName, "Bob")
+    }
+
+    /// Re-snapshotting a recording replaces its entry rather than
+    /// accumulating a second one, and doesn't consume another eviction slot.
+    func test_re_recording_the_same_recording_replaces_in_place() {
+        let snapshots = ObservedVoiceSnapshots()
+        let rec = UUID()
+
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 1, nil)]), for: rec)
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 4, nil)]), for: rec)
+
+        XCTAssertEqual(snapshots.heldRecordingCount, 1)
+        XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_00", in: rec)?.observedCount, 4)
+    }
+
+    // MARK: - Bounded retention
+
+    /// Held snapshots are capped, oldest evicted first, so embeddings don't
+    /// accumulate for the life of the process.
+    func test_retention_is_bounded_and_evicts_oldest_first() {
+        let snapshots = ObservedVoiceSnapshots(limit: 3)
+        let ids = (0..<5).map { _ in UUID() }
+        for id in ids {
+            snapshots.record(entries([("SPEAKER_00", [1, 0], 1, nil)]), for: id)
+        }
+
+        XCTAssertEqual(snapshots.heldRecordingCount, 3)
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: ids[0]), "evicted")
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: ids[1]), "evicted")
+        XCTAssertNotNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: ids[2]))
+        XCTAssertNotNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: ids[4]))
+    }
+
+    func test_a_limit_below_one_is_clamped() {
+        let snapshots = ObservedVoiceSnapshots(limit: 0)
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 1, nil)]), for: rec)
+        XCTAssertEqual(snapshots.heldRecordingCount, 1,
+                       "a zero limit would drop the snapshot it was just handed")
+    }
+
+    // MARK: - Opt-out
+
+    /// Opting out discards everything held, so an opted-out user has no voice
+    /// data in memory here either — matching `SpeakerProfileStore`, which
+    /// drops its loaded profiles on the same signal.
+    func test_opting_out_discards_held_observations() {
+        let settings = makeSettings()
+        let snapshots = ObservedVoiceSnapshots()
+        snapshots.clearOnOptOut(of: settings)
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 2, "Alice")]), for: rec)
+        XCTAssertEqual(snapshots.heldRecordingCount, 1)
+
+        settings.isEnabled = false
+
+        XCTAssertEqual(snapshots.heldRecordingCount, 0)
+        XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_00", in: rec))
+    }
+
+    /// Opting back *in* doesn't resurrect anything — those recordings' pools
+    /// are gone.
+    func test_opting_back_in_does_not_restore_discarded_observations() {
+        let settings = makeSettings()
+        let snapshots = ObservedVoiceSnapshots()
+        snapshots.clearOnOptOut(of: settings)
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 2, nil)]), for: rec)
+
+        settings.isEnabled = false
+        settings.isEnabled = true
+
+        XCTAssertEqual(snapshots.heldRecordingCount, 0)
+    }
+
+    /// Two objects observing the same settings must *both* hear an opt-out.
+    /// With a single assignable callback slot the second registrant silently
+    /// unhooked the first, so whichever was constructed last would have been
+    /// the only one to react — the store would have kept its profiles loaded,
+    /// or the snapshots their embeddings, depending on construction order.
+    func test_multiple_observers_all_hear_an_opt_out() {
+        let settings = makeSettings()
+        var heard: [String] = []
+        settings.addEnabledObserver { _ in heard.append("first") }
+        settings.addEnabledObserver { _ in heard.append("second") }
+
+        settings.isEnabled = false
+
+        XCTAssertEqual(heard, ["first", "second"])
+    }
+
+    /// The store and the snapshots are the two real registrants; assert they
+    /// coexist rather than clobbering each other.
+    func test_the_profile_store_and_snapshots_both_react_to_an_opt_out() throws {
+        let tempRoot = TestSupport.makeTempRoot(label: "ObservedVoiceSnapshotsTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        let snapshots = ObservedVoiceSnapshots()
+        snapshots.clearOnOptOut(of: settings)
+
+        profiles.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 3)
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 1, "Alice")]), for: UUID())
+        XCTAssertEqual(profiles.profiles.count, 1)
+        XCTAssertEqual(snapshots.heldRecordingCount, 1)
+
+        settings.isEnabled = false
+
+        XCTAssertTrue(profiles.profiles.isEmpty, "store dropped its loaded profiles")
+        XCTAssertEqual(snapshots.heldRecordingCount, 0, "snapshots dropped their observations")
+    }
+}

--- a/MilaTests/RecognisedSpeakerAssignerTests.swift
+++ b/MilaTests/RecognisedSpeakerAssignerTests.swift
@@ -1,0 +1,282 @@
+import XCTest
+@testable import Mila
+
+/// **Invariant: the recording that finished is the one that gets snapshotted
+/// and named — identified by the id it was handed, never inferred from the
+/// store's ordering.**
+///
+/// The previous shape ran off `.onChange(of: actions.isRecording)`, which
+/// carries no id, and recovered one with `store.recordings.first`. Two
+/// separate reasons that is unsound:
+///
+///   * `RecordingStore.add` does `recordings.insert(_, at: 0)` and does
+///     **not** re-sort, so *any* recording added afterwards becomes `first`.
+///     The Voice Memos importer calls `add` from its own async flow, so a
+///     memo landing between the meeting's `add` and SwiftUI delivering the
+///     `.onChange` made the memo "the recording that just stopped".
+///   * `load()` and `recoverOrphanRecordings()` sort by `createdAt`
+///     descending, and imported memos carry their own dates — so ordering is
+///     no proxy for recency of *finishing* either.
+///
+/// Getting the id wrong degrades safely, and that is deliberate: an unknown
+/// recording has no snapshot, so the profile silently fails to learn rather
+/// than merging a stranger's voice. `test_a_wrong_id_fails_closed` pins that
+/// property so a future change can't quietly trade it away.
+///
+/// These tests drive the real `RecognisedSpeakerAssigner`, real
+/// `LiveSpeakerDiarizer`, real `ObservedVoiceSnapshots`, real
+/// `RecordingStore` and real `SpeakerProfileStore` — extracting the assigner
+/// out of `MilaApp` is what makes the gate reachable at all.
+@MainActor
+final class RecognisedSpeakerAssignerTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    private let aliceStored: [Float] = [1, 0, 0, 0]
+    private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "RecognisedSpeakerAssignerTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    private func makeSettings(enabled: Bool = true) -> VoiceRecognitionSettings {
+        let name = "RecognisedSpeakerAssignerTests.\(UUID())"
+        suiteNames.append(name)
+        let s = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        s.diarizationReady = { true }
+        s.isEnabled = enabled
+        return s
+    }
+
+    private struct World {
+        let store: RecordingStore
+        let profiles: SpeakerProfileStore
+        let snapshots: ObservedVoiceSnapshots
+        let diarizer: LiveSpeakerDiarizer
+        let assigner: RecognisedSpeakerAssigner
+        let settings: VoiceRecognitionSettings
+    }
+
+    /// Alice on disk and a seeded pool — everything the assigner needs.
+    /// Deliberately creates no `Recording`: each test controls store contents.
+    private func makeWorld(enabled: Bool = true) -> World {
+        let settings = makeSettings(enabled: enabled)
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let snapshots = ObservedVoiceSnapshots()
+
+        // Same wiring MilaApp.init installs.
+        store.onSpeakerNamed = { recordingID, rawID, name in
+            guard settings.isConfigured else { return }
+            guard let observed = snapshots.observation(forSpeaker: rawID,
+                                                      in: recordingID) else { return }
+            profiles.updateProfile(name: name,
+                                   embedding: observed.observedCentroid,
+                                   sampleCount: observed.observedCount)
+        }
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        let assigner = RecognisedSpeakerAssigner(store: store,
+                                                 diarizer: diarizer,
+                                                 snapshots: snapshots,
+                                                 settings: settings)
+        return World(store: store, profiles: profiles, snapshots: snapshots,
+                     diarizer: diarizer, assigner: assigner, settings: settings)
+    }
+
+    /// Alice speaks once, confidently.
+    private func aliceSpeaksConfidently(_ w: World) {
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+    }
+
+    @discardableResult
+    private func add(_ title: String,
+                     createdAt: Date,
+                     source: RecordingSource = .microphone,
+                     to store: RecordingStore) -> Recording {
+        let rec = Recording(title: title, createdAt: createdAt, source: source,
+                            audioFileName: "\(title).wav")
+        store.add(rec)
+        return rec
+    }
+
+    private func alice(_ w: World) -> VoiceProfile? { w.profiles.profile(named: "Alice") }
+
+    private func recording(_ id: UUID, in store: RecordingStore) -> Recording? {
+        store.recordings.first { $0.id == id }
+    }
+
+    // MARK: - The invariant: the id is carried, not inferred
+
+    /// A recording that is newer in the store — and `first` in it — must not
+    /// steal the snapshot from the recording that actually finished.
+    func test_a_newer_recording_in_the_store_does_not_steal_the_snapshot() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+
+        // The meeting finishes and is saved...
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+        // ...then a Voice Memos import lands, carrying its own (newer) date.
+        // `add` inserts at index 0 regardless, so it is now `first` on both
+        // counts — insertion order *and* createdAt.
+        let memo = add("Memo", createdAt: Date().addingTimeInterval(60),
+                       source: .voiceMemo, to: w.store)
+        XCTAssertEqual(w.store.recordings.first?.id, memo.id,
+                       "precondition: the memo is what `recordings.first` would hand back")
+
+        w.assigner.finish(recording: meeting.id)
+
+        // Snapshot went to the meeting, not the memo.
+        XCTAssertNotNil(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: meeting.id))
+        XCTAssertNil(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: memo.id))
+        // The name landed on the meeting, not the memo.
+        XCTAssertEqual(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"], "Alice")
+        XCTAssertNil(recording(memo.id, in: w.store)?.speakerNames["SPEAKER_00"])
+        // And Alice learned exactly one sample from it.
+        XCTAssertEqual(alice(w)?.sampleCount, 41)
+    }
+
+    /// Negative control: the `store.recordings.first` shape the old code used
+    /// picks the memo, so the assertions above are discriminating. Also shows
+    /// the consequence — snapshotting against the inferred id leaves the
+    /// meeting with no snapshot at all.
+    func test_the_recordings_first_shape_would_pick_the_wrong_recording() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+        let memo = add("Memo", createdAt: Date().addingTimeInterval(60),
+                       source: .voiceMemo, to: w.store)
+
+        // The removed inference.
+        let inferred = w.store.recordings.first?.id
+        XCTAssertEqual(inferred, memo.id)
+        XCTAssertNotEqual(inferred, meeting.id,
+                          "inferring from store order picks the memo, not the meeting")
+
+        // Its consequence: the meeting never gets a snapshot, so naming it
+        // later learns nothing.
+        w.snapshots.record(w.diarizer.currentProfiles(), for: inferred!)
+        XCTAssertNil(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: meeting.id))
+        w.store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: meeting.id)
+        XCTAssertEqual(alice(w)?.sampleCount, 40,
+                       "learned nothing — the inference cost the update")
+    }
+
+    /// `add` inserting at index 0 with no re-sort is the mechanism, so pin it
+    /// directly: an *older* recording added later is still `first`. Ordering
+    /// cannot stand in for "finished most recently".
+    func test_store_ordering_is_not_a_proxy_for_which_recording_finished() {
+        let w = makeWorld()
+        let newer = add("Newer", createdAt: Date(), to: w.store)
+        let older = add("Older", createdAt: Date().addingTimeInterval(-3600), to: w.store)
+
+        XCTAssertEqual(w.store.recordings.first?.id, older.id,
+                       "add() inserts at index 0 and does not re-sort")
+        XCTAssertNotEqual(w.store.recordings.first?.id, newer.id)
+    }
+
+    /// Being handed an id for a recording that isn't in the store snapshots
+    /// against that id (harmless) and writes no voice data — the fail-closed
+    /// property that makes a wrong id survivable. Worth pinning: a future
+    /// "fall back to the newest recording" would silently undo it.
+    func test_a_wrong_id_fails_closed() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.assigner.finish(recording: UUID())
+
+        // Nothing was named on the real recording...
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
+        // ...and no voice data was written for anybody.
+        XCTAssertEqual(alice(w)?.sampleCount, 40, "no merge")
+        // Naming the real recording afterwards also learns nothing, because
+        // its snapshot went to the stray id. Silently not learning is the
+        // acceptable failure; merging the wrong voice would not be.
+        w.store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: meeting.id)
+        XCTAssertEqual(alice(w)?.sampleCount, 40)
+    }
+
+    // MARK: - The happy path still works
+
+    func test_the_finished_recording_is_named_and_learns_one_sample() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertEqual(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"], "Alice")
+        XCTAssertEqual(alice(w)?.sampleCount, 41)
+        XCTAssertGreaterThan(cosineSimilarity(alice(w)?.embedding ?? [], aliceStored), 0.99)
+    }
+
+    /// Re-running for the same recording changes nothing: the name already
+    /// matches, so `setSpeakerName` returns without firing the hook.
+    func test_running_twice_for_the_same_recording_is_idempotent() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.assigner.finish(recording: meeting.id)
+        w.assigner.finish(recording: meeting.id)
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertEqual(alice(w)?.sampleCount, 41, "one recognition, one merge")
+    }
+
+    // MARK: - The opt-in gate still holds at this layer
+
+    /// While off: no naming, and — the point of gating here rather than only
+    /// inside the store — no snapshot either, so an opted-out user has no
+    /// embeddings held in memory.
+    func test_while_off_nothing_is_named_and_nothing_is_snapshotted() {
+        let w = makeWorld(enabled: false)
+        // Seeding was refused too (`seedEntries` returns nothing while off),
+        // so this speaks into an unseeded pool.
+        _ = w.diarizer.assign(embedding: aliceSpeaking)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertEqual(w.snapshots.heldRecordingCount, 0, "no embeddings held while off")
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
+    }
+
+    /// A borderline-only speaker is not auto-named — now asserted against the
+    /// real assigner rather than a replica of its loop.
+    func test_a_borderline_only_speaker_is_not_auto_named() {
+        let w = makeWorld()
+        // cos([0.6, 0.8, 0, 0], [1, 0, 0, 0]) == 0.6: above the 0.55 create
+        // floor so it attaches to Alice's seeded entry, below the 0.7 match
+        // threshold so it is never folded in.
+        XCTAssertEqual(w.diarizer.assign(embedding: [0.6, 0.8, 0, 0]), "SPEAKER_00")
+        XCTAssertEqual(w.diarizer.currentProfiles().first?.observedCount, 0)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"],
+                     "attached but never confidently matched — must not be named")
+        XCTAssertEqual(alice(w)?.sampleCount, 40, "and nothing learned")
+    }
+}

--- a/MilaTests/RecognisedSpeakerAssignerTests.swift
+++ b/MilaTests/RecognisedSpeakerAssignerTests.swift
@@ -166,15 +166,21 @@ final class RecognisedSpeakerAssignerTests: XCTestCase {
         let memo = add("Memo", createdAt: Date().addingTimeInterval(60),
                        source: .voiceMemo, to: w.store)
 
-        // The removed inference.
-        let inferred = w.store.recordings.first?.id
+        // The removed inference. Bound rather than force-unwrapped below:
+        // `XCTAssertEqual` records a failure and carries on, so a nil here
+        // would crash the runner on the next line and bury which of the two
+        // fixture preconditions actually broke.
+        guard let inferred = w.store.recordings.first?.id else {
+            XCTFail("precondition: the store must have a recording to infer from")
+            return
+        }
         XCTAssertEqual(inferred, memo.id)
         XCTAssertNotEqual(inferred, meeting.id,
                           "inferring from store order picks the memo, not the meeting")
 
         // Its consequence: the meeting never gets a snapshot, so naming it
         // later learns nothing.
-        w.snapshots.record(w.diarizer.currentProfiles(), for: inferred!)
+        w.snapshots.record(w.diarizer.currentProfiles(), for: inferred)
         XCTAssertNil(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: meeting.id))
         w.store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: meeting.id)
         XCTAssertEqual(alice(w)?.sampleCount, 40,

--- a/MilaTests/RecognisedSpeakerAssignerTests.swift
+++ b/MilaTests/RecognisedSpeakerAssignerTests.swift
@@ -71,7 +71,15 @@ final class RecognisedSpeakerAssignerTests: XCTestCase {
 
     /// Alice on disk and a seeded pool — everything the assigner needs.
     /// Deliberately creates no `Recording`: each test controls store contents.
-    private func makeWorld(enabled: Bool = true) -> World {
+    ///
+    /// `deletionObserver` and `storedProfileGate` are the two locks that stop
+    /// a mid-recording deletion being undone at stop. Both default to on —
+    /// the shipping wiring — and the deletion tests below switch them off
+    /// individually to show each one works alone, and off together to
+    /// reconstruct the pre-fix shape as a negative control.
+    private func makeWorld(enabled: Bool = true,
+                           deletionObserver: Bool = true,
+                           storedProfileGate: Bool = true) -> World {
         let settings = makeSettings(enabled: enabled)
         let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
         profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
@@ -91,15 +99,39 @@ final class RecognisedSpeakerAssignerTests: XCTestCase {
 
         let diarizer = LiveSpeakerDiarizer()
         diarizer.similarityThreshold = 0.7
+        // Same wiring MilaApp.init installs: a deletion has to reach the
+        // pool of a recording that is already running.
+        if deletionObserver {
+            profiles.addDeletionObserver { [weak diarizer] deletion in
+                switch deletion {
+                case .all: diarizer?.forgetSeededProfiles()
+                case .named(let names): diarizer?.forgetSeededProfiles(named: names)
+                }
+            }
+        }
         diarizer.reset()
         diarizer.seedPool(with: profiles.seedEntries())
 
-        let assigner = RecognisedSpeakerAssigner(store: store,
-                                                 diarizer: diarizer,
-                                                 snapshots: snapshots,
-                                                 settings: settings)
+        let assigner = RecognisedSpeakerAssigner(
+            store: store,
+            diarizer: diarizer,
+            snapshots: snapshots,
+            settings: settings,
+            // The `false` branch is the pre-gate shape, not a shortcut: the
+            // tests that pass `storedProfileGate: false` need exactly it.
+            profileStillStored: { name in
+                storedProfileGate ? profiles.profileExists(name: name) : true
+            })
         return World(store: store, profiles: profiles, snapshots: snapshots,
                      diarizer: diarizer, assigner: assigner, settings: settings)
+    }
+
+    /// Where `SpeakerProfileStore` keeps its file, so the tests can assert
+    /// that a deleted one is not silently recreated.
+    private var profilesFile: URL { tempRoot.appendingPathComponent("speaker-profiles.json") }
+
+    private var profilesFileExists: Bool {
+        FileManager.default.fileExists(atPath: profilesFile.path)
     }
 
     /// Alice speaks once, confidently.
@@ -265,6 +297,165 @@ final class RecognisedSpeakerAssignerTests: XCTestCase {
         w.assigner.finish(recording: meeting.id)
 
         XCTAssertEqual(w.snapshots.heldRecordingCount, 0, "no embeddings held while off")
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
+    }
+
+    // MARK: - Deleting voice profiles while a recording is in flight
+
+    /// **The privacy invariant: deleting voice profiles during a recording
+    /// must not be undone when that recording stops.**
+    ///
+    /// The pool was seeded from the profiles at record-start and holds its
+    /// own copy of every centroid, so deleting the file and the in-memory
+    /// list leaves the deletion two thirds done. Left alone, `finish` names
+    /// the still-seeded speaker, `setSpeakerName` fires `onSpeakerNamed`, and
+    /// `updateProfile` — which *creates* when the name is absent, because
+    /// that is how hand-naming makes a profile — writes the deleted person
+    /// straight back, recreating `speaker-profiles.json` in the process. See
+    /// `test_without_either_lock_the_profile_comes_straight_back` for the
+    /// measured before-state: the user is told their voice data is gone
+    /// while it quietly returns.
+    func test_deleting_profiles_mid_recording_does_not_bring_them_back() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        // Mid-recording: Settings ▸ Delete Voice Profiles.
+        w.profiles.deleteAllProfiles()
+        XCTAssertFalse(profilesFileExists, "precondition: the file is gone")
+
+        // ...and now the recording stops.
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertTrue(w.profiles.profiles.isEmpty, "nothing may be back in memory")
+        XCTAssertNil(alice(w))
+        XCTAssertFalse(profilesFileExists, "speaker-profiles.json must not be recreated")
+        XCTAssertFalse(w.profiles.hasStoredProfilesOnDisk,
+                       "and Settings must not start offering to delete it again")
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"],
+                     "the deleted name must not be stamped on the transcript either")
+    }
+
+    /// Negative control — the pre-fix wiring, reconstructed from the same
+    /// real objects: no deletion observer, and the assigner's stored-profile
+    /// gate answering `true` unconditionally. It proves the assertions above
+    /// discriminate, and records exactly what the resurrection looked like.
+    ///
+    /// Note *what* comes back. Not the profile that was deleted: a fresh
+    /// `id`, a fresh `createdAt`, and `sampleCount` counting only this
+    /// recording. But the name returns, the file returns, and the embedding —
+    /// this recording's own centroid for the same person — sits at better
+    /// than 0.999 cosine to the deleted one, so it recognises them just as
+    /// well in every future recording. Partial by the numbers, complete in
+    /// effect.
+    func test_without_either_lock_the_profile_comes_straight_back() {
+        let w = makeWorld(deletionObserver: false, storedProfileGate: false)
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+        let originalID = alice(w)?.id
+
+        w.profiles.deleteAllProfiles()
+        XCTAssertFalse(profilesFileExists, "precondition: the file is gone")
+
+        w.assigner.finish(recording: meeting.id)
+
+        guard let back = alice(w) else {
+            return XCTFail("precondition for the tests above: unguarded, Alice returns")
+        }
+        XCTAssertNotEqual(back.id, originalID, "a new profile, not the deleted one")
+        XCTAssertEqual(back.sampleCount, 1, "carrying only this recording's observation")
+        XCTAssertGreaterThan(cosineSimilarity(back.embedding, aliceStored), 0.99,
+                             "but the same voice, to within rounding")
+        XCTAssertTrue(profilesFileExists, "and the deleted file is recreated")
+    }
+
+    /// Lock 1 alone — the store's deletion observer strips the seeded name
+    /// out of the live pool, so `finish` has nothing to auto-name.
+    func test_the_deletion_observer_alone_prevents_the_resurrection() {
+        let w = makeWorld(deletionObserver: true, storedProfileGate: false)
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.profiles.deleteAllProfiles()
+        XCTAssertNil(w.diarizer.currentProfiles().first?.profileName,
+                     "the pool entry stops carrying the deleted name")
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertNil(alice(w))
+        XCTAssertFalse(profilesFileExists)
+    }
+
+    /// Lock 2 alone — `finish` refuses to auto-apply the name of a profile
+    /// that is no longer stored, even with the pool still carrying it. This
+    /// is the lock that does not depend on a caller having wired the
+    /// observer up.
+    func test_the_stored_profile_gate_alone_prevents_the_resurrection() {
+        let w = makeWorld(deletionObserver: false, storedProfileGate: true)
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.profiles.deleteAllProfiles()
+        XCTAssertEqual(w.diarizer.currentProfiles().first?.profileName, "Alice",
+                       "precondition: with no observer the pool still carries it")
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertNil(alice(w))
+        XCTAssertFalse(profilesFileExists)
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
+    }
+
+    /// Deletion must stop *recognition* too, not merely persistence: a
+    /// speaker whose profile the user has just erased is not recognised for
+    /// the rest of the recording. The neutralised entry stays in the pool
+    /// (ids are positional — removing it would collide the next mint), so
+    /// the new speaker is `SPEAKER_01`, nameless.
+    func test_after_deletion_the_erased_voice_is_no_longer_recognised() {
+        let w = makeWorld()
+        // Alice has not spoken yet, so the seeded entry holds nothing but
+        // the profile that is about to be deleted.
+        w.profiles.deleteAllProfiles()
+
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_01",
+                       "a fresh speaker — the erased centroid must not match her")
+        let entries = w.diarizer.currentProfiles()
+        XCTAssertEqual(entries.count, 2, "the emptied entry stays, so ids cannot collide")
+        XCTAssertTrue(entries.allSatisfy { $0.profileName == nil })
+    }
+
+    /// Deleting one profile by name reaches the pool the same way, and
+    /// leaves the others seeded. (Only Alice is stored in this fixture; the
+    /// selective half is pinned in `LiveSpeakerDiarizerPoolTests`.)
+    func test_deleting_a_single_profile_mid_recording_also_reaches_the_pool() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.profiles.deleteProfile(name: "Alice")
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertNil(alice(w), "one deleted profile must not come back either")
+        XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
+    }
+
+    /// The same hole through a different door: a profile can also stop
+    /// existing under its seeded name because the user *renamed* it
+    /// mid-recording. Rename does not notify the pool, so this is lock 2's
+    /// work alone — and it is why the gate is worth having as well as the
+    /// observer. Not auto-naming is the conservative outcome: the recording
+    /// is left unlabelled rather than labelled with a name that is no longer
+    /// anybody's, and above all the old name is not recreated on disk.
+    func test_a_renamed_profile_is_not_recreated_under_its_old_name() {
+        let w = makeWorld()
+        aliceSpeaksConfidently(w)
+        let meeting = add("Meeting", createdAt: Date(), to: w.store)
+
+        w.profiles.renameProfile(from: "Alice", to: "Alice Smith")
+        w.assigner.finish(recording: meeting.id)
+
+        XCTAssertNil(alice(w), "the old name must not reappear as a second profile")
+        XCTAssertEqual(w.profiles.profiles.count, 1)
+        XCTAssertEqual(w.profiles.profiles.first?.name, "Alice Smith")
+        XCTAssertEqual(w.profiles.profiles.first?.sampleCount, 40, "and it learned nothing")
         XCTAssertNil(recording(meeting.id, in: w.store)?.speakerNames["SPEAKER_00"])
     }
 

--- a/MilaTests/RecognisedSpeakerMergeTests.swift
+++ b/MilaTests/RecognisedSpeakerMergeTests.swift
@@ -188,4 +188,195 @@ final class RecognisedSpeakerMergeTests: XCTestCase {
         XCTAssertEqual(alice(world.profiles)?.embedding[0] ?? 0, 0.5, accuracy: 0.0001)
         XCTAssertEqual(alice(world.profiles)?.embedding[1] ?? 0, 0.5, accuracy: 0.0001)
     }
+
+    // MARK: - Seeded weight must not leak into the persisted delta
+
+    /// **The regression this section exists for.** A seeded pool entry starts
+    /// with up to three carried samples in `sampleCount` so the persisted
+    /// centroid isn't blown away by the first live utterance. That weight is
+    /// *already on disk*. `currentProfiles()` used to report it, and the
+    /// persistence hook passed it to `updateProfile` as if it were all newly
+    /// observed — so a profile with three or more prior samples and one
+    /// confident match was persisted as four new samples.
+    ///
+    /// Unlike the tests above, these drive the **real** path end to end: real
+    /// `seedPool`, the real matching fold inside `assign`, real
+    /// `currentProfiles()`, real `SpeakerProfileStore`. Nothing is replicated.
+    func test_one_observed_utterance_persists_exactly_one_sample() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        // Alice has a well-established profile: 40 samples on disk.
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 40)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        // Alice speaks once. Near-identical embedding, so it matches the
+        // seeded entry rather than minting a new speaker.
+        let assigned = diarizer.assign(embedding: [0.99, 0.01, 0, 0])
+        XCTAssertEqual(assigned, "SPEAKER_00", "the utterance must match the seeded entry")
+
+        // Persist the way MilaApp's onSpeakerNamed hook does.
+        guard let entry = diarizer.currentProfiles().first(where: { $0.id == assigned }) else {
+            return XCTFail("no pool entry for \(assigned)")
+        }
+        XCTAssertEqual(entry.observedCount, 1,
+                       "one utterance is one observation — not one plus the seeded weight")
+        profiles.updateProfile(name: "Alice",
+                               embedding: entry.observedCentroid,
+                               sampleCount: entry.observedCount)
+
+        XCTAssertEqual(alice(profiles)?.sampleCount, 41,
+                       "40 stored + 1 observed. The bug persisted 4 here, so a profile's "
+                       + "count drifted ~4x off reality after a single recording.")
+    }
+
+    /// The worked case at the seed cap, where the inflation is at its worst
+    /// relative to the stored count: **3 stored samples + 1 confident match
+    /// must persist 4, not 7.**
+    ///
+    /// 3 is exactly `seedPool`'s cap, so the seeded entry carries all three
+    /// synthetic samples; one match took its `sampleCount` to 4; the old
+    /// `currentProfiles()` handed that 4 over as newly observed, and
+    /// `3 + 4 = 7`. Better than doubling the whole profile only because the
+    /// profile was small — for a young profile this is where the count runs
+    /// away fastest.
+    func test_seeded_profile_at_the_cap_persists_one_sample_not_four() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 3)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        XCTAssertEqual(diarizer.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_00")
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 1,
+                       "the three carried samples are already on disk — only the live "
+                       + "utterance is new")
+        profiles.updateProfile(name: "Alice",
+                               embedding: entry?.observedCentroid ?? [],
+                               sampleCount: entry?.observedCount ?? 0)
+
+        XCTAssertEqual(alice(profiles)?.sampleCount, 4, "3 stored + 1 observed")
+    }
+
+    /// Negative control for the test above, in the same style as
+    /// `test_the_regression_shape_doubles_the_sample_count`: feed
+    /// `updateProfile` the seeded-inclusive count the old `currentProfiles()`
+    /// returned (`min(3, 3) + 1 == 4`) and confirm it lands on 7. Without
+    /// this, the `4` asserted above could pass for the wrong reason.
+    func test_the_seeded_regression_shape_persists_seven() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 3)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+        XCTAssertEqual(diarizer.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_00")
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        // The count the pool's *matching* side now holds, which is what used
+        // to be persisted: the capped seed weight plus the one match.
+        let seededInclusiveCount = min(3, 3) + 1
+        profiles.updateProfile(name: "Alice",
+                               embedding: entry?.observedCentroid ?? [],
+                               sampleCount: seededInclusiveCount)
+
+        XCTAssertEqual(alice(profiles)?.sampleCount, 7,
+                       "the shape this fix removes — 4 asserted above is discriminating")
+    }
+
+    /// Three utterances persist three samples — the delta tracks observations
+    /// linearly, independent of how much seeded weight came along.
+    func test_three_observed_utterances_persist_exactly_three_samples() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 40)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        let utterances: [[Float]] = [[0.99, 0.01, 0, 0], [0.98, 0.02, 0, 0], [0.97, 0.02, 0.01, 0]]
+        for utterance in utterances {
+            XCTAssertEqual(diarizer.assign(embedding: utterance), "SPEAKER_00")
+        }
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 3)
+        profiles.updateProfile(name: "Alice",
+                               embedding: entry?.observedCentroid ?? [],
+                               sampleCount: entry?.observedCount ?? 0)
+        XCTAssertEqual(alice(profiles)?.sampleCount, 43)
+    }
+
+    /// A seeded speaker who never says a word contributes nothing: zero
+    /// observations, and `updateProfile` refuses a zero count outright, so no
+    /// spurious write can reach the stored profile.
+    func test_a_seeded_speaker_who_never_spoke_persists_nothing() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 40)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 0)
+        XCTAssertEqual(entry?.observedCentroid, [])
+
+        profiles.updateProfile(name: "Alice",
+                               embedding: entry?.observedCentroid ?? [],
+                               sampleCount: entry?.observedCount ?? 0)
+        XCTAssertEqual(alice(profiles)?.sampleCount, 40, "untouched")
+        XCTAssertEqual(alice(profiles)?.embedding, [1, 0, 0, 0], "untouched")
+    }
+
+    /// Seeding must still do its job on the *matching* side: the carried
+    /// weight is what stops one live utterance dragging the seeded centroid
+    /// across the pool. Separating out the persisted delta must not weaken
+    /// that, so assert the seeded entry still absorbs a second, noisier
+    /// utterance instead of forking a new speaker.
+    func test_seeded_weight_still_anchors_matching() {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: [1, 0, 0, 0], sampleCount: 40)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        XCTAssertEqual(diarizer.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_00")
+        XCTAssertEqual(diarizer.assign(embedding: [0.9, 0.3, 0.1, 0]), "SPEAKER_00",
+                       "the seeded centroid should still be anchoring matches")
+        XCTAssertEqual(diarizer.currentProfiles().count, 1, "no speaker was forked")
+    }
+
+    /// A speaker minted during the recording (never seeded) is unaffected:
+    /// the matching pair and the persisted pair are the same thing, so the
+    /// common case behaves exactly as before.
+    func test_an_unseeded_speaker_persists_all_of_its_observations() {
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+
+        XCTAssertEqual(diarizer.assign(embedding: [1, 0, 0, 0]), "SPEAKER_00")
+        XCTAssertEqual(diarizer.assign(embedding: [0.99, 0.01, 0, 0]), "SPEAKER_00")
+
+        let entry = diarizer.currentProfiles().first { $0.id == "SPEAKER_00" }
+        XCTAssertEqual(entry?.observedCount, 2)
+        XCTAssertNil(entry?.profileName, "not seeded")
+    }
 }

--- a/MilaTests/RecognisedSpeakerMergeTests.swift
+++ b/MilaTests/RecognisedSpeakerMergeTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import Mila
+
+/// **Invariant: one recognition folds into the stored centroid exactly
+/// once.**
+///
+/// `MilaApp.autoAssignRecognisedSpeakers` used to call
+/// `SpeakerProfileStore.updateProfile` directly *and* call
+/// `RecordingStore.setSpeakerName`, which synchronously fires
+/// `onSpeakerNamed` — wired in `MilaApp.init` to that same `updateProfile`.
+/// Every recognised speaker was therefore merged twice per recording.
+///
+/// The centroid *value* survives a double merge (a weighted average of x
+/// with x is x), which is why it went unnoticed. What doubles is
+/// `sampleCount`, and because the merge weights by sample count, each
+/// recording makes the profile more rigid until it stops adapting to the
+/// speaker at all: recognition decays with nothing visibly failing, which is
+/// strictly worse than a crash. Hence tests on the arithmetic rather than on
+/// the profile "looking right".
+///
+/// **What these tests bind to.** Real `RecordingStore`, real
+/// `SpeakerProfileStore`, and the real `setSpeakerName` → `onSpeakerNamed`
+/// mechanics that carry the merge. The hook body is the same three lines
+/// `MilaApp.init` installs. What they cannot reach is
+/// `autoAssignRecognisedSpeakers` itself — it is `private`, and its inputs
+/// (`LiveSpeakerDiarizer.pool` / `.intervals`) are private too — so that
+/// loop's pool filtering is guarded by the comment at the call site rather
+/// than from here. `test_the_regression_shape_doubles_the_sample_count`
+/// exists so the assertions below are provably discriminating rather than
+/// vacuous.
+@MainActor
+final class RecognisedSpeakerMergeTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    /// The profile already on disk from earlier recordings.
+    private let storedCentroid: [Float] = [1, 0]
+    private let storedSamples = 4
+    /// What the diarizer observed for that voice in *this* recording.
+    private let observedCentroid: [Float] = [0, 1]
+    private let observedSamples = 2
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "RecognisedSpeakerMergeTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    /// Opted-in settings on a throwaway suite — never `.standard`.
+    private func makeSettings() -> VoiceRecognitionSettings {
+        let name = "RecognisedSpeakerMergeTests.\(UUID())"
+        suiteNames.append(name)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        settings.diarizationReady = { true }
+        settings.isEnabled = true
+        return settings
+    }
+
+    /// The world as it stands when a recording stops: a stored profile for
+    /// Alice, a recording to label, and the `onSpeakerNamed` hook wired the
+    /// way `MilaApp.init` wires it.
+    private func makeWorld() -> (recordings: RecordingStore,
+                                 profiles: SpeakerProfileStore,
+                                 recording: Recording) {
+        let settings = makeSettings()
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice",
+                               embedding: storedCentroid,
+                               sampleCount: storedSamples)
+
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let recording = Recording(title: "Standup",
+                                  duration: 60,
+                                  source: .microphone,
+                                  audioFileName: "standup.wav")
+        recordings.add(recording)
+
+        // Verbatim shape of MilaApp.init's wiring. The real hook re-reads the
+        // centroid out of the diarizer pool by speaker id; substituting the
+        // observation directly is the same thing from the store's side.
+        let observed = (centroid: observedCentroid, sampleCount: observedSamples)
+        recordings.onSpeakerNamed = { _, _, name in
+            guard settings.isConfigured else { return }
+            profiles.updateProfile(name: name,
+                                   embedding: observed.centroid,
+                                   sampleCount: observed.sampleCount)
+        }
+        return (recordings, profiles, recording)
+    }
+
+    private func alice(_ profiles: SpeakerProfileStore) -> VoiceProfile? {
+        profiles.profile(named: "Alice")
+    }
+
+    // MARK: - The invariant
+
+    /// Auto-assigning a recognised speaker merges the observation once: the
+    /// stored sample count goes 4 → 6, not 4 → 8.
+    func test_one_recognition_merges_exactly_once() {
+        let world = makeWorld()
+        XCTAssertEqual(alice(world.profiles)?.sampleCount, storedSamples)
+
+        // What autoAssignRecognisedSpeakers now does, and all it does.
+        world.recordings.setSpeakerName("Alice",
+                                        forSpeaker: "SPEAKER_00",
+                                        recordingID: world.recording.id)
+
+        XCTAssertEqual(alice(world.profiles)?.sampleCount, 6,
+                       "one recognition must fold in once — 4 stored + 2 observed")
+        // (1*4 + 0*2)/6 and (0*4 + 1*2)/6. A second merge would drag these to
+        // 0.5 / 0.5, so the centroid is a second, independent witness.
+        XCTAssertEqual(alice(world.profiles)?.embedding[0] ?? 0, 2.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(alice(world.profiles)?.embedding[1] ?? 0, 1.0 / 3.0, accuracy: 0.0001)
+
+        // And the label itself landed.
+        XCTAssertEqual(world.recordings.recordings.first?.speakerNames["SPEAKER_00"], "Alice")
+    }
+
+    /// Running the auto-assign path more than once for the same recording — a
+    /// duplicated stop event, a re-entrant `.onChange` — merges nothing
+    /// further. `setSpeakerName` returns early once the name already matches,
+    /// so the hook never fires again. That idempotency is a property of
+    /// routing persistence through `setSpeakerName`, and it is exactly what a
+    /// direct `updateProfile` call alongside it destroys.
+    func test_re_running_auto_assign_for_the_same_recording_merges_nothing_further() {
+        let world = makeWorld()
+        for _ in 0..<3 {
+            world.recordings.setSpeakerName("Alice",
+                                            forSpeaker: "SPEAKER_00",
+                                            recordingID: world.recording.id)
+        }
+        XCTAssertEqual(alice(world.profiles)?.sampleCount, 6,
+                       "re-running auto-assign must not re-merge the same recording")
+    }
+
+    /// "Exactly once" is per recognition, not once ever — the next recording
+    /// must still improve the profile. 6 → 9 on a three-sample observation.
+    func test_a_later_recording_merges_again() {
+        let world = makeWorld()
+        world.recordings.setSpeakerName("Alice",
+                                        forSpeaker: "SPEAKER_00",
+                                        recordingID: world.recording.id)
+
+        let second = Recording(title: "Retro",
+                               duration: 60,
+                               source: .microphone,
+                               audioFileName: "retro.wav")
+        world.recordings.add(second)
+        // Fresh observation from the new recording.
+        world.recordings.onSpeakerNamed = { [profiles = world.profiles] _, _, name in
+            profiles.updateProfile(name: name, embedding: [0, 1], sampleCount: 3)
+        }
+        world.recordings.setSpeakerName("Alice",
+                                        forSpeaker: "SPEAKER_00",
+                                        recordingID: second.id)
+
+        XCTAssertEqual(alice(world.profiles)?.sampleCount, 9)
+    }
+
+    /// Guards the guard: reproduce the removed shape — `setSpeakerName`
+    /// followed by a direct `updateProfile` with the same entry — and confirm
+    /// it doubles the observation. Without this, the `6` asserted above could
+    /// pass for the wrong reason and the regression could slip back in
+    /// unnoticed.
+    func test_the_regression_shape_doubles_the_sample_count() {
+        let world = makeWorld()
+
+        world.recordings.setSpeakerName("Alice",
+                                        forSpeaker: "SPEAKER_00",
+                                        recordingID: world.recording.id)
+        // The line that used to sit here in autoAssignRecognisedSpeakers.
+        world.profiles.updateProfile(name: "Alice",
+                                     embedding: observedCentroid,
+                                     sampleCount: observedSamples)
+
+        XCTAssertEqual(alice(world.profiles)?.sampleCount, 8,
+                       "the removed second call is what the assertions above discriminate against")
+        XCTAssertEqual(alice(world.profiles)?.embedding[0] ?? 0, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(alice(world.profiles)?.embedding[1] ?? 0, 0.5, accuracy: 0.0001)
+    }
+}

--- a/MilaTests/SpeakerProfileStoreTests.swift
+++ b/MilaTests/SpeakerProfileStoreTests.swift
@@ -74,6 +74,81 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles[0].embedding[1], 0.5, accuracy: 0.001)
     }
 
+    /// The clamp that keeps `sampleCount` inside `maxSampleCount` must apply
+    /// to the **stored count only**, never to the divisor of the weighted
+    /// mean. Both folds weight their numerator by the true counts, so a
+    /// clamped divisor stops producing a mean and starts scaling the whole
+    /// centroid by `rawTotal / maxSampleCount`.
+    ///
+    /// Two ceiling-count profiles is the worst case — `rawTotal` is very
+    /// nearly `Int.max`, i.e. twice the clamp — so the wrong shape yields
+    /// `[1, 1]` where the mean is `[0.5, 0.5]`. The `accuracy: 0.001`
+    /// assertions below are therefore discriminating rather than decorative:
+    /// dividing by the clamped total fails them by 0.5.
+    func test_updateProfile_divides_by_true_total_when_stored_count_saturates() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+
+        let ceiling = VoiceProfile.maxSampleCount
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: ceiling)
+        store.updateProfile(name: "Alice", embedding: [0, 1], sampleCount: ceiling)
+
+        XCTAssertEqual(store.profiles.count, 1)
+        // (1*c + 0*c) / 2c = 0.5 — NOT (1*c + 0*c) / c = 1.0.
+        XCTAssertEqual(store.profiles[0].embedding[0], 0.5, accuracy: 0.001)
+        XCTAssertEqual(store.profiles[0].embedding[1], 0.5, accuracy: 0.001)
+        // The stored count saturates rather than overflowing…
+        XCTAssertEqual(store.profiles[0].sampleCount, ceiling)
+        // …and stays something `load` will hand back, which is the whole
+        // point of having a ceiling.
+        XCTAssertNil(store.profiles[0].unusableReason)
+    }
+
+    /// The control for the case above: a sum that lands exactly *on* the
+    /// ceiling is not clamped at all, so the two divisors coincide and the
+    /// mean is unaffected. Fixing the fold must not disturb this.
+    func test_updateProfile_sum_exactly_at_ceiling_is_not_clamped() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+
+        let ceiling = VoiceProfile.maxSampleCount
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: ceiling - 1)
+        store.updateProfile(name: "Alice", embedding: [0, 1], sampleCount: 1)
+
+        XCTAssertEqual(store.profiles[0].sampleCount, ceiling)
+        // The lone new sample is a ~10⁻¹⁹ share, so the centroid barely moves.
+        XCTAssertEqual(store.profiles[0].embedding[0], 1.0, accuracy: 0.001)
+        XCTAssertEqual(store.profiles[0].embedding[1], 0.0, accuracy: 0.001)
+        XCTAssertNil(store.profiles[0].unusableReason)
+    }
+
+    /// Same invariant on the other fold. `mergeProfiles` had the identical
+    /// clamped-divisor shape, so it needs its own guard — a fix applied to
+    /// one call site and not the other is exactly the failure mode here.
+    func test_mergeProfiles_divides_by_true_total_when_stored_count_saturates() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+
+        let ceiling = VoiceProfile.maxSampleCount
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: ceiling)
+        store.updateProfile(name: "Bob", embedding: [0, 1], sampleCount: ceiling)
+
+        let merged = store.mergeProfiles(keep: "Alice", absorb: "Bob")
+
+        XCTAssertEqual(store.profiles.count, 1)
+        // Same discrimination as above: the clamped divisor gives [1, 1].
+        XCTAssertEqual(merged?.embedding[0] ?? 0, 0.5, accuracy: 0.001)
+        XCTAssertEqual(merged?.embedding[1] ?? 0, 0.5, accuracy: 0.001)
+        XCTAssertEqual(merged?.sampleCount, ceiling)
+        XCTAssertNil(merged?.unusableReason)
+    }
+
     func test_updateProfile_rejects_dimension_mismatch() throws {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/MilaTests/SpeakerProfileStoreTests.swift
+++ b/MilaTests/SpeakerProfileStoreTests.swift
@@ -246,6 +246,99 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.profiles[0].sampleCount, 5)
     }
 
+    // MARK: - Deletion observers
+
+    /// Deleting is a privacy action, and the store is not the only place the
+    /// data lives: `LiveSpeakerDiarizer` was seeded with these centroids at
+    /// record-start and keeps its own copy. The notification is what lets a
+    /// recording already in flight drop them — without it the deletion is
+    /// undone at stop. `RecognisedSpeakerAssignerTests` drives the whole
+    /// chain; these pin the store's half of it.
+    func test_deleteAllProfiles_notifies_observers() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
+
+        var seen: [SpeakerProfileStore.Deletion] = []
+        store.addDeletionObserver { seen.append($0) }
+        store.deleteAllProfiles()
+
+        XCTAssertEqual(seen, [.all])
+    }
+
+    /// The case that most needs it. With the feature off the file is never
+    /// parsed, so `profiles` is empty and the store cannot say *what* it
+    /// deleted — `.all` is both the honest answer and the safe one. Firing
+    /// only when something was in memory would skip exactly the user who
+    /// switched the feature off and then deleted.
+    func test_deleteAllProfiles_notifies_even_with_nothing_in_memory() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir, enabled: false)
+        XCTAssertTrue(store.profiles.isEmpty, "precondition: nothing parsed while off")
+
+        var seen: [SpeakerProfileStore.Deletion] = []
+        store.addDeletionObserver { seen.append($0) }
+        store.deleteAllProfiles()
+
+        XCTAssertEqual(seen, [.all])
+    }
+
+    func test_deleteProfile_notifies_with_the_deleted_name() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
+        store.updateProfile(name: "Bob", embedding: [2], sampleCount: 1)
+
+        var seen: [SpeakerProfileStore.Deletion] = []
+        store.addDeletionObserver { seen.append($0) }
+        store.deleteProfile(name: "Alice")
+        let bobID = try XCTUnwrap(store.profile(named: "Bob")?.id)
+        store.deleteProfile(id: bobID)
+
+        XCTAssertEqual(seen, [.named(["Alice"]), .named(["Bob"])])
+    }
+
+    /// A delete that removed nothing must not disturb an in-flight
+    /// recording's pool.
+    func test_a_delete_that_matches_nothing_does_not_notify() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
+
+        var seen: [SpeakerProfileStore.Deletion] = []
+        store.addDeletionObserver { seen.append($0) }
+        store.deleteProfile(name: "Nobody")
+        store.deleteProfile(id: UUID())
+
+        XCTAssertTrue(seen.isEmpty)
+        XCTAssertEqual(store.profiles.count, 1)
+    }
+
+    /// Two registrants, both heard — the mistake `addEnabledObserver`'s
+    /// single-slot version made.
+    func test_every_deletion_observer_is_called() throws {
+        let dir = tempDir()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(in: dir)
+
+        var first = 0, second = 0
+        store.addDeletionObserver { _ in first += 1 }
+        store.addDeletionObserver { _ in second += 1 }
+        store.deleteAllProfiles()
+
+        XCTAssertEqual(first, 1)
+        XCTAssertEqual(second, 1)
+    }
+
     func test_seedEntries_returns_all_profiles() throws {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/MilaTests/SpeakerProfileStoreTests.swift
+++ b/MilaTests/SpeakerProfileStoreTests.swift
@@ -8,9 +8,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
             .appendingPathComponent("SpeakerProfileStoreTests-\(UUID().uuidString)")
     }
 
-    func test_updateProfile_creates_new_profile() {
+    func test_updateProfile_creates_new_profile() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -22,9 +22,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles[0].sampleCount, 1)
     }
 
-    func test_updateProfile_merges_centroids() {
+    func test_updateProfile_merges_centroids() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -38,9 +38,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles[0].embedding[1], 0.5, accuracy: 0.001)
     }
 
-    func test_updateProfile_rejects_dimension_mismatch() {
+    func test_updateProfile_rejects_dimension_mismatch() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -52,9 +52,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles[0].embedding.count, 3)
     }
 
-    func test_deleteProfile_by_name() {
+    func test_deleteProfile_by_name() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -67,9 +67,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(store.profiles[0].name, "Bob")
     }
 
-    func test_renameProfile() {
+    func test_renameProfile() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -81,9 +81,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertTrue(store.profileExists(name: "Alicia"))
     }
 
-    func test_match_returns_best_above_threshold() {
+    func test_match_returns_best_above_threshold() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -99,9 +99,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertNil(noMatch)
     }
 
-    func test_mergeProfiles() {
+    func test_mergeProfiles() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 
@@ -118,9 +118,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(merged?.embedding[0] ?? 0, 0.5, accuracy: 0.001)
     }
 
-    func test_persistence_round_trip() {
+    func test_persistence_round_trip() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
 
         do {
@@ -135,9 +135,9 @@ final class SpeakerProfileStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.profiles[0].sampleCount, 5)
     }
 
-    func test_seedEntries_returns_all_profiles() {
+    func test_seedEntries_returns_all_profiles() throws {
         let dir = tempDir()
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = SpeakerProfileStore(directory: dir)
 

--- a/MilaTests/SpeakerProfileStoreTests.swift
+++ b/MilaTests/SpeakerProfileStoreTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class SpeakerProfileStoreTests: XCTestCase {
+    private func tempDir() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("SpeakerProfileStoreTests-\(UUID().uuidString)")
+    }
+
+    func test_updateProfile_creates_new_profile() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
+
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(store.profiles[0].name, "Alice")
+        XCTAssertEqual(store.profiles[0].embedding, [1, 0, 0])
+        XCTAssertEqual(store.profiles[0].sampleCount, 1)
+    }
+
+    func test_updateProfile_merges_centroids() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 1)
+        store.updateProfile(name: "Alice", embedding: [0, 1], sampleCount: 1)
+
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(store.profiles[0].sampleCount, 2)
+        // Weighted average: (1*1 + 0*1)/2 = 0.5, (0*1 + 1*1)/2 = 0.5
+        XCTAssertEqual(store.profiles[0].embedding[0], 0.5, accuracy: 0.001)
+        XCTAssertEqual(store.profiles[0].embedding[1], 0.5, accuracy: 0.001)
+    }
+
+    func test_updateProfile_rejects_dimension_mismatch() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 1)
+
+        // Should not merge — dimension mismatch
+        XCTAssertEqual(store.profiles[0].sampleCount, 1)
+        XCTAssertEqual(store.profiles[0].embedding.count, 3)
+    }
+
+    func test_deleteProfile_by_name() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
+        store.updateProfile(name: "Bob", embedding: [2], sampleCount: 1)
+
+        store.deleteProfile(name: "Alice")
+
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(store.profiles[0].name, "Bob")
+    }
+
+    func test_renameProfile() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
+        store.renameProfile(from: "Alice", to: "Alicia")
+
+        XCTAssertEqual(store.profiles[0].name, "Alicia")
+        XCTAssertFalse(store.profileExists(name: "Alice"))
+        XCTAssertTrue(store.profileExists(name: "Alicia"))
+    }
+
+    func test_match_returns_best_above_threshold() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
+        store.updateProfile(name: "Bob", embedding: [0, 1, 0], sampleCount: 1)
+
+        // Exact match for Alice
+        let match = store.match(embedding: [1, 0, 0], threshold: 0.9)
+        XCTAssertEqual(match?.name, "Alice")
+
+        // No match above threshold
+        let noMatch = store.match(embedding: [0.5, 0.5, 0.5], threshold: 0.99)
+        XCTAssertNil(noMatch)
+    }
+
+    func test_mergeProfiles() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 2)
+        store.updateProfile(name: "Bob", embedding: [0, 1], sampleCount: 2)
+
+        let merged = store.mergeProfiles(keep: "Alice", absorb: "Bob")
+
+        XCTAssertNotNil(merged)
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(merged?.name, "Alice")
+        XCTAssertEqual(merged?.sampleCount, 4)
+        // Weighted average: (1*2 + 0*2)/4 = 0.5, (0*2 + 1*2)/4 = 0.5
+        XCTAssertEqual(merged?.embedding[0] ?? 0, 0.5, accuracy: 0.001)
+    }
+
+    func test_persistence_round_trip() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        do {
+            let store = SpeakerProfileStore(directory: dir)
+            store.updateProfile(name: "Alice", embedding: [1, 2, 3], sampleCount: 5)
+        }
+
+        let reloaded = SpeakerProfileStore(directory: dir)
+        XCTAssertEqual(reloaded.profiles.count, 1)
+        XCTAssertEqual(reloaded.profiles[0].name, "Alice")
+        XCTAssertEqual(reloaded.profiles[0].embedding, [1, 2, 3])
+        XCTAssertEqual(reloaded.profiles[0].sampleCount, 5)
+    }
+
+    func test_seedEntries_returns_all_profiles() {
+        let dir = tempDir()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = SpeakerProfileStore(directory: dir)
+
+        store.updateProfile(name: "Alice", embedding: [1], sampleCount: 3)
+        store.updateProfile(name: "Bob", embedding: [2], sampleCount: 5)
+
+        let entries = store.seedEntries()
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].name, "Alice")
+        XCTAssertEqual(entries[1].name, "Bob")
+    }
+}

--- a/MilaTests/SpeakerProfileStoreTests.swift
+++ b/MilaTests/SpeakerProfileStoreTests.swift
@@ -3,16 +3,52 @@ import XCTest
 
 @MainActor
 final class SpeakerProfileStoreTests: XCTestCase {
+
+    private var suiteNames: [String] = []
+
+    override func tearDown() async throws {
+        // Every settings object below gets its own UserDefaults suite so the
+        // opt-in flag never touches `.standard` (and never leaks between
+        // tests). Tear them all down.
+        for name in suiteNames {
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
     private func tempDir() -> URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("SpeakerProfileStoreTests-\(UUID().uuidString)")
+        TestSupport.makeTempRoot(label: "SpeakerProfileStoreTests")
+    }
+
+    /// A `VoiceRecognitionSettings` on its own throwaway suite, never
+    /// `.standard`. The setting itself is off out of the box — the point of
+    /// the feature — so `enabled` is explicit here: these tests exercise the
+    /// storage mechanics with the feature on, and
+    /// `VoiceRecognitionGateTests` covers the off state.
+    private func makeSettings(enabled: Bool, diarizationReady: Bool = true) -> VoiceRecognitionSettings {
+        let name = "SpeakerProfileStoreTests.\(UUID())"
+        suiteNames.append(name)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        settings.diarizationReady = { diarizationReady }
+        settings.isEnabled = enabled
+        return settings
+    }
+
+    /// An opted-in store rooted at `dir`. Keeps the settings object alive for
+    /// the store's lifetime by handing it back to the caller via the store's
+    /// own `settings` property.
+    private func makeStore(in dir: URL, enabled: Bool = true, diarizationReady: Bool = true) -> SpeakerProfileStore {
+        SpeakerProfileStore(directory: dir,
+                            settings: makeSettings(enabled: enabled,
+                                                   diarizationReady: diarizationReady))
     }
 
     func test_updateProfile_creates_new_profile() throws {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
 
@@ -26,7 +62,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 1)
         store.updateProfile(name: "Alice", embedding: [0, 1], sampleCount: 1)
@@ -42,7 +78,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
         store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 1)
@@ -56,7 +92,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
         store.updateProfile(name: "Bob", embedding: [2], sampleCount: 1)
@@ -71,7 +107,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1], sampleCount: 1)
         store.renameProfile(from: "Alice", to: "Alicia")
@@ -85,7 +121,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 1)
         store.updateProfile(name: "Bob", embedding: [0, 1, 0], sampleCount: 1)
@@ -103,7 +139,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1, 0], sampleCount: 2)
         store.updateProfile(name: "Bob", embedding: [0, 1], sampleCount: 2)
@@ -124,11 +160,11 @@ final class SpeakerProfileStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
 
         do {
-            let store = SpeakerProfileStore(directory: dir)
+            let store = makeStore(in: dir)
             store.updateProfile(name: "Alice", embedding: [1, 2, 3], sampleCount: 5)
         }
 
-        let reloaded = SpeakerProfileStore(directory: dir)
+        let reloaded = makeStore(in: dir)
         XCTAssertEqual(reloaded.profiles.count, 1)
         XCTAssertEqual(reloaded.profiles[0].name, "Alice")
         XCTAssertEqual(reloaded.profiles[0].embedding, [1, 2, 3])
@@ -139,7 +175,7 @@ final class SpeakerProfileStoreTests: XCTestCase {
         let dir = tempDir()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let store = SpeakerProfileStore(directory: dir)
+        let store = makeStore(in: dir)
 
         store.updateProfile(name: "Alice", embedding: [1], sampleCount: 3)
         store.updateProfile(name: "Bob", embedding: [2], sampleCount: 5)

--- a/MilaTests/VoiceProfileValidationTests.swift
+++ b/MilaTests/VoiceProfileValidationTests.swift
@@ -1,0 +1,402 @@
+import XCTest
+@testable import Mila
+
+/// `speaker-profiles.json` is untrusted input.
+///
+/// It is a plain file in Application Support: hand-editable, truncatable,
+/// restorable from a half-written backup. Decoding proves it is *syntactically*
+/// valid JSON and nothing more, and the values it can legally hold are ones the
+/// arithmetic downstream does not survive. `SpeakerProfileStore.load` therefore
+/// re-checks every decoded profile against `VoiceProfile.unusableReason` — the
+/// same invariants `updateProfile` enforces on the way in — before installing
+/// it.
+///
+/// Two distinct failure modes, and they are not the same shape:
+///
+/// 1. **`sampleCount <= 0` silently corrupts.** `seedPool` carries the stored
+///    count into the live pool and `LiveSpeakerDiarizer.assign` folds a
+///    confident match with `(centroid[i] * Float(n) + embedding[i]) /
+///    Float(n + 1)`. At `n == -1` that is a division by zero — but a `Float`
+///    one, so nothing traps: the centroid becomes ±inf/NaN, stays NaN through
+///    every later fold, and the speaker simply stops being recognised.
+/// 2. **`sampleCount == Int.max` crashes.** `updateProfile` evaluates
+///    `existing.sampleCount + sampleCount`, and Swift traps on `Int` overflow.
+///
+/// A non-finite value *stored in the embedding* would do the same damage as
+/// (1) with no fold needed, but JSON cannot express one and the decoder
+/// refuses every number too large for `Float`, so that clause is an invariant
+/// held rather than a hole plugged — asserted on the value type below, with
+/// the diarizer-level control that shows why it is worth holding.
+///
+/// Real `SpeakerProfileStore`, real `LiveSpeakerDiarizer`, real files on disk.
+/// Each guarded assertion is paired with a negative control that drives the
+/// unguarded values straight into the diarizer and shows the bad outcome
+/// actually happening, so a passing test is provably discriminating rather
+/// than merely quiet.
+@MainActor
+final class VoiceProfileValidationTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    /// Alice, as stored on disk.
+    private let aliceStored: [Float] = [1, 0, 0, 0]
+    /// Alice speaking — cosine ~0.99995 against `aliceStored`, comfortably a
+    /// confident match at the 0.7 threshold used below.
+    private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "VoiceProfileValidationTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    private var profilesFile: URL {
+        tempRoot.appendingPathComponent("speaker-profiles.json")
+    }
+
+    private func makeSettings() -> VoiceRecognitionSettings {
+        let name = "VoiceProfileValidationTests.\(UUID())"
+        suiteNames.append(name)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        settings.diarizationReady = { true }
+        settings.isEnabled = true
+        return settings
+    }
+
+    private func profile(name: String,
+                         embedding: [Float],
+                         sampleCount: Int) -> VoiceProfile {
+        VoiceProfile(id: UUID(),
+                     name: name,
+                     embedding: embedding,
+                     sampleCount: sampleCount,
+                     createdAt: Date(),
+                     lastSeenAt: Date())
+    }
+
+    /// Write profiles straight to disk, bypassing the store entirely — the
+    /// only way to produce values `updateProfile` would have refused.
+    private func writeProfilesFile(_ profiles: [VoiceProfile]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(profiles).write(to: profilesFile)
+    }
+
+    /// Write the file as literal text, for shapes no encoder will produce.
+    private func writeRawProfilesFile(_ json: String) throws {
+        try Data(json.utf8).write(to: profilesFile)
+    }
+
+    /// An opted-in store over `tempRoot`, so `init` runs `load()`.
+    private func openStore() -> SpeakerProfileStore {
+        SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+    }
+
+    private func makeDiarizer() -> LiveSpeakerDiarizer {
+        let d = LiveSpeakerDiarizer()
+        d.similarityThreshold = 0.7
+        return d
+    }
+
+    // MARK: - 1. A non-positive sampleCount never reaches the pool
+
+    func test_a_negative_sampleCount_profile_is_dropped_at_load() throws {
+        try writeProfilesFile([profile(name: "Alice", embedding: aliceStored, sampleCount: -1)])
+
+        let store = openStore()
+
+        XCTAssertTrue(store.profiles.isEmpty, "a negative sampleCount is not a usable profile")
+        XCTAssertTrue(store.seedEntries().isEmpty, "and nothing reaches the diarizer")
+    }
+
+    /// Zero is not the divide-by-zero case — `Float(0 + 1)` is a perfectly
+    /// good divisor. It is refused because a centroid that is the mean of no
+    /// observations describes nobody, and because `updateProfile` has always
+    /// refused to write one. `-1` is the arithmetic hazard; `0` is the
+    /// nonsense one, and both are caught by the same clause.
+    func test_a_zero_sampleCount_profile_is_dropped_at_load() throws {
+        try writeProfilesFile([profile(name: "Alice", embedding: aliceStored, sampleCount: 0)])
+
+        XCTAssertTrue(openStore().profiles.isEmpty,
+                      "refused on write, so refused on read")
+    }
+
+    /// Negative control, and the whole point of the guard: hand the diarizer
+    /// the *unvalidated* stored values and the fold destroys the centroid.
+    ///
+    /// The corruption is silent — no trap, no error, no log. It shows up as
+    /// the same voice, twice in a row, landing on two different speakers:
+    /// once the centroid is NaN, `cosineSimilarity` returns NaN for that
+    /// entry forever and it can never match again.
+    func test_an_unvalidated_negative_count_poisons_the_pool_centroid() {
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        // Exactly what `seedPool` would have received from an unguarded load.
+        diarizer.seedPool(with: [(id: "Alice", name: "Alice",
+                                  centroid: aliceStored, sampleCount: -1)])
+
+        // First utterance: a confident match, so it folds — divisor
+        // `Float(-1 + 1)` == 0.
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "precondition: it must match confidently, or nothing folds")
+
+        // Second, identical utterance from the same person: no longer Alice.
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_01",
+                       "the poisoned centroid can never match again — this is the damage the guard prevents")
+    }
+
+    /// Positive control for the control: with a sound count the very same
+    /// fixture matches both times, so the assertion above is discriminating
+    /// rather than an artefact of the embeddings or the threshold.
+    func test_a_sound_count_folds_and_keeps_matching() {
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: [(id: "Alice", name: "Alice",
+                                  centroid: aliceStored, sampleCount: 3)])
+
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "a valid count folds cleanly and the speaker stays recognised")
+    }
+
+    /// End to end through the guard: the corrupt file yields an empty seed, so
+    /// the speaker is minted fresh and — unlike the poisoned case — keeps
+    /// matching itself.
+    func test_with_the_guard_a_corrupt_file_costs_recognition_not_correctness() throws {
+        try writeProfilesFile([profile(name: "Alice", embedding: aliceStored, sampleCount: -1)])
+        let store = openStore()
+
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: store.seedEntries())
+
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "the pool still works — it just doesn't know this voice is Alice")
+        XCTAssertNil(diarizer.currentProfiles().first?.profileName,
+                     "and it is an unnamed speaker, not a mislabelled Alice")
+    }
+
+    /// The persistence side of the same divisor, and the reason this is worth
+    /// catching at the boundary rather than at each fold: `updateProfile` and
+    /// `mergeProfiles` compute their own weighted means, and a stored `-1`
+    /// meeting one new sample makes `Float(totalCount)` zero there too. The
+    /// resulting NaN is worse than an unrecognised speaker — `JSONEncoder`
+    /// refuses to encode it, so `save()` throws and the store silently stops
+    /// persisting *anything* for the rest of the session.
+    ///
+    /// Necessarily arithmetic rather than driven through the store: with the
+    /// guard in place a `-1` can no longer reach `profiles` to be folded.
+    func test_a_zero_divisor_fold_yields_a_value_that_cannot_be_saved() {
+        let existingCount = -1   // as decoded from the file
+        let newCount = 1         // one observation from this recording
+        let totalCount = existingCount + newCount
+        let merged = (Float(1) * Float(existingCount) + Float(1) * Float(newCount))
+                     / Float(totalCount)
+
+        XCTAssertTrue(merged.isNaN, "the weighted fold divides by Float(0)")
+        XCTAssertThrowsError(try JSONEncoder().encode([merged]),
+                             "and JSONEncoder refuses a NaN, so save() throws and nothing persists")
+    }
+
+    // MARK: - 2. A non-finite embedding never reaches the pool
+
+    /// Checked on the value rather than through a file, because **JSON cannot
+    /// carry a non-finite Float**: there is no NaN or Infinity literal, and a
+    /// number too large for `Float` fails the parse (see the test below). The
+    /// clause is the arithmetic invariant, asserted where it can be asserted;
+    /// the negative control that follows is why it is worth stating at all.
+    func test_a_non_finite_embedding_is_not_a_usable_profile() {
+        XCTAssertNotNil(profile(name: "NaN", embedding: [.nan, 0, 0, 0], sampleCount: 4)
+                            .unusableReason)
+        XCTAssertNotNil(profile(name: "Inf", embedding: [1, .infinity, 0, 0], sampleCount: 4)
+                            .unusableReason)
+        XCTAssertNil(profile(name: "Alice", embedding: aliceStored, sampleCount: 4)
+                        .unusableReason,
+                     "positive control: a sound profile has no reason to be rejected")
+    }
+
+    /// The reachable half of the same story, and the one exception to
+    /// per-entry dropping: a number the decoder cannot represent fails inside
+    /// `decode`, before any entry exists, so the whole file is refused. The
+    /// store is left empty rather than partially populated — and, crucially,
+    /// does not go on to overwrite the file.
+    func test_an_unrepresentable_number_rejects_the_whole_file() throws {
+        try writeRawProfilesFile("""
+        [{"id":"\(UUID().uuidString)","name":"Alice","embedding":[1e39,0,0,0],\
+        "sampleCount":4,"createdAt":"2026-01-01T00:00:00Z","lastSeenAt":"2026-01-01T00:00:00Z"}]
+        """)
+        let before = try Data(contentsOf: profilesFile)
+
+        let store = openStore()
+
+        XCTAssertTrue(store.profiles.isEmpty, "1e39 overflows Float, so the parse fails outright")
+        XCTAssertTrue(store.hasStoredProfilesOnDisk,
+                      "…but Settings still knows there is a file to offer deleting")
+        XCTAssertEqual(try Data(contentsOf: profilesFile), before, "and it is left untouched")
+    }
+
+    /// Negative control: a NaN centroid needs no fold to do damage. `assign`
+    /// picks its best match with `sim > best.sim`, which is **false** for NaN,
+    /// so a NaN entry that is reached first captures `best` and nothing can
+    /// displace it — including the real, perfectly good profile behind it.
+    func test_an_unvalidated_nan_centroid_shadows_the_real_profile() {
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: [
+            (id: "Corrupt", name: "Corrupt", centroid: [Float.nan, 0, 0, 0], sampleCount: 4),
+            (id: "Alice", name: "Alice", centroid: aliceStored, sampleCount: 4)
+        ])
+
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_02",
+                       "Alice is at SPEAKER_01 and matches perfectly, but the NaN entry ahead of her wins `best`")
+    }
+
+    /// Positive control: drop the NaN entry — the only change — and Alice is
+    /// found. Same embeddings, same threshold.
+    func test_without_the_nan_entry_the_real_profile_is_found() {
+        let diarizer = makeDiarizer()
+        diarizer.reset()
+        diarizer.seedPool(with: [(id: "Alice", name: "Alice",
+                                  centroid: aliceStored, sampleCount: 4)])
+
+        XCTAssertEqual(diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        XCTAssertEqual(diarizer.currentProfiles().first?.profileName, "Alice")
+    }
+
+    // MARK: - 3. An out-of-range sampleCount never reaches the arithmetic
+
+    func test_an_int_max_sampleCount_is_dropped_at_load() throws {
+        try writeProfilesFile([profile(name: "Alice", embedding: aliceStored, sampleCount: .max)])
+
+        XCTAssertTrue(openStore().profiles.isEmpty,
+                      "Int.max is not a sample count, it is a crash waiting for the next rename")
+    }
+
+    /// Negative control for the overflow, stated rather than executed: running
+    /// the unguarded addition would trap and take the whole test runner with
+    /// it, which is precisely the outcome under test. `addingReportingOverflow`
+    /// asks the same question without dying of the answer.
+    func test_the_unguarded_addition_would_have_trapped() {
+        let stored = Int.max          // as decoded from the file
+        let observed = 1              // one utterance, the ordinary case
+        XCTAssertTrue(stored.addingReportingOverflow(observed).overflow,
+                      "`existing.sampleCount + sampleCount` in updateProfile traps on these operands")
+
+        // And the ceiling is chosen so that any two *valid* counts cannot:
+        let ceiling = VoiceProfile.maxSampleCount
+        XCTAssertFalse(ceiling.addingReportingOverflow(ceiling).overflow,
+                       "two profiles at the ceiling must still be mergeable")
+    }
+
+    /// The ceiling admits every count a real store could ever hold, so the
+    /// guard rejects corruption and nothing else.
+    func test_a_large_but_plausible_sampleCount_still_loads() throws {
+        try writeProfilesFile([profile(name: "Alice", embedding: aliceStored, sampleCount: 1_000_000)])
+
+        XCTAssertEqual(openStore().profiles.first?.sampleCount, 1_000_000)
+    }
+
+    // MARK: - 4. Nothing to label with, or nothing to match against
+
+    func test_a_nameless_or_embeddingless_profile_is_dropped_at_load() throws {
+        try writeProfilesFile([
+            profile(name: "", embedding: aliceStored, sampleCount: 4),
+            profile(name: "   ", embedding: aliceStored, sampleCount: 4),
+            profile(name: "Alice", embedding: [], sampleCount: 4)
+        ])
+
+        XCTAssertTrue(openStore().profiles.isEmpty,
+                      "nothing to label with, or nothing to match against")
+    }
+
+    // MARK: - 5. One bad entry does not cost the good ones
+
+    /// The decision on what to do with an invalid profile: drop that entry and
+    /// log it, never reject the file. A single hand-broken profile must not
+    /// destroy every other voice the user has trained.
+    func test_a_corrupt_entry_does_not_take_the_rest_of_the_file_with_it() throws {
+        try writeProfilesFile([
+            profile(name: "Broken", embedding: aliceStored, sampleCount: -1),
+            profile(name: "Alice", embedding: aliceStored, sampleCount: 40),
+            profile(name: "Bob", embedding: [0, 1, 0, 0], sampleCount: 7)
+        ])
+
+        let store = openStore()
+
+        XCTAssertEqual(store.profiles.map(\.name), ["Alice", "Bob"],
+                       "the sound profiles survive, in order")
+        XCTAssertNil(store.profile(named: "Broken"))
+        XCTAssertEqual(store.seedEntries().count, 2)
+    }
+
+    /// And the drop is in memory only — `load` does not rewrite the file, so a
+    /// user who broke it by hand can still fix it by hand.
+    func test_dropping_an_entry_does_not_rewrite_the_file() throws {
+        try writeProfilesFile([
+            profile(name: "Broken", embedding: aliceStored, sampleCount: -1),
+            profile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        ])
+        let before = try Data(contentsOf: profilesFile)
+
+        _ = openStore()
+
+        XCTAssertEqual(try Data(contentsOf: profilesFile), before,
+                       "loading is a read; the bad entry stays on disk until something legitimately saves")
+    }
+
+    // MARK: - 6. The write path enforces the same invariants
+
+    /// Read and write validate identically on purpose: the store must never
+    /// accept something it would refuse to load back, or the profile would
+    /// silently vanish on the next launch.
+    func test_updateProfile_refuses_what_load_would_refuse() {
+        let store = openStore()
+
+        store.updateProfile(name: "NaN", embedding: [.nan, 0, 0, 0], sampleCount: 1)
+        store.updateProfile(name: "Inf", embedding: [1, .infinity, 0, 0], sampleCount: 1)
+        store.updateProfile(name: "TooMany", embedding: aliceStored, sampleCount: .max)
+        store.updateProfile(name: "Negative", embedding: aliceStored, sampleCount: -1)
+        store.updateProfile(name: "   ", embedding: aliceStored, sampleCount: 1)
+        store.updateProfile(name: "Empty", embedding: [], sampleCount: 1)
+
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: profilesFile.path),
+                       "and nothing unusable was written to disk either")
+    }
+
+    /// Positive control: the same call with sound values does store.
+    func test_updateProfile_still_accepts_a_sound_profile() {
+        let store = openStore()
+
+        store.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 1)
+
+        XCTAssertEqual(store.profiles.map(\.name), ["Alice"])
+    }
+
+    /// Round trip: everything `updateProfile` accepted comes back on reload.
+    /// The two guards agreeing is what this pins — a validator stricter than
+    /// the writer would eat the user's profiles at launch.
+    func test_everything_written_survives_a_reload() {
+        do {
+            let store = openStore()
+            store.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+            store.updateProfile(name: "Bob", embedding: [0, 1, 0, 0], sampleCount: 7)
+            XCTAssertEqual(store.profiles.count, 2)
+        }
+
+        let reloaded = openStore()
+        XCTAssertEqual(reloaded.profiles.map(\.name), ["Alice", "Bob"])
+        XCTAssertEqual(reloaded.profiles.map(\.sampleCount), [40, 7])
+    }
+}

--- a/MilaTests/VoiceRecognitionGateTests.swift
+++ b/MilaTests/VoiceRecognitionGateTests.swift
@@ -273,6 +273,157 @@ final class VoiceRecognitionGateTests: XCTestCase {
                        "an off-state mutation must not rewrite speaker-profiles.json")
     }
 
+    // MARK: - Opting out *during* a recording
+
+    /// Alice, as stored on disk.
+    private var aliceStored: [Float] { [1, 0, 0, 0] }
+    /// Close enough to Alice to be a confident match at threshold 0.7.
+    private var aliceSpeaking: [Float] { [0.99, 0.01, 0, 0] }
+
+    /// A recording already under way with Alice's stored profile seeded into
+    /// the pool, exactly as `MilaApp` sets one up.
+    ///
+    /// `poolObserver` is the fix under test. It defaults to on — the
+    /// shipping wiring — and the negative control below switches it off to
+    /// reconstruct the pre-fix shape, so the assertions are provably
+    /// discriminating rather than vacuously true.
+    private func startedRecordingWithAliceSeeded(
+        poolObserver: Bool = true
+    ) -> (settings: VoiceRecognitionSettings,
+          profiles: SpeakerProfileStore,
+          snapshots: ObservedVoiceSnapshots,
+          diarizer: LiveSpeakerDiarizer) {
+        let settings = makeSettings()
+        settings.isEnabled = true
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+
+        // Same wiring MilaApp.init installs, in the same order.
+        let snapshots = ObservedVoiceSnapshots()
+        snapshots.clearOnOptOut(of: settings)
+        if poolObserver {
+            settings.addEnabledObserver { [weak diarizer] nowEnabled in
+                guard !nowEnabled else { return }
+                diarizer?.forgetSeededProfiles()
+            }
+        }
+
+        // Record-start: reset, then seed behind the gate.
+        diarizer.reset()
+        XCTAssertTrue(settings.isConfigured)
+        diarizer.seedPool(with: profiles.seedEntries())
+        XCTAssertEqual(diarizer.currentProfiles().first?.profileName, "Alice",
+                       "precondition: the pool holds a copy of Alice's centroid")
+        return (settings, profiles, snapshots, diarizer)
+    }
+
+    /// **The invariant.** Opting out mid-recording has to stop the *reads*,
+    /// not just the writes.
+    ///
+    /// `seedPool` gave the diarizer its own copy of every stored centroid at
+    /// record-start, so unloading `SpeakerProfileStore.profiles` and
+    /// dropping the snapshots — the two things opting out used to do —
+    /// leaves `assign` matching against stored voices for the rest of the
+    /// recording. The persistence gates mean nothing is written back, but
+    /// the user still watches their transcript fill with names produced by a
+    /// feature they just switched off. Same shape as deleting a profile
+    /// mid-recording, and it gets the same remedy.
+    func test_opting_out_mid_recording_stops_the_pool_matching_a_stored_voice() {
+        let w = startedRecordingWithAliceSeeded()
+
+        w.settings.isEnabled = false
+
+        // Alice speaks after the opt-out. Her seeded entry was never heard
+        // in this recording, so it has nothing of its own to fall back to:
+        // it is inert, `assign` skips it, and she is simply somebody new.
+        XCTAssertNotEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                          "a stored voice must not be recognised after opting out")
+        XCTAssertTrue(w.diarizer.currentProfiles().allSatisfy { $0.profileName == nil },
+                      "no pool entry may still carry a stored profile name")
+    }
+
+    /// Negative control: the same scenario with the observer unwired, which
+    /// is what shipped before this fix. Alice is still recognised, under her
+    /// stored name. If this ever starts failing, the test above has stopped
+    /// proving anything.
+    func test_control_without_the_observer_a_stored_voice_survives_the_opt_out() {
+        let w = startedRecordingWithAliceSeeded(poolObserver: false)
+
+        w.settings.isEnabled = false
+
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "pre-fix shape: the pool goes on matching the stored centroid")
+        XCTAssertEqual(w.diarizer.currentProfiles().first?.profileName, "Alice",
+                       "pre-fix shape: and it still knows her name")
+    }
+
+    /// The other half of the opt-out, and the reason this neutralises rather
+    /// than removes: a speaker who *was* heard before the switch flipped
+    /// keeps their id for the rest of the recording, from what this
+    /// recording itself observed. Diarization is not what was switched off —
+    /// cross-recording recognition is — so the transcript stays coherent
+    /// while the stored identity is gone.
+    ///
+    /// Do not "fix" this into minting a new id: it would fork one person
+    /// across two speakers mid-transcript, and it is the name, not the
+    /// separation, that opting out revokes.
+    func test_opting_out_keeps_an_already_heard_speaker_coherent_but_nameless() {
+        let w = startedRecordingWithAliceSeeded()
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "precondition: Alice matched while the feature was on")
+
+        w.settings.isEnabled = false
+
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "in-recording continuity is deliberate")
+        XCTAssertNil(w.diarizer.currentProfiles().first?.profileName,
+                     "…but the stored name is gone, so nothing can auto-apply it")
+        XCTAssertTrue(w.profiles.profiles.isEmpty)
+        XCTAssertTrue(w.snapshots.heldRecordingCount == 0)
+    }
+
+    /// Ordering: a recording that stops *immediately* after the opt-out.
+    ///
+    /// `RecognisedSpeakerAssigner.finish` is gated on `isConfigured`, so it
+    /// returns before naming anything or taking a snapshot — the opt-out
+    /// wins whichever way the two land, and the three opt-out observers are
+    /// independent removals from three different holders, so their order
+    /// does not matter either.
+    ///
+    /// This one already held before the pool observer above existed, and it
+    /// is pinned here precisely because it is what makes that observer's job
+    /// small: stop is already safe, so the observer only has to cover the
+    /// *rest of the recording*. If this ever regresses, the opt-out stops
+    /// being fail-closed at both ends rather than one.
+    func test_stopping_right_after_an_opt_out_names_nothing_and_stores_nothing() {
+        let w = startedRecordingWithAliceSeeded()
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let recording = Recording(title: "Standup",
+                                  duration: 30,
+                                  source: .microphone,
+                                  audioFileName: "standup.wav")
+        recordings.add(recording)
+        let assigner = RecognisedSpeakerAssigner(
+            store: recordings,
+            diarizer: w.diarizer,
+            snapshots: w.snapshots,
+            settings: w.settings,
+            profileStillStored: { w.profiles.profileExists(name: $0) })
+
+        w.settings.isEnabled = false
+        assigner.finish(recording: recording.id)
+
+        XCTAssertTrue(recordings.recordings.first?.speakerNames.isEmpty ?? false,
+                      "no speaker may be auto-named from a feature just switched off")
+        XCTAssertEqual(w.snapshots.heldRecordingCount, 0,
+                       "and no embeddings may be retained for the stopped recording")
+    }
+
     // MARK: - The explicit delete path
 
     /// Deletion is the one operation that must work *while off* — that's

--- a/MilaTests/VoiceRecognitionGateTests.swift
+++ b/MilaTests/VoiceRecognitionGateTests.swift
@@ -1,0 +1,305 @@
+import XCTest
+@testable import Mila
+
+/// Tests for the **opt-in gate** on cross-recording voice recognition —
+/// separate from `SpeakerProfileStoreTests`, which covers the storage
+/// mechanics with the feature already on.
+///
+/// The thing under test here is the off state, because that's the state a
+/// user who never opts in lives in forever, and it's the one that silently
+/// regresses: the feature keeps working, so nothing fails, and voice
+/// fingerprints quietly start appearing on disk anyway. The promise is
+/// stronger than "stored but unused" — while off, nothing is written,
+/// nothing is read back, and the diarizer is seeded with nothing.
+@MainActor
+final class VoiceRecognitionGateTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "VoiceRecognitionGateTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        // Never `.standard`: each settings object gets a throwaway suite.
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func isolatedDefaults() -> UserDefaults {
+        let name = "VoiceRecognitionGateTests.\(UUID())"
+        suiteNames.append(name)
+        return UserDefaults(suiteName: name)!
+    }
+
+    /// `diarizationReady` defaults to true so a test that flips `isEnabled`
+    /// is testing *only* the opt-in half of the gate.
+    private func makeSettings(diarizationReady: Bool = true,
+                              defaults: UserDefaults? = nil) -> VoiceRecognitionSettings {
+        let settings = VoiceRecognitionSettings(defaults: defaults ?? isolatedDefaults())
+        settings.diarizationReady = { diarizationReady }
+        return settings
+    }
+
+    private var profilesFile: URL {
+        tempRoot.appendingPathComponent("speaker-profiles.json")
+    }
+
+    /// Write a profiles file directly, as a previous opt-in would have left
+    /// behind, without going through the store.
+    private func seedProfilesFileOnDisk() throws {
+        let profile = VoiceProfile(id: UUID(),
+                                   name: "Alice",
+                                   embedding: [1, 0, 0],
+                                   sampleCount: 4,
+                                   createdAt: Date(),
+                                   lastSeenAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode([profile]).write(to: profilesFile)
+    }
+
+    // MARK: - Default state
+
+    /// The headline requirement: a fresh install has the feature off.
+    func test_disabled_by_default_on_a_fresh_install() {
+        let settings = makeSettings()
+        XCTAssertFalse(settings.isEnabled)
+        XCTAssertFalse(settings.isConfigured)
+    }
+
+    /// The key is namespaced per the repo convention, and its absence — not
+    /// merely a stored `false` — is what yields the off default. Asserted on
+    /// the literal so a rename has to be deliberate: the persisted key is
+    /// what decides whether an existing user's choice survives an upgrade.
+    func test_persisted_key_is_namespaced_and_unset_by_default() {
+        let defaults = isolatedDefaults()
+        XCTAssertNil(defaults.object(forKey: "speakers.voiceRecognition.enabled"))
+
+        let settings = makeSettings(defaults: defaults)
+        XCTAssertFalse(settings.isEnabled)
+
+        settings.isEnabled = true
+        XCTAssertEqual(defaults.object(forKey: "speakers.voiceRecognition.enabled") as? Bool, true)
+    }
+
+    /// A persisted opt-in survives a relaunch (same suite, new object).
+    func test_opt_in_persists_across_relaunch() {
+        let defaults = isolatedDefaults()
+        makeSettings(defaults: defaults).isEnabled = true
+
+        let relaunched = makeSettings(defaults: defaults)
+        XCTAssertTrue(relaunched.isEnabled)
+    }
+
+    // MARK: - isConfigured: enabled AND ready, per .claude/rules/feature-gates.md
+
+    func test_isConfigured_requires_both_halves() {
+        let onAndReady = makeSettings(diarizationReady: true)
+        onAndReady.isEnabled = true
+        XCTAssertTrue(onAndReady.isConfigured)
+
+        // Enabled, but the embedding pipeline can't produce anything.
+        let onNotReady = makeSettings(diarizationReady: false)
+        onNotReady.isEnabled = true
+        XCTAssertFalse(onNotReady.isConfigured,
+                       "enabled alone must never satisfy isConfigured")
+
+        // Ready, but the user never opted in.
+        let offButReady = makeSettings(diarizationReady: true)
+        XCTAssertFalse(offButReady.isConfigured)
+    }
+
+    /// A forgotten `diarizationReady` injection must fail closed (nothing
+    /// stored), not open.
+    func test_isConfigured_fails_closed_when_readiness_is_unwired() {
+        let settings = VoiceRecognitionSettings(defaults: isolatedDefaults())
+        settings.isEnabled = true
+        XCTAssertNil(settings.diarizationReady)
+        XCTAssertFalse(settings.isConfigured)
+    }
+
+    // MARK: - While off: nothing is written
+
+    /// Naming a speaker while off must not persist an embedding — not to
+    /// memory, and above all not to disk.
+    func test_while_off_updateProfile_writes_nothing() {
+        let store = SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 3)
+
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: profilesFile.path),
+                       "speaker-profiles.json must not exist for a user who never opted in")
+    }
+
+    /// The same guarantee via the real call path: `RecordingStore` fires
+    /// `onSpeakerNamed` when the user names a speaker, wired here exactly as
+    /// `MilaApp` wires it. With the feature off, that hook must not turn a
+    /// rename into stored voice data.
+    func test_while_off_naming_a_speaker_persists_no_embedding() {
+        let settings = makeSettings()
+        let profileStore = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        let recordings = RecordingStore(rootDirectory: tempRoot)
+        let recording = Recording(title: "Standup",
+                                  duration: 30,
+                                  source: .microphone,
+                                  audioFileName: "standup.wav")
+        recordings.add(recording)
+
+        // Same shape as MilaApp.init: gate at the call site, then persist.
+        recordings.onSpeakerNamed = { _, _, name in
+            guard settings.isConfigured else { return }
+            profileStore.updateProfile(name: name, embedding: [1, 0, 0], sampleCount: 2)
+        }
+
+        recordings.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: recording.id)
+
+        // The per-recording label is unaffected — naming speakers keeps
+        // working with the feature off, it just doesn't learn voices.
+        XCTAssertEqual(recordings.recordings.first?.speakerNames["SPEAKER_00"], "Alice")
+        XCTAssertTrue(profileStore.profiles.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: profilesFile.path))
+    }
+
+    /// Enabled but diarization not ready is still off as far as storage is
+    /// concerned — `isConfigured`, not `isEnabled`, guards the writes.
+    func test_enabled_but_diarization_not_ready_writes_nothing() {
+        let settings = makeSettings(diarizationReady: false)
+        settings.isEnabled = true
+        let store = SpeakerProfileStore(directory: tempRoot, settings: settings)
+
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 3)
+
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: profilesFile.path))
+    }
+
+    // MARK: - While off: nothing is read, nothing is seeded
+
+    /// A profiles file left over from an earlier opt-in is not even parsed
+    /// while the feature is off, so no embedding reaches memory.
+    func test_while_off_an_existing_profiles_file_is_not_loaded() throws {
+        try seedProfilesFileOnDisk()
+
+        let store = SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+
+        XCTAssertTrue(store.profiles.isEmpty, "off must not read voice data back into memory")
+        XCTAssertTrue(store.hasStoredProfilesOnDisk,
+                      "…but Settings still needs to know the file is there, to offer deletion")
+    }
+
+    /// No seeding while off: the diarizer starts every recording from a
+    /// blank pool.
+    func test_while_off_seedEntries_and_match_return_nothing() throws {
+        try seedProfilesFileOnDisk()
+        let store = SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+
+        XCTAssertTrue(store.seedEntries().isEmpty)
+        XCTAssertNil(store.match(embedding: [1, 0, 0], threshold: 0.1))
+    }
+
+    /// And the diarizer end of that: seeding with nothing leaves the pool
+    /// empty, so no pool entry carries a `profileName` and nothing can be
+    /// auto-assigned.
+    func test_seeding_an_empty_set_leaves_the_diarizer_pool_empty() {
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.reset()
+
+        diarizer.seedPool(with: [])
+
+        XCTAssertTrue(diarizer.currentProfiles().isEmpty)
+    }
+
+    // MARK: - Enable, then disable
+
+    /// The decision on opting out: stored profiles are **kept on disk** (so
+    /// re-enabling picks up where the user left off) but dropped out of
+    /// memory immediately, so nothing can be seeded or matched from them.
+    func test_disabling_drops_profiles_from_memory_but_keeps_the_file() {
+        let settings = makeSettings()
+        settings.isEnabled = true
+        let store = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 3)
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: profilesFile.path))
+
+        settings.isEnabled = false
+
+        XCTAssertTrue(store.profiles.isEmpty, "opting out must unload the embeddings")
+        XCTAssertTrue(store.seedEntries().isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: profilesFile.path),
+                      "opting out is not a delete — the file stays until the user says otherwise")
+        XCTAssertTrue(store.hasStoredProfilesOnDisk)
+    }
+
+    /// Re-enabling in the same session restores them without a relaunch.
+    func test_re_enabling_restores_the_stored_profiles() {
+        let settings = makeSettings()
+        settings.isEnabled = true
+        let store = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        store.updateProfile(name: "Alice", embedding: [1, 0, 0], sampleCount: 3)
+
+        settings.isEnabled = false
+        XCTAssertTrue(store.profiles.isEmpty)
+
+        settings.isEnabled = true
+
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(store.profiles.first?.name, "Alice")
+        XCTAssertEqual(store.seedEntries().count, 1)
+    }
+
+    /// The trap on the other side of "keep the file": while off, `profiles`
+    /// is empty, so any mutation that reaches `save()` would overwrite the
+    /// stored file with `[]` and destroy exactly the data we promised to
+    /// keep. `save()` refuses while off.
+    func test_a_mutation_while_off_cannot_clobber_the_stored_file() throws {
+        try seedProfilesFileOnDisk()
+        let before = try Data(contentsOf: profilesFile)
+        let store = SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+
+        store.deleteProfile(name: "Alice")
+        store.renameProfile(from: "Alice", to: "Alicia")
+
+        XCTAssertEqual(try Data(contentsOf: profilesFile), before,
+                       "an off-state mutation must not rewrite speaker-profiles.json")
+    }
+
+    // MARK: - The explicit delete path
+
+    /// Deletion is the one operation that must work *while off* — that's
+    /// when somebody wants their voice data gone. It removes the file rather
+    /// than writing an empty array, so nothing is left at rest.
+    func test_deleteAllProfiles_works_while_off_and_removes_the_file() throws {
+        try seedProfilesFileOnDisk()
+        let store = SpeakerProfileStore(directory: tempRoot, settings: makeSettings())
+        XCTAssertTrue(store.hasStoredProfilesOnDisk)
+
+        store.deleteAllProfiles()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: profilesFile.path))
+        XCTAssertFalse(store.hasStoredProfilesOnDisk)
+        XCTAssertTrue(store.profiles.isEmpty)
+    }
+
+    /// And after deleting, re-enabling brings nothing back.
+    func test_after_delete_re_enabling_restores_nothing() throws {
+        try seedProfilesFileOnDisk()
+        let settings = makeSettings()
+        let store = SpeakerProfileStore(directory: tempRoot, settings: settings)
+
+        store.deleteAllProfiles()
+        settings.isEnabled = true
+
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertTrue(store.seedEntries().isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #24

## Credit: this feature is @noamleibovitch's work

**Cross-recording voice recognition was designed and written by
@noamleibovitch. This PR relays it — it supersedes #198, which is where the
work actually happened.** Six of his commits are cherry-picked unmodified, so
he is the `Author` on every one of them; everything I added sits in a single
commit on top, and it is a feature gate plus tests, not the feature.

> **On the `Co-authored-by` trailer.** My commit carries
> `Co-authored-by: noamleibovitch <noam@example.com>`, and that address will
> not link to his GitHub account. It is not a transcription error on my part:
> `gh api repos/island-io/mila/pulls/198/commits --jq '.[].commit.author'`
> returns `noam@example.com` for all nine of his commits — a placeholder in
> his local git config — and it is the same address recorded as `Author` on
> the cherry-picked commits here. I used it verbatim rather than substituting
> a guess. The `@noamleibovitch` handle above is therefore the attribution
> that actually resolves; please read the credit from it, not from the
> trailer.

The two commits in #198 that added and then removed an unrelated `/review`
skill cancelled out exactly (105 lines added, 105 removed) and were dropped.
Nothing else was rewritten.

It is relayed rather than merged for the usual reason (the #129 → #164
precedent): a fork PR can't get a CodeRabbit review under the contributor's
own quota, and its CI needs per-run approval. Please close #198 as superseded
by this once it's green.

## What & why

Cross-recording voice recognition. When you name a speaker, their 256-dim
voice embedding is persisted to `speaker-profiles.json`; new recordings seed
the live diarizer's pool with known profiles, so a returning speaker is
identified without being renamed again. Same design as #198:

- **`SpeakerProfileStore`** — persistence, centroid merging, cosine-similarity
  matching, CRUD.
- **`LiveSpeakerDiarizer.seedPool(with:)` / `currentProfiles()`** — pre-populate
  the pool with known speakers; snapshot it for persistence.
- **`RecordingStore.onSpeakerNamed`** — hook that fires when the user names a
  speaker, so the profile is saved from the existing `SpeakerNamePicker` flow.
- **`MilaApp`** — seeds at recording start, auto-assigns recognised names on
  stop (only for speakers who actually spoke, verified against
  `diarizer.intervals`).

### The one behavioural change: it is opt-in and off by default

Maintainer's call. As it stood, the feature persisted embeddings and seeded
recognition on its own. It now does nothing at all until the user turns it on.

**New setting** — `VoiceRecognitionSettings`, key
`speakers.voiceRecognition.enabled`, default off. Follows the house shape
(`DiarizationSettings`, `VoiceMemosSettings`): `@Published` writing through to
a namespaced key with an injectable `defaults` suite. Instantiated in
`MilaApp.init()` as a `@StateObject` and injected via `.environmentObject()` on
both the main window and the Settings scene.

**The gate is `isConfigured`, not `isEnabled`** (per
`.claude/rules/feature-gates.md`): `isEnabled && diarizationReady()`, where
readiness is injected as a read of `DiarizationSettings.isConfigured`. Voice
recognition owns no embedding pipeline of its own — every centroid it stores or
matches comes out of the live diarizer's pool, which is only populated while
diarization is enabled *and* its local Python pipeline is verified. Acting on
the toggle alone would mean seeding an empty pool and writing profiles that
could never be recognised. An unwired `diarizationReady` returns false, so a
forgotten injection fails closed.

**While off, nothing is written and nothing is read** — the promise is "never
stored", not "stored but ignored". Every step of the path is closed:

| Path | While off |
|---|---|
| Naming a speaker (`RecordingStore.onSpeakerNamed` → `updateProfile`) | Gated at the call site in `MilaApp`, so the centroid is never even read out of the diarizer pool; `updateProfile` refuses again. |
| Seeding a new recording (`seedPool` ← `seedEntries`) | Gated at the call site; `seedEntries()` returns `[]`; and `profiles` is empty anyway. |
| Auto-assign on stop (`autoAssignRecognisedSpeakers`) | Returns immediately. |
| Reading `speaker-profiles.json` | Not parsed at all — `load()` only runs on opt-in, so no embedding reaches memory. |
| Writing `speaker-profiles.json` | `save()` refuses. |

Also fixed on the way through: a `try!` in the store's production init (a
missing Application Support directory would have crashed at launch — now the
non-throwing lookup + temp fallback `SpeakerDirectory` uses, including the
`--ui-test-clean-store` branch), the store's own `UserDefaults.standard`
access (moved to the injectable settings object so tests never touch
`.standard`), and an unused `[weak store, weak diarSettings]` capture that was
producing two build warnings.

### Judgement call 1: what happens to already-stored profiles on opt-out

**Decided: keep them on disk, drop them from memory, and keep an explicit
"Delete Voice Profiles" button visible — including while the feature is off.**

Deleting on toggle-off is destructive and surprising. A user switching off to
stop *further* learning, or fat-fingering the switch, would silently lose every
named voice with no undo, and no settings toggle should behave like that.
Leaving them silently is the other failure: voice biometrics staying at rest
after somebody opted out, with nothing in the UI admitting it.

The button resolves both. Opting out takes effect completely and immediately —
nothing loaded, nothing seeded, nothing written — and separately, whenever a
profiles file exists, Settings says so and offers to delete it. Deletion is
therefore an explicit, informed decision rather than a side effect, it works
*while off* (which is exactly when somebody wants their voice data gone), and
it removes the file rather than writing an empty array over it, so nothing is
left at rest. Re-enabling picks up where the user left off.

One trap this created and closed: while off, `profiles` is empty, so any
mutation reaching `save()` would have overwritten the stored file with `[]` and
destroyed the data we just promised to keep. `save()` refuses while off, and
there's a test for it.

### Judgement call 2: the caption

Verbatim, shown in both states — it is the disclosure you need *before*
deciding, not a teaser that expands once you've already switched it on:

> Naming a speaker also saves a voice fingerprint for them: 256 numbers
> describing how the voice sounds, written to speaker-profiles.json in Mila's
> Application Support folder. The audio is not part of it and a fingerprint
> can't be played back — but it is enough to pick the same person out of a
> later recording, which is the point of it. Nothing is uploaded: the
> fingerprints stay on this Mac and are left out of diagnostic reports. They
> describe everyone whose name you fill in, not only you, so turn this on only
> where that is yours to decide.

Plain about what is stored (numbers derived from the voice, not audio), where
(named file, named folder), that it never leaves the machine, and that it
covers other people. No "telemetry", no "improve your experience". The
diagnostic-report claim was checked, not assumed: `DiagnosticReporter` copies
only `recordings.json`, `folders.json`, a prefix-whitelisted `settings.json`,
logs and crash reports — `speaker-profiles.json` is never enumerated.

### UI

Settings → **Speakers**, below the known-speakers list, in that tab's flat
divider-separated style. Off-state footprint is one toggle and one caption.
Two things appear only when they apply: the delete row (whenever a profiles
file exists, on or off) and a line explaining that an enabled toggle is waiting
on diarization when that isn't ready yet — otherwise the feature would look
broken while silently doing nothing.

## How it was tested

- `make build` — **BUILD SUCCEEDED**; `build-for-testing` — **TEST BUILD
  SUCCEEDED**. No new warnings (two pre-existing ones removed).
- Tests were **not run locally** (they're app-hosted and pop a keychain
  prompt) — CI's `unit-and-ui-tests` ran them and passed. New
  `MilaTests/VoiceRecognitionGateTests.swift`, 16 tests aimed squarely at the
  off state, since a feature gate with no test for its off-state is how these
  regress:
  - off by default on a fresh install; the persisted key is
    `speakers.voiceRecognition.enabled` and is *unset* (not a stored `false`);
    opt-in survives relaunch
  - `isConfigured` needs both halves — enabled-but-not-ready and
    ready-but-not-enabled are both false; unwired readiness fails closed
  - while off: `updateProfile` writes nothing, and no file is created; naming a
    speaker through the real `RecordingStore.onSpeakerNamed` path persists no
    embedding (while the per-recording label still works); enabled-but-not-ready
    also writes nothing
  - while off: an existing profiles file is not parsed (`profiles` empty,
    `hasStoredProfilesOnDisk` true); `seedEntries()` and `match()` return
    nothing; seeding the diarizer with `[]` leaves its pool empty
  - enable → disable keeps the file but drops memory; re-enable restores;
    an off-state mutation cannot clobber the file
  - `deleteAllProfiles()` works while off and removes the file; after deleting,
    re-enabling restores nothing
- `MilaTests/RecognisedSpeakerMergeTests.swift`, 4 tests on the merge-count
  invariant (above).
- `MilaTests/SpeakerProfileStoreTests.swift` (9 tests from #198) updated for the
  new init and moved onto per-test `UserDefaults` suites — never `.standard`.
- Not verified: no manual end-to-end run with real audio (two people, two
  recordings, returning-speaker recognition). Worth a pass before release.

## Fixed: the double merge (CodeRabbit finding, Major)

`MilaApp.autoAssignRecognisedSpeakers` called `updateProfile` directly *and*
called `setSpeakerName`, which synchronously fires `onSpeakerNamed` — wired in
`MilaApp.init` to that same `updateProfile`. Every recognised speaker was
merged twice per recording.

The centroid *value* survives a double merge (a weighted average of x with x is
x), which is why it went unnoticed. What doubles is `sampleCount`, and since
the merge weights by sample count, each recording makes the profile more rigid
until it stops adapting — recognition decays with nothing visibly failing.
That is worse than a crash, so it is fixed here rather than deferred.

The fix is to delete the direct `updateProfile` call: `setSpeakerName` is the
single persistence trigger. That also makes the path idempotent — a duplicated
stop event finds the name already set, so `setSpeakerName` returns without
firing the hook, and nothing is re-merged. A direct call alongside it is
exactly what would destroy that, so the call site now carries a comment saying
so.

New `MilaTests/RecognisedSpeakerMergeTests.swift` (4 tests) names the
invariant — *one recognition merges exactly once* — against real
`RecordingStore` + real `SpeakerProfileStore` through the real hook: 4 stored +
2 observed samples must give 6, not 8, with the resulting centroid as a second
independent witness (2/3, 1/3 rather than 0.5, 0.5); re-running for the same
recording merges nothing further; a *later* recording does merge again (the
invariant is per recognition, not once ever); and one test reproduces the
removed shape and asserts it yields 8, so the `6` above is provably
discriminating rather than vacuous.

## Also fixed — seeded sample-count inflation

CodeRabbit's second Major finding. Seeded pool entries start at
`min(sampleCount, 3)`, and `currentProfiles()` handed that total back as if it
were all new samples, so a profile with three prior samples and one confident
match merged with the weight of four — `3 + 4 = 7` persisted where `4` is
correct.

This was initially left for a follow-up issue as a design question. That was
wrong, and the reason is worth recording: a correct delta needs a count **and**
a centroid to merge against. Persisting `observedCount` while handing back the
pool's matching centroid gives the right count with the wrong centroid, because
that centroid already contains the seeded profile's own contribution —
`updateProfile` would merge the stored centroid against something that already
contains it. So an observed-only centroid is not a separable redesign, it is
required for the count fix to mean anything. It came to ~15 lines.

`SpeakerProfile` now carries two pairs with distinct jobs:

- `centroid` / `sampleCount` — **matching**. Seeded entries still start at the
  persisted centroid with capped weight, unchanged, so seeding still anchors
  against one noisy utterance.
- `observedCentroid` / `observedCount` — a running mean over **only this
  recording's** embeddings, empty for a seeded entry until it first matches.
  This is what `currentProfiles()` reports and the only thing ever persisted.

For a speaker minted during the recording the two pairs are identical, so the
common path is untouched. A seeded speaker who never spoke reports count 0,
which `updateProfile` already refuses, so no spurious write is possible.

`RecognisedSpeakerMergeTests` is now 11 tests, driving the real `seedPool` →
real `assign` fold → real `currentProfiles()` → real `SpeakerProfileStore`:
3 stored + 1 confident match persists **4, not 7**, with a negative control
asserting the old seeded-inclusive path lands on 7; 40 stored + 1 match → 41;
three utterances → 43; a seeded speaker who never spoke persists nothing; and
seeded weight still anchors matching and forks no speaker, which guards against
"fixed the count, broke the seeding".

One sub-claim in that finding was **not** acted on: a dimension guard on the
fold, for a seeded profile from a different embedding model. It is unreachable —
`cosineSimilarity` returns 0 on a count mismatch, so such an entry can never be
the best match above threshold. The reasoning is documented at the fold instead
of adding dead code.

What genuinely remains is narrower and is filed separately: the seed anchor
weight (`min(sampleCount, 3)`) was picked without measurement, and now that
seeded weight never reaches persistence it can be tuned in isolation.

## Also fixed — three further Major findings from later review rounds

Two more review rounds after the above each found a caller still on the old
semantics, plus one unsound assumption. All are fixed.

### Cross-recording label bleed

Naming a speaker in an **older** recording could persist a **different**
recording's voice into that profile. Diarizer labels (`SPEAKER_00`, …) are
reused after `reset()`, and the `onSpeakerNamed` hook was originally
`{ _, rawID, name in }` — it ignored the `recordingID` that
`RecordingStore.setSpeakerName` already provides, and resolved `rawID` against
whatever was currently in the live pool.

New `ObservedVoiceSnapshots` keys observations by recording id, snapshotted
before anything can trigger a name. The hook resolves through the snapshot and
never touches the live pool. A recording with no snapshot resolves to `nil` and
persists nothing — honest rather than a guess, since its pool is gone. Bounded
to 8 recordings, and dropped entirely on opt-out.

### The auto-naming gate had no confidence check

`assign` deliberately attaches borderline matches and sub-second utterances to
the nearest existing speaker *without* folding them into the centroid. Those
attachments still produce intervals, and the gate tested only intervals — so a
stored profile's name could be stamped onto a speaker that never confidently
matched it: a misattributed transcript, with the wrong person's name against
their words. The gate now requires `observedCount > 0`, which is precisely the
"confidently observed this recording" signal.

Both of these were **pre-existing**, not introduced by the delta fix above:
`c377ede` (the fork's final commit) already had the intervals-only gate and the
`rawID`-only hook. The delta fix had, however, already halved the second one's
blast radius — `observedCount == 0` was failing `updateProfile`'s guard, so the
profile was no longer corrupted, leaving only the wrong label.

The interval check was then **removed** rather than kept alongside, because the
rationale for keeping it did not survive checking. `intervals` holds diarizer
*utterance* intervals, appended in `process` before anything is matched to
transcript segments (`applySpeakerLabels` does that later) — so it never
evidenced transcript presence. And it was redundant: `observedCount` is only
incremented by `assign`, whose sole production caller is `process`, which
appends an interval for exactly the id `assign` returned, while `reset()` clears
pool and intervals together so they cannot drift. A dead check defended by a
false rationale is worse than no check.

### The finished recording was identified by list order

The snapshot was keyed off `store.recordings.first`. That is unsound, though not
for the reason it first appears: `createdAt` is set in the *finalize* path, so it
is effectively stop time, and date ordering would mostly work. The actual problem
is that `add()` does `recordings.insert(_, at: 0)` and never re-sorts — ordering
is not consulted at all, so **any** recording added afterwards becomes `first`
regardless of its date, and `.onChange(of: isRecording)` is delivered a runloop
tick later, which leaves that window open (the Voice Memos importer adds from an
async flow). A test pins this directly: an *older* recording added later is still
`first`.

The id is now carried, not inferred, via
`QuickActionsController.onRecordingFinalized`. That site was chosen over
publishing a last-finalised id because it is also the only moment at which
reading the live diarizer is sound — after `awaitPending()` so intervals are
final, after `store.update(updated)` so assigned names are not clobbered, and
inside the `isFinalizingRecording` window so no new recording can have `reset()`
the pool. The deferred `.onChange` had none of those guarantees.

Fail-closed behaviour is pinned by `test_a_wrong_id_fails_closed`, so a future
"fall back to the newest recording" cannot quietly undo it.

### Two things fixed in passing

- **`onEnabledChange` became `addEnabledObserver`.** A single assignable slot
  meant a second registrant silently unhooked the first, so only the
  last-constructed object would ever hear an opt-out. With
  `ObservedVoiceSnapshots` now needing that signal too, this would have silently
  broken the store's unload. A test pins both registrants firing.
- **The assign loop moved into `RecognisedSpeakerAssigner`** with explicit
  dependencies. The gate had only ever been testable through a replica, which is
  a poor way to pin a security-relevant invariant; it is now driven directly and
  the replica is deleted (its negative control kept).

61 tests now cover this feature across six files, with negative controls on each
invariant: the live-pool lookup provably leaks the stranger, the intervals-only
gate provably names the borderline speaker, and the ordering test provably picks
the wrong recording.

### Known, not addressed here

- Naming a speaker on the **live** transcript still creates no profile —
  `LiveAIRecordingView` writes `transcriber.speakerNames[raw]` directly and never
  reaches `setSpeakerName`. Pre-existing and unchanged by this PR; filed as #209.
- The seed anchor cap (`min(sampleCount, 3)`) is unmeasured; filed as #206.
- No manual end-to-end run with real audio and two speakers has been done.

## Checklist

- [x] Builds locally (`make build`); tests written, left for CI to run
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, entries are written per release, not per PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional cross-recording voice recognition for previously named speakers.
  - Added speaker profile management, including renaming, merging, and deletion.
  - Added voice recognition settings with opt-in controls and readiness status.

- **Privacy**
  - Voice recognition is off by default and profiles are stored locally.
  - Deleting a profile immediately stops future matching.
  - Voice observations remain associated with their recordings.

- **Bug Fixes**
  - Improved speaker naming when recordings are finalized.
  - Prevented duplicate profile updates and inaccurate sample counts.
  - Improved handling of invalid or incompatible voice-profile data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

