### PR TITLE
Add Cloud Agent (Linux) development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Mila (Linux Swift packages)",
+  "install": "bash scripts/cloud-agent-setup.sh"
+}

--- a/scripts/cloud-agent-setup.sh
+++ b/scripts/cloud-agent-setup.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent (Linux) setup for the cross-platform surface of Mila.
+#
+# The Mila app itself is macOS-only (Xcode / SwiftUI) and cannot be built on
+# Linux. What IS cross-platform — and what a Cloud Agent can build, test, and
+# run end to end here — is:
+#
+#   * Packages/MilaKit           — the zero-dependency MCP/store package
+#   * Packages/TranscriptionCore — WhisperEngine (whisper.cpp bindings), WAVReader,
+#                                  WER calculator, VAD, and the whisper-e2e CLI
+#
+# TranscriptionCore links against whisper.cpp, which on Linux is provided as a
+# system library (see Packages/TranscriptionCore/Sources/CWhisper/module.modulemap),
+# so this script builds the whisper.cpp submodule into shared libraries and
+# installs them where the Swift toolchain's linker finds them by default.
+#
+# This runs as the environment `install` step. It is safe to run repeatedly:
+# every stage checks for existing state and skips work that is already done, so
+# on a prebuilt snapshot it is a fast no-op, while on a bare Ubuntu image it
+# bootstraps everything from scratch.
+set -euo pipefail
+
+SWIFT_VERSION="6.1.2"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WHISPER_DIR="$REPO_ROOT/Packages/TranscriptionCore/vendor/whisper.cpp"
+WHISPER_MARKER="/usr/local/lib/.mila-whisper-sha"
+MODEL_DIR="$HOME/.cache/whisper-models"
+
+cd "$REPO_ROOT"
+
+if [ "$(id -u)" -eq 0 ]; then SUDO=""; else SUDO="sudo"; fi
+
+log() { printf '\n==> %s\n' "$1"; }
+
+ensure_system_deps() {
+  # Build toolchain + Swift runtime dependencies. Guarded so a snapshot that
+  # already has them skips apt entirely.
+  if command -v cmake >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1 \
+     && command -v git >/dev/null 2>&1 && command -v curl >/dev/null 2>&1 \
+     && dpkg -s libncurses-dev >/dev/null 2>&1; then
+    log "System build dependencies already present; skipping apt"
+    return
+  fi
+  log "Installing system build + Swift runtime dependencies"
+  $SUDO apt-get update -qq
+  $SUDO DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+    build-essential g++ cmake git curl ca-certificates pkg-config unzip \
+    binutils libc6-dev libcurl4-openssl-dev libedit2 libncurses-dev \
+    libpython3-dev libsqlite3-0 libxml2-dev libz3-dev tzdata zlib1g-dev \
+    libgcc-13-dev libstdc++-13-dev
+}
+
+ensure_swift() {
+  if command -v swift >/dev/null 2>&1; then
+    log "Swift already installed: $(swift --version 2>/dev/null | head -1)"
+    return
+  fi
+  log "Installing Swift $SWIFT_VERSION toolchain"
+  local url tarball
+  # Official swift.org build for Ubuntu 24.04 (x86_64).
+  url="https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu24.04.tar.gz"
+  tarball="$(mktemp /tmp/swift-XXXXXX.tar.gz)"
+  curl -fL --retry 4 --retry-delay 4 -o "$tarball" "$url"
+  $SUDO mkdir -p /opt/swift
+  $SUDO tar xzf "$tarball" -C /opt/swift --strip-components=1
+  rm -f "$tarball"
+  # Put the toolchain on the default PATH for every shell. Each symlink resolves
+  # its sibling tools via its real location under /opt/swift.
+  for b in /opt/swift/usr/bin/*; do
+    $SUDO ln -sf "$b" "/usr/local/bin/$(basename "$b")"
+  done
+  swift --version | head -1
+}
+
+build_whisper() {
+  log "Initializing whisper.cpp submodule"
+  git submodule update --init --recursive
+
+  local sha
+  sha="$(git -C "$WHISPER_DIR" rev-parse HEAD)"
+
+  if [ -f /usr/local/lib/libwhisper.so ] && [ -f "$WHISPER_MARKER" ] \
+     && [ "$(cat "$WHISPER_MARKER")" = "$sha" ]; then
+    log "whisper.cpp libraries already built for $sha; skipping"
+    return
+  fi
+
+  log "Building whisper.cpp shared libraries ($sha)"
+  # Use gcc/g++: the toolchain image's default clang c++ driver cannot locate
+  # libstdc++ for linking the C++ sources.
+  cmake -S "$WHISPER_DIR" -B "$WHISPER_DIR/build-linux" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DWHISPER_BUILD_EXAMPLES=OFF \
+    -DWHISPER_BUILD_TESTS=OFF \
+    -DGGML_NATIVE=OFF \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++
+  cmake --build "$WHISPER_DIR/build-linux" -j"$(nproc)"
+  $SUDO cmake --install "$WHISPER_DIR/build-linux" --prefix /usr/local
+
+  # Expose the dev symlinks on the default linker search path so `swift build`
+  # resolves -lwhisper / -lggml* without needing LIBRARY_PATH.
+  for lib in libwhisper.so libggml.so libggml-base.so libggml-cpu.so; do
+    $SUDO ln -sf "/usr/local/lib/$lib" "/usr/lib/x86_64-linux-gnu/$lib"
+  done
+  $SUDO ldconfig
+  echo "$sha" | $SUDO tee "$WHISPER_MARKER" >/dev/null
+}
+
+build_packages() {
+  log "Building Swift packages (MilaKit, TranscriptionCore)"
+  ( cd "$REPO_ROOT/Packages/MilaKit" && swift build )
+  ( cd "$REPO_ROOT/Packages/TranscriptionCore" && swift build )
+}
+
+fetch_e2e_model() {
+  local model="$MODEL_DIR/ggml-tiny.bin"
+  if [ -f "$model" ]; then
+    log "whisper tiny model already present; skipping download"
+    return
+  fi
+  log "Downloading ggml-tiny.bin for the whisper-e2e transcription check"
+  mkdir -p "$MODEL_DIR"
+  curl -fL --retry 4 --retry-delay 4 -o "$model" \
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"
+}
+
+ensure_system_deps
+ensure_swift
+build_whisper
+build_packages
+fetch_e2e_model
+
+log "Cloud Agent setup complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- No issue yet — this is Cloud Agent environment tooling. If the "Linked issue" check requires one, an issue can be opened and linked, or the `no-issue-needed` label applied. -->

## What & why

Adds a committed Cloud Agent environment so agents get a working, reproducible Linux dev setup for the parts of this repo that are **not** macOS-only.

The Mila app itself needs Xcode/SwiftUI and can't build on Linux, but the cross-platform surface can — and now builds, tests, and runs end to end in a Cloud Agent:

- `Packages/MilaKit` — the zero-dependency MCP/store package
- `Packages/TranscriptionCore` — `WhisperEngine` (whisper.cpp bindings), `WAVReader`, WER calculator, VAD, and the `whisper-e2e` CLI
- the `whisper.cpp` transcription core `TranscriptionCore` links against (built from the pinned submodule as Linux shared libraries)

Files:

- `.cursor/environment.json` — `install` runs `scripts/cloud-agent-setup.sh`.
- `scripts/cloud-agent-setup.sh` — idempotent, self-bootstrapping setup:
  - installs the Swift 6.1.2 toolchain + build/runtime deps (skips when already present);
  - initializes the `whisper.cpp` submodule and builds it into shared libraries (`libwhisper`/`libggml*`), installing them on the default linker search path so `swift build` links `-lwhisper`/`-lggml*` without extra env vars (keyed on the submodule SHA so a version bump rebuilds automatically);
  - builds both Swift packages;
  - pre-fetches `ggml-tiny.bin` for the `whisper-e2e` transcription check.

## How it was tested

Everything below ran on the Cloud Agent's Ubuntu 24.04 x86_64 VM:

- `make package-test` — **116 tests pass** (`TranscriptionCore` 43 + `MilaKit` 73).
- `make e2e` — **9/9 transcription fixtures pass** (English + Hebrew) through the real `whisper.cpp` pipeline, e.g. `en_hello_world` WER 0.00, `he_toda_raba` WER 0.00.
- `scripts/cloud-agent-setup.sh` run twice — second run is a fast idempotent no-op.
- A fresh Cloud Agent booted from a draft build of this branch re-ran the same checks (see PR discussion / agent summary).

The macOS-only `make build` / `make test` are not runnable on Linux and are out of scope for this environment.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — N/A on Linux; validated `make package-test` + `make e2e` instead
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — N/A (tooling only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64b7c21a-652e-4e09-b193-7ad6001447e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64b7c21a-652e-4e09-b193-7ad6001447e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated setup support for Linux cloud development environments.
  - Installs required system tools and Swift 6.1.2.
  - Builds the required audio processing components and downloads the Whisper tiny model.
- **Improvements**
  - Setup can be safely rerun without repeating completed installations.
  - Detects existing dependencies, toolchains, libraries, and models.
  - Stops promptly when configuration or installation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->