### PR TITLE
fix(logging): keep recording titles, user paths and subprocess output out of public log fields

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -129,8 +129,24 @@ enum LLMRunnerError: LocalizedError {
     /// can also fail with an `OpenAIRequestError`, a `CancellationError`, or
     /// something from `Foundation` — so the redaction has to be applied where
     /// the type is still unknown, or it gets skipped exactly when it matters.
+    ///
+    /// `OpenAIRequestError` needs the same treatment as `LLMRunnerError`, not
+    /// the pass-through: `run`'s `.openaiCompatible` branch rethrows it
+    /// unchanged from `runOpenAICompatible`, and its `errorDescription`
+    /// embeds the endpoint's own response body (a real 401 quotes a fragment
+    /// of the API key) or, for `.invalidEndpoint`, the configured Base URL
+    /// that this file otherwise refuses to log in full. Falling through to the
+    /// `LocalizedError` branch published both. See
+    /// `OpenAIRequestError.logDescription`. (CodeRabbit; issue #193.)
+    ///
+    /// The final fallback stays `errorDescription`/`localizedDescription` on
+    /// purpose — the helper is a redaction of the two types that are *known*
+    /// to carry someone else's bytes, not a gag on every error. A
+    /// `CancellationError` or a `URLError` reading "The Internet connection
+    /// appears to be offline" is the whole diagnostic and names nothing.
     static func logMessage(for error: Error) -> String {
         if let runnerError = error as? LLMRunnerError { return runnerError.logDescription }
+        if let openAIError = error as? OpenAIRequestError { return openAIError.logDescription }
         return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 }

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -71,6 +71,68 @@ enum LLMRunnerError: LocalizedError {
             return "LLM call was cancelled."
         }
     }
+
+    /// The log-safe twin of `errorDescription`, for the unified log.
+    ///
+    /// The two audiences are not the same one. `errorDescription` is rendered
+    /// on a surface the user is looking at *because they asked* — the Settings
+    /// test panel, the rename sheet, the post-recording banner — and there the
+    /// CLI's own words are the whole value: "command not found", "credit
+    /// balance too low", "unknown flag --foo". The unified log is a plaintext
+    /// store any process on the machine can read without private-data logging
+    /// enabled, and it keeps what it is given for days.
+    ///
+    /// Only `.nonZeroExit` differs between the two, and it is the only case
+    /// that carries the child's own output rather than a sentence Mila wrote:
+    ///
+    ///   * A CLI run verbosely echoes the composed prompt back on stderr —
+    ///     that prompt is the meeting transcript.
+    ///   * `run` constructs this case as
+    ///     `stderr.isEmpty ? outcome.stdout : outcome.stderr`, so a tool that
+    ///     fails silently puts the model's *answer about the meeting* here.
+    ///   * The user's "Extra args" are free text people put credentials in,
+    ///     and a CLI rejecting a bad flag commonly prints its argv back.
+    ///
+    /// So the log gets the shape of the failure — exit status and how many
+    /// bytes the tool produced — and never the bytes. That is the same split
+    /// `logRunEnd` already makes for its `stderr-tail` field, which is
+    /// `.private` for exactly these reasons; this closes the pre-existing hole
+    /// that field's doc comment pointed at. (Issue #193, CWE-532.)
+    ///
+    /// Every other case is a sentence Mila composed out of configuration the
+    /// user typed (tool name, executable path, timeout), which is already
+    /// logged `.public` as `exe=` on the run-start line — so they pass through
+    /// unchanged rather than being redacted for symmetry's sake. A log that
+    /// says `<private>` where it could have said "Could not find claude on
+    /// PATH" is a worse log for no privacy gain.
+    var logDescription: String {
+        switch self {
+        case .nonZeroExit(let code, let stderr):
+            // Byte count, not character count: it answers "did the tool say
+            // anything at all, and roughly how much?" without depending on
+            // how the bytes decode.
+            let bytes = stderr.utf8.count
+            return """
+                LLM CLI exited with status \(code) \
+                (\(bytes)B of tool output withheld — it can contain the \
+                transcript; see Settings → AI Provider → Test)
+                """
+        case .toolDisabled, .executableNotFound, .launchFailed,
+             .timedOut, .emptyOutput, .cancelled:
+            return errorDescription ?? "\(self)"
+        }
+    }
+
+    /// The log-safe message for *any* error thrown by an LLM path.
+    ///
+    /// Call sites catch `Error`, not `LLMRunnerError` — a summary or a Send
+    /// can also fail with an `OpenAIRequestError`, a `CancellationError`, or
+    /// something from `Foundation` — so the redaction has to be applied where
+    /// the type is still unknown, or it gets skipped exactly when it matters.
+    static func logMessage(for error: Error) -> String {
+        if let runnerError = error as? LLMRunnerError { return runnerError.logDescription }
+        return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
 }
 
 /// Everything the Settings → AI Provider test panel needs to explain a run to
