### PR TITLE
fix(speakers): stop matching stored voices when diarization is turned off mid-recording

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -641,21 +641,37 @@ struct MilaApp: App {
         // …and the third holder of copied voice data: the live pool. The two
         // lines above unload the profiles (`SpeakerProfileStore`'s own
         // observer) and drop the snapshots, but `seedPool` handed the
-        // diarizer its own copy of every centroid at record-start, so an
-        // opt-out mid-recording otherwise leaves `assign` matching against
-        // stored voices for the rest of it. The write gates stop the result
-        // being persisted; they do not stop it being *read*, and the user
-        // still watches their transcript auto-fill with names from a feature
-        // they just switched off.
+        // diarizer its own copy of every centroid at record-start, so the
+        // feature becoming unusable mid-recording otherwise leaves `assign`
+        // matching against stored voices for the rest of it. The write gates
+        // stop the result being persisted; they do not stop it being *read*,
+        // and the user still watches their transcript auto-fill with names
+        // from a feature that is no longer on.
         //
         // Exactly the deletion path's problem, so it gets the deletion
-        // path's remedy — see `addDeletionObserver` below. Opt-out is the
+        // path's remedy — see `addDeletionObserver` below. This one is the
         // broader of the two, so it forgets every seeded entry rather than
         // named ones.
-        voiceSettings.addEnabledObserver { [weak liveDiar] nowEnabled in
-            guard !nowEnabled else { return }
+        //
+        // Registered on the **gate**, not the toggle. `isConfigured` is
+        // `isEnabled && diarizationReady`, and either half closing revokes
+        // the feature just as completely: turning diarization off in
+        // Settings mid-recording used to fire nothing at all, so the pool
+        // went on recognising stored voices (#215). `trackDiarizationReadiness`
+        // below is what lets the settings object notice the second half.
+        voiceSettings.addConfiguredObserver { [weak liveDiar] nowConfigured in
+            guard !nowConfigured else { return }
             liveDiar?.forgetSeededProfiles()
         }
+        // The readiness half of that gate lives on `DiarizationSettings`, and
+        // `diarizationReady` above only *reads* it — nothing tells this
+        // object when the answer changes. Both publishers are needed:
+        // `isConfigured` there is `isEnabled && (hasBundledRuntime ?
+        // bootstrap.isReady : status.isGood)`, so the bootstrap's readiness
+        // is a genuinely separate source of truth (`nuclearRepair` clears it
+        // without touching the settings object at all).
+        voiceSettings.trackDiarizationReadiness(diarSettings.objectWillChange,
+                                                diarSettings.bootstrap.objectWillChange)
         // Auto-naming + the per-recording snapshot, driven by the finalize
         // drain rather than by observing `isRecording`. The drain hands over
         // the id of the recording that actually finished, and calls

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -174,8 +174,9 @@ final class SpeakerProfileStore: ObservableObject {
     /// recording's centroid, which is the same person's fingerprint to
     /// within rounding. `MilaApp` wires this to
     /// `LiveSpeakerDiarizer.forgetSeededProfiles`, so the deletion takes
-    /// effect immediately and everywhere, exactly as opting out does through
-    /// `VoiceRecognitionSettings.addEnabledObserver`.
+    /// effect immediately and everywhere, exactly as the feature ceasing to
+    /// be configured does through
+    /// `VoiceRecognitionSettings.addConfiguredObserver`.
     ///
     /// A list rather than one slot, for the same reason `addEnabledObserver`
     /// is: a second registrant must not silently unhook the first.

--- a/Mila/Models/VoiceRecognitionSettings.swift
+++ b/Mila/Models/VoiceRecognitionSettings.swift
@@ -42,6 +42,11 @@ final class VoiceRecognitionSettings: ObservableObject {
             // while `isEnabled` still read the old value, and the observers'
             // own guards read it.
             for observer in enabledObservers { observer(isEnabled) }
+            // …and then the gate, which the toggle is only *half* of. Kept
+            // after the loop above so the two channels fire in a fixed
+            // order; they are independent removals from different holders,
+            // so the order is arbitrary but should not be accidental.
+            refreshConfiguredState()
         }
     }
 
@@ -50,16 +55,17 @@ final class VoiceRecognitionSettings: ObservableObject {
     /// Register a handler for actual changes to `isEnabled`, called
     /// synchronously with the new value.
     ///
-    /// Three registrants, one per place a copied embedding can be sitting
-    /// when the user flips the switch: `SpeakerProfileStore` loads stored
-    /// profiles on opt-in and drops them from memory on opt-out;
-    /// `ObservedVoiceSnapshots` discards the observations it is holding; and
-    /// `MilaApp` calls `LiveSpeakerDiarizer.forgetSeededProfiles()` so the
-    /// pool of a recording that is *already running* stops matching against
-    /// centroids `seedPool` copied out of the store at record-start. Miss
-    /// that last one and opting out stops the writes but not the reads —
-    /// the transcript goes on being auto-labelled from stored voices until
-    /// the recording ends.
+    /// Two registrants, one per place a copied embedding sits that belongs
+    /// to the *toggle* rather than to the gate: `SpeakerProfileStore` loads
+    /// stored profiles on opt-in and drops them from memory on opt-out, and
+    /// `ObservedVoiceSnapshots` discards the observations it is holding.
+    ///
+    /// Both are deliberately keyed on `isEnabled` and not on `isConfigured`.
+    /// Diarization becoming unready is not the user withdrawing consent: the
+    /// Settings pane still has to list the stored profiles so they can be
+    /// renamed or deleted, and a name applied to a just-finished recording
+    /// still has to resolve through its snapshot. Only the *live pool* is
+    /// the gate's business — see `addConfiguredObserver`.
     ///
     /// A list rather than one assignable slot on purpose: with a single slot
     /// the second registrant silently unhooked the first, so whichever
@@ -67,6 +73,91 @@ final class VoiceRecognitionSettings: ObservableObject {
     /// about an opt-out.
     func addEnabledObserver(_ observer: @escaping (Bool) -> Void) {
         enabledObservers.append(observer)
+    }
+
+    private var configuredObservers: [(Bool) -> Void] = []
+
+    /// The last value `configuredObservers` were told about, so a refresh
+    /// only fires on an actual transition. Starts at `isConfigured`'s value
+    /// for a freshly-built object — `false`, since `diarizationReady` is
+    /// still unwired at that point.
+    private var lastConfigured = false
+
+    /// Register a handler for changes to **`isConfigured`** — the gate —
+    /// called synchronously with its new value.
+    ///
+    /// This is the channel for anything that must stop the moment the
+    /// feature stops being usable, whichever half of the gate closed.
+    /// `MilaApp` registers exactly one handler: `LiveSpeakerDiarizer`'s
+    /// `forgetSeededProfiles()`, so a recording that is *already running*
+    /// stops matching against the centroids `seedPool` copied out of the
+    /// store at record-start.
+    ///
+    /// **Why the gate and not the toggle.** `isConfigured` is `isEnabled &&
+    /// diarizationReady`, so there are two ways for it to close, and #204
+    /// wired only the first. Turning *diarization* off mid-recording (or its
+    /// Python pipeline becoming unavailable) left the pool holding the
+    /// seeded centroids and `assign` matching against them for the rest of
+    /// the recording: the write gates held, so nothing was persisted, but
+    /// the transcript went on auto-filling with names from stored voices
+    /// after the feature had stopped being configured. Deleting a profile,
+    /// opting out, and diarization going away are the same revocation and
+    /// now take the same effect (#215).
+    func addConfiguredObserver(_ observer: @escaping (Bool) -> Void) {
+        configuredObservers.append(observer)
+    }
+
+    /// Re-evaluate `isConfigured` and notify `configuredObservers` if it
+    /// changed. Idempotent and cheap (one closure call and a comparison), so
+    /// callers may fire it as often as they like.
+    ///
+    /// Called internally whenever this object owns the change — `isEnabled`
+    /// and `diarizationReady` — and externally by `trackDiarizationReadiness`
+    /// for the half this object does not own.
+    func refreshConfiguredState() {
+        let nowConfigured = isConfigured
+        guard nowConfigured != lastConfigured else { return }
+        lastConfigured = nowConfigured
+        for observer in configuredObservers { observer(nowConfigured) }
+    }
+
+    private var readinessCancellables: Set<AnyCancellable> = []
+
+    /// Watch the objects behind `diarizationReady` so a change *there*
+    /// reaches `configuredObservers` too. `MilaApp` passes
+    /// `DiarizationSettings.objectWillChange` and its bootstrap's, which
+    /// between them cover every input to `DiarizationSettings.isConfigured`:
+    /// the toggle, the verification state, the Python path, and the
+    /// runtime-torch bootstrap.
+    ///
+    /// Subscribing to `objectWillChange` rather than to named properties is
+    /// deliberate — `isConfigured` is derived from four of them across two
+    /// objects, and a list of individual sinks would silently stop covering
+    /// the gate the next time someone adds a fifth. The recompute is a
+    /// closure call, so over-firing costs nothing.
+    ///
+    /// **The hop is required, not incidental.** `objectWillChange` fires on
+    /// *willSet*, so reading `isConfigured` inside the sink would see the
+    /// pre-change value — the same trap documented on `isEnabled` above,
+    /// which is why that side uses a synchronous callback instead. Deferring
+    /// to the next main-actor turn reads the settled value. It also lands in
+    /// time: the pool is only ever read from `LiveSpeakerDiarizer.process`,
+    /// which `submit` likewise enqueues as a main-actor task, so an
+    /// utterance captured *after* the change queues behind this refresh.
+    /// One captured before it may still be labelled, which is correct — the
+    /// feature was configured when that audio was spoken.
+    ///
+    /// Re-tracking replaces any previous subscriptions rather than adding
+    /// to them.
+    func trackDiarizationReadiness(_ publishers: ObservableObjectPublisher...) {
+        readinessCancellables.removeAll()
+        for publisher in publishers {
+            publisher
+                .sink { [weak self] in
+                    Task { @MainActor in self?.refreshConfiguredState() }
+                }
+                .store(in: &readinessCancellables)
+        }
     }
 
     /// Answers "can the embedding pipeline this feature rides on actually
@@ -77,7 +168,13 @@ final class VoiceRecognitionSettings: ObservableObject {
     ///
     /// Defaults to `false` — an unwired instance is never "ready", so a
     /// forgotten injection fails closed (nothing stored) rather than open.
-    var diarizationReady: (() -> Bool)?
+    ///
+    /// Assigning it re-evaluates the gate, so wiring readiness up (or a test
+    /// swapping the closure) cannot leave `configuredObservers` believing a
+    /// stale answer.
+    var diarizationReady: (() -> Bool)? {
+        didSet { refreshConfiguredState() }
+    }
 
     private let defaults: UserDefaults
 

--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -264,14 +264,17 @@ final class LiveSpeakerDiarizer: ObservableObject {
     /// `names` is nil.
     ///
     /// Two callers, both wired in `MilaApp.init`, both answering the same
-    /// question — "the user just revoked something; does the recording that
-    /// is already running honour it?":
+    /// question — "the feature just stopped being allowed to do this; does
+    /// the recording that is already running honour it?":
     ///
     ///   * `SpeakerProfileStore`'s deletion observer, passing the deleted
     ///     `names` (or nil for "delete everything");
-    ///   * `VoiceRecognitionSettings`' enabled observer on opt-out, passing
-    ///     nil — switching the feature off revokes every seeded voice at
-    ///     once, not a named subset.
+    ///   * `VoiceRecognitionSettings`' **gate** observer, passing nil — the
+    ///     feature ceasing to be configured revokes every seeded voice at
+    ///     once, not a named subset. That covers both halves of the gate:
+    ///     the user opting out, and diarization itself being switched off or
+    ///     going unavailable, which is the same revocation reached from the
+    ///     other side (#215).
     ///
     /// Deleting voice profiles is a privacy action, and `seedPool` gave this
     /// object its own copy of the centroids at record-start. Deleting the

--- a/MilaTests/VoiceRecognitionGateTests.swift
+++ b/MilaTests/VoiceRecognitionGateTests.swift
@@ -1,5 +1,83 @@
 import XCTest
+import Combine
 @testable import Mila
+
+/// Alice, as stored on disk.
+private let aliceStored: [Float] = [1, 0, 0, 0]
+/// Close enough to Alice to be a confident match at threshold 0.7.
+private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+
+/// Which generation of the revocation wiring to install, so every test in the
+/// mid-recording section says out loud which shape it is exercising.
+private enum PoolWiring {
+    /// Pre-#204: nothing tells the live pool that access was revoked.
+    case none
+    /// #204: forget on the `isEnabled` toggle only. The shape #215 fixes —
+    /// it covers opting out and nothing else.
+    case toggleOnly
+    /// Shipping: forget whenever the **gate** closes, whichever half did it.
+    case gate
+}
+
+/// A recording already under way with Alice's stored profile seeded into the
+/// pool, wired exactly as `MilaApp.init` wires it — including a stand-in for
+/// `DiarizationSettings`, so a test can close either half of the gate.
+@MainActor
+private final class SeededRecording {
+    let settings: VoiceRecognitionSettings
+    let profiles: SpeakerProfileStore
+    let snapshots = ObservedVoiceSnapshots()
+    let diarizer = LiveSpeakerDiarizer()
+
+    /// The `DiarizationSettings` stand-in. `ready` is what the injected
+    /// `diarizationReady` closure reads; `changes` is the `objectWillChange`
+    /// publisher `MilaApp` hands to `trackDiarizationReadiness` — the same
+    /// `ObservableObjectPublisher` type, driven the same way.
+    private var ready = true
+    private let changes = ObservableObjectPublisher()
+
+    init(defaults: UserDefaults, directory: URL, wiring: PoolWiring) {
+        settings = VoiceRecognitionSettings(defaults: defaults)
+        profiles = SpeakerProfileStore(directory: directory, settings: settings)
+        settings.diarizationReady = { [weak self] in self?.ready ?? false }
+        settings.isEnabled = true
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        diarizer.similarityThreshold = 0.7
+        snapshots.clearOnOptOut(of: settings)
+        switch wiring {
+        case .none:
+            break
+        case .toggleOnly:
+            settings.addEnabledObserver { [weak diarizer] nowEnabled in
+                guard !nowEnabled else { return }
+                diarizer?.forgetSeededProfiles()
+            }
+        case .gate:
+            settings.addConfiguredObserver { [weak diarizer] nowConfigured in
+                guard !nowConfigured else { return }
+                diarizer?.forgetSeededProfiles()
+            }
+            settings.trackDiarizationReadiness(changes)
+        }
+
+        // Record-start: reset, then seed behind the gate.
+        diarizer.reset()
+        XCTAssertTrue(settings.isConfigured)
+        diarizer.seedPool(with: profiles.seedEntries())
+        XCTAssertEqual(diarizer.currentProfiles().first?.profileName, "Alice",
+                       "precondition: the pool holds a copy of Alice's centroid")
+    }
+
+    /// Turn diarization off (or back on) the way `DiarizationSettings` does:
+    /// `objectWillChange` is sent **before** the value settles. Reproducing
+    /// that order is the point — an implementation that read `isConfigured`
+    /// straight from the sink would see the stale `true` and forget nothing.
+    func setDiarizationReady(_ isReady: Bool) {
+        changes.send()
+        ready = isReady
+    }
+}
 
 /// Tests for the **opt-in gate** on cross-recording voice recognition —
 /// separate from `SpeakerProfileStoreTests`, which covers the storage
@@ -273,51 +351,30 @@ final class VoiceRecognitionGateTests: XCTestCase {
                        "an off-state mutation must not rewrite speaker-profiles.json")
     }
 
-    // MARK: - Opting out *during* a recording
-
-    /// Alice, as stored on disk.
-    private var aliceStored: [Float] { [1, 0, 0, 0] }
-    /// Close enough to Alice to be a confident match at threshold 0.7.
-    private var aliceSpeaking: [Float] { [0.99, 0.01, 0, 0] }
+    // MARK: - Losing the feature *during* a recording
 
     /// A recording already under way with Alice's stored profile seeded into
-    /// the pool, exactly as `MilaApp` sets one up.
-    ///
-    /// `poolObserver` is the fix under test. It defaults to on — the
-    /// shipping wiring — and the negative control below switches it off to
-    /// reconstruct the pre-fix shape, so the assertions are provably
+    /// the pool. `wiring` selects which generation of the revocation wiring
+    /// is installed: `.gate` is what ships, and the negative controls below
+    /// reconstruct the earlier shapes so the assertions are provably
     /// discriminating rather than vacuously true.
     private func startedRecordingWithAliceSeeded(
-        poolObserver: Bool = true
-    ) -> (settings: VoiceRecognitionSettings,
-          profiles: SpeakerProfileStore,
-          snapshots: ObservedVoiceSnapshots,
-          diarizer: LiveSpeakerDiarizer) {
-        let settings = makeSettings()
-        settings.isEnabled = true
-        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
-        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        wiring: PoolWiring = .gate
+    ) -> SeededRecording {
+        SeededRecording(defaults: isolatedDefaults(), directory: tempRoot, wiring: wiring)
+    }
 
-        let diarizer = LiveSpeakerDiarizer()
-        diarizer.similarityThreshold = 0.7
-
-        // Same wiring MilaApp.init installs, in the same order.
-        let snapshots = ObservedVoiceSnapshots()
-        snapshots.clearOnOptOut(of: settings)
-        if poolObserver {
-            settings.addEnabledObserver { [weak diarizer] nowEnabled in
-                guard !nowEnabled else { return }
-                diarizer?.forgetSeededProfiles()
-            }
+    /// Let the main-actor task `trackDiarizationReadiness` schedules actually
+    /// run. `objectWillChange` fires on *willSet*, so the refresh is
+    /// deliberately deferred one turn — see `trackDiarizationReadiness`.
+    ///
+    /// Yields rather than sleeps: bounded, no wall-clock, and a control case
+    /// whose condition never holds costs microseconds instead of a timeout.
+    private func settle(until condition: () -> Bool = { false }) async {
+        for _ in 0..<100 {
+            if condition() { return }
+            await Task.yield()
         }
-
-        // Record-start: reset, then seed behind the gate.
-        diarizer.reset()
-        XCTAssertTrue(settings.isConfigured)
-        diarizer.seedPool(with: profiles.seedEntries())
-        XCTAssertEqual(diarizer.currentProfiles().first?.profileName, "Alice",
-                       "precondition: the pool holds a copy of Alice's centroid")
-        return (settings, profiles, snapshots, diarizer)
     }
 
     /// **The invariant.** Opting out mid-recording has to stop the *reads*,
@@ -345,12 +402,12 @@ final class VoiceRecognitionGateTests: XCTestCase {
                       "no pool entry may still carry a stored profile name")
     }
 
-    /// Negative control: the same scenario with the observer unwired, which
-    /// is what shipped before this fix. Alice is still recognised, under her
-    /// stored name. If this ever starts failing, the test above has stopped
-    /// proving anything.
+    /// Negative control: the same scenario with nothing wired to the pool,
+    /// which is what shipped before #204. Alice is still recognised, under
+    /// her stored name. If this ever starts failing, the test above has
+    /// stopped proving anything.
     func test_control_without_the_observer_a_stored_voice_survives_the_opt_out() {
-        let w = startedRecordingWithAliceSeeded(poolObserver: false)
+        let w = startedRecordingWithAliceSeeded(wiring: .none)
 
         w.settings.isEnabled = false
 
@@ -422,6 +479,114 @@ final class VoiceRecognitionGateTests: XCTestCase {
                       "no speaker may be auto-named from a feature just switched off")
         XCTAssertEqual(w.snapshots.heldRecordingCount, 0,
                        "and no embeddings may be retained for the stopped recording")
+    }
+
+    // MARK: - Turning *diarization* off during a recording (#215)
+
+    /// The same invariant as the opt-out above, reached through the other
+    /// half of the gate.
+    ///
+    /// `isConfigured` is `isEnabled && diarizationReady`, so switching
+    /// diarization off in Settings revokes voice recognition just as
+    /// completely as switching voice recognition off does — the embedding
+    /// pipeline every centroid comes out of is gone. #204 wired the toggle
+    /// and only the toggle, so this path fired nothing at all: the pool kept
+    /// the centroids `seedPool` copied at record-start and went on
+    /// auto-labelling the transcript from stored voices. The write gates
+    /// held, so nothing was persisted; the *reads* were the leak.
+    func test_turning_diarization_off_mid_recording_stops_the_pool_matching_a_stored_voice() async {
+        let w = startedRecordingWithAliceSeeded()
+
+        w.setDiarizationReady(false)
+        await settle(until: { w.diarizer.currentProfiles().first?.profileName == nil })
+
+        XCTAssertFalse(w.settings.isConfigured,
+                       "precondition: the gate is closed even though the toggle never moved")
+        XCTAssertTrue(w.settings.isEnabled,
+                      "…and it closed on the readiness half, which is the whole point")
+        // Alice speaks after diarization went away. Her seeded entry was
+        // never heard in this recording, so it has nothing of its own to fall
+        // back to: it is inert, `assign` skips it, and she is somebody new.
+        XCTAssertNotEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                          "a stored voice must not be recognised once the gate has closed")
+        XCTAssertTrue(w.diarizer.currentProfiles().allSatisfy { $0.profileName == nil },
+                      "no pool entry may still carry a stored profile name")
+    }
+
+    /// Negative control: the #204 wiring, which listens to the `isEnabled`
+    /// toggle only. Diarization going away moves no toggle, so nothing fires
+    /// and Alice is still recognised under her stored name — exactly the bug
+    /// #215 reports. If this ever starts failing, the test above has stopped
+    /// proving anything.
+    func test_control_toggle_only_wiring_keeps_matching_after_diarization_goes_off() async {
+        let w = startedRecordingWithAliceSeeded(wiring: .toggleOnly)
+
+        w.setDiarizationReady(false)
+        await settle(until: { w.diarizer.currentProfiles().first?.profileName == nil })
+
+        XCTAssertFalse(w.settings.isConfigured,
+                       "the gate really is closed — the control is not vacuous")
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "pre-fix shape: the pool goes on matching the stored centroid")
+        XCTAssertEqual(w.diarizer.currentProfiles().first?.profileName, "Alice",
+                       "pre-fix shape: and it still knows her name")
+    }
+
+    /// The same nuance as the opt-out: a speaker who *was* heard before the
+    /// gate closed keeps their id for the rest of the recording, falling back
+    /// to what this recording itself observed. Minting a new id here would
+    /// fork one person across two speakers mid-transcript, and in-recording
+    /// diarization is not what was revoked — the stored identity is.
+    func test_turning_diarization_off_keeps_an_already_heard_speaker_coherent_but_nameless() async {
+        let w = startedRecordingWithAliceSeeded()
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "precondition: Alice matched while the feature was configured")
+
+        w.setDiarizationReady(false)
+        await settle(until: { w.diarizer.currentProfiles().first?.profileName == nil })
+
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00",
+                       "in-recording continuity is deliberate")
+        XCTAssertNil(w.diarizer.currentProfiles().first?.profileName,
+                     "…but the stored name is gone, so nothing can auto-apply it")
+    }
+
+    /// Opting out keeps working through the gate channel — and synchronously,
+    /// with no turn of the run loop, because `isEnabled`'s `didSet` refreshes
+    /// the gate itself rather than going through the publisher. The two
+    /// triggers therefore reach `forgetSeededProfiles` by different routes
+    /// and both land; #204's behaviour is not traded away for #215's.
+    func test_the_gate_channel_still_covers_the_opt_out_synchronously() {
+        let w = startedRecordingWithAliceSeeded()
+
+        w.settings.isEnabled = false
+
+        XCTAssertTrue(w.diarizer.currentProfiles().allSatisfy { $0.profileName == nil },
+                      "opting out must forget the seeded pool without waiting for a hop")
+    }
+
+    /// `trackDiarizationReadiness` subscribes to `objectWillChange`, which
+    /// fires for *every* published change on the diarization settings, not
+    /// only ones that move the gate. Observers must therefore see
+    /// transitions, not notifications — otherwise a settings pane that
+    /// updates a progress string would re-run the revocation handler on a
+    /// loop.
+    func test_the_gate_notifies_on_transitions_not_on_every_refresh() {
+        let settings = VoiceRecognitionSettings(defaults: isolatedDefaults())
+        var ready = true
+        settings.diarizationReady = { ready }
+        var seen: [Bool] = []
+        settings.addConfiguredObserver { seen.append($0) }
+
+        settings.isEnabled = true          // false → true
+        settings.refreshConfiguredState()  // unchanged
+        settings.refreshConfiguredState()  // unchanged
+        ready = false
+        settings.refreshConfiguredState()  // true → false
+        settings.refreshConfiguredState()  // unchanged
+        settings.isEnabled = false         // gate already closed
+
+        XCTAssertEqual(seen, [true, false])
     }
 
     // MARK: - The explicit delete path


### PR DESCRIPTION
Closes #215

#204 established that revoking access to learned voices takes effect
**immediately and completely**, and wired two observers to enforce it — profiles
deleted, and the user opting out. Both call
`LiveSpeakerDiarizer.forgetSeededProfiles(...)`.

There is a third way for the feature to stop being available mid-recording, and
it was not wired: `isConfigured` is `isEnabled && diarizationReady`, so turning
**diarization** off (or it becoming unavailable) leaves the pool holding the
centroids it copied at record-start, and `assign` keeps matching against them
until the recording stops.

Confirmed before changing anything, with a standalone harness compiling the real
`LiveSpeakerDiarizer` / `VoiceRecognitionSettings` / `SpeakerProfileStore` /
`ObservedVoiceSnapshots` out of the worktree. Against unfixed `main`:

- diarization off mid-recording → `assign` still returned `SPEAKER_00`, pool
  still held `profileName == "Alice"` — the bug;
- opt-out → correctly minted a new nameless speaker (#204's path, working).

The write gates always held, so nothing was ever persisted. What survived was the
**read** path: stored voices could still put a name on the in-flight transcript
after the feature stopped being configured. The inconsistency between the three
revocation triggers is the actual defect here rather than the impact.

## The fix — observe the gate, not the toggle

`VoiceRecognitionSettings` gains `addConfiguredObserver(_:)` /
`refreshConfiguredState()`: a second observer channel keyed on `isConfigured`,
firing on **transitions only**. It is driven by `isEnabled`'s `didSet` (so opt-out
still lands synchronously) and by assignments to `diarizationReady`.
`trackDiarizationReadiness(_:)` subscribes to the `objectWillChange` publishers
behind `diarizationReady`. `MilaApp` moves the `forgetSeededProfiles()`
registration onto the new channel.

**The main-actor hop is load-bearing.** `objectWillChange` fires on *willSet*, so
reading `isConfigured` inside the sink would see the pre-change value — the exact
trap the existing `isEnabled` comment documents. It still lands in time: the
pool's only reader (`process` → `assign`) is enqueued as a main-actor task too,
so an utterance captured *after* the change queues behind the refresh, while one
captured before it is legitimately labelled.

**`addEnabledObserver` deliberately keeps its two remaining registrants.**
`SpeakerProfileStore` (load/unload) and `ObservedVoiceSnapshots` answer to the
user's *consent*, not to diarization's availability. Moving them onto the gate
would empty the Settings profile-management list whenever the Python pipeline was
merely unready — a regression well outside this issue.

Both readiness publishers are subscribed, because `DiarizationSettings.isConfigured`
reads `bootstrap.isReady` on the bundled-runtime path and `nuclearRepair` clears
that without touching the settings object.

## Tests

`VoiceRecognitionGateTests` gains a `SeededRecording` fixture and a `PoolWiring`
enum (`.none` = pre-#204, `.toggleOnly` = #204, `.gate` = shipping) so each
control names the shape it reconstructs. The fixture sends `objectWillChange`
**before** the value settles, exactly as `@Published` does, so an implementation
that skipped the hop fails it.

Covered: the diarization-off case for a not-yet-heard speaker; a **negative
control** on `.toggleOnly` that still matches `SPEAKER_00` as "Alice", so the
main assertion is provably discriminating; the already-heard nuance (keeps
`SPEAKER_00`, loses the name — pinned against a future "fix" that mints a new id
and forks one person across two speakers mid-transcript); opt-out still landing
synchronously through the new channel; and transition-only notification, so an
`objectWillChange` firehose cannot re-run the handler on a loop.

## Verification

`xcodebuild build-for-testing` clean twice, no new warnings in the touched files.
The XCTest target was **not** run locally (app-hosted tests are not run on the
dev machine); instead every new assertion was mirrored into the harness and run
against the real objects — all pass, and both negative controls reproduce their
pre-fix shapes. CI is the first real XCTest run.

## Checklist

- [x] Builds locally (`make build`); tests written, left for CI to run
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, entries are written per release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice recognition data is now cleared when diarization becomes unavailable during an active recording, not only when users disable the feature.
  * Speaker continuity during recording is preserved while the feature remains configured.
  * Configuration change notifications now occur only when the effective feature state changes.

* **Documentation**
  * Updated guidance to clarify when voice recognition profiles are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live voice-recognition revocation during recording (privacy-sensitive read path), but scope is narrow and heavily regression-tested.
> 
> **Overview**
> Fixes **#215**: during an active recording, turning **diarization** off (or losing pipeline readiness) no longer leaves the live speaker pool matching stored voice centroids copied at record-start. Writes were already gated; this closes the **read** path that kept auto-labeling the transcript after the feature stopped being usable.
> 
> **`VoiceRecognitionSettings`** adds a second observer channel on **`isConfigured`** (`isEnabled && diarizationReady`): `addConfiguredObserver`, transition-only `refreshConfiguredState()`, and `trackDiarizationReadiness` on diarization `objectWillChange` publishers (with a deferred main-actor refresh so reads see settled state). **`MilaApp`** registers `LiveSpeakerDiarizer.forgetSeededProfiles()` on that gate instead of the opt-out toggle. **`addEnabledObserver`** stays for consent-scoped holders (in-memory profiles and snapshots).
> 
> **`VoiceRecognitionGateTests`** adds a `SeededRecording` / `PoolWiring` fixture and coverage for diarization-off mid-recording, toggle-only negative control, transition-only notifications, and opt-out still clearing the pool synchronously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770011805c8b29613ed7737f0c7663b80f840e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->