### PR TITLE
ci: make the setup-swift 3.x Dependabot ignore actually match

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       # `v3` tag and its `v3.0.0-beta.1` tag point at the SAME commit
       # (364295d9c23900ce04d4e5cc708387921b4e50f9). That build's Swiftly-based
       # installer fails GPG verification on the Ubuntu runner ("gpg: Can't
-      # check signature: No public key") and reds the e2e-transcription job.
+      # check signature: No public key") and fails the e2e-transcription job.
       # It is not a flake — reruns do not clear it.
       #
       # Do NOT "tidy" this back to `versions: ["3.x"]`. Dependabot parses these
@@ -38,7 +38,12 @@ updates:
       # `>= 3.a, < 4` is ONE comma-ANDed requirement: `3.a` is Dependabot's own
       # lower bound for "any 3.x, pre-releases included" (it is what
       # `version-update:semver-major` expands to from 2.4.0), and `< 4` stops
-      # this from silently swallowing a future v4. 2.x updates still flow.
+      # this from silently swallowing a future *stable* v4. Note the asymmetry,
+      # which is RubyGems semantics rather than an oversight: `< 4` admits
+      # `4.0.0` but still excludes `4.0.0-beta.1`, because a pre-release of 4
+      # sorts below 4. So a v4 beta stays ignored until v4 goes stable — which
+      # is the behaviour we want here, given a v3 pre-release is exactly what
+      # caused this. 2.x updates still flow.
       #
       # Revisit when a stable v3 ships: bump the pin in
       # .github/workflows/e2e-transcription.yml and drop this entry.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,30 @@ updates:
       actions:
         patterns: ["*"]
     ignore:
-      # setup-swift's only v3 tag is the 3.0.0-beta.1 pre-release. Its
-      # Swiftly-based installer fails GPG verification on the Ubuntu runner
-      # ("gpg: Can't check signature: No public key"), which reds the
-      # e2e-transcription job. Stay on v2.x until a stable v3 ships.
+      # HOLD swift-actions/setup-swift at v2.x. Upstream has no stable v3: its
+      # `v3` tag and its `v3.0.0-beta.1` tag point at the SAME commit
+      # (364295d9c23900ce04d4e5cc708387921b4e50f9). That build's Swiftly-based
+      # installer fails GPG verification on the Ubuntu runner ("gpg: Can't
+      # check signature: No public key") and reds the e2e-transcription job.
+      # It is not a flake — reruns do not clear it.
+      #
+      # Do NOT "tidy" this back to `versions: ["3.x"]`. Dependabot parses these
+      # strings as RubyGems requirements, and `3.x` is itself a valid RubyGems
+      # *version literal*, so `["3.x"]` compiles to the equality requirement
+      # `= 3.x` and matches nothing whatsoever — neither `3` (what the moving
+      # `v3` tag resolves to) nor `3.0.0-beta.1`. The rule looked right and was
+      # silently inert, which is how PRs #195 and #212 proposed the bump
+      # anyway. Wildcards are not supported here; only comparison operators.
+      #
+      # `>= 3.a, < 4` is ONE comma-ANDed requirement: `3.a` is Dependabot's own
+      # lower bound for "any 3.x, pre-releases included" (it is what
+      # `version-update:semver-major` expands to from 2.4.0), and `< 4` stops
+      # this from silently swallowing a future v4. 2.x updates still flow.
+      #
+      # Revisit when a stable v3 ships: bump the pin in
+      # .github/workflows/e2e-transcription.yml and drop this entry.
       - dependency-name: "swift-actions/setup-swift"
-        versions: ["3.x"]
+        versions: [">= 3.a, < 4"]
 
   - package-ecosystem: "docker"
     directory: "/docker/speaches-hebrew"

--- a/.github/workflows/e2e-transcription.yml
+++ b/.github/workflows/e2e-transcription.yml
@@ -78,10 +78,11 @@ jobs:
 
       - name: Install Swift
         if: steps.changes.outputs.relevant == 'true'
-        # HELD at v2.4.0 on purpose: setup-swift's only v3 tag is the
-        # 3.0.0-beta.1 pre-release, whose Swiftly-based installer fails GPG
-        # verification on the Ubuntu runner ("gpg: Can't check signature: No
-        # public key") and kills this job. Dependabot is told to skip 3.x in
+        # HELD at v2.4.0 on purpose: setup-swift has no stable v3 — its `v3`
+        # tag and its `v3.0.0-beta.1` tag are the same commit, and that build's
+        # Swiftly-based installer fails GPG verification on the Ubuntu runner
+        # ("gpg: Can't check signature: No public key"), which kills this job
+        # every run (not a flake). Dependabot is told to skip 3.x in
         # .github/dependabot.yml — revisit when a stable v3 ships.
         uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:


### PR DESCRIPTION
Closes #203

Dependabot keeps proposing `swift-actions/setup-swift` v3, which reds the `e2e`
check with the GPG failure the repo already documents — most recently in #195
and again in the currently-open #212. The workflow pins v2.4.0 deliberately and
its comment claims "Dependabot is told to skip 3.x in `.github/dependabot.yml`".
It is told that. The instruction does nothing.