@@ -1103,10 +1165,12 @@ enum LLMRunner {
     /// structured always-on excerpt of that content is not something to
     /// enable by default.
     ///
-    /// The precedent that `LLMRunnerError.nonZeroExit` already embeds stderr
-    /// verbatim in `errorDescription` — which `PostRecordingCoordinator` logs
-    /// `.public` — argues that the *existing* line is too loose, not that a
-    /// new and broader one is fine. (Worth tightening separately.)
+    /// `LLMRunnerError.nonZeroExit` used to embed stderr verbatim in
+    /// `errorDescription`, which `PostRecordingCoordinator` logged `.public` —
+    /// a looser leak than this field, through a path that had no annotation to
+    /// tighten. That is now closed: `LLMRunnerError.logDescription` gives the
+    /// log the exit status and a byte count, and every log site goes through
+    /// `LLMRunnerError.logMessage(for:)`. (Issue #193.)
     ///
     /// What stays `.public` is the part that answers the question at a
     /// glance: exit code, stderr/stdout byte counts, duration, and the
@@ -1225,10 +1289,12 @@ enum LLMRunner {
     /// A run that never got as far as a process: no tool configured, no
     /// executable found, or (for the HTTP path) no base URL. `error` because
     /// the user asked for something and got nothing, and the message is
-    /// `errorDescription` — the same sentence the UI shows, which contains
-    /// only the tool/path the user typed.
+    /// `logDescription` — for every error this path can actually see, the same
+    /// sentence the UI shows, which contains only the tool/path the user typed.
+    /// Routed through `logMessage(for:)` anyway so a future error that *does*
+    /// carry tool output can't reach the log by being thrown one frame higher.
     static func logSetupFailure(feature: LLMFeature, tool: LLMTool, error: Error) {
-        let message = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+        let message = LLMRunnerError.logMessage(for: error)
         llmRunnerLog.error("""
             llm run setup failed feature=\(feature.rawValue, privacy: .public) \
             tool=\(tool.rawValue, privacy: .public): \(message, privacy: .public)
@@ -1243,7 +1309,7 @@ enum LLMRunner {
                                  duration: TimeInterval,
                                  command: String,
                                  error: Error) {
-        let message = (error as? LLMRunnerError)?.errorDescription ?? error.localizedDescription
+        let message = LLMRunnerError.logMessage(for: error)
         llmRunnerLog.error("""
             llm run launch failed feature=\(feature.rawValue, privacy: .public) \
             tool=\(tool.rawValue, privacy: .public) \
@@ -1272,7 +1338,7 @@ enum LLMRunner {
                                host: String,
                                duration: TimeInterval,
                                error: Error) {
-        let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        let message = LLMRunnerError.logMessage(for: error)
         llmRunnerLog.error("""
             llm http failed feature=\(feature.rawValue, privacy: .public) \
             host=\(host, privacy: .public) \

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -537,7 +537,21 @@ TRANSCRIPT SO FAR:
                 }
             } catch {
                 let elapsed = Date().timeIntervalSince(llmStart)
-                print(String(format: "LiveAI[%@]: FAILED after %.1fs: %@", kickTag, elapsed, error.localizedDescription))
+                // Was a `print`, which is the worst version of this: no
+                // privacy annotation exists on it at all, and an app launched
+                // by launchd has its stdio captured into the unified log
+                // anyway. Live AI's prompt is the in-progress meeting
+                // transcript, so a CLI that echoes its input on stderr put the
+                // live transcript here on every failed tick — and ticks repeat
+                // for the whole meeting. `logMessage(for:)` keeps the exit
+                // status and a byte count. (Issue #193.) `lastError` below
+                // still carries the full text: that one is the in-app banner
+                // the user is watching.
+                liveAILog.error("""
+                    tick \(kickTag, privacy: .public): FAILED after \
+                    \(String(format: "%.1f", elapsed), privacy: .public)s: \
+                    \(LLMRunnerError.logMessage(for: error), privacy: .public)
+                    """)
                 // Same drop-the-stale-tick check as the success path.
                 guard let self, self.sessionID == kickSessionID else {
                     return

--- a/Mila/Actions/ObsidianExporter.swift
+++ b/Mila/Actions/ObsidianExporter.swift
@@ -1,5 +1,16 @@
 import Foundation
+import OSLog
 import MilaKit
+
+// Every path this file logs is doubly user content: the vault root is a folder
+// the user picked, the subfolder under it is a Mila folder name they typed, and
+// the note's own filename is `<date> <title>.md` — the recording title,
+// verbatim. So paths are `.private` throughout and the recording's UUID is the
+// public correlation key; `NSError.domain`/`code` stay public because they are
+// what separates "no permission" from a full disk or a missing vault, and they
+// name nothing. (Issue #213, CWE-532.)
+private let obsidianLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                 category: "ObsidianExporter")
 
 /// Writes a completed recording into the configured Obsidian vault as a
 /// Markdown note, then optionally kicks the git sync.
@@ -121,14 +132,23 @@ final class ObsidianExporter: ObservableObject {
         // It also covers what no naming rule can — a symlink inside the vault
         // whose target is outside it, which is spelled entirely under the vault.
         guard ObsidianPathSanitizer.isContained(destDir, in: vault, fileManager: fileManager) else {
-            print("ObsidianExporter: refusing to write outside the vault: \(destDir.path)")
+            obsidianLog.error("""
+                refusing to write outside the vault for \
+                \(recording.id, privacy: .public): \(destDir.path, privacy: .private)
+                """)
             return nil
         }
 
         do {
             try fileManager.createDirectory(at: destDir, withIntermediateDirectories: true)
         } catch {
-            print("ObsidianExporter: failed to create \(destDir.path): \(error)")
+            let ns = error as NSError
+            obsidianLog.error("""
+                failed to create vault directory for \(recording.id, privacy: .public) \
+                (\(destDir.path, privacy: .private)) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return nil
         }
 
@@ -147,7 +167,10 @@ final class ObsidianExporter: ObservableObject {
         // Re-checked for the file itself, not just its directory: the note name
         // could already exist as a symlink pointing out of the vault.
         guard ObsidianPathSanitizer.isContained(target, in: vault, fileManager: fileManager) else {
-            print("ObsidianExporter: refusing to write outside the vault: \(target.path)")
+            obsidianLog.error("""
+                refusing to write outside the vault for \
+                \(recording.id, privacy: .public): \(target.path, privacy: .private)
+                """)
             return nil
         }
         let newRelative = Self.relativePath(of: target, vault: vault)
@@ -167,7 +190,13 @@ final class ObsidianExporter: ObservableObject {
         do {
             try Self.markdown(for: recording).write(to: target, atomically: true, encoding: .utf8)
         } catch {
-            print("ObsidianExporter: failed to write \(target.path): \(error)")
+            let ns = error as NSError
+            obsidianLog.error("""
+                failed to write note for \(recording.id, privacy: .public) \
+                (\(target.path, privacy: .private)) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return nil
         }
         index[key] = newRelative

--- a/Mila/Actions/OpenAIClient.swift
+++ b/Mila/Actions/OpenAIClient.swift
@@ -31,6 +31,54 @@ enum OpenAIRequestError: LocalizedError, Equatable {
             return "“\(baseURL)” is not a valid endpoint URL. Check the Base URL in Settings → AI Provider (it must look like https://api.openai.com/v1)."
         }
     }
+
+    /// The log-safe twin of `errorDescription`, matching
+    /// `LLMRunnerError.logDescription` and
+    /// `SpeakerDiarizer.Error.logDescription`.
+    ///
+    /// This is the HTTP half of the same defect those two closed on the
+    /// subprocess side: the content is inside the string before any `Logger`
+    /// sees it, so annotating the call sites cannot help. `LLMRunner.run`
+    /// rethrows this type unchanged from `runOpenAICompatible`, and every LLM
+    /// log site funnels through `LLMRunnerError.logMessage(for:)` — so
+    /// whatever `errorDescription` says lands in a `.public` field.
+    ///
+    ///   * `.auth` / `.notFound` / `.server` carry `message`, which is the
+    ///     remote endpoint's own response body (`OpenAIClient.parse` pulls
+    ///     `error.message`). It is third-party output of unbounded shape: a
+    ///     real OpenAI 401 reads "Incorrect API key provided: sk-…XYZ", so the
+    ///     log field gets a fragment of the user's credential, once per failed
+    ///     call.
+    ///   * `.invalidEndpoint` carries the configured Base URL verbatim.
+    ///     `runOpenAICompatible` deliberately logs `host=` and *never* the
+    ///     full URL, because "a user's endpoint can carry a token in its query
+    ///     string" — and then this case handed the whole URL back through the
+    ///     failure field, defeating that on the one path where the URL is
+    ///     malformed enough that `URL(string:)` produced no host to log.
+    ///
+    /// What survives is what triages: which failure, and the HTTP status. A
+    /// 401 versus a 404 versus a 500 is the entire first question, and none of
+    /// those numbers names anything. `.emptyOutput` carries nothing and passes
+    /// through unchanged.
+    ///
+    /// `errorDescription` is untouched on purpose — the Settings → AI Provider
+    /// test panel and the post-recording banner are surfaces the user opened
+    /// themselves, and there the server's own words are the whole value.
+    /// (CodeRabbit; issues #193 / #213, CWE-532.)
+    var logDescription: String {
+        switch self {
+        case .auth:
+            return "Authentication failed (401) — server message withheld (it can quote your API key)"
+        case .notFound:
+            return "Model or endpoint not found (404) — server message withheld"
+        case .server(let status, _):
+            return "Server returned HTTP \(status) — server message withheld"
+        case .emptyOutput:
+            return errorDescription ?? "\(self)"
+        case .invalidEndpoint:
+            return "Configured Base URL is not a valid endpoint URL (URL withheld — it can carry a token); check Settings → AI Provider"
+        }
+    }
 }
 
 /// Host-locality classification for an OpenAI-compatible base URL, used by

--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -400,9 +400,25 @@ final class PostRecordingCoordinator: ObservableObject {
                 // send) — no banner, the cancellation was deliberate.
             } catch {
                 if Task.isCancelled { return }
+                // The BANNER keeps `localizedDescription` — for
+                // `LLMRunnerError.nonZeroExit` that is the CLI's own stderr,
+                // and it is the only thing that turns "Claude failed" into
+                // something the user can act on. It is their transcript, on
+                // their screen, in response to a button they pressed.
+                //
+                // The LOG gets `logMessage(for:)` instead: exit status and a
+                // byte count, no tool output. This line was the reported site
+                // in issue #193 — a verbose CLI echoes the composed prompt
+                // (the transcript) on stderr, and `nonZeroExit` falls back to
+                // stdout (the model's answer about the meeting), so `.public`
+                // here put meeting content into a plaintext system log that
+                // needs no private-data logging to read.
                 self.postStatus("\(toolName) failed: \(error.localizedDescription)",
                                 isError: true)
-                postRecordingLog.error("send failed \(recordingID.uuidString.prefix(8), privacy: .public): \(error.localizedDescription, privacy: .public)")
+                postRecordingLog.error("""
+                    send failed \(recordingID.uuidString.prefix(8), privacy: .public): \
+                    \(LLMRunnerError.logMessage(for: error), privacy: .public)
+                    """)
             }
         }
         sendTasks[recordingID] = task

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -460,7 +460,18 @@ final class RecordingSummarizer: ObservableObject {
                 summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(cleaned.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
                 self.onSummaryFinished?(current)
             } catch {
-                summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // `logMessage(for:)`, not `localizedDescription`: this catches
+                // whatever `LLMRunner.run` threw, and
+                // `LLMRunnerError.nonZeroExit.errorDescription` embeds the
+                // CLI's stderr verbatim — which for a summary run is the
+                // composed prompt, i.e. the meeting transcript. Same leak as
+                // `PostRecordingCoordinator`'s send line, found in the same
+                // sweep. (Issue #193.) The summarizer has no user-facing
+                // surface for a failure, so nothing is lost here.
+                summarizerLog.error("""
+                    failed \(self?.shortID(id) ?? "?", privacy: .public): \
+                    \(LLMRunnerError.logMessage(for: error), privacy: .public)
+                    """)
                 // Failed generation — signal so a pending export can still
                 // write the transcript fallback. A permanent delete cancels
                 // the task, which lands here as a CancellationError, so the

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -5,6 +5,13 @@ import OSLog
 import Sparkle
 import TranscriptionCore
 
+/// File-scope destination for the launch-recovery sweep, matching the
+/// convention in `RecordingStore` / `TranscriptionService`. The rest of this
+/// file constructs `os.Logger` inline at each site; those lines are UI-test
+/// seams and Live AI wiring, and are left as they are.
+private let appLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                            category: "MilaApp")
+
 /// Wraps Sparkle's `SPUStandardUpdaterController` so SwiftUI menu items can
 /// observe `canCheckForUpdates` and disable themselves while a check is
 /// already in flight. Created once at app launch — Sparkle starts its
@@ -1802,12 +1809,24 @@ struct MilaApp: App {
                     fixed.status = .pending
                     statusChanged.append(fixed)
                 }
-                print("MilaApp: re-enqueuing stale \(recording.status.rawValue) recording \(recording.audioFileName)")
+                // `audioFileName` is derived from the recording's TITLE
+                // (`RecordingStore.freshAudioURL(suggestedName:)`), so logging
+                // it publicly publishes the meeting name. The UUID is the safe
+                // correlation key; the status is app state. (Issue #213.)
+                appLog.log("""
+                    re-enqueuing stale \(recording.status.rawValue, privacy: .public) \
+                    recording \(recording.id, privacy: .public) \
+                    (\(recording.audioFileName, privacy: .private))
+                    """)
                 toEnqueue.append(fixed)
             case .markFailed:
                 fixed.status = .failed
                 statusChanged.append(fixed)
-                print("MilaApp: reset stale \(recording.status.rawValue) recording \(recording.audioFileName) to .failed (WAV missing)")
+                appLog.log("""
+                    reset stale \(recording.status.rawValue, privacy: .public) \
+                    recording \(recording.id, privacy: .public) \
+                    (\(recording.audioFileName, privacy: .private)) to .failed (WAV missing)
+                    """)
             case .leaveAlone:
                 break  // unreachable given the `where` filter above
             }
@@ -1830,7 +1849,10 @@ struct MilaApp: App {
             // the batch run reads it. Awaited so this recording is only
             // enqueued once its own repair has finished.
             await WAVHeaderRepair.repairInBackground(at: store.audioURL(for: recording))
-            print("MilaApp: re-enqueuing recovered recording \(recording.audioFileName)")
+            appLog.log("""
+                re-enqueuing recovered recording \(recording.id, privacy: .public) \
+                (\(recording.audioFileName, privacy: .private))
+                """)
             transcription.enqueue(recording)
         }
     }

--- a/Mila/Audio/AudioCompressor.swift
+++ b/Mila/Audio/AudioCompressor.swift
@@ -47,7 +47,16 @@ enum AudioCompressor {
                 if buffer.frameLength == 0 { break }
                 try output.write(from: buffer)
             }
-            compressorLog.log("compressed \(wavURL.lastPathComponent, privacy: .public) → \(destURL.lastPathComponent, privacy: .public)")
+            // Both names are title-derived — the caller
+            // (`RecordingStore.compressRecordingAudio`) already redacts its own
+            // copy of the destination name for this reason; this line is the
+            // one it wraps and needs the same treatment. The compressor has no
+            // recording id to correlate on, but `RecordingStore` logs the id
+            // either side of this call. (Issue #213, CWE-532.)
+            compressorLog.log("""
+                compressed \(wavURL.lastPathComponent, privacy: .private) → \
+                \(destURL.lastPathComponent, privacy: .private)
+                """)
         }.value
     }
 

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -162,7 +162,20 @@ final class RecordingSession: ObservableObject {
             // Recording permission denied) left the mic engine hot and the
             // WAV file open, appending mic audio indefinitely — and since
             // `state` is still .idle, `cancelAll()` refused to clean it up.
-            recLog.error("start(\(source.rawValue, privacy: .public)) failed mid-bring-up — tearing down partial session: \(error.localizedDescription, privacy: .public)")
+            // `AVAudioFile(forWriting: outputURL, …)` is inside this `do`, so
+            // the failure being reported can be "couldn't create the recording
+            // file" — and `outputURL` is `freshAudioURL`, a title-derived name
+            // inside the user's chosen recordings folder, both of which Cocoa
+            // quotes in `localizedDescription`. The far more common failure
+            // here (Screen Recording permission denied) is fully described by
+            // the source + domain + code, which stay public. (Issue #213.)
+            let ns = error as NSError
+            recLog.error("""
+                start(\(source.rawValue, privacy: .public)) failed mid-bring-up \
+                — tearing down partial session \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             micTask?.cancel(); micTask = nil
             systemTask?.cancel(); systemTask = nil
             await mic.stop()
@@ -492,7 +505,19 @@ final class RecordingSession: ObservableObject {
         do {
             try file.write(from: buffer)
         } catch {
-            recLog.error("audio file write error: \(error.localizedDescription, privacy: .public)")
+            // The file being written lives in the recordings directory, which
+            // is the folder the user chose in Settings → Storage, and Cocoa
+            // quotes both the file and its containing folder in
+            // `localizedDescription`. Domain + code stay public — a disk-full
+            // versus a revoked-permission versus a vanished-volume write
+            // failure is exactly what this line exists to tell apart, and
+            // neither names a path. (Issue #213, CWE-532.)
+            let ns = error as NSError
+            recLog.error("""
+                audio file write error \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
         }
         // Live-transcription feed: `.microphone` and `.meeting` fire
         // `onLiveSamples` from `consumeMic` (the latter with the mic+system

--- a/Mila/Audio/WAVHeaderRepair.swift
+++ b/Mila/Audio/WAVHeaderRepair.swift
@@ -164,7 +164,23 @@ enum WAVHeaderRepair {
                 try handle.write(contentsOf: bytes)
                 return true
             } catch {
-                wavRepairLog.error("WAV header write failed at \(offset): \(error.localizedDescription, privacy: .public)")
+                // Same redaction as the success line below, for the same
+                // reason — the failure path had been left `.public` while the
+                // success path was fixed, which is the more dangerous half of
+                // the pair: a repair that *works* logs a name, one that fails
+                // logs the name AND the folder holding it, because Cocoa
+                // quotes both inside `localizedDescription`. `url` here is a
+                // title-derived WAV inside the user's chosen recordings
+                // directory. Domain + code stay public: a read-only volume, a
+                // full disk and a vanished file are what this line exists to
+                // tell apart, and none of them names anything.
+                // (Bugbot, issue #213, CWE-532.)
+                let ns = error as NSError
+                wavRepairLog.error("""
+                    WAV header write failed at \(offset, privacy: .public) \
+                    [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                    \(error.localizedDescription, privacy: .private)
+                    """)
                 return false
             }
         }
@@ -178,7 +194,15 @@ enum WAVHeaderRepair {
         do {
             try handle.synchronize()
         } catch {
-            wavRepairLog.error("WAV header fsync failed: \(error.localizedDescription, privacy: .public)")
+            // As above. `synchronize()` fails against the same title-derived
+            // file in the same user-chosen folder, so its message quotes the
+            // same two things. (Bugbot, issue #213, CWE-532.)
+            let ns = error as NSError
+            wavRepairLog.error("""
+                WAV header fsync failed \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return false
         }
         // The WAV's name is title-derived (`freshAudioURL(suggestedName:)`), so

--- a/Mila/Audio/WAVHeaderRepair.swift
+++ b/Mila/Audio/WAVHeaderRepair.swift
@@ -181,7 +181,13 @@ enum WAVHeaderRepair {
             wavRepairLog.error("WAV header fsync failed: \(error.localizedDescription, privacy: .public)")
             return false
         }
-        wavRepairLog.log("repaired unfinalized WAV header for \(url.lastPathComponent, privacy: .public) (data size -> \(plan.newDataSize))")
+        // The WAV's name is title-derived (`freshAudioURL(suggestedName:)`), so
+        // it is `.private`; the repaired size is the diagnostic and stays
+        // public. (Issue #213.)
+        wavRepairLog.log("""
+            repaired unfinalized WAV header for \(url.lastPathComponent, privacy: .private) \
+            (data size -> \(plan.newDataSize, privacy: .public))
+            """)
         return true
     }
 

--- a/Mila/Dictation/DictationController.swift
+++ b/Mila/Dictation/DictationController.swift
@@ -2,7 +2,11 @@ import Foundation
 import AppKit
 import Combine
 import AVFoundation
+import OSLog
 import TranscriptionCore
+
+private let dictationLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                  category: "DictationController")
 
 /// Press the bound hotkey to start a dictation in that language. Press the same
 /// hotkey again to stop, transcribe, and paste at the cursor.
@@ -280,7 +284,21 @@ final class DictationController: ObservableObject {
                 try file.write(from: buffer)
             }
         } catch {
-            print("Dictation save error: \(error)")
+            // `url` is `store.freshAudioURL(...)` — inside the recordings
+            // directory, which is the folder the user chose in Settings →
+            // Storage. Cocoa quotes the file AND its containing folder in
+            // `localizedDescription` ("…in the folder “Acme Corp Client X”"),
+            // so the message leaks that choice even though the filename
+            // itself is the fixed "Dictation" stem. Domain + code stay public:
+            // "no permission" (NSCocoaErrorDomain 513) versus a full disk
+            // versus a missing directory is the entire diagnostic, and neither
+            // names a path. (Issue #213, CWE-532.)
+            let ns = error as NSError
+            dictationLog.error("""
+                dictation save failed \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return
         }
         let title = "Dictation · \(Self.titleFormatter.string(from: Date()))"

--- a/Mila/MCP/LiveTranscriptSidecarWriter.swift
+++ b/Mila/MCP/LiveTranscriptSidecarWriter.swift
@@ -19,6 +19,17 @@ private let sidecarLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
 @MainActor
 final class LiveTranscriptSidecarWriter: ObservableObject {
 
+    /// Every file this type writes lives at `<root>/live/`, and `root` is
+    /// `RecordingStore.originalRootDirectory` in production (see `MilaApp`) —
+    /// the fixed app-support root, which `relocateRecordings` never moves. So
+    /// the three write-failure lines below keep `error.localizedDescription`
+    /// `.public` on purpose: the folder Cocoa quotes in the message can only
+    /// ever be “Mila”, no title or user-chosen path can reach them, and a
+    /// readable message is what makes a broken MCP handoff diagnosable. Same
+    /// established exception as `store-location.json` and `persistTombstones`
+    /// in `RecordingStore`; contrast `persist()` / `persistFolders()` there,
+    /// which follow the user's chosen directory and therefore redact.
+    /// (Issue #213.)
     private let root: URL
     private let minWriteInterval: TimeInterval
     private let heartbeatInterval: TimeInterval

--- a/Mila/Models/MilaConfig.swift
+++ b/Mila/Models/MilaConfig.swift
@@ -123,8 +123,10 @@ extension MilaConfig {
         /// where the concrete type is still unknown — `MilaConfigImporter`
         /// catches `Error`.
         ///
-        /// The fallback is deliberately **not** `localizedDescription`, unlike
-        /// the LLM and diarizer helpers. `load(from:)` only ever throws
+        /// The fallback is deliberately **not** `localizedDescription`, as in
+        /// `SpeakerDiarizer.Error.logMessage(for:)` and unlike the LLM helper —
+        /// whose fallback stays a pass-through because nothing on that path
+        /// opens a file the user named. `load(from:)` only ever throws
         /// `LoadError`, so anything else arriving here came from the
         /// surrounding file-open path (the security-scope dance, a future
         /// caller) — which is exactly the shape that quotes the user's path.

--- a/Mila/Models/MilaConfig.swift
+++ b/Mila/Models/MilaConfig.swift
@@ -85,6 +85,55 @@ extension MilaConfig {
                     + "Update Mila and try again."
             }
         }
+
+        /// The log-safe twin of `errorDescription`, matching
+        /// `LLMRunnerError.logDescription` and
+        /// `SpeakerDiarizer.Error.logDescription`.
+        ///
+        /// `MilaConfigImporter` logs the staged filename `.private` because a
+        /// `.milaconfig` passed round a team is commonly named for the org or
+        /// the server it configures — and then its `catch` published the same
+        /// name straight back, because these two cases are built from someone
+        /// else's message:
+        ///
+        ///   * `.unreadable` wraps `Data(contentsOf:).localizedDescription`
+        ///     for a file the user double-clicked, and Cocoa quotes both the
+        ///     filename and its containing folder in that sentence.
+        ///   * `.malformed` wraps `JSONDecoder`'s message, which quotes coding
+        ///     keys and — for a type/value mismatch — the offending value,
+        ///     e.g. the endpoint URL or model name in the config.
+        ///
+        /// `.unsupportedVersion` is the opposite case and passes through: two
+        /// integers Mila composed itself, which are the entire diagnostic
+        /// ("update Mila") and name nothing. Redacting it would be the
+        /// over-redaction `bugbot-rules/no-user-content-in-logs.md` warns
+        /// about. (Issue #213, CWE-532.)
+        var logDescription: String {
+            switch self {
+            case .unreadable:
+                return "Couldn't read the configuration file (detail withheld — it quotes the file's name and folder)"
+            case .malformed:
+                return "Not a valid Mila configuration file (detail withheld — decoder messages quote keys and values)"
+            case .unsupportedVersion:
+                return errorDescription ?? "\(self)"
+            }
+        }
+
+        /// The log-safe message for any error a config load can throw, applied
+        /// where the concrete type is still unknown — `MilaConfigImporter`
+        /// catches `Error`.
+        ///
+        /// The fallback is deliberately **not** `localizedDescription`, unlike
+        /// the LLM and diarizer helpers. `load(from:)` only ever throws
+        /// `LoadError`, so anything else arriving here came from the
+        /// surrounding file-open path (the security-scope dance, a future
+        /// caller) — which is exactly the shape that quotes the user's path.
+        /// Domain + code keep it diagnosable without guessing.
+        static func logMessage(for error: Swift.Error) -> String {
+            if let loadError = error as? LoadError { return loadError.logDescription }
+            let ns = error as NSError
+            return "unexpected error [\(ns.domain) \(ns.code)]"
+        }
     }
 
     /// Parse a `.milaconfig` file, throwing a user-facing `LoadError`.

--- a/Mila/Models/MilaConfigImporter.swift
+++ b/Mila/Models/MilaConfigImporter.swift
@@ -78,7 +78,15 @@ final class MilaConfigImporter: ObservableObject {
             pending = PendingImport(config: config,
                                     changes: plannedChanges(for: config),
                                     sourceName: url.lastPathComponent)
-            log.log("staged \(url.lastPathComponent, privacy: .public) for import (\(self.pending?.changes.count ?? 0) change(s))")
+            // The FILENAME is user-chosen — a `.milaconfig` handed round a
+            // team is commonly named for the org or the server it configures
+            // ("acme-asr.milaconfig"), which is the same "names an employer or
+            // a customer" exposure as the storage folder. The change count is
+            // the diagnostic and stays public. (Issue #213.)
+            log.log("""
+                staged \(url.lastPathComponent, privacy: .private) for import \
+                (\(self.pending?.changes.count ?? 0, privacy: .public) change(s))
+                """)
         } catch {
             errorMessage = (error as? MilaConfig.LoadError)?.errorDescription
                 ?? error.localizedDescription

--- a/Mila/Models/MilaConfigImporter.swift
+++ b/Mila/Models/MilaConfigImporter.swift
@@ -88,9 +88,24 @@ final class MilaConfigImporter: ObservableObject {
                 (\(self.pending?.changes.count ?? 0, privacy: .public) change(s))
                 """)
         } catch {
+            // `errorMessage` is the sheet the user is looking at — it keeps
+            // the full text, including the quoted filename. The LOG does not:
+            // the success line above redacts `url.lastPathComponent` for a
+            // reason, and `String(describing:)` on a
+            // `MilaConfig.LoadError.unreadable` published exactly that name
+            // (plus its containing folder) right back, because the case wraps
+            // `Data(contentsOf:).localizedDescription`. Same success-redacted
+            // / failure-public asymmetry Bugbot found in `WAVHeaderRepair`.
+            // The failure KIND stays public; the message goes `.private` so it
+            // is still there for anyone who enables private-data logging.
+            // (Issue #213, CWE-532.)
             errorMessage = (error as? MilaConfig.LoadError)?.errorDescription
                 ?? error.localizedDescription
-            log.error("failed to load config: \(String(describing: error), privacy: .public)")
+            log.error("""
+                failed to load config: \
+                \(MilaConfig.LoadError.logMessage(for: error), privacy: .public) \
+                (\(String(describing: error), privacy: .private))
+                """)
         }
     }
 

--- a/Mila/Models/ObsidianVaultSettings.swift
+++ b/Mila/Models/ObsidianVaultSettings.swift
@@ -1,5 +1,9 @@
 import Foundation
 import Combine
+import OSLog
+
+private let vaultSettingsLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                      category: "ObsidianVaultSettings")
 
 /// Filesystem-name safety for everything Mila writes into the vault.
 ///
@@ -321,7 +325,17 @@ final class ObsidianVaultSettings: ObservableObject {
                 bookmarkDataIsStale: &isStale
             )
         } catch {
-            print("ObsidianVaultSettings: failed to resolve bookmark: \(error)")
+            // Same shape as `RecordingStorageSettings`: the bookmark points at
+            // a folder the user chose, and Cocoa quotes it (or its parent) in
+            // the error text. An Obsidian vault path is if anything more
+            // revealing than the recordings folder — it is someone's personal
+            // notes tree. Domain + code stay public. (Issue #213.)
+            let ns = error as NSError
+            vaultSettingsLog.error("""
+                failed to resolve bookmark \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             defaults.removeObject(forKey: Self.bookmarkKey)
             return
         }
@@ -366,7 +380,12 @@ final class ObsidianVaultSettings: ObservableObject {
             resolveAndStartAccessing()
             return vaultURL != nil
         } catch {
-            print("ObsidianVaultSettings: failed to mint bookmark for \(url.path): \(error)")
+            let ns = error as NSError
+            vaultSettingsLog.error("""
+                failed to mint bookmark for \(url.path, privacy: .private) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return false
         }
     }

--- a/Mila/Models/RecordingStorageSettings.swift
+++ b/Mila/Models/RecordingStorageSettings.swift
@@ -1,5 +1,9 @@
 import Foundation
 import Combine
+import OSLog
+
+private let storageSettingsLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                        category: "RecordingStorageSettings")
 
 /// User-configurable destination for new recordings + the per-recording
 /// metadata sidecars (`recordings.json`, `folders.json`, `.txt` transcripts,
@@ -163,7 +167,20 @@ final class RecordingStorageSettings: ObservableObject {
         } catch {
             // Bookmark blob unreadable — drop it so we don't keep
             // failing on every launch.
-            print("RecordingStorageSettings: failed to resolve bookmark: \(error)")
+            // The bookmark blob resolves to the folder the user picked for
+            // their recordings, and a resolution failure names it: Cocoa
+            // quotes the path (or its containing folder) in
+            // `localizedDescription`, and that folder can be a client name, an
+            // employer, a project. Domain + code stay public — they are what
+            // says "the volume is gone" versus "permission denied" versus
+            // "corrupt blob", which is the whole diagnostic here.
+            // (Issue #213, CWE-532.)
+            let ns = error as NSError
+            storageSettingsLog.error("""
+                failed to resolve bookmark \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             defaults.removeObject(forKey: Self.bookmarkKey)
             return
         }
@@ -219,7 +236,15 @@ final class RecordingStorageSettings: ObservableObject {
             resolveAndStartAccessing()
             return customDirectory != nil
         } catch {
-            print("RecordingStorageSettings: failed to mint bookmark for \(url.path): \(error)")
+            // `url` IS the folder the user just chose in the open panel — the
+            // reported site in issue #213, and the most direct version of the
+            // leak: a full POSIX path straight into the log.
+            let ns = error as NSError
+            storageSettingsLog.error("""
+                failed to mint bookmark for \(url.path, privacy: .private) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return false
         }
     }

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -88,9 +88,23 @@ final class RecordingStore: ObservableObject {
            let legacy = legacyRoots.first(where: { fm.fileExists(atPath: $0.path) }) {
             do {
                 try fm.moveItem(at: legacy, to: newRoot)
-                print("RecordingStore: migrated \(legacy.path) -> \(newRoot.path)")
+                // Deliberately `.public`, both paths and the error text. These
+                // are the fixed legacy app-support roots
+                // (`…/Application Support/IslandWhisper` or `…/IvritWhisper`)
+                // and the fixed new one (`…/Mila`) — this runs BEFORE any user
+                // storage override exists, and none of the three names can be
+                // anything the user chose. A once-per-upgrade migration that
+                // fails silently is unfixable by anyone; the paths are the
+                // report. (Issue #213.)
+                recStoreLog.log("""
+                    migrated \(legacy.path, privacy: .public) -> \
+                    \(newRoot.path, privacy: .public)
+                    """)
             } catch {
-                print("RecordingStore: migration from \(legacy.lastPathComponent) failed (\(error)) — falling back to fresh dir")
+                recStoreLog.error("""
+                    migration from \(legacy.lastPathComponent, privacy: .public) failed \
+                    (\(error.localizedDescription, privacy: .public)) — falling back to fresh dir
+                    """)
             }
         }
         self.init(rootDirectory: newRoot)
@@ -995,7 +1009,17 @@ final class RecordingStore: ObservableObject {
             let data = try JSONEncoder().encode(voiceMemoTombstones)
             try data.write(to: tombstonesURL, options: .atomic)
         } catch {
-            print("RecordingStore tombstones persist error: \(error)")
+            // Deliberately `.public`, and the second of the two writes that
+            // still are — the other is the store-location pointer above.
+            // `tombstonesURL` is anchored to `originalRootDirectory`, which
+            // `relocateRecordings` never moves (it moves `recordingsDirectory`
+            // / `storeURL` / `foldersURL` and leaves this alone), so the folder
+            // Cocoa quotes in the message can only ever be “Mila”. Contrast
+            // `persist()` / `persistFolders()` below, which follow the user's
+            // chosen directory and therefore redact. Was a bare `print`, which
+            // is public with no annotation to reason about at all.
+            // (Issue #213.)
+            recStoreLog.error("tombstones persist error: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Mila/Models/SpeakerDirectory.swift
+++ b/Mila/Models/SpeakerDirectory.swift
@@ -1,4 +1,8 @@
 import Foundation
+import OSLog
+
+private let speakerDirLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                   category: "SpeakerDirectory")
 
 /// App-wide directory of speaker names the user has assigned across
 /// recordings — the pick-list behind the speaker rename popover. Most
@@ -92,7 +96,14 @@ final class SpeakerDirectory: ObservableObject {
                                                     withIntermediateDirectories: true)
             try data.write(to: fileURL, options: .atomic)
         } catch {
-            print("SpeakerDirectory persist error: \(error)")
+            // Deliberately `.public`, on the same grounds as the voice-memo
+            // tombstones: `speaker-names.json` sits at the Application
+            // Support/Mila root and does NOT travel with a relocated
+            // recordings folder (see this type's doc comment), so the folder
+            // Cocoa quotes can only ever be “Mila”. The NAMES are user content
+            // and are never logged — only the failure to write the file is.
+            // (Issue #213.)
+            speakerDirLog.error("persist error: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -189,6 +189,15 @@ final class SpeakerProfileStore: ObservableObject {
 
     /// `directory` is the folder that holds `speaker-profiles.json`.
     /// Injectable so tests can point at a temp directory.
+    ///
+    /// In production it is the fixed `Application Support/Mila` root (see the
+    /// convenience init), NOT the user's chosen recordings folder — voice
+    /// profiles are app state and deliberately do not travel with a relocated
+    /// store, exactly like `speaker-names.json` and the voice-memo tombstones.
+    /// That is why the load/save/delete failures below keep
+    /// `error.localizedDescription` `.public`: the folder Cocoa quotes in the
+    /// message can only ever be “Mila”. The profile NAMES are user content and
+    /// are already `.private` at the one site that logs one. (Issue #213.)
     init(directory: URL, settings: VoiceRecognitionSettings) {
         self.settings = settings
         self.storeURL = directory.appendingPathComponent("speaker-profiles.json")

--- a/Mila/Models/VoiceMemosSettings.swift
+++ b/Mila/Models/VoiceMemosSettings.swift
@@ -1,5 +1,9 @@
 import Foundation
 import Combine
+import OSLog
+
+private let voiceMemosSettingsLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                           category: "VoiceMemosSettings")
 
 /// User settings for iPhone Voice Memos folder integration. Persists which
 /// Voice Memos folders Mila watches + auto-transcribes. Follows the same
@@ -125,7 +129,18 @@ final class VoiceMemosSettings: ObservableObject {
                                bookmarkDataIsStale: &isStale)
         } catch {
             // Unreadable blob — drop it so we don't fail on every launch.
-            print("VoiceMemosSettings: failed to resolve folder bookmark: \(error)")
+            //
+            // The bookmark is the folder grant the user made in the open panel
+            // (PR #73 replaced Full Disk Access with this), so the error text
+            // names a path they picked. Domain + code stay public — they say
+            // whether the volume vanished or the blob is corrupt.
+            // (Issue #213.)
+            let ns = error as NSError
+            voiceMemosSettingsLog.error("""
+                failed to resolve folder bookmark \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             defaults.removeObject(forKey: Keys.folderBookmark)
             return
         }
@@ -164,7 +179,12 @@ final class VoiceMemosSettings: ObservableObject {
             resolveFolderAccess()
             return grantedFolderURL != nil
         } catch {
-            print("VoiceMemosSettings: failed to mint folder bookmark for \(url.path): \(error)")
+            let ns = error as NSError
+            voiceMemosSettingsLog.error("""
+                failed to mint folder bookmark for \(url.path, privacy: .private) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             return false
         }
     }

--- a/Mila/Transcription/RemoteWhisperEngine.swift
+++ b/Mila/Transcription/RemoteWhisperEngine.swift
@@ -55,6 +55,54 @@ actor RemoteWhisperEngine: RemoteTranscribing {
             }
         }
 
+        /// The log-safe twin of `errorDescription`, matching
+        /// `LLMRunnerError.logDescription`,
+        /// `SpeakerDiarizer.Error.logDescription` and
+        /// `OpenAIRequestError.logDescription`.
+        ///
+        /// Only `.http` differs, and it is the only case that carries bytes
+        /// Mila did not write. `shortMessage(from:)` prefers the endpoint's
+        /// `error.message` but falls back to `String(body.prefix(200))` — an
+        /// unbounded 200-character slice of whatever a configured ASR endpoint
+        /// returned. A real OpenAI 401 reads "Incorrect API key provided:
+        /// sk-…XYZ", so that slice can be a fragment of the user's
+        /// credential, and a proxy answering 502 with the upstream payload can
+        /// put transcript text there.
+        ///
+        /// Volume is what makes it matter: `TranscriptionService`'s live path
+        /// logs this once per *utterance* for the whole recording (its own
+        /// comment says a remote failure "repeats on every utterance"), so one
+        /// misconfigured endpoint writes hundreds of copies into a plaintext
+        /// system log.
+        ///
+        /// The status code stays — 401 vs 404 vs 500 is the entire first
+        /// question and names nothing — and the byte count says whether the
+        /// server explained itself at all. `errorDescription` is untouched:
+        /// `lastError` puts it in the app's own error banner, which is the
+        /// user reading their own failure on their own screen.
+        /// (Issue #213, CWE-532.)
+        var logDescription: String {
+            switch self {
+            case .http(let status, let body):
+                return """
+                    Remote server returned HTTP \(status) \
+                    (\(body.utf8.count)B of server response withheld — it can \
+                    quote your API key)
+                    """
+            case .notConfigured, .noAudioCaptured, .badResponse, .emptyResult:
+                return errorDescription ?? "\(self)"
+            }
+        }
+
+        /// The log-safe message for any error a remote transcription can
+        /// throw — applied where the concrete type is still unknown, since
+        /// `TranscriptionService` catches `Error` and a `CancellationError` or
+        /// a `URLError` lands there too.
+        static func logMessage(for error: Swift.Error) -> String {
+            if let remoteError = error as? RemoteError { return remoteError.logDescription }
+            return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+
         /// Pull a human-readable `error.message` out of an OpenAI-style error
         /// body, falling back to a trimmed prefix of the raw body.
         private static func shortMessage(from body: String) -> String? {

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -43,6 +43,39 @@ enum SpeakerDiarizer {
                 return "Speaker diarization failed: \(msg)"
             }
         }
+
+        /// The log-safe twin of `errorDescription`, matching
+        /// `LLMRunnerError.logDescription`.
+        ///
+        /// `.diarizationFailed` is built from the Python subprocess's stderr
+        /// (falling back to its stdout), and that stderr is not neutral: the
+        /// inline diarize script prints `diarize: running on {wav_path}`, and
+        /// the WAV's name is derived from the recording's title — see
+        /// `RecordingStore.freshAudioURL(suggestedName:)` and
+        /// `FileTranscriber`'s `safeStem`. A traceback also quotes the path.
+        /// So logging the message `.public` publishes the meeting title, the
+        /// same way `LLMRunnerError.nonZeroExit` published the transcript.
+        /// (Issues #213 / #193, CWE-532.)
+        ///
+        /// `.pythonNotFound` passes through: the interpreter path is a value
+        /// the user typed into Settings → Speakers, it names no recording, and
+        /// it is the entire diagnostic.
+        var logDescription: String {
+            switch self {
+            case .pythonNotFound:
+                return errorDescription ?? "\(self)"
+            case .diarizationFailed(let msg):
+                return "Speaker diarization failed (\(msg.utf8.count)B of subprocess output withheld)"
+            }
+        }
+
+        /// The log-safe message for any error a diarization call can throw —
+        /// applied where the concrete type is still unknown, since callers
+        /// catch `Error` and a cancellation or a decode failure lands here too.
+        static func logMessage(for error: Swift.Error) -> String {
+            if let diarError = error as? SpeakerDiarizer.Error { return diarError.logDescription }
+            return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
     }
 
     struct PythonResult {

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -72,9 +72,28 @@ enum SpeakerDiarizer {
         /// The log-safe message for any error a diarization call can throw —
         /// applied where the concrete type is still unknown, since callers
         /// catch `Error` and a cancellation or a decode failure lands here too.
+        ///
+        /// The fallback is deliberately **not** `localizedDescription`, for the
+        /// same reason as `MilaConfig.LoadError.logMessage(for:)`: `diarize` is
+        /// a file-open path. Any recording that is not already a WAV goes
+        /// through `AudioCompressor.decodeToTempWAV`, so an
+        /// `AVAudioFile(forReading:)` failure on a title-derived `.m4a` in the
+        /// user-chosen recordings folder arrives here as a plain `NSError` —
+        /// the shape Cocoa fills with the file's name and its containing
+        /// folder. Passing it through undid the redaction the two
+        /// `SpeakerDiarizer.Error` cases above had just applied, at the same
+        /// two `.public` log fields. Domain + code keep it diagnosable without
+        /// guessing. (Issue #213, CWE-532.)
+        ///
+        /// Cancellation is named explicitly because it is the common non-error
+        /// arrival here and carries nothing worth withholding — a bare
+        /// `[Swift.CancellationError 1]` would be the over-redaction
+        /// `bugbot-rules/no-user-content-in-logs.md` warns about.
         static func logMessage(for error: Swift.Error) -> String {
             if let diarError = error as? SpeakerDiarizer.Error { return diarError.logDescription }
-            return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            if error is CancellationError { return "diarization cancelled" }
+            let ns = error as NSError
+            return "unexpected error [\(ns.domain) \(ns.code)]"
         }
     }
 

--- a/Mila/Transcription/TranscriptExporter.swift
+++ b/Mila/Transcription/TranscriptExporter.swift
@@ -1,5 +1,9 @@
 import Foundation
+import OSLog
 import TranscriptionCore
+
+private let exporterLog = Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                 category: "TranscriptExporter")
 
 enum TranscriptExporter {
 
@@ -17,9 +21,31 @@ enum TranscriptExporter {
         }
         do {
             try body.write(to: url, atomically: true, encoding: .utf8)
-            print("TranscriptExporter: wrote \(srtName)")
+            // `srtName` is `recording.audioFileName` with the extension
+            // swapped, and `audioFileName` comes from the recording's TITLE
+            // (`RecordingStore.freshAudioURL(suggestedName:)`, and
+            // `FileTranscriber`'s `safeStem` for imports). This line fires on
+            // every completed transcription — the highest-volume title leak in
+            // the app — so the name is `.private` and the recording's UUID is
+            // the public correlation key. (Issue #213, CWE-532.)
+            exporterLog.log("""
+                wrote SRT for \(recording.id, privacy: .public) \
+                (\(srtName, privacy: .private))
+                """)
         } catch {
-            print("TranscriptExporter: failed to write \(srtName): \(error)")
+            // The error string needs the same care as the name: Cocoa quotes
+            // the offending file — and its containing folder, which is the
+            // user's chosen recordings directory — inside
+            // `localizedDescription`. Domain + code stay public so "no
+            // permission" is still distinguishable from a full disk or a
+            // missing directory without exposing either.
+            let ns = error as NSError
+            exporterLog.error("""
+                failed to write SRT for \(recording.id, privacy: .public) \
+                (\(srtName, privacy: .private)) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
         }
     }
 

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -5,6 +5,37 @@ import TranscriptionCore
 
 private let serviceLog = Logger(subsystem: "io.island.whisper.IslandWhisper", category: "TranscriptionService")
 
+// MARK: - Logging privacy in this file
+//
+// Every line the transcription pass emits used to be a `print`, and a `print`
+// is public by construction — it has no privacy annotation, and an app
+// launched by launchd has its stdio captured into the unified log regardless.
+// The pass is also the highest-volume producer of these lines: one set per
+// recording, forever.
+//
+// `recording.title` is a meeting name — "Q3 board call", a client, a
+// candidate's name — and it was interpolated into roughly fourteen of them.
+// So the rule here, the one PR #183 settled for `RecordingStore`:
+//
+//   * the recording's UUID is the PUBLIC correlation key. It carries no
+//     content, and it is what lets you follow one recording across the queue,
+//     the run and the failure.
+//   * the title, and any filename derived from it, are `.private`. Audio,
+//     transcript, summary and subtitle names all come from the title via
+//     `RecordingStore.freshAudioURL(suggestedName:)` / `FileTranscriber`'s
+//     `safeStem`, so logging a filename logs a title.
+//   * an `error`'s message is `.private` wherever the failure touched one of
+//     those files, because Cocoa quotes the offending file — and its
+//     containing folder — inside `localizedDescription`. `NSError.domain` and
+//     `code` stay public: they are what separates "no permission" from a full
+//     disk, and they name nothing.
+//   * everything that is model/engine/queue state — model names, sample
+//     counts, segment counts, speaker counts, durations — stays `.public`.
+//     Redacting those would make a real failure undiagnosable and protect
+//     nothing.
+//
+// (Issue #213, CWE-532.)
+
 /// Coordinates batch transcription of recordings + one-shot transcription
 /// for dictation.
 ///
@@ -180,7 +211,7 @@ final class TranscriptionService: ObservableObject {
     func prewarm(language: String) {
         guard let model = modelManager.model(for: language),
               modelManager.isInstalled(model) else {
-            print("TranscriptionService.prewarm: skipping — no installed model for lang=\(language)")
+            serviceLog.log("prewarm: skipping — no installed model for lang=\(language, privacy: .public)")
             return
         }
         let modelURL = modelManager.url(for: model)
@@ -189,7 +220,7 @@ final class TranscriptionService: ObservableObject {
         // unwrapped on the property but force-imports here would
         // re-promote it to Optional inside the closure.
         let observerTask: Task<Void, Never> = observerSetupTask
-        print("TranscriptionService.prewarm: kicking off load for \(displayName)")
+        serviceLog.log("prewarm: kicking off load for \(displayName, privacy: .public)")
         Task.detached(priority: .userInitiated) { [engine] in
             // Bugbot #3: ensure the preparation observer is registered
             // BEFORE the first CoreML compile starts — otherwise the
@@ -202,11 +233,16 @@ final class TranscriptionService: ObservableObject {
             await observerTask.value
             do {
                 try await engine.loadIfNeeded(modelURL: modelURL, displayName: displayName)
-                print("TranscriptionService.prewarm: completed for \(displayName)")
+                serviceLog.log("prewarm: completed for \(displayName, privacy: .public)")
             } catch {
                 // Silent — the real transcription call will retry and
                 // can surface any error through its own path.
-                print("TranscriptionService.prewarm: failed for \(displayName) (will retry on first use): \(error)")
+                // The model name and the whisper error are app/model state,
+                // not user content — no recording is involved in a prewarm.
+                serviceLog.error("""
+                    prewarm: failed for \(displayName, privacy: .public) \
+                    (will retry on first use): \(error.localizedDescription, privacy: .public)
+                    """)
             }
         }
     }
@@ -232,7 +268,11 @@ final class TranscriptionService: ObservableObject {
         queue.append(recording)
         publishPending()
         startWorkerIfNeeded()
-        print("Transcribe queue: enqueued \(recording.title) [\(recording.id.uuidString.prefix(8))], queue depth: \(queue.count)")
+        serviceLog.log("""
+            queue: enqueued \(recording.id.uuidString.prefix(8), privacy: .public) \
+            (\(recording.title, privacy: .private)), \
+            queue depth: \(self.queue.count, privacy: .public)
+            """)
     }
 
     /// Wait until the worker has fully drained the queue and gone idle.
@@ -439,7 +479,13 @@ final class TranscriptionService: ObservableObject {
             serviceLog.log("rediarizeSegments: offline pass labeled \(normalized.count, privacy: .public) segments with \(distinct, privacy: .public) speakers (was \(Set(segments.compactMap(\.speaker)).count, privacy: .public) live)")
             return normalized
         } catch {
-            serviceLog.log("rediarizeSegments: failed (keeping live speakers): \(error.localizedDescription, privacy: .public)")
+            // Same subprocess-output leak as the batch diarization path:
+            // `SpeakerDiarizer.Error.diarizationFailed` carries the Python
+            // stderr, which prints the title-derived WAV path. (Issue #213.)
+            serviceLog.log("""
+                rediarizeSegments: failed (keeping live speakers): \
+                \(SpeakerDiarizer.Error.logMessage(for: error), privacy: .public)
+                """)
             return nil
         }
     }
@@ -498,7 +544,10 @@ final class TranscriptionService: ObservableObject {
         // The user may have hit Cancel between enqueue and now. Don't spin up
         // the model just to throw the result away.
         if cancellation.contains(recording.id) {
-            print("Transcribe skipped: \(recording.title) was cancelled before processing")
+            serviceLog.log("""
+                skipped \(recording.id.uuidString.prefix(8), privacy: .public) \
+                (\(recording.title, privacy: .private)): cancelled before processing
+                """)
             cancellation.remove(recording.id)
             return
         }
@@ -531,7 +580,10 @@ final class TranscriptionService: ObservableObject {
         let isFirstTranscription = !wasRetranscribeEnqueue
             && working.fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         if working.isTrashed {
-            print("Transcribe skipped: \(working.title) was deleted before processing")
+            serviceLog.log("""
+                skipped \(working.id.uuidString.prefix(8), privacy: .public) \
+                (\(working.title, privacy: .private)): deleted before processing
+                """)
             return
         }
 
@@ -565,7 +617,7 @@ final class TranscriptionService: ObservableObject {
             }
             guard modelManager.isInstalled(model) else {
                 lastError = "Whisper model is still downloading. Try again once it's ready."
-                print("Transcribe skipped: model \(model.name) not installed yet")
+                serviceLog.log("skipped: model \(model.name, privacy: .public) not installed yet")
                 markFailed(recording)
                 return
             }
@@ -611,7 +663,10 @@ final class TranscriptionService: ObservableObject {
             }
         }
 
-        print("Transcribe begin: \(working.title) [\(recordingID.uuidString.prefix(8))]")
+        serviceLog.log("""
+            begin \(recordingID.uuidString.prefix(8), privacy: .public) \
+            (\(working.title, privacy: .private))
+            """)
 
         // Bugbot #3: make sure the preparation observer is installed
         // before `loadIfNeeded` — see `init` for the race.
@@ -639,8 +694,16 @@ final class TranscriptionService: ObservableObject {
             let samples = try AudioConvert.loadAsWhisperSamples(url: audioURL)
             let durationSeconds = Double(samples.count) / Double(WhisperAudioFormat.sampleRate)
             let peak = samples.map { abs($0) }.max() ?? 0
-            print(String(format: "Transcribe: loaded %d samples (%.2fs, peak=%.4f) from %@",
-                         samples.count, durationSeconds, peak, audioURL.lastPathComponent))
+            // The audio FILENAME is title-derived (`freshAudioURL`), so it is
+            // `.private`; the sample count, duration and peak are the numbers
+            // that make a silent-capture report diagnosable and stay public.
+            serviceLog.log("""
+                loaded \(samples.count, privacy: .public) samples \
+                (\(String(format: "%.2f", durationSeconds), privacy: .public)s, \
+                peak=\(String(format: "%.4f", peak), privacy: .public)) \
+                for \(recordingID.uuidString.prefix(8), privacy: .public) \
+                from \(audioURL.lastPathComponent, privacy: .private)
+                """)
 
             // Reject essentially-silent / extremely-short audio BEFORE handing
             // it to Whisper. Otherwise the auto-gain step would amplify mic
@@ -656,7 +719,11 @@ final class TranscriptionService: ObservableObject {
                 // status in the list is enough self-serve signal; the
                 // detail view shows "No transcript yet" + a Transcribe
                 // button if the user wants to retry on a noisier mic.
-                print("Transcribe: rejecting \(working.title) — too short or too quiet to be real speech")
+                serviceLog.log("""
+                    rejecting \(recordingID.uuidString.prefix(8), privacy: .public) \
+                    (\(working.title, privacy: .private)) — too short or too quiet \
+                    to be real speech
+                    """)
                 working.status = .failed
                 working.fullText = ""
                 working.segments = []
@@ -686,17 +753,28 @@ final class TranscriptionService: ObservableObject {
 
             async let diarizeTask: [SpeakerTurn] = {
                 guard shouldDiarize else { return [] }
-                print("Transcribe: running speaker diarization...")
+                serviceLog.log("running speaker diarization…")
                 do {
                     let turns = try await SpeakerDiarizer.diarize(
                         wavURL: audioURL,
                         pythonPath: diarPythonPath
                     )
                     let speakerCount = Set(turns.map(\.speaker)).count
-                    print("Transcribe: diarization found \(speakerCount) speakers across \(turns.count) turns")
+                    serviceLog.log("""
+                        diarization found \(speakerCount, privacy: .public) speakers \
+                        across \(turns.count, privacy: .public) turns
+                        """)
                     return turns
                 } catch {
-                    print("Transcribe: diarization failed (continuing without speakers): \(error)")
+                    // `SpeakerDiarizer.Error.diarizationFailed` wraps the
+                    // Python subprocess's stderr verbatim, and that stderr
+                    // prints the WAV path it was handed — a title-derived
+                    // filename. `logMessage(for:)` keeps the failure and drops
+                    // the bytes. (Issue #213.)
+                    serviceLog.error("""
+                        diarization failed (continuing without speakers): \
+                        \(SpeakerDiarizer.Error.logMessage(for: error), privacy: .public)
+                        """)
                     return []
                 }
             }()
@@ -749,7 +827,10 @@ final class TranscriptionService: ObservableObject {
             // coordinator is about to delete the recording. Don't write a
             // `.completed` row to a recording that's already gone.
             if cancellation.contains(recordingID) {
-                print("Transcribe cancelled post-run: \(working.title)")
+                serviceLog.log("""
+                    cancelled post-run \(recordingID.uuidString.prefix(8), privacy: .public) \
+                    (\(working.title, privacy: .private))
+                    """)
                 cancellation.remove(recordingID)
                 return
             }
@@ -766,7 +847,10 @@ final class TranscriptionService: ObservableObject {
             // silently misalign the result. Server labels win. (issue #180)
             if Self.hasSpeakerLabels(segments) {
                 let distinct = Set(segments.compactMap(\.speaker)).count
-                print("Transcribe: keeping the \(distinct) server-side speaker labels — not overwriting them with the offline pass")
+                serviceLog.log("""
+                    keeping the \(distinct, privacy: .public) server-side speaker labels \
+                    — not overwriting them with the offline pass
+                    """)
             } else if !speakerTurns.isEmpty {
                 for i in enrichedSegments.indices {
                     enrichedSegments[i].speaker = SpeakerDiarizer.assignSpeaker(
@@ -784,15 +868,29 @@ final class TranscriptionService: ObservableObject {
                 enrichedSegments = Self.normalizeSpeakerLabels(in: enrichedSegments)
                 let labeled = enrichedSegments.compactMap(\.speaker).count
                 let distinct = Set(enrichedSegments.compactMap(\.speaker)).count
-                print("Transcribe: applied speaker labels — \(labeled)/\(enrichedSegments.count) segments labeled, \(distinct) distinct speakers")
+                serviceLog.log("""
+                    applied speaker labels — \(labeled, privacy: .public)/\
+                    \(enrichedSegments.count, privacy: .public) segments labeled, \
+                    \(distinct, privacy: .public) distinct speakers
+                    """)
             } else {
-                print("Transcribe: NO speaker labels — shouldDiarize=\(shouldDiarize), speakerTurns.count=0. Either diarization is not configured, returned no turns, or the pyannote subprocess failed (check stderr above).")
+                serviceLog.log("""
+                    NO speaker labels — shouldDiarize=\(shouldDiarize, privacy: .public), \
+                    speakerTurns.count=0. Either diarization is not configured, returned \
+                    no turns, or the pyannote subprocess failed (see the diarization \
+                    failure line above).
+                    """)
             }
 
             let text = enrichedSegments.map(\.text)
                 .joined()
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            print("Transcribe done: \(working.title) -> \(enrichedSegments.count) segments, \(text.count) chars")
+            serviceLog.log("""
+                done \(recordingID.uuidString.prefix(8), privacy: .public) \
+                (\(working.title, privacy: .private)) -> \
+                \(enrichedSegments.count, privacy: .public) segments, \
+                \(text.count, privacy: .public) chars
+                """)
 
             working.segments = enrichedSegments
             // The batch pass minted fresh speaker IDs (new clustering, new
@@ -834,7 +932,11 @@ final class TranscriptionService: ObservableObject {
                     $0.speakerNames = working.speakerNames
                 }
             }) else {
-                print("Transcribe: \(working.title) vanished from the store mid-pass — result discarded, row not recreated")
+                serviceLog.log("""
+                    \(recordingID.uuidString.prefix(8), privacy: .public) \
+                    (\(working.title, privacy: .private)) vanished from the store \
+                    mid-pass — result discarded, row not recreated
+                    """)
                 return
             }
             if persisted.status == .completed {
@@ -844,7 +946,11 @@ final class TranscriptionService: ObservableObject {
                     // the *user-facing* completion work: no stray `.srt` sidecar
                     // on disk, and no summarizer/LLM spend on something the user
                     // just threw away.
-                    print("Transcribe: \(persisted.title) was moved to Recently Deleted mid-pass — transcript saved, skipping SRT + summary")
+                    serviceLog.log("""
+                        \(persisted.id.uuidString.prefix(8), privacy: .public) \
+                        (\(persisted.title, privacy: .private)) was moved to Recently \
+                        Deleted mid-pass — transcript saved, skipping SRT + summary
+                        """)
                 } else {
                     TranscriptExporter.writeSRT(for: persisted, in: store.recordingsDirectory)
                     onTranscriptionCompleted?(persisted, hadSummaryBeforeRun)
@@ -865,10 +971,25 @@ final class TranscriptionService: ObservableObject {
             // also going to hard-delete the recording from the store — don't
             // race with that by writing a `.failed` status, and don't surface
             // a scary error banner for what was a user-initiated action.
-            print("Transcribe cancelled mid-run: \(working.title)")
+            serviceLog.log("""
+                cancelled mid-run \(recordingID.uuidString.prefix(8), privacy: .public) \
+                (\(working.title, privacy: .private))
+                """)
             cancellation.remove(recording.id)
         } catch {
-            print("Transcribe error for \(working.title): \(error)")
+            // The pass reads the recording's own audio and writes its
+            // transcript, both under the (possibly user-chosen) recordings
+            // directory with title-derived names — so a Cocoa error here
+            // quotes a title, or the folder holding it. Domain + code stay
+            // public: they separate "file missing" from "no permission" from
+            // a decode failure, and name nothing.
+            let ns = error as NSError
+            serviceLog.error("""
+                error for \(recordingID.uuidString.prefix(8), privacy: .public) \
+                (\(working.title, privacy: .private)) \
+                [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                \(error.localizedDescription, privacy: .private)
+                """)
             // A failed pass produced no transcript, so `status` is the ONLY
             // field it owns here — in particular it must not overwrite
             // `speakerNames`/`segments`, which it never re-keyed. Merging onto
@@ -987,7 +1108,12 @@ final class TranscriptionService: ObservableObject {
         // which can be stale (crash-recovered rows are seeded with 0) and
         // would let a long-but-silent clip slip under the threshold.
         guard shouldAutoDropShortEmpty?(duration, transcript) == true else { return false }
-        print("Transcribe: auto-dropping \(recording.title) [\(recording.id.uuidString.prefix(8))] — \(duration)s + empty transcript (issue #61)")
+        serviceLog.log("""
+            auto-dropping \(recording.id.uuidString.prefix(8), privacy: .public) \
+            (\(recording.title, privacy: .private)) — \
+            \(String(format: "%.2f", duration), privacy: .public)s + empty transcript \
+            (issue #61)
+            """)
         store.permanentlyDelete(recording)
         return true
     }

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -402,7 +402,21 @@ final class TranscriptionService: ObservableObject {
                 // on every utterance for the whole recording and silently empties
                 // the live pane. Error level so it's visible in `log show`
                 // WITHOUT --debug and stands out from the debug firehose.
-                serviceLog.error("transcribeOnceSegments(remote): FAILED error=\(error.localizedDescription, privacy: .public)")
+                // `logMessage(for:)`, not `localizedDescription`: this is the
+                // same "someone else's bytes are already inside the string"
+                // shape as `LLMRunnerError.nonZeroExit` and
+                // `SpeakerDiarizer.Error.diarizationFailed`, just over HTTP.
+                // `RemoteWhisperEngine.RemoteError.http` embeds up to 200
+                // characters of the endpoint's raw response body, and the
+                // comment above says this line repeats on every utterance —
+                // so a 401 wrote a fragment of the user's API key into the log
+                // once per utterance, all recording long. The status code and
+                // a byte count survive; `lastError` below keeps the full text
+                // for the banner. (Issue #213, CWE-532.)
+                serviceLog.error("""
+                    transcribeOnceSegments(remote): FAILED \
+                    error=\(RemoteWhisperEngine.RemoteError.logMessage(for: error), privacy: .public)
+                    """)
                 // Surface the failure instead of returning a silently-empty
                 // result that's indistinguishable from "no speech". Set once
                 // (only when nothing is already showing) so a per-utterance

--- a/Mila/VoiceMemos/VoiceMemosImporter.swift
+++ b/Mila/VoiceMemos/VoiceMemosImporter.swift
@@ -299,7 +299,21 @@ final class VoiceMemosImporter: ObservableObject {
                 summary.imported += 1
             } catch {
                 summary.failedImport += 1
-                log.error("VoiceMemos import failed for \(memo.fileURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // A Voice Memo's filename is its user-visible name — the title
+                // the user (or iOS's location naming) gave the memo — and the
+                // import writes into the recordings directory, so the error
+                // text names both that file and the folder the user chose.
+                // Domain + code stay public: they separate "no permission"
+                // from a full disk from an unreadable source file, which is
+                // what a failed import needs answered. The memo's own id keeps
+                // the line correlatable. (Issue #213, CWE-532.)
+                let ns = error as NSError
+                log.error("""
+                    VoiceMemos import failed for \(memo.uniqueID, privacy: .public) \
+                    (\(memo.fileURL.lastPathComponent, privacy: .private)) \
+                    [\(ns.domain, privacy: .public) \(ns.code, privacy: .public)]: \
+                    \(error.localizedDescription, privacy: .private)
+                    """)
             }
         }
 

--- a/MilaTests/LogPrivacyRedactionTests.swift
+++ b/MilaTests/LogPrivacyRedactionTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import Mila
+
+/// Issues #213 and #193 — user content reaching the unified log as **public**
+/// values.
+///
+/// ## What can and cannot be tested here
+///
+/// There is no way to assert an `OSLog` field's privacy level from a unit
+/// test: `privacy: .private` is a compile-time property of the interpolation,
+/// and nothing reads it back. Issue #193 says as much. So the ~30 annotated
+/// call sites in this change are verifiable **by inspection only**, and this
+/// file makes no attempt to pretend otherwise.
+///
+/// What *is* testable is the part of the fix that is a pure function, and it
+/// happens to be the part that was the actual bug: two error types whose
+/// `errorDescription` embeds a **child process's output verbatim**. Annotating
+/// their call sites would not have been enough — the content is inside the
+/// string before any `Logger` sees it — so each grew a `logDescription` twin
+/// that the log sites use instead. Those are pure, and pinning them pins the
+/// invariant rather than the formatting.
+///
+/// The other half of the contract matters just as much and is pinned too:
+/// `errorDescription` must KEEP the tool's own words. It is what the Settings
+/// test panel, the rename sheet and the post-recording banner render, and a
+/// blanket redaction there would trade a log leak for an undiagnosable app.
+final class LogPrivacyRedactionTests: XCTestCase {
+
+    // MARK: - #193: LLMRunnerError.nonZeroExit
+
+    /// A verbosely-run CLI echoes the composed prompt back on stderr, and the
+    /// composed prompt is the meeting transcript. This is the exposure issue
+    /// #193 describes, stated as an assertion.
+    func test_nonZeroExit_logDescription_never_contains_the_tool_output() {
+        let transcript = "Acme is acquiring Globex for $4.2M; announce Friday."
+        let stderr = """
+            + exec claude -p 'Summarize this call.
+
+            ---
+            Transcript:
+            \(transcript)'
+            error: credit balance too low
+            """
+        let error = LLMRunnerError.nonZeroExit(code: 1, stderr: stderr)
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains(transcript),
+                       "transcript leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains("credit balance too low"),
+                       "raw stderr leaked into the log message: \(logged)")
+    }
+
+    /// …and what survives is enough to triage: which exit code, and whether
+    /// the tool said anything at all. "exit 1, 0 bytes" and "exit 1, 4 KB" are
+    /// different bugs.
+    func test_nonZeroExit_logDescription_keeps_the_exit_code_and_a_byte_count() {
+        let stderr = String(repeating: "x", count: 4096)
+        let logged = LLMRunnerError.nonZeroExit(code: 137, stderr: stderr).logDescription
+
+        XCTAssertTrue(logged.contains("137"), logged)
+        XCTAssertTrue(logged.contains("4096B"), logged)
+    }
+
+    /// The byte count is UTF-8 bytes, not characters — it answers "how much
+    /// did the tool emit?", which must not depend on how the bytes decode.
+    func test_nonZeroExit_byte_count_is_utf8_not_characters() {
+        let stderr = "שגיאה"  // 5 characters, 10 UTF-8 bytes
+        let logged = LLMRunnerError.nonZeroExit(code: 2, stderr: stderr).logDescription
+
+        XCTAssertTrue(logged.contains("10B"), logged)
+        XCTAssertFalse(logged.contains("5B"), logged)
+    }
+
+    /// The other half of the contract. `errorDescription` is what the user
+    /// reads on a surface they asked for, and there the CLI's own words are
+    /// the entire value — "command not found", "unknown flag". #193 flagged
+    /// that fixing the log would change user-visible text; it does not.
+    func test_nonZeroExit_errorDescription_still_shows_the_user_the_tool_output() {
+        let error = LLMRunnerError.nonZeroExit(code: 1, stderr: "  unknown flag --foo\n")
+
+        XCTAssertEqual(error.errorDescription,
+                       "LLM CLI exited with status 1. unknown flag --foo")
+    }
+
+    /// Every other case is a sentence Mila composed out of configuration the
+    /// user typed. Redacting those would make the log worse for no gain, so
+    /// the two descriptions must stay identical.
+    func test_cases_without_tool_output_log_exactly_what_the_user_sees() {
+        let cases: [LLMRunnerError] = [
+            .toolDisabled,
+            .executableNotFound("claude"),
+            .timedOut(seconds: 90),
+            .emptyOutput,
+            .cancelled
+        ]
+        for error in cases {
+            XCTAssertEqual(error.logDescription, error.errorDescription,
+                           "\(error) should not be redacted — it carries no tool output")
+        }
+    }
+
+    /// Call sites catch `Error`, not `LLMRunnerError`, so the redaction has to
+    /// survive the type being erased — otherwise it is skipped exactly when
+    /// it matters. This is the shape `PostRecordingCoordinator`,
+    /// `RecordingSummarizer` and `LiveAISession` actually use.
+    func test_logMessage_redacts_a_nonZeroExit_thrown_as_a_bare_error() {
+        let secret = "We agreed to let Dana go at the end of Q3."
+        let thrown: Error = LLMRunnerError.nonZeroExit(code: 1, stderr: secret)
+
+        let logged = LLMRunnerError.logMessage(for: thrown)
+        XCTAssertFalse(logged.contains(secret),
+                       "content leaked once the concrete type was erased: \(logged)")
+        XCTAssertTrue(logged.contains("status 1"), logged)
+    }
+
+    /// A non-runner error still gets its readable message — the helper is a
+    /// redaction, not a gag. An `OpenAIRequestError` is the realistic case:
+    /// the same catch blocks see it, and "Authentication failed (401)" is the
+    /// whole diagnostic.
+    func test_logMessage_passes_through_other_localized_errors() {
+        let thrown: Error = OpenAIRequestError.auth("Incorrect API key provided")
+
+        XCTAssertEqual(LLMRunnerError.logMessage(for: thrown),
+                       OpenAIRequestError.auth("Incorrect API key provided").errorDescription)
+    }
+
+    // MARK: - #213: SpeakerDiarizer.Error.diarizationFailed
+
+    /// The same shape as `nonZeroExit`, found by sweeping for it: the case is
+    /// built from the pyannote subprocess's stderr, and that script prints
+    /// `diarize: running on {wav_path}` — a path whose filename Mila derives
+    /// from the recording's title. So the "harmless subprocess chatter" is a
+    /// meeting name.
+    func test_diarizationFailed_logDescription_never_contains_the_subprocess_output() {
+        let wavPath = "/Users/x/Recordings/Q3 layoffs — legal review 2026-08-30.wav"
+        let stderr = """
+            diarize: loading pipeline from /Applications/Mila.app/…/DiarizationModels
+            diarize: running on \(wavPath)
+            Traceback (most recent call last):
+              File "<string>", line 41, in <module>
+            RuntimeError: MPS backend out of memory
+            """
+        let logged = SpeakerDiarizer.Error.diarizationFailed(stderr).logDescription
+
+        XCTAssertFalse(logged.contains(wavPath),
+                       "title-derived path leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains("Q3 layoffs"),
+                       "recording title leaked into the log message: \(logged)")
+        XCTAssertTrue(logged.contains("\(stderr.utf8.count)B"), logged)
+    }
+
+    /// The interpreter path is a value the user typed into Settings, names no
+    /// recording, and is the entire diagnostic for this case — so it passes
+    /// through unredacted.
+    func test_pythonNotFound_is_not_redacted() {
+        let error = SpeakerDiarizer.Error.pythonNotFound("/opt/homebrew/bin/python3")
+
+        XCTAssertEqual(error.logDescription, error.errorDescription)
+        XCTAssertTrue(error.logDescription.contains("/opt/homebrew/bin/python3"))
+    }
+
+    /// Same type-erasure guard as the LLM path: `TranscriptionService` catches
+    /// `Error` around both the batch and the re-diarize calls.
+    func test_diarizer_logMessage_redacts_through_a_bare_error() {
+        let thrown: Error = SpeakerDiarizer.Error.diarizationFailed("running on /x/Board offsite.wav")
+
+        XCTAssertFalse(SpeakerDiarizer.Error.logMessage(for: thrown).contains("Board offsite"),
+                       "title leaked once the concrete type was erased")
+    }
+
+    /// A cancellation or a decode failure reaches the same catch blocks and
+    /// must still read normally.
+    func test_diarizer_logMessage_passes_through_other_errors() {
+        let thrown: Error = CocoaError(.fileNoSuchFile)
+
+        XCTAssertEqual(SpeakerDiarizer.Error.logMessage(for: thrown),
+                       thrown.localizedDescription)
+    }
+}

--- a/MilaTests/LogPrivacyRedactionTests.swift
+++ b/MilaTests/LogPrivacyRedactionTests.swift
@@ -269,13 +269,39 @@ final class LogPrivacyRedactionTests: XCTestCase {
                        "title leaked once the concrete type was erased")
     }
 
-    /// A cancellation or a decode failure reaches the same catch blocks and
-    /// must still read normally.
-    func test_diarizer_logMessage_passes_through_other_errors() {
-        let thrown: Error = CocoaError(.fileNoSuchFile)
+    /// The decode failure that reaches the same catch blocks. `diarize` sends
+    /// every non-WAV recording through `AudioCompressor.decodeToTempWAV`, so an
+    /// unreadable `.m4a` in the user-chosen recordings folder surfaces here as
+    /// a bare Cocoa file error — and Cocoa's sentence for that names the file
+    /// and its folder. This assertion fails against the previous
+    /// `localizedDescription` fallback, which published it.
+    func test_diarizer_logMessage_withholds_a_bare_file_error() {
+        let thrown: Error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileReadNoSuchFileError,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "The file “Q3 board offsite.m4a” couldn’t be opened because "
+                    + "there is no such file.",
+                NSFilePathErrorKey: "/Users/x/Audio Notes/Q3 board offsite.m4a"
+            ]
+        )
 
-        XCTAssertEqual(SpeakerDiarizer.Error.logMessage(for: thrown),
-                       thrown.localizedDescription)
+        let logged = SpeakerDiarizer.Error.logMessage(for: thrown)
+
+        XCTAssertFalse(logged.contains("Q3 board offsite"),
+                       "the recording title reached a public log field")
+        XCTAssertFalse(logged.contains("Audio Notes"),
+                       "the user-chosen recordings folder reached a public log field")
+        XCTAssertEqual(logged, "unexpected error [\(NSCocoaErrorDomain) \(NSFileReadNoSuchFileError)]",
+                       "domain + code should survive so the failure stays diagnosable")
+    }
+
+    /// Cancellation is the common non-error arrival at that same fallback, and
+    /// it must still read as itself rather than as a bare domain/code pair.
+    func test_diarizer_logMessage_names_cancellation() {
+        XCTAssertEqual(SpeakerDiarizer.Error.logMessage(for: CancellationError()),
+                       "diarization cancelled")
     }
 
     // MARK: - #213: RemoteWhisperEngine.RemoteError.http

--- a/MilaTests/LogPrivacyRedactionTests.swift
+++ b/MilaTests/LogPrivacyRedactionTests.swift
@@ -13,12 +13,15 @@ import XCTest
 /// file makes no attempt to pretend otherwise.
 ///
 /// What *is* testable is the part of the fix that is a pure function, and it
-/// happens to be the part that was the actual bug: two error types whose
-/// `errorDescription` embeds a **child process's output verbatim**. Annotating
-/// their call sites would not have been enough — the content is inside the
-/// string before any `Logger` sees it — so each grew a `logDescription` twin
-/// that the log sites use instead. Those are pure, and pinning them pins the
-/// invariant rather than the formatting.
+/// happens to be the part that was the actual bug: four error types whose
+/// `errorDescription` embeds **output Mila did not write** — a child process's
+/// stderr (`LLMRunnerError.nonZeroExit`, `SpeakerDiarizer.Error`), a remote
+/// endpoint's response body (`OpenAIRequestError`,
+/// `RemoteWhisperEngine.RemoteError`), or Cocoa's own quoted-path message
+/// (`MilaConfig.LoadError`). Annotating their call sites would not have been
+/// enough — the content is inside the string before any `Logger` sees it — so
+/// each grew a `logDescription` twin that the log sites use instead. Those are
+/// pure, and pinning them pins the invariant rather than the formatting.
 ///
 /// The other half of the contract matters just as much and is pinned too:
 /// `errorDescription` must KEEP the tool's own words. It is what the Settings
@@ -113,15 +116,104 @@ final class LogPrivacyRedactionTests: XCTestCase {
         XCTAssertTrue(logged.contains("status 1"), logged)
     }
 
-    /// A non-runner error still gets its readable message — the helper is a
-    /// redaction, not a gag. An `OpenAIRequestError` is the realistic case:
-    /// the same catch blocks see it, and "Authentication failed (401)" is the
-    /// whole diagnostic.
-    func test_logMessage_passes_through_other_localized_errors() {
-        let thrown: Error = OpenAIRequestError.auth("Incorrect API key provided")
+    /// An error the helper has no special knowledge of still gets its readable
+    /// message — the helper is a redaction of the types that are known to
+    /// carry someone else's bytes, not a gag on every error. A transport
+    /// failure ("The Internet connection appears to be offline") is the whole
+    /// diagnostic and names nothing.
+    func test_logMessage_passes_through_an_unrelated_error() {
+        let thrown: Error = CocoaError(.fileNoSuchFile)
 
         XCTAssertEqual(LLMRunnerError.logMessage(for: thrown),
-                       OpenAIRequestError.auth("Incorrect API key provided").errorDescription)
+                       thrown.localizedDescription)
+    }
+
+    // MARK: - #193: OpenAIRequestError (the HTTP twin of nonZeroExit)
+    //
+    // This case previously read "a non-runner error passes through", and that
+    // assertion was itself the bug: `OpenAIRequestError` is not a bystander
+    // type, it is the second error whose `errorDescription` embeds bytes Mila
+    // did not write. `LLMRunner.run`'s `.openaiCompatible` branch rethrows it
+    // unchanged, so every log site that goes through `logMessage(for:)` —
+    // `PostRecordingCoordinator`, `RecordingSummarizer`, `LiveAISession`,
+    // `logSetupFailure`, `logLaunchFailure`, `logHTTPFailure` — published it.
+    // (Found by CodeRabbit on this PR.)
+
+    /// The endpoint's own response body reaches `errorDescription` through
+    /// `.auth`/`.notFound`/`.server`. A real OpenAI 401 quotes a fragment of
+    /// the API key, so the log field was getting a piece of a credential.
+    func test_openAIRequestError_logDescription_never_contains_the_server_message() {
+        let serverMessage = "Incorrect API key provided: sk-proj-9aBcDeF***XYZ. "
+            + "You can find your API key at https://platform.openai.com/account/api-keys."
+        let error = OpenAIRequestError.auth(serverMessage)
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains("sk-proj-9aBcDeF"),
+                       "API key fragment leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains(serverMessage),
+                       "raw server message leaked into the log message: \(logged)")
+        // …and what survives is the part that triages: which status.
+        XCTAssertTrue(logged.contains("401"), logged)
+    }
+
+    /// `.server` carries an arbitrary upstream body — a proxy answering 502
+    /// with the payload it was given can put transcript text there.
+    func test_openAIRequestError_logDescription_keeps_the_status_and_drops_the_body() {
+        let error = OpenAIRequestError.server(status: 502,
+                                              message: "upstream rejected: Acme is acquiring Globex")
+
+        let logged = error.logDescription
+        XCTAssertTrue(logged.contains("502"), logged)
+        XCTAssertFalse(logged.contains("Acme is acquiring Globex"),
+                       "upstream body leaked into the log message: \(logged)")
+    }
+
+    /// `.invalidEndpoint` is the sharper half: `runOpenAICompatible`
+    /// deliberately logs `host=` and never the full URL, because a user's
+    /// endpoint can carry a token in its query string — and this case handed
+    /// the whole URL back through the failure field, on the one path where the
+    /// URL is malformed enough that there was no host to log instead.
+    func test_openAIRequestError_logDescription_never_contains_the_configured_endpoint() {
+        let baseURL = "https://llm.acme-internal.example/v1?access_token=s3cr3t"
+        let error = OpenAIRequestError.invalidEndpoint(baseURL)
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains("s3cr3t"),
+                       "endpoint token leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains("acme-internal"),
+                       "configured endpoint leaked into the log message: \(logged)")
+    }
+
+    /// The other half of the contract, as for `nonZeroExit`: the Settings → AI
+    /// Provider test panel and the post-recording banner keep the server's own
+    /// words, because that is the only thing that turns "the LLM failed" into
+    /// something the user can act on.
+    func test_openAIRequestError_errorDescription_still_shows_the_user_the_server_message() {
+        XCTAssertEqual(OpenAIRequestError.auth("Incorrect API key provided").errorDescription,
+                       "Authentication failed (401). Incorrect API key provided")
+
+        let shown = OpenAIRequestError.invalidEndpoint("https://x y/v1").errorDescription ?? ""
+        XCTAssertTrue(shown.contains("https://x y/v1"),
+                      "the user must still see which URL was rejected: \(shown)")
+    }
+
+    /// `.emptyOutput` carries nothing of anyone's, so the two descriptions
+    /// must stay identical — redacting it would be pure loss.
+    func test_openAIRequestError_emptyOutput_is_not_redacted() {
+        XCTAssertEqual(OpenAIRequestError.emptyOutput.logDescription,
+                       OpenAIRequestError.emptyOutput.errorDescription)
+    }
+
+    /// The shape the catch blocks actually see: `run` rethrows the typed error
+    /// into a `catch { }` that only knows `Error`.
+    func test_logMessage_redacts_an_openAIRequestError_thrown_as_a_bare_error() {
+        let secret = "sk-proj-9aBcDeF***XYZ"
+        let thrown: Error = OpenAIRequestError.auth("Incorrect API key provided: \(secret)")
+
+        let logged = LLMRunnerError.logMessage(for: thrown)
+        XCTAssertFalse(logged.contains(secret),
+                       "credential leaked once the concrete type was erased: \(logged)")
+        XCTAssertTrue(logged.contains("401"), logged)
     }
 
     // MARK: - #213: SpeakerDiarizer.Error.diarizationFailed
@@ -152,6 +244,15 @@ final class LogPrivacyRedactionTests: XCTestCase {
     /// The interpreter path is a value the user typed into Settings, names no
     /// recording, and is the entire diagnostic for this case — so it passes
     /// through unredacted.
+    ///
+    /// CodeRabbit asked for this one to be redacted on PR #218. Deliberately
+    /// not done, and this assertion is the record of that: the value is
+    /// configuration, not content — no title, no transcript, and not the
+    /// recordings folder — and the analogous CLI path is already logged
+    /// `.public` as `exe=` by design (see `LLMRunner.logRunStart`). "Python not
+    /// found at `<private>`" is the over-redaction
+    /// `bugbot-rules/no-user-content-in-logs.md` warns about: it removes the
+    /// only fact the line exists to report.
     func test_pythonNotFound_is_not_redacted() {
         let error = SpeakerDiarizer.Error.pythonNotFound("/opt/homebrew/bin/python3")
 
@@ -175,5 +276,159 @@ final class LogPrivacyRedactionTests: XCTestCase {
 
         XCTAssertEqual(SpeakerDiarizer.Error.logMessage(for: thrown),
                        thrown.localizedDescription)
+    }
+
+    // MARK: - #213: RemoteWhisperEngine.RemoteError.http
+    //
+    // The remote transcription path is the third instance of the same shape,
+    // found by sweeping the files this PR already touched:
+    // `RemoteError.http`'s `errorDescription` runs the endpoint's response
+    // body through `shortMessage(from:)`, which falls back to a 200-character
+    // slice of the raw body. `TranscriptionService.transcribeOnceSegments`
+    // logged that `.public` — and its own comment notes the line "repeats on
+    // every utterance for the whole recording".
+
+    /// A real OpenAI 401 body quotes a fragment of the API key, and
+    /// `shortMessage` lifts exactly that field out of the JSON.
+    func test_remoteWhisperError_logDescription_never_contains_the_server_body() {
+        let body = """
+            {"error":{"message":"Incorrect API key provided: sk-proj-9aBcDeF***XYZ. \
+            You can find your API key at https://platform.openai.com/account/api-keys.",\
+            "type":"invalid_request_error"}}
+            """
+        let error = RemoteWhisperEngine.RemoteError.http(status: 401, body: body)
+
+        // Precondition: the leak is real — the user-facing description does
+        // carry the key fragment, which is why annotating the call site could
+        // never have fixed this.
+        let shown = error.errorDescription ?? ""
+        XCTAssertTrue(shown.contains("sk-proj-9aBcDeF"),
+                      "expected errorDescription to carry the server message: \(shown)")
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains("sk-proj-9aBcDeF"),
+                       "API key fragment leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains("Incorrect API key provided"),
+                       "server body leaked into the log message: \(logged)")
+        // Status and volume survive: "401 with 0 bytes" and "401 with 300
+        // bytes" are different bugs.
+        XCTAssertTrue(logged.contains("401"), logged)
+        XCTAssertTrue(logged.contains("\(body.utf8.count)B"), logged)
+    }
+
+    /// A proxy that answers with the payload it was handed puts transcript
+    /// text in the body — the same exposure as a CLI echoing its prompt.
+    func test_remoteWhisperError_logDescription_drops_an_echoed_transcript() {
+        let transcript = "We agreed to let Dana go at the end of Q3."
+        let error = RemoteWhisperEngine.RemoteError.http(
+            status: 502,
+            body: "Bad gateway. Upstream request was: \(transcript)")
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains(transcript),
+                       "transcript leaked into the log message: \(logged)")
+        XCTAssertTrue(logged.contains("502"), logged)
+    }
+
+    /// Every other case is a sentence Mila wrote, so the two descriptions must
+    /// stay identical — redacting them would make a misconfigured endpoint
+    /// undiagnosable for no gain.
+    func test_remoteWhisperError_cases_without_a_server_body_are_not_redacted() {
+        let cases: [RemoteWhisperEngine.RemoteError] = [
+            .notConfigured, .noAudioCaptured, .badResponse, .emptyResult
+        ]
+        for error in cases {
+            XCTAssertEqual(error.logDescription, error.errorDescription,
+                           "\(error) should not be redacted — it carries no server output")
+        }
+    }
+
+    /// The shape `TranscriptionService` uses: the live path catches `Error`.
+    func test_remote_logMessage_redacts_through_a_bare_error() {
+        let thrown: Error = RemoteWhisperEngine.RemoteError.http(
+            status: 401, body: "Incorrect API key provided: sk-proj-XYZ")
+
+        let logged = RemoteWhisperEngine.RemoteError.logMessage(for: thrown)
+        XCTAssertFalse(logged.contains("sk-proj-XYZ"),
+                       "credential leaked once the concrete type was erased: \(logged)")
+        XCTAssertTrue(logged.contains("401"), logged)
+    }
+
+    /// …and a transport failure still reads normally.
+    func test_remote_logMessage_passes_through_other_errors() {
+        let thrown: Error = CocoaError(.fileNoSuchFile)
+
+        XCTAssertEqual(RemoteWhisperEngine.RemoteError.logMessage(for: thrown),
+                       thrown.localizedDescription)
+    }
+
+    // MARK: - #213: MilaConfig.LoadError
+    //
+    // The success/failure asymmetry, in the form Bugbot flagged on
+    // `WAVHeaderRepair`: `MilaConfigImporter.handleOpen` logs the staged
+    // filename `.private` — a `.milaconfig` handed round a team is commonly
+    // named for the org it configures — and then its own `catch` published
+    // that name straight back through `String(describing: error)`.
+
+    /// `LoadError.unreadable` wraps `Data(contentsOf:).localizedDescription`
+    /// verbatim, and Cocoa quotes the filename (and its folder) in there.
+    func test_configLoadError_logDescription_never_contains_the_quoted_filename() {
+        // The shape Cocoa produces for a file the user double-clicked.
+        let cocoaMessage = "The file “Acme Corp — ASR rollout.milaconfig” couldn’t be "
+            + "opened because there is no such file."
+        let error = MilaConfig.LoadError.unreadable(cocoaMessage)
+
+        let logged = error.logDescription
+        XCTAssertFalse(logged.contains("Acme Corp"),
+                       "config filename leaked into the log message: \(logged)")
+        XCTAssertFalse(logged.contains(cocoaMessage),
+                       "raw Cocoa message leaked into the log message: \(logged)")
+        XCTAssertEqual(MilaConfig.LoadError.logMessage(for: error), logged)
+    }
+
+    /// `.malformed` wraps `JSONDecoder`'s message, which quotes coding keys
+    /// and — on a type mismatch — the offending value out of the config.
+    func test_configLoadError_malformed_logDescription_never_contains_the_decoder_detail() {
+        let detail = "Expected to decode String but found a number instead, "
+            + "at CodingKeys(stringValue: \"baseURL\"): https://llm.acme-internal.example/v1"
+        let logged = MilaConfig.LoadError.malformed(detail).logDescription
+
+        XCTAssertFalse(logged.contains("acme-internal"),
+                       "decoder detail leaked into the log message: \(logged)")
+    }
+
+    /// The opposite case, kept public on purpose: two integers Mila composed
+    /// itself, which are the entire diagnostic and name nothing.
+    func test_configLoadError_unsupportedVersion_is_not_redacted() {
+        let error = MilaConfig.LoadError.unsupportedVersion(found: 4, supported: 1)
+
+        XCTAssertEqual(error.logDescription, error.errorDescription)
+        XCTAssertTrue(error.logDescription.contains("v4"), error.logDescription)
+    }
+
+    /// The user-facing half is unchanged: the confirmation sheet still tells
+    /// the user which file it couldn't read.
+    func test_configLoadError_errorDescription_still_names_the_file_for_the_user() {
+        let cocoaMessage = "The file “Acme Corp — ASR rollout.milaconfig” couldn’t be "
+            + "opened because there is no such file."
+        let shown = MilaConfig.LoadError.unreadable(cocoaMessage).errorDescription ?? ""
+
+        XCTAssertTrue(shown.contains("Acme Corp"),
+                      "the sheet must still tell the user which file failed: \(shown)")
+    }
+
+    /// Unlike the LLM and diarizer helpers, this fallback must NOT pass an
+    /// unknown error through: `load(from:)` only ever throws `LoadError`, so
+    /// anything else here came from the surrounding file-open path — which is
+    /// exactly the shape that quotes the user's path.
+    func test_configLoadError_logMessage_does_not_pass_through_an_unexpected_file_error() {
+        let thrown: Error = CocoaError(.fileNoSuchFile)
+        let logged = MilaConfig.LoadError.logMessage(for: thrown)
+
+        XCTAssertNotEqual(logged, thrown.localizedDescription,
+                          "an unexpected file error was passed through verbatim: \(logged)")
+        let ns = thrown as NSError
+        XCTAssertTrue(logged.contains(ns.domain), logged)
+        XCTAssertTrue(logged.contains("\(ns.code)"), logged)
     }
 }

--- a/bugbot-rules/no-user-content-in-logs.md
+++ b/bugbot-rules/no-user-content-in-logs.md
@@ -32,12 +32,36 @@ The user seeing their own content, on a surface they asked for, on their own
 screen, is not a leak — prefer splitting the loggable message from the displayed
 one over weakening the UI.
 
+## Redaction is per branch, not per function
+
+The most common way this reappears is **half-fixed**: the success log in a
+function is redacted and the error / `catch` / fallback branch a few lines below
+still interpolates the same value — or the `localizedDescription` that quotes it
+— as `.public`. It reads as done, and the failure branch is the worse of the two
+to leak from, because Cocoa's message names the *containing folder* as well as
+the file.
+
+Bugbot caught exactly this on PR #218 in `WAVHeaderRepair.repairIfNeeded`: the
+success line marked the title-derived WAV name `.private`, while the write-failure
+and `fsync`-failure lines above it still published `error.localizedDescription`.
+The same sweep found it again in `MilaConfigImporter.handleOpen`, whose success
+line redacts the user-chosen `.milaconfig` filename and whose `catch` logged
+`String(describing: error)` — the same filename, plus its folder.
+
+So: check **every** branch that logs, not the one the diff draws attention to.
+A `catch` is not exempt for being an error path.
+
 ## What to flag
 
 - `print(` carrying a title, path, transcript or subprocess output.
 - Public `Logger` interpolation of anything the user can relocate or name.
 - `error.localizedDescription` logged publicly where the error came from a file
   operation on a user-chosen path.
-- An `errorDescription` that embeds stdout/stderr from a child process.
+- A function whose success log redacts a title or path while its error, `catch`
+  or fallback branch still logs that value — or an error message that quotes it
+  — `.public`.
+- An `errorDescription` that embeds stdout/stderr from a child process, **or a
+  response body from a remote endpoint**. Both are output Mila did not write, and
+  a 401 body commonly quotes a fragment of the user's API key.
 - Redaction of a value that is purely diagnostic (domain, code, counts,
   durations, exit codes) — flag that as over-redaction.


### PR DESCRIPTION
Closes #213
Closes #193

Both issues are the same defect in two places — user content reaching the unified
log as a **public** field — so they are fixed together. A sweep found the class is
considerably wider than either issue described: 23 files, not the five they named.

## Why this leaks more than it looks

Three mechanisms, each verified while fixing #183:

1. **`print` has no privacy annotation at all**, so everything it emits is public
   by construction — and a launchd-launched app has its stdio captured into the
   log regardless.
2. **Cocoa quotes the offending path in `localizedDescription`, including the
   containing folder** — `You don't have permission to save the file
   "recordings.json" in the folder "Acme Corp Client X"`. Redacting a URL while
   logging the error object still leaks through the error string.
3. **Transcript filenames are derived from titles**, so logging a filename logs a
   meeting name.

## What changed, by leak shape

**Title or title-derived filename in a `print`**
`TranscriptionService` (all 24 prints → `serviceLog`; ~14 interpolated titles),
`TranscriptExporter:20,22` (the highest-volume one — every completed
transcription), `MilaApp:1805,1810,1833` (launch-recovery sweep),
`DictationController:283`, `ObsidianExporter` (4 sites — vault root, Mila folder,
`<date> <title>.md`), `RecordingStore` migration + tombstone writes.

**Path in a public `Logger` interpolation** — none of these were listed in #213.
`AudioCompressor:50` is the notable one: #183 redacted `RecordingStore`'s copy of
the destination name but not the line *inside* the compressor it wraps, so the
same value was still public one frame down. Also `WAVHeaderRepair:184`,
`VoiceMemosImporter:302`, `MilaConfigImporter:81`.

**`errorDescription` quoting a movable path**
`RecordingSession:495,:165`, plus bookmark resolve/mint in
`RecordingStorageSettings`, `ObsidianVaultSettings`, `VoiceMemosSettings`.

**Subprocess output inside an `errorDescription`** — annotating call sites cannot
fix these, because the content is already in the string before any `Logger` sees
it. `LLMRunnerError.nonZeroExit` (#193) and — found by sweeping, same class,
unreported — **`SpeakerDiarizer.Error.diarizationFailed`**, built from pyannote's
stderr, whose script prints `diarize: running on {wav_path}`. Both gained a
`logDescription` used at every logging site.

## #193: the user-visible string is deliberately unchanged

#193 notes that fixing it alters a user-visible error string, and that this
deserved its own review. The resolution here is to **not** alter it: the loggable
message is split from the user-facing one rather than editing `errorDescription`.

The banner, rename sheet and Settings test panel still show
`LLM CLI exited with status 1. <stderr>`. The CLI's own words are the only thing
that makes such a failure actionable, and that is the user's own content, on a
surface they explicitly asked for, on their own screen. The **log** now reads:

```
LLM CLI exited with status 1 (4096B of tool output withheld — it can contain the
transcript; see Settings → AI Provider → Test)
```

A test pins the exact UI string, so a future log-redaction change cannot quietly
take the UI with it.

## Deliberately left public

- Writes anchored to `originalRootDirectory` — `store-location.json`,
  `persistTombstones`, `speaker-names.json`, `speaker-profiles.json`, and
  `LiveTranscriptSidecarWriter`'s `live/` files. `relocateRecordings` never moves
  that root, so the quoted folder is only ever `Mila`. The last three carried no
  note explaining this; each now does.
- `NSError.domain` + `code` everywhere — this is the actual diagnostic, and it
  distinguishes "no permission" from a full disk or a missing directory while
  revealing nothing. A blanket redaction that makes real failures undiagnosable
  would be its own bug.
- Model names, sample/segment/speaker counts, durations, exit codes, byte counts,
  device names, model-cache and legacy migration paths; `LLMRunner`'s
  `exe=`/sandbox paths (an existing documented decision); every `LLMRunnerError`
  case except `nonZeroExit`.
- Untouched: prints carrying no user content (`SleepGuard`, `HotkeyManager`,
  `ContentView`, LiveAI's counts-only lines).

## Verification, and its honest limits

`make build` and `xcodebuild build-for-testing` both clean; the new
`MilaTests/LogPrivacyRedactionTests.swift` compiles into the bundle. App-hosted
tests were not run locally (they are left to CI).

**Only the two pure `logDescription` functions are unit-testable.** An OSLog
field's privacy level cannot be read back from a test — as #193 itself notes — so
the ~30 annotated call sites are verifiable by **inspection only**. The test file
says so explicitly rather than implying broader coverage.

## Notes for the reviewer

- **`MilaConfigImporter`** was the closest judgement call: the `.milaconfig`
  filename is redacted because a config passed around a team is often named for
  the org. The change count stays public. Easy to revert if that reads as
  over-redaction.
- **`DiagnosticReporter:253`** tells the user "Mila uses plain print() statements
  which don't land in OSLogStore" — less true after this, but it is user-facing
  copy shown only when zero entries were captured, so it is left alone. Related
  upside: that reporter uses `composedMessage`, so a diagnostic zip a user shares
  now renders titles as `<private>`.

## Checklist

- [x] Builds locally (`make build`); tests written, left for CI to run
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, entries are written per release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are logging and privacy annotations only; UI error text is intentionally unchanged. Residual risk is missing a call site in the large sweep, mitigated by tests on redaction helpers and inspection of OSLog privacy (not unit-testable).
> 
> **Overview**
> Stops meeting titles, transcripts, user-chosen paths, and third-party error bodies from landing in the macOS unified log as **public** values, while **user-facing** banners and Settings still use full `errorDescription` / `localizedDescription`.
> 
> **Log-safe error twins:** `LLMRunnerError`, `OpenAIRequestError`, `SpeakerDiarizer.Error`, `RemoteWhisperEngine.RemoteError`, and `MilaConfig.LoadError` gain `logDescription` plus `logMessage(for:)` so logs get exit codes, HTTP status, and byte counts instead of CLI stderr, API response bodies, or pyannote paths. LLM, Live AI, post-recording send, summarizer, and related `LLMRunner` log helpers route failures through `LLMRunnerError.logMessage(for:)`.
> 
> **Structured logging sweep:** Replaces high-volume `print` (especially `TranscriptionService`) with `Logger` and `privacy:` annotations — recording **UUID** public, **titles** and title-derived filenames **private**, Cocoa `localizedDescription` **private** on file/bookmark failures while `NSError` domain/code stay public. Same treatment for Obsidian export paths, launch recovery, dictation, WAV repair, storage/vault/voice-memo bookmarks, and importers.
> 
> **Tests & docs:** `MilaTests/LogPrivacyRedactionTests` pins the pure redaction helpers; `bugbot-rules/no-user-content-in-logs.md` adds guidance on redacting every branch (success vs `catch`), not just happy paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcf7c4d9b0d76fd01b5d5198310adb474c7a71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive transcripts, subprocess output, filenames, paths, API details, and error information are now redacted from diagnostic logs.
  * User-facing error messages continue to provide full details where appropriate.
  * Improved structured error reporting across recording, transcription, export, storage, and import workflows.

* **Tests**
  * Added coverage verifying log redaction while preserving safe status and size information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->