### PR TITLE
fix(llm): restore action items on the one-shot summary (relay of #200)

### DIFF
--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -581,9 +581,11 @@ final class RecordingSummarizer: ObservableObject {
     ///   2. A JSON envelope `{"summary":...,"items":[...]}` the model may have
     ///      returned out of habit — decoded via `LiveAISession.parseEnvelope`.
     ///   3. Malformed JSON that LOOKS like an envelope (the failure the user
-    ///      hit: unescaped quotes broke the object decode). Salvage the
-    ///      summary text so a raw `{...}` blob is never shown, and keep any
-    ///      items the lenient array parse recovered.
+    ///      hit: unescaped quotes broke the object decode) — bare, inside
+    ///      ```` ```json ```` fences, or behind a one-line label, since
+    ///      `parseEnvelope` accepts all three. Salvage the summary text so a
+    ///      raw `{...}` blob is never shown, and keep any items the lenient
+    ///      array parse recovered.
     ///   4. Plain prose — the whole output is the summary, no items.
     ///
     /// A JSON object that reaches step 3 and yields nothing readable returns
@@ -603,10 +605,11 @@ final class RecordingSummarizer: ObservableObject {
         if !parsed.summary.isEmpty {
             return (parsed.summary, parsed.items, .envelope)
         }
-        // Object decode produced no summary. If it still looks like an
-        // envelope, salvage the summary value rather than surfacing the blob.
-        if trimmed.hasPrefix("{") {
-            let salvaged = Self.salvageSummaryValue(from: trimmed)
+        // Object decode produced no summary. If the output still IS an
+        // envelope — bare, fenced, or behind a label — salvage the summary
+        // value rather than surfacing the blob.
+        if let envelope = Self.envelopeBody(in: trimmed) {
+            let salvaged = Self.salvageSummaryValue(from: envelope)
             if !salvaged.isEmpty {
                 return (salvaged, parsed.items, .salvagedEnvelope)
             }
@@ -625,7 +628,72 @@ final class RecordingSummarizer: ObservableObject {
             // lenient array parse recovered are still returned.
             return ("", parsed.items, .unreadableEnvelope)
         }
+        // Genuine prose. Items stay empty: every shape from which the lenient
+        // parse can actually recover an items array is an envelope, and those
+        // now route through the branch above instead of falling to here.
         return (trimmed, [], .plain)
+    }
+
+    /// The envelope-shaped payload inside the wrappers
+    /// `LiveAISession.parseEnvelope` accepts — a ```` ```json ```` fence, or a
+    /// one-line "Here is the JSON:" label — or nil when the output is prose
+    /// that merely CONTAINS a brace.
+    ///
+    /// Why this exists: the salvage and `unreadableEnvelope` branches were
+    /// gated on `trimmed.hasPrefix("{")`, but `parseEnvelope` does not require
+    /// its object to be at position 0 — it plucks the first balanced block out
+    /// of the string (`findFirstJSONStructure`) precisely because "the CLI
+    /// occasionally wraps output in prose or ```json fences". A fenced or
+    /// prefixed BROKEN envelope therefore failed the object decode *and* the
+    /// prefix test and landed in `.plain`, which stores the raw blob as the
+    /// summary — the exact bug this fix exists to remove, and the
+    /// self-perpetuating one, since a stored blob satisfies
+    /// `shouldSummarize`'s "already has a summary" gate and is never retried.
+    /// Fences are the single most likely shape for an LLM to emit, so the
+    /// promise held only for the tidiest case.
+    ///
+    /// Deliberately NOT "contains a `{`": a legitimate prose summary can quote
+    /// braces, and blanking a good summary is a worse outcome than showing the
+    /// blob. The object must be what the output IS, not something it mentions
+    /// — so only a short single-line label may precede it and nothing but
+    /// whitespace may follow it.
+    static func envelopeBody(in trimmed: String) -> String? {
+        var body = trimmed
+        // Unwrap a ``` / ```json fenced block. Matched wherever it starts, not
+        // just at position 0, because a chatty model puts a label line ahead
+        // of the fence — the commonest shape of all.
+        if let opening = body.range(of: "```") {
+            // Only a short label may precede the fence and nothing but
+            // whitespace may follow it; otherwise this is prose that quotes a
+            // code block, not an envelope in a wrapper.
+            guard body[..<opening.lowerBound].count <= 80 else { return nil }
+            let afterOpening = body[opening.upperBound...]
+            // Drop the info string (`json`) up to the end of the fence line.
+            var inner = afterOpening
+            if let newline = afterOpening.firstIndex(of: "\n") {
+                inner = afterOpening[afterOpening.index(after: newline)...]
+            }
+            if let closing = inner.range(of: "```") {
+                guard inner[closing.upperBound...]
+                    .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { return nil }
+                inner = inner[..<closing.lowerBound]
+            }
+            body = inner.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        // The object IS the payload. Accepted without a balanced-block check,
+        // because the malformed input this path exists for can defeat the
+        // depth counter (an odd number of unescaped quotes leaves `inString`
+        // inverted) while `salvageSummaryValue` still reads the summary fine.
+        if body.hasPrefix("{") { return body }
+        guard let range = LiveAISession.findFirstJSONStructure(
+            in: body, opening: "{", closing: "}"
+        ) else { return nil }
+        guard body[..<range.lowerBound].count <= 80,
+              body[range.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return String(body[range])
     }
 
     /// Which branch of `parseSummaryAndItems` produced the result. Logged so

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -652,48 +652,75 @@ final class RecordingSummarizer: ObservableObject {
     /// Fences are the single most likely shape for an LLM to emit, so the
     /// promise held only for the tidiest case.
     ///
-    /// Deliberately NOT "contains a `{`": a legitimate prose summary can quote
-    /// braces, and blanking a good summary is a worse outcome than showing the
-    /// blob. The object must be what the output IS, not something it mentions
-    /// — so only a short single-line label may precede it and nothing but
-    /// whitespace may follow it.
+    /// Unwrapping is an OPTIMISTIC normalisation, judged separately from the
+    /// envelope/prose decision, and it must never be able to make the parse
+    /// worse than not having attempted it. So: if a fence is confidently
+    /// identifiable and what it wraps is envelope-shaped, that is the payload;
+    /// otherwise the ORIGINAL text is judged on its own merits. An
+    /// unrecognised wrapper — an over-long prefix, content after the closer,
+    /// no closer at all, or a shape neither of us has thought of — costs
+    /// nothing beyond the failed attempt.
+    ///
+    /// The first cut of this stripped the fence *before* the shape test and
+    /// returned nil when the wrapper looked wrong, which re-broke the very
+    /// case it was added for: a malformed envelope whose summary TEXT mentions
+    /// ```` ``` ```` (a meeting that discussed code) was hijacked by the fence
+    /// branch and aborted, though its leading `{` alone should have been
+    /// enough to salvage it.
     static func envelopeBody(in trimmed: String) -> String? {
-        var body = trimmed
-        // Unwrap a ``` / ```json fenced block. Matched wherever it starts, not
-        // just at position 0, because a chatty model puts a label line ahead
-        // of the fence — the commonest shape of all.
-        if let opening = body.range(of: "```") {
-            // Only a short label may precede the fence and nothing but
-            // whitespace may follow it; otherwise this is prose that quotes a
-            // code block, not an envelope in a wrapper.
-            guard body[..<opening.lowerBound].count <= 80 else { return nil }
-            let afterOpening = body[opening.upperBound...]
-            // Drop the info string (`json`) up to the end of the fence line.
-            var inner = afterOpening
-            if let newline = afterOpening.firstIndex(of: "\n") {
-                inner = afterOpening[afterOpening.index(after: newline)...]
-            }
-            if let closing = inner.range(of: "```") {
-                guard inner[closing.upperBound...]
-                    .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                else { return nil }
-                inner = inner[..<closing.lowerBound]
-            }
-            body = inner.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let unwrapped = Self.unfencedBody(in: trimmed),
+           let body = Self.objectPayload(in: unwrapped) {
+            return body
         }
-        // The object IS the payload. Accepted without a balanced-block check,
-        // because the malformed input this path exists for can defeat the
-        // depth counter (an odd number of unescaped quotes leaves `inString`
-        // inverted) while `salvageSummaryValue` still reads the summary fine.
-        if body.hasPrefix("{") { return body }
-        guard let range = LiveAISession.findFirstJSONStructure(
-            in: body, opening: "{", closing: "}"
-        ) else { return nil }
-        guard body[..<range.lowerBound].count <= 80,
-              body[range.upperBound...]
+        return Self.objectPayload(in: trimmed)
+    }
+
+    /// The contents of a ``` / ```json fenced block. Nil means only "no
+    /// wrapper I can be confident about" — NOT "not an envelope"; the caller
+    /// falls back to the unmodified text, never to a failed parse.
+    private static func unfencedBody(in trimmed: String) -> String? {
+        guard let opening = trimmed.range(of: "```") else { return nil }
+        // Only a short label may precede the fence, and nothing but
+        // whitespace may follow its closer. Otherwise the backticks are far
+        // more likely part of the content than a wrapper around it.
+        guard trimmed[..<opening.lowerBound].count <= 80 else { return nil }
+        let afterOpening = trimmed[opening.upperBound...]
+        // Drop the info string (`json`) up to the end of the fence line.
+        var inner = afterOpening
+        if let newline = afterOpening.firstIndex(of: "\n") {
+            inner = afterOpening[afterOpening.index(after: newline)...]
+        }
+        guard let closing = inner.range(of: "```"),
+              inner[closing.upperBound...]
                 .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { return nil }
-        return String(body[range])
+        return inner[..<closing.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The envelope-shaped payload in `text`, or nil when this is prose that
+    /// merely MENTIONS a brace block. This nil IS the envelope/prose
+    /// discriminator `parseSummaryAndItems` needs, which is why it cannot
+    /// simply fail open: accepting everything would route every plain-prose
+    /// summary into the salvage branch and blank it.
+    ///
+    /// Deliberately not "contains a `{`": a real summary can quote braces, and
+    /// blanking a GOOD summary is a worse outcome than showing a blob. The
+    /// object must be what the text IS, not something it mentions.
+    private static func objectPayload(in text: String) -> String? {
+        // A leading `{` is accepted without the balanced-block check, because
+        // the malformed input this path exists for can defeat the depth
+        // counter (an odd number of unescaped quotes leaves `inString`
+        // inverted) while `salvageSummaryValue` reads the summary fine.
+        if text.hasPrefix("{") { return text }
+        guard let range = LiveAISession.findFirstJSONStructure(
+            in: text, opening: "{", closing: "}"
+        ) else { return nil }
+        guard text[..<range.lowerBound].count <= 80,
+              text[range.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return String(text[range])
     }
 
     /// Which branch of `parseSummaryAndItems` produced the result. Logged so

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -657,9 +657,16 @@ final class RecordingSummarizer: ObservableObject {
     /// worse than not having attempted it. So: if a fence is confidently
     /// identifiable and what it wraps is envelope-shaped, that is the payload;
     /// otherwise the ORIGINAL text is judged on its own merits. An
-    /// unrecognised wrapper — an over-long prefix, content after the closer,
-    /// no closer at all, or a shape neither of us has thought of — costs
-    /// nothing beyond the failed attempt.
+    /// unrecognised wrapper — an over-long label, quoted material rather than
+    /// a wrapper, or a shape nobody enumerated — costs nothing beyond the
+    /// failed attempt.
+    ///
+    /// The reverse is NOT symmetric, which is the trap this went through
+    /// twice: unwrapping too eagerly is not free. A candidate that is
+    /// object-shaped but carries no `"summary"` gets BLANKED as
+    /// `unreadableEnvelope`, so substituting a quoted config snippet for a
+    /// real prose summary destroys it. Hence `unfencedBody` still refuses the
+    /// cases where the block is plainly quoted material.
     ///
     /// The first cut of this stripped the fence *before* the shape test and
     /// returned nil when the wrapper looked wrong, which re-broke the very
@@ -679,12 +686,12 @@ final class RecordingSummarizer: ObservableObject {
     /// wrapper I can be confident about" — NOT "not an envelope"; the caller
     /// falls back to the unmodified text, never to a failed parse.
     private static func unfencedBody(in trimmed: String) -> String? {
-        guard let opening = trimmed.range(of: "```") else { return nil }
-        // Only a short label may precede the fence. THIS guard is load-bearing
-        // and is the one restriction worth keeping: without it, a long prose
-        // summary that happens to quote a fenced JSON object would have that
-        // object substituted for it and then be blanked — losing a good
-        // summary, which is worse than showing a blob.
+        guard let opening = Self.lineLeadingFence(in: trimmed, from: trimmed.startIndex)
+        else { return nil }
+        // Only a short label may precede the fence. Without this, a long prose
+        // summary that quotes a fenced JSON object would have that object
+        // substituted for it and then be blanked — losing a good summary,
+        // which is worse than showing a blob.
         guard trimmed[..<opening.lowerBound].count <= 80 else { return nil }
         let afterOpening = trimmed[opening.upperBound...]
         // Drop the info string (`json`) up to the end of the fence line.
@@ -692,18 +699,43 @@ final class RecordingSummarizer: ObservableObject {
         if let newline = afterOpening.firstIndex(of: "\n") {
             inner = afterOpening[afterOpening.index(after: newline)...]
         }
-        // Neither a MISSING closer nor content after one is a veto. This
-        // function only ever offers a candidate; `envelopeBody` re-tests the
-        // original text when the candidate is not envelope-shaped, so being
-        // generous here cannot cost anything — whereas vetoing can, and did:
-        // an unclosed fence (the model stopped early) sent a labelled
-        // envelope to `.plain` as a raw blob, because a labelled envelope has
-        // no leading `{` to fall back on and `findFirstJSONStructure` gives up
-        // on the odd unescaped quote this whole path exists for.
-        if let closing = inner.range(of: "```") {
-            inner = inner[..<closing.lowerBound]
+        if let closing = Self.lineLeadingFence(in: trimmed, from: inner.startIndex) {
+            // Content after the closer means the block is material QUOTED
+            // INSIDE a larger prose summary, not a wrapper around the whole
+            // output. Taking the block would substitute a config snippet for
+            // the summary and then blank it, discarding the real prose either
+            // side. So this stays a veto, and the caller judges the original.
+            guard trimmed[closing.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { return nil }
+            inner = trimmed[inner.startIndex..<closing.lowerBound]
         }
+        // A MISSING closer, by contrast, is not a veto: the model simply
+        // stopped early, there is no trailing prose to lose, and what follows
+        // the opener is still the best candidate.
         return inner.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The next ```` ``` ```` that BEGINS A LINE, at or after `from`.
+    ///
+    /// A fence delimits a block only at the start of a line. Backticks in the
+    /// middle of one are content — a summary quoting `` `code` `` — and must
+    /// neither open a block nor close one. Matching them anywhere let an inner
+    /// run masquerade as the closer, which truncated the candidate mid-value
+    /// and produced a short, plausible-looking WRONG summary: worse than the
+    /// blob, because nothing about it looks broken.
+    private static func lineLeadingFence(
+        in text: String, from start: String.Index
+    ) -> Range<String.Index>? {
+        var searchStart = start
+        while let candidate = text.range(of: "```", range: searchStart..<text.endIndex) {
+            if candidate.lowerBound == text.startIndex
+                || text[text.index(before: candidate.lowerBound)] == "\n" {
+                return candidate
+            }
+            searchStart = candidate.upperBound
+        }
+        return nil
     }
 
     /// The envelope-shaped payload in `text`, or nil when this is prose that

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -373,8 +373,15 @@ final class RecordingSummarizer: ObservableObject {
                 return "Hebrew"
             }
         }()
-        let prompt = liveAISettings.summaryPrompt
+        let basePrompt = liveAISettings.summaryPrompt
             .replacingOccurrences(of: "{{LANGUAGE}}", with: promptLanguageName)
+        // Wrap the user's plain-text summary prompt so the one-shot call
+        // also returns action items. Restores the summary + action-items
+        // pair the pre-#87 inline final Live-AI tick used to produce. See
+        // `promptWithActionItems`: the summary stays PLAIN TEXT and only a
+        // compact item array is JSON, so a long multi-line Hebrew summary
+        // full of quotes can't corrupt the parse.
+        let prompt = Self.promptWithActionItems(base: basePrompt)
         let transcript = recording.fullText
         let timeout = timeoutSeconds
         // OpenAI-compatible config captured up front so the detached call
@@ -425,8 +432,15 @@ final class RecordingSummarizer: ObservableObject {
                     false,
                     nil
                 )
-                let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !cleaned.isEmpty else {
+                // Split the CLI output into the plain-text summary and the
+                // action-items list. `parseSummaryAndItems` handles the
+                // sentinel format the prompt asks for, tolerates a model
+                // that returned a JSON envelope instead, and — crucially —
+                // never surfaces a raw `{...}` blob as the summary when the
+                // model emits malformed JSON (unescaped quotes / newlines in
+                // a long summary value, which broke the object decode).
+                let (summaryText, parsedItems) = Self.parseSummaryAndItems(from: raw)
+                guard !summaryText.isEmpty else {
                     summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
                     // No summary landed — let a pending export fall back to
                     // the transcript rather than waiting forever. Skip the
@@ -454,10 +468,18 @@ final class RecordingSummarizer: ObservableObject {
                     self.onSummaryFinished?(current)
                     return
                 }
-                current.summary = cleaned
+                current.summary = summaryText
+                // Replace the recording's action items with the fresh
+                // full-transcript set whenever the model returned any. An
+                // empty list is treated as "keep what's there" so a glitchy
+                // empty response can't wipe the rolling live snapshot a
+                // Live-AI recording already captured at stop.
+                if !parsedItems.isEmpty {
+                    current.actionItems = parsedItems
+                }
                 self.store.update(current)
                 let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(cleaned.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
+                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(summaryText.count, privacy: .public) items=\(parsedItems.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
                 self.onSummaryFinished?(current)
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -502,6 +524,106 @@ final class RecordingSummarizer: ObservableObject {
 
     private func shortID(_ id: UUID) -> String {
         String(id.uuidString.prefix(8))
+    }
+
+    /// Marker the one-shot prompt asks the model to place between the
+    /// plain-text summary and the JSON action-items array. Keeping the
+    /// summary OUTSIDE any JSON is deliberate: LLMs routinely emit long,
+    /// multi-line summaries with unescaped quotes/newlines, which makes an
+    /// enclosing JSON object un-decodable. Only the compact item array — far
+    /// less prone to stray quotes — needs to be valid JSON.
+    static let actionItemsSentinel = "###ACTION_ITEMS###"
+
+    /// Wrap the user's plain-text summary prompt so the one-shot call also
+    /// returns action items, WITHOUT embedding the summary in JSON. The
+    /// user's `summaryPrompt` still drives the summary's content and style
+    /// (including its `{{LANGUAGE}}` directive); this only appends the
+    /// output-format + action-item contract. Building the request here rather
+    /// than baking it into the persisted `summaryPrompt` means a user's
+    /// customised prompt keeps working and no persisted-default migration is
+    /// needed.
+    static func promptWithActionItems(base: String) -> String {
+        """
+        \(base)
+
+        After the summary, list the action items. Format your ENTIRE response \
+        exactly like this — the plain-text summary first, then the marker on \
+        its own line, then a JSON array:
+
+        <the summary as plain text>
+        \(actionItemsSentinel)
+        [{"id": "stable-slug", "text": "...", "source": "inferred"}]
+
+        Write the summary as plain text — do NOT wrap it in JSON or quotes. \
+        Output the marker \(actionItemsSentinel) verbatim on its own line, then \
+        ONLY the JSON array and nothing after it. An action item is a concrete \
+        task someone committed to do (with or without a deadline) or an \
+        explicit follow-up or request. If there are none, output an empty \
+        array: []
+        """
+    }
+
+    /// Split raw CLI output into `(summary, items)`.
+    ///
+    /// Resolution order, most-trusted first:
+    ///   1. Sentinel format (what `promptWithActionItems` asks for): plain
+    ///      summary before `actionItemsSentinel`, JSON array after it.
+    ///   2. A JSON envelope `{"summary":...,"items":[...]}` the model may have
+    ///      returned out of habit — decoded via `LiveAISession.parseEnvelope`.
+    ///   3. Malformed JSON that LOOKS like an envelope (the failure the user
+    ///      hit: unescaped quotes broke the object decode). Salvage the
+    ///      summary text so a raw `{...}` blob is never shown, and keep any
+    ///      items the lenient array parse recovered.
+    ///   4. Plain prose — the whole output is the summary, no items.
+    static func parseSummaryAndItems(from raw: String) -> (summary: String, items: [ActionItem]) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let sentinel = trimmed.range(of: actionItemsSentinel) {
+            let summary = String(trimmed[..<sentinel.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let items = LiveAISession.parseActionItems(from: String(trimmed[sentinel.upperBound...]))
+            return (summary, items)
+        }
+        // No sentinel — the model returned a JSON envelope (or prose).
+        let parsed = LiveAISession.parseEnvelope(from: trimmed)
+        if !parsed.summary.isEmpty {
+            return (parsed.summary, parsed.items)
+        }
+        // Object decode produced no summary. If it still looks like an
+        // envelope, salvage the summary value rather than surfacing the blob.
+        if trimmed.hasPrefix("{"), trimmed.range(of: "\"summary\"") != nil {
+            return (Self.salvageSummaryValue(from: trimmed), parsed.items)
+        }
+        return (trimmed, [])
+    }
+
+    /// Best-effort extraction of the `"summary"` value from a JSON string the
+    /// decoder rejected (typically because the value itself contains
+    /// unescaped `"`). Anchors on the structural `"items"` key that follows
+    /// the summary value, so quotes INSIDE the summary don't cut it short,
+    /// then un-escapes the common JSON escapes so `\n` renders as newlines.
+    static func salvageSummaryValue(from json: String) -> String {
+        guard let keyRange = json.range(of: "\"summary\"") else { return "" }
+        let afterKey = json[keyRange.upperBound...]
+        guard let colon = afterKey.firstIndex(of: ":") else { return "" }
+        let afterColon = afterKey[afterKey.index(after: colon)...]
+        guard let openQuote = afterColon.firstIndex(of: "\"") else { return "" }
+        let valueStart = afterColon.index(after: openQuote)
+        let rest = afterColon[valueStart...]
+        let endIdx: Substring.Index
+        if let itemsAnchor = rest.range(of: "\", \"items\"")
+            ?? rest.range(of: "\",\"items\"") {
+            endIdx = itemsAnchor.lowerBound
+        } else if let lastQuote = rest.lastIndex(of: "\"") {
+            endIdx = lastQuote
+        } else {
+            endIdx = rest.endIndex
+        }
+        let value = String(rest[..<endIdx])
+            .replacingOccurrences(of: "\\n", with: "\n")
+            .replacingOccurrences(of: "\\t", with: "\t")
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\/", with: "/")
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// The freshest copy of a recording from the store, or `fallback` when

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -680,9 +680,11 @@ final class RecordingSummarizer: ObservableObject {
     /// falls back to the unmodified text, never to a failed parse.
     private static func unfencedBody(in trimmed: String) -> String? {
         guard let opening = trimmed.range(of: "```") else { return nil }
-        // Only a short label may precede the fence, and nothing but
-        // whitespace may follow its closer. Otherwise the backticks are far
-        // more likely part of the content than a wrapper around it.
+        // Only a short label may precede the fence. THIS guard is load-bearing
+        // and is the one restriction worth keeping: without it, a long prose
+        // summary that happens to quote a fenced JSON object would have that
+        // object substituted for it and then be blanked — losing a good
+        // summary, which is worse than showing a blob.
         guard trimmed[..<opening.lowerBound].count <= 80 else { return nil }
         let afterOpening = trimmed[opening.upperBound...]
         // Drop the info string (`json`) up to the end of the fence line.
@@ -690,12 +692,18 @@ final class RecordingSummarizer: ObservableObject {
         if let newline = afterOpening.firstIndex(of: "\n") {
             inner = afterOpening[afterOpening.index(after: newline)...]
         }
-        guard let closing = inner.range(of: "```"),
-              inner[closing.upperBound...]
-                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else { return nil }
-        return inner[..<closing.lowerBound]
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Neither a MISSING closer nor content after one is a veto. This
+        // function only ever offers a candidate; `envelopeBody` re-tests the
+        // original text when the candidate is not envelope-shaped, so being
+        // generous here cannot cost anything — whereas vetoing can, and did:
+        // an unclosed fence (the model stopped early) sent a labelled
+        // envelope to `.plain` as a raw blob, because a labelled envelope has
+        // no leading `{` to fall back on and `findFirstJSONStructure` gives up
+        // on the odd unescaped quote this whole path exists for.
+        if let closing = inner.range(of: "```") {
+            inner = inner[..<closing.lowerBound]
+        }
+        return inner.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// The envelope-shaped payload in `text`, or nil when this is prose that

--- a/Mila/Actions/RecordingSummarizer.swift
+++ b/Mila/Actions/RecordingSummarizer.swift
@@ -439,9 +439,16 @@ final class RecordingSummarizer: ObservableObject {
                 // never surfaces a raw `{...}` blob as the summary when the
                 // model emits malformed JSON (unescaped quotes / newlines in
                 // a long summary value, which broke the object decode).
-                let (summaryText, parsedItems) = Self.parseSummaryAndItems(from: raw)
+                let (summaryText, parsedItems, origin) = Self.parseSummaryAndItems(from: raw)
                 guard !summaryText.isEmpty else {
-                    summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): empty CLI output")
+                    // `origin` distinguishes "the CLI printed nothing" from
+                    // "the CLI printed a JSON object we could not read a
+                    // summary out of" — two very different diagnoses that
+                    // used to log identically. It is a fixed keyword, never
+                    // the model's text: summary output is derived from the
+                    // transcript and is user content, so it must not reach a
+                    // `.public` log field (`bugbot-rules/no-user-content-in-logs.md`).
+                    summarizerLog.log("skipped \(self?.shortID(id) ?? "?", privacy: .public): no summary parsed origin=\(origin.rawValue, privacy: .public) output=\(raw.count, privacy: .public)c")
                     // No summary landed — let a pending export fall back to
                     // the transcript rather than waiting forever. Skip the
                     // signal entirely if the recording went away mid-flight.
@@ -470,16 +477,18 @@ final class RecordingSummarizer: ObservableObject {
                 }
                 current.summary = summaryText
                 // Replace the recording's action items with the fresh
-                // full-transcript set whenever the model returned any. An
-                // empty list is treated as "keep what's there" so a glitchy
-                // empty response can't wipe the rolling live snapshot a
-                // Live-AI recording already captured at stop.
+                // full-transcript set whenever the model returned any — but
+                // never at the cost of an item the user DICTATED out loud.
+                // An empty list is treated as "keep what's there" so a
+                // glitchy empty response can't wipe the rolling live snapshot
+                // a Live-AI recording already captured at stop.
                 if !parsedItems.isEmpty {
-                    current.actionItems = parsedItems
+                    current.actionItems = Self.merged(fresh: parsedItems,
+                                                      keepingDictatedFrom: current.actionItems ?? [])
                 }
                 self.store.update(current)
                 let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) length=\(summaryText.count, privacy: .public) items=\(parsedItems.count, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
+                summarizerLog.log("succeeded \(self.shortID(id), privacy: .public) origin=\(origin.rawValue, privacy: .public) length=\(summaryText.count, privacy: .public) items=\(current.actionItems?.count ?? 0, privacy: .public) elapsed=\(elapsedMs, privacy: .public)ms")
                 self.onSummaryFinished?(current)
             } catch {
                 summarizerLog.error("failed \(self?.shortID(id) ?? "?", privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -563,7 +572,8 @@ final class RecordingSummarizer: ObservableObject {
         """
     }
 
-    /// Split raw CLI output into `(summary, items)`.
+    /// Split raw CLI output into `(summary, items, origin)`, where `origin`
+    /// names the branch that produced it so the tolerant paths are loggable.
     ///
     /// Resolution order, most-trusted first:
     ///   1. Sentinel format (what `promptWithActionItems` asks for): plain
@@ -575,25 +585,114 @@ final class RecordingSummarizer: ObservableObject {
     ///      summary text so a raw `{...}` blob is never shown, and keep any
     ///      items the lenient array parse recovered.
     ///   4. Plain prose — the whole output is the summary, no items.
-    static func parseSummaryAndItems(from raw: String) -> (summary: String, items: [ActionItem]) {
+    ///
+    /// A JSON object that reaches step 3 and yields nothing readable returns
+    /// an EMPTY summary rather than the blob — see `unreadableEnvelope`.
+    static func parseSummaryAndItems(
+        from raw: String
+    ) -> (summary: String, items: [ActionItem], origin: SummaryParseOrigin) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if let sentinel = trimmed.range(of: actionItemsSentinel) {
             let summary = String(trimmed[..<sentinel.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let items = LiveAISession.parseActionItems(from: String(trimmed[sentinel.upperBound...]))
-            return (summary, items)
+            return (summary, items, .sentinel)
         }
         // No sentinel — the model returned a JSON envelope (or prose).
         let parsed = LiveAISession.parseEnvelope(from: trimmed)
         if !parsed.summary.isEmpty {
-            return (parsed.summary, parsed.items)
+            return (parsed.summary, parsed.items, .envelope)
         }
         // Object decode produced no summary. If it still looks like an
         // envelope, salvage the summary value rather than surfacing the blob.
-        if trimmed.hasPrefix("{"), trimmed.range(of: "\"summary\"") != nil {
-            return (Self.salvageSummaryValue(from: trimmed), parsed.items)
+        if trimmed.hasPrefix("{") {
+            let salvaged = Self.salvageSummaryValue(from: trimmed)
+            if !salvaged.isEmpty {
+                return (salvaged, parsed.items, .salvagedEnvelope)
+            }
+            // A JSON object we cannot read a summary out of at all (no
+            // `"summary"` key, or an empty one). Storing it verbatim is the
+            // exact bug this fix exists to remove, and doing so is
+            // self-perpetuating: a stored blob satisfies `shouldSummarize`'s
+            // "already has a summary" gate, so the recording would never be
+            // retried and the blob would be what the detail view, the Obsidian
+            // note and the MCP surface all report forever. Report NO summary
+            // instead — logged with this origin at the call site, exported as
+            // the transcript fallback, and still picked up by the next
+            // `backfillIfNeeded` sweep. That is the same treatment empty CLI
+            // output has always had (`test_summarize_drops_empty_output`), so
+            // it is an established shape rather than a new one. Items the
+            // lenient array parse recovered are still returned.
+            return ("", parsed.items, .unreadableEnvelope)
         }
-        return (trimmed, [])
+        return (trimmed, [], .plain)
+    }
+
+    /// Which branch of `parseSummaryAndItems` produced the result. Logged so
+    /// the tolerant paths are VISIBLE — a model that quietly ignores the
+    /// output contract on every call should be diagnosable from Console
+    /// instead of hiding behind a summary that looks fine.
+    ///
+    /// A fixed keyword, deliberately: the model's output is derived from the
+    /// user's transcript and is user content, so it must never reach a
+    /// `.public` log field (`bugbot-rules/no-user-content-in-logs.md`). This
+    /// records WHICH SHAPE arrived, never what it said.
+    enum SummaryParseOrigin: String {
+        /// The sentinel format `promptWithActionItems` asks for.
+        case sentinel
+        /// A decodable `{"summary":…,"items":[…]}` envelope.
+        case envelope
+        /// A broken envelope whose summary value was recovered textually.
+        case salvagedEnvelope = "salvaged-envelope"
+        /// Plain prose — the whole output is the summary.
+        case plain
+        /// A JSON object with no readable summary. Yields no summary at all.
+        case unreadableEnvelope = "unreadable-envelope"
+    }
+
+    /// Fold the fresh full-transcript items into what the recording already
+    /// has, keeping every item the user DICTATED (`source == .voiceCommand`,
+    /// i.e. "Mila, action item: …") ahead of the model's inferred set.
+    ///
+    /// Why this is not a plain replace: for a Live-AI recording,
+    /// `QuickActionsController` snapshots the live list — voice-command items
+    /// included — onto the recording at stop and then immediately calls
+    /// `regenerate`. The one-shot prompt is not shown the existing list and
+    /// only ever asks for `source: "inferred"`, so a wholesale replace would
+    /// trade an item the user said out loud for the model's guess at it, or
+    /// lose it entirely. `ActionItem.source` is also mirrored all the way out
+    /// to the MCP surface precisely so a client can tell a spoken commitment
+    /// from an inferred one (see `MilaKit.StoredRecording.ActionItem.source`),
+    /// which is the answer this would have degraded.
+    ///
+    /// Fresh items are deduped by id and by normalised text — the model
+    /// re-derives a dictated task from the transcript under a new id, and it
+    /// also duplicates ids outright, which the live path already guards
+    /// against ("LLM duplicated an id; keep first" in
+    /// `LiveAISession.applyResponse`).
+    static func merged(fresh: [ActionItem],
+                       keepingDictatedFrom existing: [ActionItem]) -> [ActionItem] {
+        let dictated = existing.filter { $0.source == .voiceCommand }
+        var seenIDs = Set(dictated.map(\.id))
+        var seenTexts = Set(dictated.map { Self.dedupKey($0.text) })
+        var result = dictated
+        for item in fresh {
+            let textKey = Self.dedupKey(item.text)
+            guard !seenIDs.contains(item.id), !seenTexts.contains(textKey) else { continue }
+            seenIDs.insert(item.id)
+            seenTexts.insert(textKey)
+            result.append(item)
+        }
+        return result
+    }
+
+    /// Normalised form used only to spot "the model re-emitted this dictated
+    /// item under a different id": trimmed, case-folded, inner whitespace
+    /// collapsed. Never persisted or displayed.
+    private static func dedupKey(_ text: String) -> String {
+        text.lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
     }
 
     /// Best-effort extraction of the `"summary"` value from a JSON string the
@@ -610,9 +709,17 @@ final class RecordingSummarizer: ObservableObject {
         let valueStart = afterColon.index(after: openQuote)
         let rest = afterColon[valueStart...]
         let endIdx: Substring.Index
-        if let itemsAnchor = rest.range(of: "\", \"items\"")
-            ?? rest.range(of: "\",\"items\"") {
-            endIdx = itemsAnchor.lowerBound
+        // Find the `"items"` KEY, then walk back to the last quote before it:
+        // that quote is the summary value's terminator whatever separates the
+        // two. Matching the separator literally (`", "items"` / `","items"`)
+        // only covered compact output — a pretty-printed malformed envelope
+        // (`",\n  "items"`, which is what a CLI emitting multi-line JSON
+        // produces) fell through to `lastIndex(of:)` and dragged the entire
+        // items array into the summary, i.e. exactly the scaffolding leak
+        // this function exists to prevent.
+        if let itemsKey = rest.range(of: "\"items\"") {
+            let head = rest[..<itemsKey.lowerBound]
+            endIdx = head.lastIndex(of: "\"") ?? itemsKey.lowerBound
         } else if let lastQuote = rest.lastIndex(of: "\"") {
             endIdx = lastQuote
         } else {

--- a/Mila/Models/LiveAISettings.swift
+++ b/Mila/Models/LiveAISettings.swift
@@ -273,7 +273,18 @@ final class LiveAISettings: ObservableObject {
         self.prompt = defaults.string(forKey: Keys.prompt) ?? Self.defaultPrompt
         let langRaw = defaults.string(forKey: Keys.outputLanguage) ?? OutputLanguage.auto.rawValue
         self.outputLanguage = OutputLanguage(rawValue: langRaw) ?? .auto
-        self.summaryPrompt = defaults.string(forKey: Keys.summaryPrompt) ?? Self.defaultSummaryPrompt
+        // Migrate users still on the pre-1.8.x concise default up to the
+        // richer `defaultSummaryPrompt`. A nil value (never set) or an exact
+        // match of the old default both adopt the new default; any other
+        // value is a user customisation and is preserved as-is. Idempotent:
+        // the migration is a pure read (we don't write the default back), so
+        // a later prompt revision can migrate the same way.
+        let storedSummaryPrompt = defaults.string(forKey: Keys.summaryPrompt)
+        if let stored = storedSummaryPrompt, stored != Self.legacySummaryPromptV1 {
+            self.summaryPrompt = stored
+        } else {
+            self.summaryPrompt = Self.defaultSummaryPrompt
+        }
     }
 
     /// Default model. Currently `claude-sonnet-4-6` — better
@@ -326,13 +337,40 @@ If the call has just started and there is no transcript yet, output \
 {"summary": "", "items": []}.
 """
 
-    /// Default one-shot summary prompt. Plain-text, meeting-style — no
-    /// JSON envelope, no action items, no "you've been called repeatedly"
-    /// framing. This runs ONCE against the full transcript after a
-    /// recording finishes, so the prompt can assume the model has the
-    /// complete picture and just needs to produce a concise human-readable
-    /// summary. `{{LANGUAGE}}` is substituted at send time.
+    /// Default one-shot summary prompt. Plain-text, meeting-style — this
+    /// runs ONCE against the full transcript after a recording finishes, so
+    /// the prompt can assume the model has the complete picture. The one-shot
+    /// caller (`RecordingSummarizer`) appends the action-items contract at
+    /// send time, so this prompt only governs the SUMMARY content/style.
+    /// `{{LANGUAGE}}` is substituted at send time.
+    ///
+    /// Depth deliberately matches the pre-#87 live summary: an overview, the
+    /// main topics with their key points, decisions made, and — when the
+    /// conversation centres on specific people / projects / items — a
+    /// per-item breakdown so each one's situation and next steps are clear.
     static let defaultSummaryPrompt = """
+You are summarizing a meeting transcript. Output everything in {{LANGUAGE}}.
+
+Write a thorough summary for someone who did not attend. Cover:
+  • A short overview of what the meeting was about.
+  • The main topics discussed, with the key points for each.
+  • Any decisions that were made.
+  • When the conversation centres on specific people, projects, or items,
+    break the summary down per person / topic so each one's situation and
+    the next steps for it are clear.
+
+Use short paragraphs or bullet points, and **bold** the key names and
+topics so the summary is easy to skim. Be comprehensive but do not repeat
+yourself. Do NOT include a preamble like "Here is the summary"; start
+directly with the content.
+"""
+
+    /// The pre-1.8.x concise default. Kept verbatim so `init` can migrate a
+    /// user still on the old default up to `defaultSummaryPrompt` without
+    /// clobbering a genuinely customised prompt. Do not edit — changing it
+    /// would break the migration match. (Retire once enough releases have
+    /// passed that no one is on the old default.)
+    static let legacySummaryPromptV1 = """
 You are summarizing a meeting transcript. Output everything in {{LANGUAGE}}.
 
 Read the transcript below and produce a concise summary suitable for

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1728,7 +1728,14 @@ private struct AIFeaturesSettingsTab: View {
                     AIPromptEditor(title: "Summary prompt",
                                    text: $liveAI.summaryPrompt,
                                    defaultText: LiveAISettings.defaultSummaryPrompt,
-                                   caption: "Sent with the full transcript. `{{LANGUAGE}}` becomes the output language above.",
+                                   // The editor governs the SUMMARY only.
+                                   // `RecordingSummarizer.promptWithActionItems`
+                                   // appends the action-items request at send
+                                   // time, so say so here rather than letting a
+                                   // user wonder where the extra list came
+                                   // from — or delete it from their own prompt
+                                   // and find it still arriving.
+                                   caption: "Sent with the full transcript. Mila also asks for the action items alongside it. `{{LANGUAGE}}` becomes the output language above.",
                                    isEnabled: settings.summaryEnabled)
                 }
                 Divider()

--- a/MilaTests/LiveAISettingsMigrationTests.swift
+++ b/MilaTests/LiveAISettingsMigrationTests.swift
@@ -100,4 +100,36 @@ final class LiveAISettingsMigrationTests: XCTestCase {
         let settings = LiveAISettings(defaults: defaults)
         XCTAssertEqual(settings.speakerSimilarityThreshold, 0.55, accuracy: 0.0001)
     }
+
+    // MARK: - summaryPrompt
+
+    func test_summaryPrompt_unset_uses_new_default() {
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt)
+    }
+
+    /// A user still carrying the pre-1.8.x concise default must be migrated
+    /// up to the richer default so the summary regains its pre-#87 depth.
+    func test_summaryPrompt_legacy_default_migrates_to_new_default() {
+        defaults.set(LiveAISettings.legacySummaryPromptV1, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt,
+                       "The legacy concise default must be migrated to the richer default")
+    }
+
+    /// A genuinely customised prompt must never be clobbered by the migration.
+    func test_summaryPrompt_custom_value_is_preserved() {
+        let custom = "Summarise in exactly three bullet points."
+        defaults.set(custom, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, custom,
+                       "A user's customised summary prompt must survive the migration")
+    }
+
+    /// A user already on the new default keeps it (no spurious reset).
+    func test_summaryPrompt_new_default_is_preserved() {
+        defaults.set(LiveAISettings.defaultSummaryPrompt, forKey: "liveAI.summaryPrompt")
+        let settings = LiveAISettings(defaults: defaults)
+        XCTAssertEqual(settings.summaryPrompt, LiveAISettings.defaultSummaryPrompt)
+    }
 }

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -773,6 +773,77 @@ final class RecordingSummarizerTests: XCTestCase {
                       "an unreadable object must yield no summary; got \(parsed.summary)")
     }
 
+    /// The same malformed envelope, WRAPPED — a label line plus ```json
+    /// fences, which is the shape an LLM emits most often. `parseEnvelope`
+    /// accepts that wrapper (it plucks the first balanced block out of the
+    /// string rather than requiring position 0), but the salvage and
+    /// `unreadableEnvelope` branches were gated on `trimmed.hasPrefix("{")`.
+    /// So the wrapped form failed the object decode AND the prefix test and
+    /// landed in `.plain`, storing the whole fenced blob as the summary — the
+    /// reported bug, for the commonest shape.
+    func test_parse_salvages_a_malformed_envelope_inside_fences_and_a_label() {
+        let fenced = """
+        Here is the summary:
+        ```json
+        {
+          "summary": "Team review. Baylis acts as if he is "on another planet".",
+          "items": [
+            {"id": "a", "text": "Give Baylis direct feedback", "source": "inferred"}
+          ]
+        }
+        ```
+        """
+
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: fenced)
+
+        XCTAssertEqual(parsed.origin, .salvagedEnvelope,
+                       "a fenced malformed envelope is still an envelope")
+        XCTAssertFalse(parsed.summary.contains("```"),
+                       "fence scaffolding must never reach the summary")
+        XCTAssertFalse(parsed.summary.contains("\"items\""),
+                       "the items scaffolding must not leak into the summary")
+        XCTAssertFalse(parsed.summary.hasPrefix("Here is the summary:"),
+                       "the label must not be stored as the summary")
+        XCTAssertTrue(parsed.summary.hasSuffix("\"on another planet\"."),
+                      "the salvaged value must be the summary; got \(parsed.summary)")
+        XCTAssertEqual(parsed.items.map(\.text), ["Give Baylis direct feedback"],
+                       "items recovered by the lenient parse must survive the wrapper")
+
+        // The unfenced label-only variant takes the same branch.
+        let labelled = #"""
+        Here is the JSON:
+        {"summary": "A "quoted" thing.", "items": []}
+        """#
+        let labelledParse = RecordingSummarizer.parseSummaryAndItems(from: labelled)
+        XCTAssertEqual(labelledParse.origin, .salvagedEnvelope)
+        XCTAssertEqual(labelledParse.summary, "A \"quoted\" thing.")
+    }
+
+    /// The counterweight to the test above, and the reason the fix is not
+    /// simply "the output contains a `{`". A real summary may quote braces or
+    /// a code block; blanking a GOOD summary is a worse outcome than showing
+    /// a blob, so an object must be what the output IS — nothing but
+    /// whitespace after it, and at most a short label before it.
+    func test_parse_keeps_prose_that_merely_quotes_braces_or_a_code_block() {
+        let braces = "The team reviewed the config {mode: fast} and shipped it."
+        let bracesParse = RecordingSummarizer.parseSummaryAndItems(from: braces)
+        XCTAssertEqual(bracesParse.origin, .plain)
+        XCTAssertEqual(bracesParse.summary, braces,
+                       "prose that mentions a brace block must survive intact")
+
+        let withCode = """
+        The team walked through the retry handler at length and agreed the \
+        default should change before the next release ships to users.
+        ```
+        {"retries": 3}
+        ```
+        """
+        let codeParse = RecordingSummarizer.parseSummaryAndItems(from: withCode)
+        XCTAssertEqual(codeParse.origin, .plain)
+        XCTAssertTrue(codeParse.summary.hasPrefix("The team walked through"),
+                      "a prose summary quoting a fenced block must survive intact")
+    }
+
     // MARK: - Dictated action items survive the one-shot pass
 
     /// For a Live-AI recording, `QuickActionsController` snapshots the live
@@ -882,6 +953,42 @@ final class RecordingSummarizerTests: XCTestCase {
         let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
         XCTAssertNil(updated.summary,
                      "a blob must not be stored — the recording stays eligible for a retry")
+        XCTAssertTrue(summarizer.shouldSummarize(updated),
+                      "and the retry gate must actually still be open")
+    }
+
+    /// The same end-to-end control for the WRAPPED shape. This is the half of
+    /// the bug that bites hardest: the stored blob satisfies
+    /// `shouldSummarize`'s "already has a summary" gate, so the recording is
+    /// never retried and the blob is what the detail view, the Obsidian note
+    /// and the MCP surface report forever. Fences are the likeliest wrapper,
+    /// so gating the recovery on a leading `{` left the common case broken.
+    func test_summarize_never_stores_a_fenced_unreadable_json_object() async throws {
+        llm.tool = .claude
+        let fenced = """
+        Here is the summary:
+        ```json
+        {"resumen": "clave equivocada", "items": []}
+        ```
+        """
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in fenced }
+
+        let audioURL = store.freshAudioURL(suggestedName: "FencedUnreadable")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "FencedUnreadable",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertNil(updated.summary,
+                     "a fenced blob must not be stored; got \(updated.summary ?? "nil")")
         XCTAssertTrue(summarizer.shouldSummarize(updated),
                       "and the retry gate must actually still be open")
     }

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -506,6 +506,197 @@ final class RecordingSummarizerTests: XCTestCase {
                        "The OpenAI summary path must send openAIModelName, not the Live AI model")
     }
 
+    // MARK: - JSON envelope (summary + action items)
+
+    /// The one-shot summarizer now asks for a JSON envelope so it can
+    /// populate BOTH the summary and the action-items list from the full
+    /// transcript — restoring the pair the pre-#87 inline final Live-AI
+    /// tick used to produce. A well-formed envelope must land both halves.
+    func test_summarize_parses_envelope_and_stores_summary_and_action_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            #"{"summary": "We agreed to ship next week.", "items": [{"id": "ship", "text": "Ship the beta", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}, {"id": "deck", "text": "Dana sends the deck", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}]}"#
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Envelope")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Envelope",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "we discussed the roadmap and agreed to ship next week"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "We agreed to ship next week.")
+        let items = try XCTUnwrap(updated.actionItems)
+        XCTAssertEqual(items.map(\.text), ["Ship the beta", "Dana sends the deck"])
+    }
+
+    /// Back-compat: a model that ignores the JSON instruction and returns
+    /// plain prose must still have its whole output stored as the summary,
+    /// with no action items — exactly the pre-change behaviour.
+    func test_summarize_plain_text_output_still_stored_as_summary_without_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "Just a plain prose summary." }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Prose")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Prose",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "transcript text"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Just a plain prose summary.")
+        XCTAssertNil(updated.actionItems,
+                     "plain-text output must not fabricate an action-items list")
+    }
+
+    /// `regenerate` (the Live-AI finalize path + manual affordance) must
+    /// REPLACE stale action items with the fresh full-transcript set, the
+    /// same way it already replaces the summary.
+    func test_regenerate_replaces_action_items_from_full_transcript() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            #"{"summary": "Fresh summary.", "items": [{"id": "new", "text": "New follow-up", "speaker": null, "timestamp_seconds": 0, "source": "inferred"}]}"#
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "RegenItems")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "RegenItems",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.summary = "stale summary"
+        rec.actionItems = [ActionItem(id: "old", text: "Stale item", speaker: nil,
+                                      timestampSeconds: 0, source: .llmInferred,
+                                      addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Fresh summary.")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["New follow-up"],
+                       "regenerate must replace the stale action items")
+    }
+
+    /// An empty (or absent) items list must NOT wipe action items the
+    /// recording already has — e.g. a Live-AI recording's rolling snapshot.
+    /// A glitchy prose response shouldn't cost the user their items.
+    func test_regenerate_empty_items_preserves_existing_action_items() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in "Only a prose summary, no JSON." }
+
+        let audioURL = store.freshAudioURL(suggestedName: "KeepItems")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "KeepItems",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.summary = "stale summary"
+        rec.actionItems = [ActionItem(id: "keep", text: "Keep me", speaker: nil,
+                                      timestampSeconds: 0, source: .llmInferred,
+                                      addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Only a prose summary, no JSON.")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["Keep me"],
+                       "an empty items response must not wipe existing action items")
+    }
+
+    /// The prompt's preferred shape: a plain-text summary, the sentinel on
+    /// its own line, then a JSON array. The summary stays plain text (no JSON
+    /// wrapping) and the items are parsed from the trailing array.
+    func test_summarize_parses_sentinel_format() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            """
+            We agreed to ship next week and Dana owns the deck.
+            \(RecordingSummarizer.actionItemsSentinel)
+            [{"id": "ship", "text": "Ship the beta", "source": "inferred"}, {"id": "deck", "text": "Dana sends the deck", "source": "inferred"}]
+            """
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Sentinel")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Sentinel",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "we discussed the roadmap"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "We agreed to ship next week and Dana owns the deck.")
+        XCTAssertFalse(updated.summary?.contains(RecordingSummarizer.actionItemsSentinel) ?? true,
+                       "the sentinel marker must not leak into the summary")
+        XCTAssertEqual(updated.actionItems?.map(\.text), ["Ship the beta", "Dana sends the deck"])
+    }
+
+    /// Regression for the reported bug: the model returned a JSON envelope
+    /// whose summary value had UNESCAPED quotes and newlines (Hebrew review),
+    /// so the object decode failed. The summarizer must NOT dump the raw
+    /// `{...}` blob into the summary — it salvages the summary text and still
+    /// recovers the (independently valid) items array.
+    func test_summarize_salvages_summary_from_malformed_json_envelope() async throws {
+        llm.tool = .claude
+        // Note the unescaped inner quotes around על חלל and the literal \n —
+        // exactly what broke JSONDecoder in production.
+        let malformed = #"{"summary": "השיחה עסקה בניהול צוות.\n\n• בייליס מתנהג כאילו הוא "על חלל" ואינו לוקח אחריות.", "items": [{"id": "a", "text": "להחזיר לבייליס ביקורת ישירה", "source": "inferred"}, {"id": "b", "text": "לנטרל את גוליאן משיחות פרודקט", "source": "inferred"}]}"#
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in malformed }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Malformed")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Malformed",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        let summary = try XCTUnwrap(updated.summary)
+        XCTAssertFalse(summary.hasPrefix("{"),
+                       "a raw JSON blob must never be shown as the summary")
+        XCTAssertFalse(summary.contains("\"items\""),
+                       "the items scaffolding must not leak into the summary")
+        XCTAssertTrue(summary.contains("השיחה עסקה בניהול צוות"),
+                      "the real summary text must be salvaged")
+        XCTAssertTrue(summary.contains("\n"),
+                      "escaped newlines must be restored so it renders as lines")
+        XCTAssertEqual(updated.actionItems?.count, 2,
+                       "the valid items array must still be recovered")
+    }
+
     // MARK: - Helpers
 
     /// Rebuild `summarizer` with a deterministic `runLLM` stub so the

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -697,7 +697,222 @@ final class RecordingSummarizerTests: XCTestCase {
                        "the valid items array must still be recovered")
     }
 
+    // MARK: - Parsing the one-shot output (pure, no runner)
+
+    /// `parseSummaryAndItems` must say WHICH shape it got. The tolerant
+    /// paths are the whole point of this fix, and a model that quietly
+    /// ignores the output contract on every single call should be
+    /// diagnosable from Console rather than invisible.
+    func test_parse_origin_reports_which_shape_arrived() {
+        XCTAssertEqual(RecordingSummarizer.parseSummaryAndItems(from: "Plain prose.").origin,
+                       .plain)
+        XCTAssertEqual(
+            RecordingSummarizer.parseSummaryAndItems(
+                from: "A summary.\n\(RecordingSummarizer.actionItemsSentinel)\n[]"
+            ).origin,
+            .sentinel)
+        XCTAssertEqual(
+            RecordingSummarizer.parseSummaryAndItems(
+                from: #"{"summary": "A summary.", "items": []}"#
+            ).origin,
+            .envelope)
+    }
+
+    /// A malformed envelope that is PRETTY-PRINTED. The salvage anchored on
+    /// the separator spelled exactly `", "items"` / `","items"`, so
+    /// multi-line JSON — what a CLI printing an indented object emits — fell
+    /// through to "take everything up to the last quote" and dragged the
+    /// whole items array into the summary. That is the same scaffolding leak
+    /// the fix exists to prevent, just one whitespace variation away.
+    ///
+    /// `legacySalvageSummaryValue` below reproduces the old anchor and is
+    /// asserted to leak, so the assertions here are provably discriminating
+    /// rather than vacuous.
+    func test_parse_salvages_pretty_printed_malformed_envelope_without_leaking_scaffolding() {
+        let malformed = """
+        {
+          "summary": "Team review. Baylis acts as if he is "on another planet" and takes no ownership.",
+          "items": [
+            {"id": "a", "text": "Give Baylis direct feedback", "source": "inferred"}
+          ]
+        }
+        """
+
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: malformed)
+
+        XCTAssertEqual(parsed.origin, .salvagedEnvelope)
+        XCTAssertFalse(parsed.summary.hasPrefix("{"),
+                       "a raw JSON blob must never be shown as the summary")
+        XCTAssertFalse(parsed.summary.contains("\"items\""),
+                       "the items scaffolding must not leak into the summary")
+        XCTAssertFalse(parsed.summary.contains("\"source\""),
+                       "no item field may leak into the summary")
+        XCTAssertTrue(parsed.summary.hasSuffix("takes no ownership."),
+                      "the summary must end where its value ended; got \(parsed.summary)")
+        XCTAssertTrue(parsed.summary.contains("\"on another planet\""),
+                      "the unescaped quotes that broke the decode are part of the text")
+        XCTAssertEqual(parsed.items.map(\.text), ["Give Baylis direct feedback"],
+                       "the independently valid items array must still be recovered")
+
+        // Negative control: the pre-fix anchor swallows the array.
+        XCTAssertTrue(legacySalvageSummaryValue(from: malformed).contains("\"items\""),
+                      "control: the literal-separator anchor must leak, or this test proves nothing")
+    }
+
+    /// A JSON object with no readable summary at all. Storing it verbatim is
+    /// the reported bug, and it is self-perpetuating — a stored blob passes
+    /// the "already summarized" gate, so the recording is never retried.
+    /// No summary is the honest answer; the origin makes it diagnosable.
+    func test_parse_unreadable_json_object_yields_no_summary_rather_than_the_blob() {
+        let blob = #"{"resumen": "clave equivocada", "items": []}"#
+
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: blob)
+
+        XCTAssertEqual(parsed.origin, .unreadableEnvelope)
+        XCTAssertTrue(parsed.summary.isEmpty,
+                      "an unreadable object must yield no summary; got \(parsed.summary)")
+    }
+
+    // MARK: - Dictated action items survive the one-shot pass
+
+    /// For a Live-AI recording, `QuickActionsController` snapshots the live
+    /// action items — including ones the user DICTATED ("Mila, action
+    /// item: …", `source == .voiceCommand`) — onto the recording at stop and
+    /// then immediately calls `regenerate`. The one-shot prompt is never
+    /// shown that list and only ever asks for `source: "inferred"`, so a
+    /// wholesale replace trades what the user said out loud for the model's
+    /// guess at it. Dictated items must survive.
+    func test_regenerate_preserves_action_items_the_user_dictated() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            """
+            Fresh summary.
+            \(RecordingSummarizer.actionItemsSentinel)
+            [{"id": "fresh", "text": "Ship the beta", "source": "inferred"}]
+            """
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Dictated")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "Dictated",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.summary = "stale summary"
+        rec.actionItems = [ActionItem(id: "dictated", text: "Call the bank",
+                                      speaker: nil, timestampSeconds: 12,
+                                      source: .voiceCommand, addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertEqual(updated.summary, "Fresh summary.")
+        let items = try XCTUnwrap(updated.actionItems)
+        XCTAssertEqual(items.map(\.text), ["Call the bank", "Ship the beta"],
+                       "a dictated item must not be dropped for the inferred set")
+        XCTAssertEqual(items.first?.source, .voiceCommand,
+                       "it must stay marked as dictated — the MCP surface reports that field")
+    }
+
+    /// The model usually DOES re-derive a dictated task from the transcript,
+    /// under an id of its own. Keeping both would show the user the same
+    /// task twice, so the fresh copy is dropped and the dictated one — the
+    /// authoritative record of an explicit instruction — is kept. Matching
+    /// is case- and whitespace-insensitive, which this fixture exercises.
+    func test_regenerate_does_not_duplicate_a_dictated_item_the_model_re_derived() async throws {
+        llm.tool = .claude
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in
+            """
+            Fresh summary.
+            \(RecordingSummarizer.actionItemsSentinel)
+            [{"id": "reinferred", "text": "call the   BANK", "source": "inferred"},
+             {"id": "other", "text": "Ship the beta", "source": "inferred"}]
+            """
+        }
+
+        let audioURL = store.freshAudioURL(suggestedName: "NoDupes")
+        try Data("x".utf8).write(to: audioURL)
+        var rec = Recording(
+            title: "NoDupes",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        rec.actionItems = [ActionItem(id: "dictated", text: "Call the bank",
+                                      speaker: nil, timestampSeconds: 12,
+                                      source: .voiceCommand, addedAt: Date())]
+        store.add(rec)
+
+        summarizer.regenerate(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        let items = try XCTUnwrap(updated.actionItems)
+        XCTAssertEqual(items.map(\.text), ["Call the bank", "Ship the beta"],
+                       "the re-derived copy of a dictated item must be folded away")
+        XCTAssertEqual(items.first?.source, .voiceCommand)
+    }
+
+    /// End-to-end negative control for the malformed-JSON path: output the
+    /// summarizer cannot read a summary out of must leave the recording
+    /// WITHOUT a summary — never with the raw `{...}` blob, which is what
+    /// shipped and what permanently blocked a retry.
+    func test_summarize_never_stores_an_unreadable_json_object_as_the_summary() async throws {
+        llm.tool = .claude
+        let blob = #"{"resumen": "clave equivocada", "items": []}"#
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in blob }
+
+        let audioURL = store.freshAudioURL(suggestedName: "Unreadable")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "Unreadable",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertNil(updated.summary,
+                     "a blob must not be stored — the recording stays eligible for a retry")
+        XCTAssertTrue(summarizer.shouldSummarize(updated),
+                      "and the retry gate must actually still be open")
+    }
+
     // MARK: - Helpers
+
+    /// The pre-fix salvage end-anchor, kept ONLY as a negative control for
+    /// `test_parse_salvages_pretty_printed_malformed_envelope_without_leaking_scaffolding`.
+    /// It matched the separator between the summary value and the `"items"`
+    /// key literally, so any other spelling of it fell through to
+    /// `lastIndex(of:)`. Do not use for anything else.
+    private func legacySalvageSummaryValue(from json: String) -> String {
+        guard let keyRange = json.range(of: "\"summary\"") else { return "" }
+        let afterKey = json[keyRange.upperBound...]
+        guard let colon = afterKey.firstIndex(of: ":") else { return "" }
+        let afterColon = afterKey[afterKey.index(after: colon)...]
+        guard let openQuote = afterColon.firstIndex(of: "\"") else { return "" }
+        let rest = afterColon[afterColon.index(after: openQuote)...]
+        let endIdx: Substring.Index
+        if let itemsAnchor = rest.range(of: "\", \"items\"")
+            ?? rest.range(of: "\",\"items\"") {
+            endIdx = itemsAnchor.lowerBound
+        } else if let lastQuote = rest.lastIndex(of: "\"") {
+            endIdx = lastQuote
+        } else {
+            endIdx = rest.endIndex
+        }
+        return String(rest[..<endIdx])
+            .replacingOccurrences(of: "\\n", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     /// Rebuild `summarizer` with a deterministic `runLLM` stub so the
     /// end-to-end tests don't depend on a real subprocess. Call after

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -843,6 +843,45 @@ final class RecordingSummarizerTests: XCTestCase {
         XCTAssertEqual(parsed.items.map(\.text), ["Ship the retry change"])
     }
 
+    /// The unwrapper must never VETO, only offer. Two shapes proved that: a
+    /// fence the model never closed (it stopped early), and a fence followed
+    /// by a chatty sign-off. Both used to abort the unwrap, and a labelled
+    /// envelope has no leading `{` of its own to fall back on.
+    ///
+    /// Each payload carries an ODD number of unescaped quotes, which leaves
+    /// `findFirstJSONStructure`'s `inString` inverted so the balanced-block
+    /// search fails outright — exactly the malformed input this salvage path
+    /// exists for. The fence candidate is therefore the ONLY route to the
+    /// leading-`{` bypass, which is what makes these assertions discriminating
+    /// rather than incidentally true.
+    func test_parse_salvages_a_wrapped_envelope_when_the_fence_is_unclosed_or_trailed() {
+        let unclosed = #"""
+        Here is the summary:
+        ```json
+        {"summary": "He said "hi" and left, "items": []}
+        """#
+
+        let trailed = #"""
+        Here is the summary:
+        ```json
+        {"summary": "He said "hi" and left, "items": []}
+        ```
+        Hope that helps!
+        """#
+
+        for (shape, raw) in [("unclosed fence", unclosed), ("trailed fence", trailed)] {
+            let parsed = RecordingSummarizer.parseSummaryAndItems(from: raw)
+            XCTAssertEqual(parsed.origin, .salvagedEnvelope,
+                           "\(shape): must still reach the salvage")
+            XCTAssertFalse(parsed.summary.hasPrefix("{"),
+                           "\(shape): a raw blob must never be shown as the summary")
+            XCTAssertFalse(parsed.summary.contains("```"),
+                           "\(shape): fence scaffolding must not reach the summary")
+            XCTAssertTrue(parsed.summary.contains("He said"),
+                          "\(shape): got \(parsed.summary)")
+        }
+    }
+
     /// The counterweight to the test above, and the reason the fix is not
     /// simply "the output contains a `{`". A real summary may quote braces or
     /// a code block; blanking a GOOD summary is a worse outcome than showing

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -819,6 +819,30 @@ final class RecordingSummarizerTests: XCTestCase {
         XCTAssertEqual(labelledParse.summary, "A \"quoted\" thing.")
     }
 
+    /// The wrapper-stripper must never ABORT the salvage. A malformed
+    /// envelope whose summary text mentions ```` ``` ```` — a meeting that
+    /// discussed code — has backticks that are content, not a wrapper, and the
+    /// first cut of the fence handling let that hijack the parse: it stripped
+    /// before the shape test and bailed when the wrapper looked wrong, so this
+    /// landed in `.plain` as a raw blob even though the leading `{` alone was
+    /// always enough to salvage it. Unwrapping is optimistic; when it cannot
+    /// identify a wrapper the original text is judged on its own merits.
+    func test_parse_salvages_a_malformed_envelope_whose_summary_mentions_backticks() {
+        let malformed = #"{"summary": "The team reviewed the ```retry``` helper and called it "fine".", "items": [{"id": "a", "text": "Ship the retry change", "source": "inferred"}]}"#
+
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: malformed)
+
+        XCTAssertEqual(parsed.origin, .salvagedEnvelope,
+                       "backticks in the summary TEXT must not abort the salvage")
+        XCTAssertFalse(parsed.summary.hasPrefix("{"),
+                       "a raw JSON blob must never be shown as the summary")
+        XCTAssertTrue(parsed.summary.contains("```retry```"),
+                      "the backticks are part of the summary; got \(parsed.summary)")
+        XCTAssertFalse(parsed.summary.contains("\"items\""),
+                       "the items scaffolding must not leak into the summary")
+        XCTAssertEqual(parsed.items.map(\.text), ["Ship the retry change"])
+    }
+
     /// The counterweight to the test above, and the reason the fix is not
     /// simply "the output contains a `{`". A real summary may quote braces or
     /// a code block; blanking a GOOD summary is a worse outcome than showing
@@ -989,6 +1013,36 @@ final class RecordingSummarizerTests: XCTestCase {
         let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
         XCTAssertNil(updated.summary,
                      "a fenced blob must not be stored; got \(updated.summary ?? "nil")")
+        XCTAssertTrue(summarizer.shouldSummarize(updated),
+                      "and the retry gate must actually still be open")
+    }
+
+    /// End-to-end proof that the CLASS is closed, not one instance of it: an
+    /// unreadable object whose text mentions ```` ``` ```` is the shape the
+    /// fence-stripper used to abort on, and aborting stored the blob and shut
+    /// the retry gate. Whatever the stripper makes of a wrapper, the pipeline
+    /// must end up no worse than if it had never tried.
+    func test_summarize_never_stores_a_blob_whose_text_mentions_backticks() async throws {
+        llm.tool = .claude
+        let blob = #"{"resumen": "hablamos del helper ```retry```", "items": []}"#
+        useStubRunner { _, _, _, _, _, _, _, _, _, _, _ in blob }
+
+        let audioURL = store.freshAudioURL(suggestedName: "BacktickBlob")
+        try Data("x".utf8).write(to: audioURL)
+        let rec = Recording(
+            title: "BacktickBlob",
+            source: .microphone,
+            audioFileName: audioURL.lastPathComponent,
+            fullText: "the full transcript"
+        )
+        store.add(rec)
+
+        summarizer.summarizeIfNeeded(rec)
+        await summarizer.awaitInFlight(rec.id)
+
+        let updated = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        XCTAssertNil(updated.summary,
+                     "a blob must not be stored; got \(updated.summary ?? "nil")")
         XCTAssertTrue(summarizer.shouldSummarize(updated),
                       "and the retry gate must actually still be open")
     }

--- a/MilaTests/RecordingSummarizerTests.swift
+++ b/MilaTests/RecordingSummarizerTests.swift
@@ -843,43 +843,79 @@ final class RecordingSummarizerTests: XCTestCase {
         XCTAssertEqual(parsed.items.map(\.text), ["Ship the retry change"])
     }
 
-    /// The unwrapper must never VETO, only offer. Two shapes proved that: a
-    /// fence the model never closed (it stopped early), and a fence followed
-    /// by a chatty sign-off. Both used to abort the unwrap, and a labelled
-    /// envelope has no leading `{` of its own to fall back on.
+    /// An UNCLOSED fence must not abort the unwrap: the model simply stopped
+    /// early, and a labelled envelope has no leading `{` of its own to fall
+    /// back on.
     ///
-    /// Each payload carries an ODD number of unescaped quotes, which leaves
+    /// The payload carries an ODD number of unescaped quotes, which leaves
     /// `findFirstJSONStructure`'s `inString` inverted so the balanced-block
     /// search fails outright — exactly the malformed input this salvage path
     /// exists for. The fence candidate is therefore the ONLY route to the
     /// leading-`{` bypass, which is what makes these assertions discriminating
     /// rather than incidentally true.
-    func test_parse_salvages_a_wrapped_envelope_when_the_fence_is_unclosed_or_trailed() {
+    func test_parse_salvages_a_wrapped_envelope_when_the_fence_is_never_closed() {
         let unclosed = #"""
         Here is the summary:
         ```json
         {"summary": "He said "hi" and left, "items": []}
         """#
 
-        let trailed = #"""
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: unclosed)
+
+        XCTAssertEqual(parsed.origin, .salvagedEnvelope,
+                       "an unclosed fence must still reach the salvage")
+        XCTAssertFalse(parsed.summary.hasPrefix("{"),
+                       "a raw blob must never be shown as the summary")
+        XCTAssertFalse(parsed.summary.contains("```"),
+                       "fence scaffolding must not reach the summary")
+        XCTAssertTrue(parsed.summary.contains("He said"), "got \(parsed.summary)")
+    }
+
+    /// A fenced block with prose AFTER it is quoted material inside a real
+    /// summary — a meeting that showed a config — not a wrapper around the
+    /// output. Taking the block substitutes the snippet for the summary and
+    /// then blanks it (no `"summary"` key → `unreadableEnvelope`), destroying
+    /// the prose on both sides. The lead-in here is deliberately SHORT, so the
+    /// 80-char label guard cannot be what saves it: the structural check has
+    /// to.
+    func test_parse_keeps_prose_that_continues_after_a_quoted_fenced_object() {
+        let prose = """
+        Notes:
+        ```json
+        {"retries": 3}
+        ```
+        The team agreed to raise it next sprint after the incident review.
+        """
+
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: prose)
+
+        XCTAssertEqual(parsed.origin, .plain)
+        XCTAssertTrue(parsed.summary.contains("next sprint after the incident review"),
+                      "the prose after the block must survive; got \(parsed.summary)")
+    }
+
+    /// Backticks in the MIDDLE of a line are content, not a fence. Closing the
+    /// block at the first inner run truncated the candidate mid-value and
+    /// stored a short, plausible-looking WRONG summary ("We fixed the") —
+    /// worse than a blob, because nothing about it looks broken, and the retry
+    /// gate shuts on it just the same.
+    func test_parse_does_not_let_inner_backticks_truncate_a_fenced_salvage() {
+        // Unescaped quotes around "done" break the object decode, which is
+        // what routes this to the salvage in the first place.
+        let fenced = #"""
         Here is the summary:
         ```json
-        {"summary": "He said "hi" and left, "items": []}
+        {"summary": "We fixed the ```retry``` helper and called it "done".", "items": []}
         ```
-        Hope that helps!
         """#
 
-        for (shape, raw) in [("unclosed fence", unclosed), ("trailed fence", trailed)] {
-            let parsed = RecordingSummarizer.parseSummaryAndItems(from: raw)
-            XCTAssertEqual(parsed.origin, .salvagedEnvelope,
-                           "\(shape): must still reach the salvage")
-            XCTAssertFalse(parsed.summary.hasPrefix("{"),
-                           "\(shape): a raw blob must never be shown as the summary")
-            XCTAssertFalse(parsed.summary.contains("```"),
-                           "\(shape): fence scaffolding must not reach the summary")
-            XCTAssertTrue(parsed.summary.contains("He said"),
-                          "\(shape): got \(parsed.summary)")
-        }
+        let parsed = RecordingSummarizer.parseSummaryAndItems(from: fenced)
+
+        XCTAssertEqual(parsed.origin, .salvagedEnvelope)
+        XCTAssertTrue(parsed.summary.hasSuffix("called it \"done\"."),
+                      "the summary must not be clipped at an inner backtick run; got \(parsed.summary)")
+        XCTAssertTrue(parsed.summary.contains("```retry```"),
+                      "the quoted backticks are part of the summary text")
     }
 
     /// The counterweight to the test above, and the reason the fix is not


### PR DESCRIPTION
Closes #199

## Credit: this fix is @ValeroK's work

**The one-shot summary fix was written by @ValeroK. This PR relays it — it
supersedes #200, which is where the work actually happened.** His commit is
cherry-picked unmodified; everything I added sits in a single commit on top,
and it is three follow-up fixes plus tests, not the fix.

It is relayed rather than merged for the usual reason (the #198 → #204 and
#129 → #164 precedent): a fork PR can't get an automated review under the
contributor's own quota — #200 never got one, CodeRabbit refused it twice for
"review limit reached" on his account — and fork CI needs per-run approval on
every run.

> **On authorship.** The relay was prepared with `git cherry-pick`, so his
> commit keeps `Author: KobiValero-Pagaya <kobi.valero@pagaya.com>` — the
> address recorded on #200's head. My commit carries
> `Co-authored-by: ValeroK <8961499+ValeroK@users.noreply.github.com>`, which
> is the form that resolves to his GitHub account.

## What & why

After #87 the post-recording summarizer only stored plain text: the one-shot
call never asked for action items, and any JSON envelope a model returned out
of habit landed in `Recording.summary` verbatim — a raw `{...}` blob in the
detail view, the Obsidian note and the MCP surface.

**@ValeroK's commit** (`Mila/Actions/RecordingSummarizer.swift`,
`Mila/Models/LiveAISettings.swift`):

- The one-shot prompt is wrapped at send time with an output contract: the
  plain-text summary, then `###ACTION_ITEMS###` on its own line, then a JSON
  array. Keeping the summary *outside* JSON is the point — a long multi-line
  Hebrew summary full of unescaped quotes cannot break the parse, because only
  the compact item array has to be valid JSON. The contract is appended, not
  persisted, so a customised `summaryPrompt` keeps working.
- Parse order: sentinel → decodable envelope → salvage a broken envelope →
  prose. Items land on the recording; an empty list is treated as "keep what's
  there", so a glitchy response can't wipe the live snapshot taken at stop.
- The default summary prompt regains its pre-#87 depth, with users still on
  the old concise default migrated up (`legacySummaryPromptV1`) and custom
  prompts left alone. I verified `legacySummaryPromptV1` is byte-identical to
  the default on `main`, so the match can't silently miss, and the migration is
  a pure read (property observers don't fire during `init`), so it is
  idempotent as its comment claims.

**On top of that (my commit), three things found by reading the paths this
change now owns:**

1. **Dictated action items were being replaced by the model's guess.** For a
   Live-AI recording, `QuickActionsController` snapshots the live items onto
   the recording at stop — voice-command items included, the ones the user
   said out loud — and then immediately calls `regenerate`. The one-shot
   prompt is never shown that list and only ever asks for
   `source: "inferred"`, so replacing wholesale traded an explicit instruction
   for the model's re-derivation of it, or lost it. `ActionItem.source` is
   mirrored all the way out to the MCP surface precisely so a client can tell
   a spoken commitment from an inferred one, which is the answer that
   degraded. `merged(fresh:keepingDictatedFrom:)` keeps every dictated item
   and folds the fresh set in after it, deduped by id and by normalised text.
2. **The salvage leaked the items array on pretty-printed JSON.** Its end
   anchor matched the separator literally (`", "items"` / `","items"`), so a
   multi-line malformed envelope fell through to "everything up to the last
   quote" and dragged the whole items array into the summary — the same
   scaffolding leak the function exists to prevent, one whitespace variation
   away. It now finds the structural `"items"` key and walks back to the last
   quote before it.
3. **The fallback is now honest and observable.** A JSON object with no
   readable summary (no `"summary"` key, or an empty one) still landed
   verbatim, and that failure is self-perpetuating: a stored blob satisfies the
   "already has a summary" gate, so the recording is never retried. It now
   yields *no* summary — the same treatment empty CLI output has always had —
   so the next backfill sweep picks it up. `parseSummaryAndItems` also reports
   which shape arrived (`sentinel` / `envelope` / `salvaged-envelope` /
   `plain` / `unreadable-envelope`) and both log lines carry it. It is a fixed
   keyword, never the model's text: summary output is derived from the
   transcript and is user content, which must not reach a `.public` log field.

Also: the Settings prompt editor now says Mila asks for the action items
alongside the summary, since the appended contract isn't visible in the box
the user is editing.

**Persisted contracts:** nothing to mirror. `Recording.encode(to:)` and
`ActionItem` are untouched — the change is what *value* lands in
`actionItems`, not its shape — and `MilaKit.StoredRecording.ActionItem`
already carries all six fields including `source`.

### One design question for you, not changed here

The one-shot prompt is not shown the recording's existing items, so the model
cannot consolidate or update them the way the live tick does (`encodeForPrompt`
feeds the current list back in). Preserving dictated items covers the data-loss
half; feeding the list in would let the model merge instead of re-derive. Left
alone deliberately — it is a prompt-design change, not a bug fix.

## How it was tested

- **Not built or run.** There is no Xcode, no `xcodebuild` and no Swift
  toolchain on the machine this relay was prepared on, so the code was verified
  by reading it against the real call sites (`QuickActionsController.stopTail`
  → `regenerate`, `LiveAISession.parseEnvelope` / `parseActionItems` /
  `makeItem`, `LiveAISettings.summaryPrompt`'s `didSet`,
  `AIOverviewSection`/`RecordingDetailView` item rendering) and by checking
  every symbol referenced actually exists. CI is the first compile.
- @ValeroK reports `RecordingSummarizerTests` + `LiveAISettingsMigrationTests`
  green on #200 (36/36).
- **Tests that fail on `main`** — his: a one-shot response yielding populated
  action items (`test_summarize_parses_envelope_and_stores_summary_and_action_items`,
  `test_summarize_parses_sentinel_format`) and the Hebrew malformed-envelope
  salvage. On `main` the raw output is stored verbatim and `actionItems` is
  never written, so all three fail there.
- **Negative controls** — mine: `test_parse_salvages_pretty_printed_malformed_envelope_without_leaking_scaffolding`
  reproduces the old literal anchor in the test file and asserts it *leaks*, so
  the assertion isn't vacuous; `test_summarize_never_stores_an_unreadable_json_object_as_the_summary`
  feeds a JSON object the parser can't read and asserts the summary stays nil —
  specifically not a raw `{...}` blob — with the retry gate still open.
- No test on `main` pinned the buggy behaviour (all 18 in
  `RecordingSummarizerTests` and the 4 migration tests checked), so nothing had
  to be un-asserted.
- Not verified: no manual end-to-end run with a real CLI and a real Hebrew
  transcript.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — could not be
      run in the relay environment; CI is the first build
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, entries are written per release, not per PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core post-recording summarization path and persisted `summary`/`actionItems` data, with complex LLM output parsing; risk is mitigated by extensive tests and conservative fallbacks (no blob storage, preserve dictated items).
> 
> **Overview**
> Restores **summary + action items** from the post-recording one-shot LLM pass (behavior lost after #87) and stops malformed model output from being saved as the recording summary.
> 
> **`RecordingSummarizer`** appends an output contract at send time (`promptWithActionItems`): plain-text summary, then `###ACTION_ITEMS###`, then a JSON array—so long Hebrew/multiline summaries are not embedded in JSON. CLI output is split via `parseSummaryAndItems` (sentinel → envelope → salvage broken JSON → prose). Unreadable JSON objects yield **no** summary (retry/backfill still possible) instead of a permanent `{...}` blob. Parsed items update `actionItems` when non-empty; empty lists keep existing items. **`merged(keepingDictatedFrom:)`** keeps voice-command items ahead of inferred ones on `regenerate`.
> 
> **`LiveAISettings`** ships a richer default summary prompt and migrates users still on the old concise default (`legacySummaryPromptV1`); custom prompts are unchanged. **Settings** copy notes that action items are requested alongside the summary.
> 
> Large test additions cover parsing edge cases (fenced JSON, salvage, dictated-item merge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73f45adad545fa9d9295d352bf52cdc54c1bc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->