## Root cause: the ignore rule matches *nothing*

`.github/dependabot.yml` carried `versions: ["3.x"]`. Dependabot parses
`ignore.versions` entries as **RubyGems requirements** (`GithubActions::Requirement
< Gem::Requirement`, passed through verbatim by `Config::IgnoreCondition` — no
wildcard preprocessing, and GitHub's docs confirm `versions` supports comparison
operators, not globs).

`3.x` happens to be a *valid RubyGems version literal* — segments `[3, "x"]`, a
prerelease — so `["3.x"]` compiles to the **equality** requirement `= 3.x`.
Checked directly against both candidates:

```
req "3.x" vs version "3"            => false
req "3.x" vs version "3.0.0-beta.1" => false
```

It matches neither. The rule read as if it worked and was silently inert. This is
a nastier failure mode than a rule that is merely too narrow, because nothing
ever signals it.

## Why `v3` also slips the pre-release filter

Upstream tags **`v3` and `v3.0.0-beta.1` at the same commit**
(`364295d9c23900ce04d4e5cc708387921b4e50f9`, confirmed with `git ls-remote`).
Dependabot rejects prereleases via `version_from_tag(tag).prerelease?`, but `v3`
resolves to `3`, which is not a prerelease — so the beta arrives wearing a
stable-looking name. #212's diff is exactly this:
`setup-swift@364295d9... # v3`.

## Grouping is not implicated

Worth stating since these arrive as grouped PRs: `group_update_creation.rb:394`
builds each in-group dependency's checker with
`ignored_versions: job.ignore_conditions_for(dependency)`, so ignores apply
inside grouped runs identically. `groups.exclude-patterns` would only have split
the bad bump into its own PR rather than preventing it, so it is not used here.

## The change

- `.github/dependabot.yml` — `versions: ["3.x"]` → `versions: [">= 3.a, < 4"]`,
  one comma-ANDed requirement. `3.a` is Dependabot's own idiom for "any 3.x
  including prereleases"; `< 4` avoids silently swallowing a future v4 that may
  well be fine. The comment now explains the `3.x` parsing trap so the rule does
  not get "tidied" back into a no-op.
- `.github/workflows/e2e-transcription.yml` — comment accuracy only (`v3` and
  `v3.0.0-beta.1` are the same commit; the failure is not a flake). **The pin is
  byte-identical.**

`update-types: ["version-update:semver-major"]` would also work, but it depends
on `dependency.version` resolving the pinned SHA back to its tag — a silent
no-op failure mode identical to the one being fixed — and it would block v4
forever. The explicit bound was preferred for both reasons.

## Verified vs reasoned

**Executed:** the `= 3.x` parse and its non-match via Ruby/RubyGems; the upstream
tag list and the `v3`/`v3.0.0-beta.1` same-commit collision via `git ls-remote`;
#212's actual diff; dependabot-core's `IgnoreCondition`,
`GithubActions::Requirement`/`Version`, `git_commit_checker.rb` and
`group_update_creation.rb`; both YAML files parse and `">= 3.a, < 4"`
round-trips exactly. Dependabot's `allowed_versions` filter was also simulated
over the real 40-tag list: the old rule proposes **`v3`** (reproducing #212), the
new rule proposes **`v2.4.0`**, with all 2.x still offered.

**Reasoned, not executable here:** that GitHub's hosted Dependabot runs the same
`main`-branch dependabot-core logic that was read, and that its config validator
accepts a comma inside a version string (the docs' own Maven example `[1.4,)`
contains one).

## Follow-up

#212 should be **closed rather than salvaged** once this lands. Its other five
bumps are legitimate, but Dependabot force-pushes over manual edits to its own
branches, so reverting the setup-swift hunk would not survive — and it would need
a fresh review at the new head regardless. Its next scheduled run rebuilds the
group PR with setup-swift correctly excluded.

## Checklist

- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, CI configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management rules to keep the Swift setup action on the v2 release line.
  * Clarified why the Swift setup action remains pinned to a stable v2 version for reliable automated builds.
  * No changes were made to application functionality or workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration and comments only; workflow pins and runtime behavior are unchanged.
> 
> **Overview**
> Dependabot was still opening PRs to bump **`swift-actions/setup-swift`** to v3 despite an ignore rule, because **`versions: ["3.x"]`** is parsed as RubyGems **`= 3.x`** and matches neither **`3`** (the moving **`v3`** tag) nor **`3.0.0-beta.1`**.
> 
> The ignore is replaced with **`[">= 3.a, < 4"]`** so all 3.x (including pre-releases) are skipped while 2.x updates and a future stable v4 can still be proposed. Comments in **`.github/dependabot.yml`** document the **`3.x`** trap and when to remove the hold.
> 
> **`.github/workflows/e2e-transcription.yml`** only updates the install-Swift step comment (same v2.4.0 SHA pin; clarifies **`v3`** / beta same commit and deterministic GPG failure on Ubuntu).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa55b25aa8caeef83db3d306c7da242eeb62bbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->