### PR TITLE
fix(speakers): naming a speaker mid-recording now creates a voice profile

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -166,7 +166,20 @@ final class QuickActionsController: ObservableObject {
     /// recovering one from `store.recordings.first` is unreliable because
     /// `add` inserts at index 0 with no re-sort, so any recording added in
     /// between (a Voice Memos import, say) becomes `first`.
-    var onRecordingFinalized: ((UUID) -> Void)?
+    ///
+    /// The second argument is the speaker names the user assigned from the
+    /// LIVE transcript pane while the recording ran (`LiveTranscriber.
+    /// speakerNames`). They travel through this hook rather than being copied
+    /// onto the row here because that copy was the bug in island-io/mila#209:
+    /// a name already on the row makes `RecordingStore.setSpeakerName`
+    /// no-change-guard out before it can fire `onSpeakerNamed`, the one hook
+    /// that persists a voice profile — so a mid-recording label stuck to the
+    /// transcript and taught the recogniser nothing, silently. There is no
+    /// row to name while the recording runs (`store.add` happens in
+    /// `stopRecording`), so deferring to here is what makes that single
+    /// persistence trigger reachable at all. See `RecognisedSpeakerAssigner.
+    /// finish(recording:liveSpeakerNames:)`.
+    var onRecordingFinalized: ((_ recordingID: UUID, _ liveSpeakerNames: [String: String]) -> Void)?
 
     /// Late-bound by MilaApp. When the live-transcript path saves a
     /// recording directly (skipping `transcription.enqueue` because the
@@ -679,6 +692,20 @@ final class QuickActionsController: ObservableObject {
         // and chunk modes produce live segments we want to preserve,
         // so the initial-status gate is segment-presence, not mode.
         let initialStatus: TranscriptionStatus = initialSegments.isEmpty ? .pending : .running
+        // `speakerNames` is deliberately NOT seeded from `liveTranscriber`
+        // below, and neither is it copied onto `updated` in the drain. Both
+        // copies used to exist, and between them they made mid-recording
+        // speaker naming teach the recogniser nothing at all
+        // (island-io/mila#209): the name was already on the row by the time
+        // `onRecordingFinalized` fired, so `setSpeakerName`'s no-change guard
+        // returned before firing `onSpeakerNamed` — the only hook that writes
+        // a voice profile. The live map now travels through that hook instead,
+        // which applies it via `setSpeakerName` and so keeps ONE persistence
+        // trigger (a parallel write is what caused the double-merge fixed in
+        // #204). Nothing reads the row's names in the meantime: the
+        // post-record sheet renders the transcript only once the row leaves
+        // `.pending`/`.running`, and the live MCP sidecar carries its own copy
+        // of the map.
         let recording = Recording(
             title: title,
             duration: duration,
@@ -691,8 +718,7 @@ final class QuickActionsController: ObservableObject {
             appName: appName,
             appBundleID: appBundleID,
             summary: initialSummary.isEmpty ? nil : initialSummary,
-            actionItems: initialItems.isEmpty ? nil : initialItems,
-            speakerNames: liveTranscriber?.speakerNames ?? [:]
+            actionItems: initialItems.isEmpty ? nil : initialItems
         )
         store.add(recording)
         // The live sidecar is deliberately NOT closed here. `finish()`
@@ -867,11 +893,15 @@ final class QuickActionsController: ObservableObject {
             return
         }
         updated.segments = finalTranscriptSegments
-        // Mid-recording speaker renames from the live pane. Snapshotted
-        // here (before `liveTranscriber?.stop()` below) alongside the
-        // segments they label; `finalizeTail` remaps them if the offline
-        // re-diarize pass re-keys the speaker IDs.
-        updated.speakerNames = liveTranscriber?.speakerNames ?? [:]
+        // Mid-recording speaker renames from the live pane are NOT copied
+        // onto the row here — see the note at `store.add` above. They are
+        // handed to `onRecordingFinalized` below (still before
+        // `liveTranscriber?.stop()`, so the map is intact) and applied with
+        // `store.setSpeakerName`, which is what lets them persist a voice
+        // profile. `finalizeTail` still remaps whatever the row ends up
+        // holding if the offline re-diarize pass re-keys the speaker IDs — it
+        // re-reads the row rather than using this snapshot, precisely so a
+        // name assigned after this line is not lost.
         // Always preserve fullText when we have live segments — the
         // sheet should show what the user just saw on screen, even
         // for chunk mode while the batch diarization pass is still
@@ -927,7 +957,21 @@ final class QuickActionsController: ObservableObject {
         // which carries no id and had to guess with `store.recordings.first`
         // — and `add` inserts at index 0, so a Voice Memos import landing in
         // between made the memo "the recording that just stopped".
-        onRecordingFinalized?(recording.id)
+        //
+        // It also carries the live pane's speaker names, which is what makes
+        // naming a speaker mid-recording learn a voice profile at all
+        // (island-io/mila#209). Read from `liveTranscriber` here — before the
+        // teardown below — and applied on the far side through
+        // `store.setSpeakerName`, the single persistence trigger.
+        onRecordingFinalized?(recording.id, liveTranscriber?.speakerNames ?? [:])
+        // Those names are written into the STORED row by `setSpeakerName`, not
+        // into this local copy, so re-read it. Without this the tail below
+        // carries a `speakerNames`-less snapshot and its
+        // `TranscriptExporter.writeSRT(for: updated, …)` would overwrite the
+        // named `.srt` that `setSpeakerName` just wrote with an unnamed one.
+        if let named = store.recordings.first(where: { $0.id == recording.id }) {
+            updated = named
+        }
 
         // ---- END OF THE LIVE-PIPELINE-OWNING PHASE.
         //

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -681,8 +681,8 @@ struct MilaApp: App {
             case .named(let names): liveDiar?.forgetSeededProfiles(named: names)
             }
         }
-        actions.onRecordingFinalized = { [assigner] recordingID in
-            assigner.finish(recording: recordingID)
+        actions.onRecordingFinalized = { [assigner] recordingID, liveSpeakerNames in
+            assigner.finish(recording: recordingID, liveSpeakerNames: liveSpeakerNames)
         }
         // Save a voice profile when a speaker is named — if the live
         // diarizer observed that speaker *in that recording*, persist it.

--- a/Mila/Models/RecognisedSpeakerAssigner.swift
+++ b/Mila/Models/RecognisedSpeakerAssigner.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// Applies stored voice-profile names to the speakers a finished recording
-/// actually recognised, and snapshots that recording's observations so a
-/// later rename can persist the right voice.
+/// Reconciles a finished recording's speaker names: applies the names the
+/// user typed into the live transcript, applies stored voice-profile names to
+/// the speakers it actually recognised, and snapshots that recording's
+/// observations so a later rename can persist the right voice.
 ///
 /// Extracted from `MilaApp` for one reason above all: **it must be told which
 /// recording finished, never infer it.** The previous version ran off
@@ -59,12 +60,36 @@ final class RecognisedSpeakerAssigner {
         self.profileStillStored = profileStillStored
     }
 
-    /// Call once per finished recording, with that recording's id.
+    /// Call once per finished recording, with that recording's id and the
+    /// names the user assigned from the live transcript while it ran.
     ///
-    /// No-ops entirely while voice recognition is off — the pool would carry
-    /// no `profileName` anyway (nothing was seeded), but an explicit gate
-    /// keeps the guarantee readable rather than emergent, and it also stops
-    /// the snapshot below from holding embeddings for an opted-out user.
+    /// **Why the live names arrive here rather than being written onto the
+    /// row.** There is no `Recording` in the store while a recording is
+    /// running — `QuickActionsController.stopRecording` calls `store.add`
+    /// *after* `session.stop()` — so `setSpeakerName(recordingID:)` is
+    /// literally unreachable from the live pane: it resolves the id to a row
+    /// index and returns when there is none. The live pane therefore holds
+    /// the name in `LiveTranscriber.speakerNames`, and the drain used to copy
+    /// that map straight onto the row (`store.add(speakerNames:)`, then
+    /// `updated.speakerNames = …`). The label stuck and nothing was learned:
+    /// by the time this method ran, the row already carried the name, so
+    /// `setSpeakerName`'s no-change guard returned before firing
+    /// `onSpeakerNamed` — the one hook that persists a voice profile
+    /// (island-io/mila#209). Naming the same speaker afterwards from the
+    /// detail view *did* persist, which is what made it easy to miss.
+    ///
+    /// So the drain no longer writes those names at all; it hands them here,
+    /// and they go through `store.setSpeakerName` like every other name. That
+    /// keeps **one** persistence trigger, which is the invariant the loop
+    /// below documents at length — a second, parallel write is what caused
+    /// the double-merge fixed in #204.
+    ///
+    /// The voice-recognition gate covers the snapshot and the auto-naming
+    /// loop, **not** the live names: a display name is not voice data, it
+    /// must keep working with recognition switched off (see
+    /// `VoiceRecognitionGateTests.test_while_off_naming_a_speaker_persists_no_embedding`),
+    /// and gating it would have silently dropped every mid-recording label
+    /// for the majority of users who never opt in.
     ///
     /// **On the removed `intervals` check.** This loop used to also require
     /// `diarizer.intervals.contains { $0.speaker == entry.id }`, justified as
@@ -81,16 +106,44 @@ final class RecognisedSpeakerAssigner {
     /// expecting extra safety; it adds none, and it made this method
     /// unreachable from a unit test (`intervals` is `private(set)` and only
     /// fills via the daemon).
-    func finish(recording recordingID: UUID) {
-        guard settings.isConfigured else { return }
-        let poolEntries = diarizer.currentProfiles()
+    func finish(recording recordingID: UUID, liveSpeakerNames: [String: String] = [:]) {
+        // `isConfigured` is a computed property over two settings values, and
+        // it now gates two separate things here (the snapshot, and the
+        // auto-naming loop) with an ungated stretch between them. Read once
+        // into a local so those two can never disagree — snapshotting
+        // embeddings and then skipping the loop that consumes them, or the
+        // reverse, would each be a silent half-behaviour.
+        let recognitionOn = settings.isConfigured
+        let poolEntries = recognitionOn ? diarizer.currentProfiles() : []
 
         // Snapshot against this recording's id BEFORE naming anything:
         // `setSpeakerName` fires `onSpeakerNamed` synchronously, and that
         // hook resolves the voice through this snapshot. Every pool entry is
         // kept, not just seeded ones, because a speaker the user names by
-        // hand later needs the same lookup.
-        snapshots.record(poolEntries, for: recordingID)
+        // hand — mid-recording in the loop just below, or later from the
+        // detail view — needs the same lookup.
+        //
+        // Gated: an opted-out user has no embeddings held here either. That
+        // is also why `poolEntries` is left empty above rather than read and
+        // discarded.
+        if recognitionOn {
+            snapshots.record(poolEntries, for: recordingID)
+        }
+
+        // The names the user typed into the live transcript while this
+        // recording ran. Applied through `setSpeakerName` — the single
+        // persistence trigger — and applied FIRST, so a label the user chose
+        // deliberately is never overwritten by the auto-naming loop below,
+        // and so each raw id fires `onSpeakerNamed` at most once.
+        //
+        // Sorted for a deterministic order: `Dictionary` iteration order is
+        // unspecified and varies per process, and this drives log lines and
+        // an `.srt` rewrite per entry.
+        for (rawID, name) in liveSpeakerNames.sorted(by: { $0.key < $1.key }) {
+            store.setSpeakerName(name, forSpeaker: rawID, recordingID: recordingID)
+        }
+
+        guard recognitionOn else { return }
 
         // Persistence is `setSpeakerName`'s job, not this loop's — one
         // recognition must fold into the stored centroid exactly once.
@@ -107,6 +160,15 @@ final class RecognisedSpeakerAssigner {
         // for the same recording idempotent: the name already matches, so
         // `setSpeakerName` returns without firing the hook.
         for entry in poolEntries {
+            // 0. The user did not already name this speaker themselves.
+            //    Their label wins over a recogniser's guess, and skipping
+            //    is what keeps the hook to one fire per raw id: overwriting
+            //    "Bob" with "Alice" here would fire `onSpeakerNamed` a second
+            //    time and fold this recording's centroid into *both*
+            //    profiles. (Before the live names came through this method
+            //    the auto-name silently clobbered them — the label the user
+            //    typed mid-recording was replaced by the seeded profile's.)
+            guard liveSpeakerNames[entry.id] == nil else { continue }
             // 1. Seeded from a stored profile — there is a name to assign.
             guard let profileName = entry.profileName else { continue }
             // 2. Confidently matched this recording. `assign` deliberately

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -430,6 +430,28 @@ struct LiveAIRecordingView: View {
                                 TranscriptLineView(segment: seg, language: language,
                                                    useSpeakerColor: hasMultipleSpeakers,
                                                    speakerNames: transcriber.speakerNames,
+                                                   // The live transcriber is the only
+                                                   // place this name can go: there is no
+                                                   // `Recording` in the store yet
+                                                   // (`store.add` happens in
+                                                   // `stopRecording`), so
+                                                   // `RecordingStore.setSpeakerName` —
+                                                   // and the `onSpeakerNamed` hook that
+                                                   // persists a voice profile — cannot
+                                                   // resolve an id to name.
+                                                   //
+                                                   // The map is handed to
+                                                   // `onRecordingFinalized` at stop and
+                                                   // applied through `setSpeakerName`
+                                                   // there, so naming a speaker here does
+                                                   // learn their voice (island-io/mila#209)
+                                                   // — with ONE persistence trigger. Do
+                                                   // not add a profile write at this site:
+                                                   // a parallel one is what caused the
+                                                   // double-merge fixed in #204, and the
+                                                   // embeddings for this recording are not
+                                                   // final until the diarizer's queue has
+                                                   // drained at stop anyway.
                                                    onAssignName: { raw, name in
                                                        if let name {
                                                            transcriber.speakerNames[raw] = name

--- a/MilaTests/LiveSpeakerNamingTests.swift
+++ b/MilaTests/LiveSpeakerNamingTests.swift
@@ -1,0 +1,514 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+/// **Invariant: naming a speaker DURING a recording learns their voice, and
+/// learns it exactly once.**
+///
+/// REGRESSION (island-io/mila#209): it did neither. `LiveAIRecordingView`
+/// names a speaker by writing `LiveTranscriber.speakerNames[raw]`, because
+/// there is no `Recording` in the store while a recording runs —
+/// `QuickActionsController.stopRecording` calls `store.add` *after*
+/// `session.stop()`, so `RecordingStore.setSpeakerName(recordingID:)` has no
+/// row to resolve and returns without doing anything. The drain then copied
+/// that map straight onto the row (`store.add(speakerNames:)`, and again as
+/// `updated.speakerNames = …` before `store.update`). By the time
+/// `onRecordingFinalized` fired, the row already carried the name, so
+/// `setSpeakerName`'s no-change guard returned *before* firing
+/// `onSpeakerNamed` — the one hook that persists a voice profile. The label
+/// stuck to the transcript, no profile was created, and nothing said so.
+///
+/// The fix routes those names through `setSpeakerName` at finalization rather
+/// than adding a second persistence call at the live site, because "one
+/// persistence trigger" is a deliberate invariant: a parallel `updateProfile`
+/// alongside it is what caused the double-merge fixed in #204, where every
+/// recognised speaker folded in twice and the profile went progressively
+/// rigid. So these tests assert the fire *count*, not merely that a profile
+/// exists.
+///
+/// `test_the_pre_fix_shape_learns_nothing` is the negative control: it
+/// reconstructs the old sequence from the same real objects and measures the
+/// silence.
+@MainActor
+final class LiveSpeakerNamingTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    /// What `onSpeakerNamed` was called with, in order. The count is the
+    /// point: "exactly once" is what stops the double-merge coming back.
+    private struct Fire: Equatable {
+        let recordingID: UUID
+        let rawID: String
+        let name: String
+    }
+    private var fires: [Fire] = []
+
+    private let aliceStored: [Float] = [1, 0, 0, 0]
+    private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+    /// Nothing like Alice — cos(bob, aliceStored) == 0, so a seeded Alice
+    /// cannot claim him even at the 0.40 create floor.
+    private let bobSpeaking: [Float] = [0, 1, 0, 0]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "LiveSpeakerNamingTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        fires.removeAll()
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    private func makeSettings(enabled: Bool = true) -> VoiceRecognitionSettings {
+        let name = "LiveSpeakerNamingTests.\(UUID())"
+        suiteNames.append(name)
+        let s = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: name)!)
+        s.diarizationReady = { true }
+        s.isEnabled = enabled
+        return s
+    }
+
+    private struct World {
+        let store: RecordingStore
+        let profiles: SpeakerProfileStore
+        let snapshots: ObservedVoiceSnapshots
+        let diarizer: LiveSpeakerDiarizer
+        let assigner: RecognisedSpeakerAssigner
+        let settings: VoiceRecognitionSettings
+    }
+
+    /// The shipping wiring, assembled from real objects — the same shape
+    /// `MilaApp.init` installs, plus a tap on the hook so the tests can count
+    /// its fires. `seedAlice` controls whether a stored profile exists to be
+    /// auto-recognised; the live-naming tests that do not need one leave the
+    /// pool unseeded, which is the ordinary case (a brand-new voice the user
+    /// puts a name to).
+    private func makeWorld(enabled: Bool = true, seedAlice: Bool = false) -> World {
+        let settings = makeSettings(enabled: enabled)
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        if seedAlice {
+            profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+        }
+
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let snapshots = ObservedVoiceSnapshots()
+
+        // Same wiring MilaApp.init installs, with the fire log wrapped around
+        // it. `[weak self]` so the stored closure can't keep the test case
+        // alive past tearDown.
+        store.onSpeakerNamed = { [weak self] recordingID, rawID, name in
+            self?.fires.append(Fire(recordingID: recordingID, rawID: rawID, name: name))
+            guard settings.isConfigured else { return }
+            guard let observed = snapshots.observation(forSpeaker: rawID,
+                                                      in: recordingID) else { return }
+            profiles.updateProfile(name: name,
+                                   embedding: observed.observedCentroid,
+                                   sampleCount: observed.observedCount)
+        }
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        profiles.addDeletionObserver { [weak diarizer] deletion in
+            switch deletion {
+            case .all: diarizer?.forgetSeededProfiles()
+            case .named(let names): diarizer?.forgetSeededProfiles(named: names)
+            }
+        }
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        let assigner = RecognisedSpeakerAssigner(
+            store: store,
+            diarizer: diarizer,
+            snapshots: snapshots,
+            settings: settings,
+            profileStillStored: { profiles.profileExists(name: $0) })
+        return World(store: store, profiles: profiles, snapshots: snapshots,
+                     diarizer: diarizer, assigner: assigner, settings: settings)
+    }
+
+    @discardableResult
+    private func add(_ title: String, to store: RecordingStore) -> Recording {
+        let rec = Recording(title: title, source: .microphone,
+                            audioFileName: "\(title).wav")
+        store.add(rec)
+        return rec
+    }
+
+    private func names(_ id: UUID, in store: RecordingStore) -> [String: String] {
+        store.recordings.first { $0.id == id }?.speakerNames ?? [:]
+    }
+
+    // MARK: - The fix
+
+    /// The bug, from the user's side: someone speaks, the user labels them in
+    /// the live pane, the recording stops — and the voice is now stored, so
+    /// the next recording recognises them.
+    func test_a_name_assigned_during_the_recording_creates_a_voice_profile() {
+        let w = makeWorld()
+        // A voice nobody has a profile for — the ordinary case for naming.
+        XCTAssertEqual(w.diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+        let meeting = add("Meeting", to: w.store)
+
+        // What the live pane put in `LiveTranscriber.speakerNames`, handed
+        // over by `stopRecording` at finalization.
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_00": "Bob"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store)["SPEAKER_00"], "Bob",
+                       "the label must still land on the transcript")
+        // Bound, not force-unwrapped: `XCTAssertNil` records a failure and
+        // carries on, so a force-unwrap here would abort the runner and hide
+        // which assertion actually broke.
+        let bob = w.profiles.profile(named: "Bob")
+        XCTAssertNotNil(bob, "and the voice must now be learned — this is #209")
+        XCTAssertEqual(bob?.sampleCount, 1, "one observation, folded in once")
+        XCTAssertEqual(bob?.embedding, bobSpeaking)
+        XCTAssertEqual(fires, [Fire(recordingID: meeting.id,
+                                    rawID: "SPEAKER_00", name: "Bob")],
+                       "exactly one persistence trigger, for exactly this speaker")
+    }
+
+    /// **Negative control — the pre-fix shape, reconstructed from the same
+    /// real objects.** `stopRecording` used to copy `LiveTranscriber.
+    /// speakerNames` onto the row before `onRecordingFinalized` ran (twice
+    /// over: at `store.add`, then again onto `updated`). That is all it takes:
+    /// with the name already there, `setSpeakerName` no-change-guards out and
+    /// `onSpeakerNamed` never fires.
+    ///
+    /// It proves the test above discriminates — the assigner's call alone is
+    /// not what makes the profile appear, *not having pre-written the row* is
+    /// — and it records what the silence looked like: a correct-looking
+    /// transcript label and no voice data at all.
+    func test_the_pre_fix_shape_learns_nothing() throws {
+        let w = makeWorld()
+        XCTAssertEqual(w.diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+        let meeting = add("Meeting", to: w.store)
+
+        // The removed copy: the drain writing the live map onto the row.
+        var preWritten = try XCTUnwrap(w.store.recordings.first { $0.id == meeting.id })
+        preWritten.speakerNames = ["SPEAKER_00": "Bob"]
+        w.store.update(preWritten)
+
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_00": "Bob"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store)["SPEAKER_00"], "Bob",
+                       "the label looks right, which is why this was easy to miss")
+        XCTAssertNil(w.profiles.profile(named: "Bob"),
+                     "…but nothing was learned: the no-change guard swallowed the write")
+        XCTAssertTrue(fires.isEmpty, "onSpeakerNamed never fired — the whole bug")
+    }
+
+    /// Re-running finalization for the same recording — a duplicated stop, a
+    /// re-entrant hook — must not fold the same observation in again. This is
+    /// the property that routing through `setSpeakerName` buys and that a
+    /// parallel `updateProfile` at the live site would destroy (#204).
+    func test_running_finalization_twice_folds_the_live_name_in_once() {
+        let w = makeWorld()
+        XCTAssertEqual(w.diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+        let meeting = add("Meeting", to: w.store)
+
+        for _ in 0..<3 {
+            w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_00": "Bob"])
+        }
+
+        XCTAssertEqual(w.profiles.profile(named: "Bob")?.sampleCount, 1,
+                       "one observation, one merge, however many times we finalize")
+        XCTAssertEqual(fires.count, 1)
+    }
+
+    /// A name the user typed wins over the name the recogniser would have
+    /// applied, and the loser does not get a second hook fire. Before the live
+    /// names came through this path the auto-name silently clobbered them: the
+    /// user labelled SPEAKER_00 "Bob", stop replaced it with the seeded
+    /// "Alice", and Alice's profile learned Bob's voice.
+    func test_a_live_name_wins_over_the_recognised_profile_name() {
+        let w = makeWorld(seedAlice: true)
+        // Alice is seeded as SPEAKER_00 and confidently matched, so without
+        // the precedence rule the auto-name loop would stamp "Alice" here.
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        XCTAssertEqual(w.diarizer.currentProfiles().first?.profileName, "Alice",
+                       "precondition: the pool entry carries the seeded name")
+        let meeting = add("Meeting", to: w.store)
+
+        // The user disagrees with the recogniser and says so during the call.
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_00": "Bob"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store)["SPEAKER_00"], "Bob",
+                       "the user's label must survive finalization")
+        XCTAssertEqual(fires.map(\.name), ["Bob"],
+                       "one fire, for the user's name — not two, and not Alice's")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 40,
+                       "Alice must not learn a voice the user says isn't hers")
+        XCTAssertEqual(w.profiles.profile(named: "Bob")?.sampleCount, 1)
+    }
+
+    /// A speaker the user did NOT name is still auto-named from their stored
+    /// profile — the live names must suppress only their own raw ids.
+    func test_an_unnamed_speaker_is_still_auto_named() {
+        let w = makeWorld(seedAlice: true)
+        XCTAssertEqual(w.diarizer.assign(embedding: aliceSpeaking), "SPEAKER_00")
+        XCTAssertEqual(w.diarizer.assign(embedding: bobSpeaking), "SPEAKER_01")
+        let meeting = add("Meeting", to: w.store)
+
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_01": "Bob"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store),
+                       ["SPEAKER_00": "Alice", "SPEAKER_01": "Bob"])
+        XCTAssertEqual(Set(fires.map(\.name)), ["Alice", "Bob"])
+        XCTAssertEqual(fires.count, 2, "one fire per speaker, no more")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 41)
+    }
+
+    /// The label is not voice data. With voice recognition off — the default,
+    /// and where most users are — naming a speaker in the live pane must still
+    /// label the transcript, while storing nothing and snapshotting nothing.
+    ///
+    /// Gating the live names on `isConfigured` alongside the snapshot would
+    /// have silently dropped every mid-recording label for those users, which
+    /// is a worse bug than the one being fixed.
+    func test_a_live_name_is_applied_with_voice_recognition_off() {
+        let w = makeWorld(enabled: false)
+        // Seeding was refused while off, so this speaks into an empty pool.
+        _ = w.diarizer.assign(embedding: bobSpeaking)
+        let meeting = add("Meeting", to: w.store)
+
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_00": "Bob"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store)["SPEAKER_00"], "Bob",
+                       "naming a speaker keeps working with the feature off")
+        XCTAssertTrue(w.profiles.profiles.isEmpty, "and stores no voice data")
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: tempRoot.appendingPathComponent("speaker-profiles.json").path),
+            "no profiles file may be created for an opted-out user")
+        XCTAssertEqual(w.snapshots.heldRecordingCount, 0,
+                       "and holds no embeddings in memory either")
+    }
+
+    /// A live name for a speaker this recording never observed labels the
+    /// transcript and persists nothing — `ObservedVoiceSnapshots` has no
+    /// observation for that raw id, so there is no embedding to learn from and
+    /// the hook's own guard refuses. Fail-closed, same as a stale id.
+    func test_a_live_name_for_an_unobserved_speaker_stores_nothing() {
+        let w = makeWorld()
+        XCTAssertEqual(w.diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+        let meeting = add("Meeting", to: w.store)
+
+        // SPEAKER_07 was never minted — a stale label from a re-keyed
+        // transcript would look like this.
+        w.assigner.finish(recording: meeting.id, liveSpeakerNames: ["SPEAKER_07": "Ghost"])
+
+        XCTAssertEqual(names(meeting.id, in: w.store)["SPEAKER_07"], "Ghost")
+        XCTAssertNil(w.profiles.profile(named: "Ghost"))
+        XCTAssertEqual(fires.count, 1,
+                       "the hook still fires — it is the hook's own snapshot guard that refuses")
+    }
+}
+
+/// The controller half of island-io/mila#209, driven through the real
+/// `QuickActionsController.stopRecording`.
+///
+/// `LiveSpeakerNamingTests` above pins what the assigner does once it is
+/// handed the live names. This pins the part that was actually broken: that
+/// `stopRecording` **hands them over** instead of copying them onto the row.
+/// The distinction matters because the two failures are independent — an
+/// assigner that applies live names perfectly still learns nothing if the
+/// drain has already written them, which is precisely the shape
+/// `LiveSpeakerNamingTests.test_the_pre_fix_shape_learns_nothing` measures.
+/// Re-adding either copy (`store.add(speakerNames:)` or
+/// `updated.speakerNames = …`) turns this test red.
+@MainActor
+final class LiveSpeakerNamingStopRecordingTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var store: RecordingStore!
+    private var manager: ModelManager!
+    private var stub: StubWhisperEngine!
+    private var service: TranscriptionService!
+    private var session: RecordingSession!
+    private var languageSettings: RecordingLanguageSettings!
+    private var postRecording: PostRecordingCoordinator!
+    private var controller: QuickActionsController!
+
+    private var voiceSettings: VoiceRecognitionSettings!
+    private var profiles: SpeakerProfileStore!
+    private var snapshots: ObservedVoiceSnapshots!
+    private var diarizer: LiveSpeakerDiarizer!
+    private var transcriber: LiveTranscriber!
+
+    private struct Fire: Equatable {
+        let rawID: String
+        let name: String
+    }
+    private var fires: [Fire] = []
+
+    private let suitePrefix = "LiveSpeakerNamingStopRecordingTests"
+    private var savedSelection: String?
+
+    /// A voice no stored profile matches, so the only way its name can reach
+    /// a profile is the live-naming path under test.
+    private let bobSpeaking: [Float] = [0, 1, 0, 0]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: suitePrefix)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+        store = RecordingStore(rootDirectory: tempRoot)
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        try TestSupport.installFakeModel(into: manager)
+
+        stub = StubWhisperEngine()
+        // No canned segments anywhere: the live drain has no buffered audio to
+        // transcribe, and the batch pass this recording gets enqueued for
+        // comes back empty — which, per `TranscriptionService.mergePassResult`,
+        // is the one pass that does NOT own `speakerNames`. That keeps the
+        // assertions below independent of whether the background tail has run.
+        await stub.setDefaultCanned([])
+        service = TranscriptionService(
+            store: store,
+            modelManager: manager,
+            diarizationSettings: DiarizationSettings(
+                defaults: .init(suiteName: "\(suitePrefix).diarization")!),
+            remoteSettings: TestSupport.isolatedRemoteSettings(label: suitePrefix),
+            engine: stub)
+        session = RecordingSession()
+        languageSettings = RecordingLanguageSettings(
+            defaults: UserDefaults(suiteName: "\(suitePrefix).language")!)
+        postRecording = PostRecordingCoordinator(
+            store: store,
+            transcription: service,
+            llm: LLMSettings(defaults: UserDefaults(suiteName: "\(suitePrefix).llm")!))
+        controller = QuickActionsController(session: session,
+                                            store: store,
+                                            transcription: service,
+                                            languageSettings: languageSettings,
+                                            postRecording: postRecording)
+
+        voiceSettings = VoiceRecognitionSettings(
+            defaults: UserDefaults(suiteName: "\(suitePrefix).voice")!)
+        voiceSettings.diarizationReady = { true }
+        voiceSettings.isEnabled = true
+        profiles = SpeakerProfileStore(directory: tempRoot, settings: voiceSettings)
+        snapshots = ObservedVoiceSnapshots()
+
+        // The live singletons `MilaApp` hands the controller. The transcriber
+        // is deliberately never `start()`ed — `start` clears `speakerNames`,
+        // and with no detector and no buffered audio the drain's
+        // `transcribeNow()` is a no-op, so the recording stays on the
+        // no-live-segments path.
+        diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.reset()
+        transcriber = LiveTranscriber(transcription: service)
+        controller.liveDiarizer = diarizer
+        controller.liveTranscriber = transcriber
+
+        // Same wiring MilaApp.init installs, with a tap on the hook.
+        // Explicitly typed so the implicitly-unwrapped properties are captured
+        // as non-optionals rather than inferred back into `Optional`.
+        let profilesRef: SpeakerProfileStore = profiles
+        let snapshotsRef: ObservedVoiceSnapshots = snapshots
+        let settingsRef: VoiceRecognitionSettings = voiceSettings
+        store.onSpeakerNamed = { [weak self] recordingID, rawID, name in
+            self?.fires.append(Fire(rawID: rawID, name: name))
+            guard settingsRef.isConfigured else { return }
+            guard let observed = snapshotsRef.observation(forSpeaker: rawID,
+                                                         in: recordingID) else { return }
+            profilesRef.updateProfile(name: name,
+                                      embedding: observed.observedCentroid,
+                                      sampleCount: observed.observedCount)
+        }
+        let assigner = RecognisedSpeakerAssigner(
+            store: store,
+            diarizer: diarizer,
+            snapshots: snapshots,
+            settings: voiceSettings,
+            profileStillStored: { profilesRef.profileExists(name: $0) })
+        controller.onRecordingFinalized = { [assigner] recordingID, liveSpeakerNames in
+            assigner.finish(recording: recordingID, liveSpeakerNames: liveSpeakerNames)
+        }
+    }
+
+    override func tearDown() async throws {
+        controller?.onRecordingFinalized = nil
+        store?.onSpeakerNamed = nil
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let savedSelection {
+            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        for suffix in ["diarization", "language", "llm", "voice"] {
+            UserDefaults().removePersistentDomain(forName: "\(suitePrefix).\(suffix)")
+        }
+        try await super.tearDown()
+    }
+
+    /// The whole reported bug, end to end: a speaker is heard, the user labels
+    /// them from the live pane mid-recording, Stop is pressed — and the voice
+    /// is stored, once.
+    ///
+    /// This fails on the pre-fix code: `stopRecording` copied
+    /// `transcriber.speakerNames` onto the row at `store.add` and again onto
+    /// `updated`, so by the time the finalize hook ran the name already
+    /// matched and `setSpeakerName` returned without firing `onSpeakerNamed`
+    /// — `fires` empty, no profile, and the transcript label looking correct.
+    func test_naming_a_speaker_mid_recording_learns_the_voice_exactly_once() async throws {
+        let url = store.freshAudioURL(suggestedName: "LiveNaming")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+
+        // The diarizer hears one voice it has never heard before…
+        XCTAssertEqual(diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+        // …and the user names them in the live transcript. This is exactly
+        // what `LiveAIRecordingView`'s `onAssignName` does.
+        transcriber.speakerNames["SPEAKER_00"] = "Bob"
+
+        await controller.stopRecording()
+        // Drain the background tail so nothing lands mid-assertion.
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+
+        XCTAssertEqual(fires, [Fire(rawID: "SPEAKER_00", name: "Bob")],
+                       "the finalize hook must fire once, for the name the user typed")
+        let bob = profiles.profile(named: "Bob")
+        XCTAssertNotNil(bob, "naming a speaker mid-recording must create a voice profile")
+        XCTAssertEqual(bob?.sampleCount, 1, "one observation, folded in exactly once")
+        XCTAssertEqual(bob?.embedding, bobSpeaking)
+
+        let saved = try XCTUnwrap(store.recordings.first)
+        XCTAssertEqual(saved.speakerNames, ["SPEAKER_00": "Bob"],
+                       "and the label is on the saved recording, via setSpeakerName")
+    }
+
+    /// The other half of the same wiring: with nothing named in the live pane,
+    /// the saved row carries no names and the hook never fires. Pins that the
+    /// hook's new argument is the live map and not, say, a stale or synthesised
+    /// one — a hook that fired here would be inventing labels.
+    func test_naming_nothing_leaves_the_saved_recording_unnamed() async throws {
+        let url = store.freshAudioURL(suggestedName: "LiveNamingNone")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        XCTAssertEqual(diarizer.assign(embedding: bobSpeaking), "SPEAKER_00")
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+
+        XCTAssertTrue(fires.isEmpty)
+        XCTAssertTrue(profiles.profiles.isEmpty)
+        let saved = try XCTUnwrap(store.recordings.first)
+        XCTAssertTrue(saved.speakerNames.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #209

## What & why

Naming a speaker **during** a recording, from the live transcript, never created or
updated a voice profile. The label appeared and stuck, no error was shown, and the same
person was unrecognised in the next recording. Naming them afterwards from
`RecordingDetailView` *did* persist, which is what made this easy to miss.

### The finding the issue asked for: there is no store row at naming time

Confirmed by reading the code, not inferred. `QuickActionsController.stopRecording`
creates the `Recording` and calls `store.add(recording)` **inside stop**, after
`await session.stop()` returns the output URL — there is no `Recording` in the store at
any point while the recording is running. So `RecordingStore.setSpeakerName(_:forSpeaker:
recordingID:)` is not merely unused from the live pane, it is *unreachable*: its first
line is `guard let idx = recordings.firstIndex(where: { $0.id == recordingID }) else
{ return }`.

That is why `LiveAIRecordingView` writes `transcriber.speakerNames[raw]` directly, and
it is the reason the fix has to defer rather than reroute at the live site.

### Why nothing was learned

Voice-profile persistence hangs off exactly one trigger: `setSpeakerName` fires
`store.onSpeakerNamed`, which `MilaApp.init` wires to
`SpeakerProfileStore.updateProfile`. One trigger is a **deliberate invariant** — a
parallel `updateProfile` call alongside it is what caused the double-merge fixed in
#204, where every recognised speaker folded in twice, `sampleCount` doubled, and the
profile went progressively rigid with no visible failure.

The live map reached the row without ever passing through that trigger, twice over:

* `store.add(Recording(… speakerNames: liveTranscriber?.speakerNames ?? [:]))`
* `updated.speakerNames = liveTranscriber?.speakerNames ?? [:]` before `store.update`

Both run *before* `onRecordingFinalized?(recording.id)`. So by the time
`RecognisedSpeakerAssigner.finish` called `setSpeakerName`, the row already carried the
name and the no-change guard (`guard recordings[idx].speakerNames[rawID] != trimmed else
{ return }`) returned before firing the hook.

### The fix

Route the live names through the same single trigger, at the one moment it is reachable
and the embeddings are final.

* **`QuickActionsController`** — both pre-writes are gone. `onRecordingFinalized` is now
  `(UUID, [String: String]) -> Void` and carries `liveTranscriber?.speakerNames`, read
  before the live-singleton teardown.
* **`RecognisedSpeakerAssigner.finish(recording:liveSpeakerNames:)`** — after snapshotting
  the pool (which must happen before anything can fire the hook), applies each live name
  with `store.setSpeakerName`. No second persistence call anywhere.
* **`MilaApp`** — passes the map through to `finish`.
* **`LiveAIRecordingView`** — comment only, recording why the write goes to the
  transcriber and where persistence happens, so the next reader doesn't "fix" it by
  adding a profile write at the live site.

Three consequences, all deliberate:

1. **Live names are applied before the auto-naming loop, and that loop now skips any raw
   id the user named.** The user's label beats a recogniser's guess, and each raw id
   fires the hook at most once — letting the auto-name overwrite "Bob" with a seeded
   "Alice" would fire `onSpeakerNamed` twice and fold this recording's centroid into
   *both* profiles. This also fixes a smaller adjacent bug: previously the auto-name
   silently clobbered a mid-recording label.
2. **Live names are not behind the voice-recognition gate**; the snapshot and the
   auto-naming loop still are. A display name is not voice data and has to keep working
   with recognition off (`VoiceRecognitionGateTests.
   test_while_off_naming_a_speaker_persists_no_embedding` already pins that for the
   detail-view path). Gating it would have dropped every mid-recording label for the
   majority of users who never opt in — a worse bug than the one being fixed.
   `isConfigured` is read once into a local so the two gated regions cannot disagree.
3. **`stopRecording` re-reads the row after the hook.** `setSpeakerName` writes into the
   store, not into the local `updated` snapshot the finalize tail carries; without the
   re-read, `finalizeTail`'s `TranscriptExporter.writeSRT(for: updated, …)` would
   overwrite the named `.srt` that `setSpeakerName` had just written with an unnamed one.

Nothing reads the row's `speakerNames` in the window where they are briefly absent: the
post-record sheet and `PostRecordingCoordinator.awaitTranscript` both render the
transcript only once the row leaves `.pending`/`.running`, and the live MCP sidecar
carries its own copy of the map (`LiveTranscriptSidecarWriter.update(segments:
speakerNames:)`), so the MCP surface is unaffected.

### Not done, on purpose

The issue's own comment thread proposed calling the hook **directly** after
`store.update(updated)`. That is the second persistence call #204 exists to prevent, and
it would also bypass `setSpeakerName`'s idempotency — a duplicated stop would merge
twice. Deferring the *name* instead of duplicating the *write* keeps one trigger.

## How it was tested

`make build` / `make test` could not be run: no Xcode, no Swift toolchain on this
machine. Verification is by reading the actual call paths (cited above) plus CI on this
PR. New tests, in `MilaTests/LiveSpeakerNamingTests.swift`:

**`LiveSpeakerNamingTests`** (real `RecordingStore`, `SpeakerProfileStore`,
`LiveSpeakerDiarizer`, `ObservedVoiceSnapshots`, `RecognisedSpeakerAssigner`, hook wired
exactly as `MilaApp.init` does, with a tap that logs every fire):

* `test_a_name_assigned_during_the_recording_creates_a_voice_profile` — the fix.
* `test_the_pre_fix_shape_learns_nothing` — **negative control.** Reconstructs the
  removed copy (writes the live map onto the row, then finalizes) and measures the
  silence: label present, no profile, hook never fired. Proves the test above
  discriminates — it is *not having pre-written the row* that makes the profile appear.
* `test_running_finalization_twice_folds_the_live_name_in_once` — the anti-double-merge
  invariant.
* `test_a_live_name_wins_over_the_recognised_profile_name` — precedence, and exactly one
  fire; the seeded profile must not learn a voice the user says isn't theirs.
* `test_an_unnamed_speaker_is_still_auto_named` — the skip is per raw id, not global.
* `test_a_live_name_is_applied_with_voice_recognition_off` — label lands, nothing stored,
  no profiles file, no embeddings held.
* `test_a_live_name_for_an_unobserved_speaker_stores_nothing` — fail-closed on a raw id
  this recording never observed.

**`LiveSpeakerNamingStopRecordingTests`** — drives the real
`QuickActionsController.stopRecording` (fake-session seam + `StubWhisperEngine`, as
`LiveSidecarHandoffOrderingTests` does):

* `test_naming_a_speaker_mid_recording_learns_the_voice_exactly_once` — the reported bug
  end to end. **Fails on the pre-fix code**: with either copy in place the hook never
  fires, so `fires` is empty and no profile exists. Re-adding either pre-write turns it
  red again.
* `test_naming_nothing_leaves_the_saved_recording_unnamed` — the hook's new argument is
  the live map, not a synthesised one.

Both classes assert the **fire count**, not merely that a profile exists, because "one
persistence trigger" is the invariant that a passing profile-exists assertion would hide.

No pre-existing test asserted the buggy behaviour (checked every `speakerNames` /
`setSpeakerName` / `onSpeakerNamed` reference under `MilaTests/`), so nothing had to be
inverted. `VoiceRecognitionGateTests.test_stopping_right_after_an_opt_out_names_nothing_and_stores_nothing`
and the whole of `RecognisedSpeakerAssignerTests` keep compiling and passing unchanged —
`liveSpeakerNames` defaults to `[:]`, which is the "no live names" no-op, and the
opt-out test passes none.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible on this
      machine (no Xcode / no Swift toolchain); relying on CI**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, the
      changelog is per release and there is no version bump here

## Related

#206 (seed anchor weight) was evaluated alongside this and deliberately **not** changed —
analysis and an evaluation protocol are posted on that issue. No code change there, so it
is not closed by this PR.

## The build is unverified

Stated plainly because it changes how the first CI run should be read: this was written
on Linux with **no Xcode, no `xcodebuild` and no Swift toolchain**, so `make build` and
`make test` were never run and CI is the first compiler to see this diff. What was done
instead, by hand:

* Every project symbol referenced by the new test file was grep-confirmed to exist with
  the signature used (`TestSupport.*`, `StubWhisperEngine.setDefaultCanned`,
  `SpeakerProfileStore.Deletion.all`/`.named`, `VoiceProfile.sampleCount`/`.embedding`,
  `QuickActionsController.startFakeRecordingForTesting`/`awaitFinalizeTails`,
  `TranscriptionService.waitForIdle`, `LiveSpeakerDiarizer.assign`/`currentProfiles`/
  `seedPool`/`forgetSeededProfiles`, `ObservedVoiceSnapshots.observation(forSpeaker:in:)`/
  `heldRecordingCount`, `RecordingStore.freshAudioURL`/`update`/`setSpeakerName`). The
  only unresolved names left over were Foundation APIs and string literals.
* Brace / paren / bracket balance checked on all four changed Swift files.
* `UserDefaults` isolation follows the convention in `CLAUDE.md`: the assigner-level class
  uses a fresh `"LiveSpeakerNamingTests.<UUID>"` suite per fixture (collected and removed
  in `tearDown`, mirroring `RecognisedSpeakerAssignerTests`); the controller-level class
  uses `"LiveSpeakerNamingStopRecordingTests.{diarization,language,llm,voice}"` and
  `TestSupport.isolatedRemoteSettings(label:)`, all removed in `tearDown`. No test reads
  or writes `.standard` except the `selectedModelName` save/restore the sibling suites
  already do.
* Every existing caller of the two changed signatures was enumerated: `.finish(recording:`
  has one production call site (`MilaApp`, updated) and 15 test call sites, all of which
  keep compiling because `liveSpeakerNames` defaults to `[:]`; `onRecordingFinalized` has
  exactly three references, all updated.
* The blast radius of removing the two `speakerNames` pre-writes was traced to every
  reader of `Recording.speakerNames` between `store.add` and the finalize hook
  (`RenameRecordingSheet`, `SendToLLMSheet`, `PostRecordingCoordinator.awaitTranscript`,
  `TranscriptExporter`, `SpeakerNameRemapper` in `finalizeTail`, and the MCP
  `MilaStoreReader` path) — none of them observe the gap, for the reasons given above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes finalize-time speaker naming and voice-profile persistence on the recording stop path; mistakes could regress learning, double-merge profiles, or corrupt SRT sidecars, but the flow is narrow and heavily tested.
> 
> **Overview**
> Fixes **island-io/mila#209**: labels typed in the **live transcript** during a recording appeared on the saved transcript but never created or updated a voice profile, because `stopRecording` copied `LiveTranscriber.speakerNames` onto the new row **before** `onRecordingFinalized` ran. That made `RecordingStore.setSpeakerName` hit its no-change guard and skip `onSpeakerNamed` — the only path that writes embeddings.
> 
> **`QuickActionsController`** stops seeding or copying live speaker names at `store.add` and in the finalize drain. **`onRecordingFinalized`** now passes `(recordingID, liveSpeakerNames)` read from the transcriber before teardown, then **re-reads the row** so `finalizeTail`’s SRT export does not overwrite named subtitles.
> 
> **`RecognisedSpeakerAssigner.finish(recording:liveSpeakerNames:)`** applies live names first via `setSpeakerName` (including when voice recognition is off), then auto-names from stored profiles only for speakers the user did not label. User-chosen names win over recogniser guesses and each raw speaker id triggers persistence at most once.
> 
> **`MilaApp`** wires the new callback signature. **`LiveAIRecordingView`** adds comments documenting why naming stays on the transcriber until finalize.
> 
> New **`LiveSpeakerNamingTests`** and **`LiveSpeakerNamingStopRecordingTests`** cover profile creation, the pre-fix negative control, idempotency, precedence, recognition-off labeling, and end-to-end `stopRecording`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e6efe078fdcace87115f9817fd81be2edca9ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->