### PR TITLE
feat(meetings): detect Google Meet in Chrome, Safari, Arc, and Island (relay of #214)

### DIFF
--- a/Mila/Audio/MeetingDetector.swift
+++ b/Mila/Audio/MeetingDetector.swift
@@ -36,14 +36,38 @@ final class MeetingDetector: ObservableObject {
     /// actively capturing the mic; `meetingTitleHints` is the window-title
     /// fallback used only when the audio API is unavailable.
     struct App: Hashable {
+        /// Stable identity key for this detector entry — used in the
+        /// per-app silence list, the state machine's `firedFor` /
+        /// `endArmed` sets, and Settings display. For native apps this
+        /// is the app's bundle ID; for browser-based meetings it is a
+        /// synthetic ID like `"meet.google.com"`.
         let bundleID: String
         let displayName: String
+        /// Bundle IDs of the macOS apps that host this meeting type.
+        /// For native apps (Zoom, Teams) this is one entry matching
+        /// `bundleID`. For browser-based meetings (Google Meet) this
+        /// lists every supported browser.
+        let appBundleIDs: [String]
         /// Any running audio process whose bundle ID has one of these
-        /// prefixes AND is capturing mic input ⇒ this app is in a meeting.
-        /// A prefix (not exact) because Zoom may capture under a helper
-        /// bundle ID (`us.zoom.*`) rather than `us.zoom.xos`.
+        /// prefixes AND is capturing mic input ⇒ this app is in a
+        /// meeting. A prefix (not exact) because Zoom may capture
+        /// under a helper (`us.zoom.*`). Empty for browser-based
+        /// meetings — see `helperBundlePrefixes`.
         let captureBundlePrefixes: [String]
-        /// Lowercased window-title substrings, fallback path only. A hint
+        /// Additional bundle-ID prefixes for helper processes that
+        /// capture audio on behalf of this app. Browsers delegate mic
+        /// capture to helper subprocesses whose bundle IDs differ from
+        /// the main app (e.g. Safari → `com.apple.WebKit`, Arc →
+        /// `company.thebrowser.browser.helper`). Checked alongside
+        /// `appBundleIDs` during mic-capture matching (case-insensitive).
+        /// Empty for native apps that capture under their own prefix.
+        let helperBundlePrefixes: [String]
+        /// Lowercased window-title substrings. For native apps (Zoom,
+        /// Teams) this is a fallback when the mic-capture API is
+        /// unavailable. For browsers (empty `captureBundlePrefixes`) it
+        /// is the fallback on older macOS where the mic-capture API
+        /// doesn't exist. On macOS 14.4+ browsers use mic capture as
+        /// the primary signal (titles are unreliable on Tahoe). A hint
         /// must identify a *meeting* window specifically, not merely the
         /// app being open — the fallback treats a match as "in a call".
         /// Empty ⇒ no usable meeting-specific title exists for this app, so
@@ -59,12 +83,15 @@ final class MeetingDetector: ObservableObject {
         App(
             bundleID: "us.zoom.xos",
             displayName: "Zoom",
+            appBundleIDs: ["us.zoom.xos"],
             captureBundlePrefixes: ["us.zoom"],
+            helperBundlePrefixes: [],
             meetingTitleHints: ["zoom meeting"]
         ),
         App(
             bundleID: "com.microsoft.teams2",
             displayName: "Microsoft Teams",
+            appBundleIDs: ["com.microsoft.teams2"],
             captureBundlePrefixes: ["com.microsoft.teams2"],
             // Deliberately none. Zoom can use a title hint because its
             // meeting window is titled "Zoom Meeting" while the idle app
@@ -76,8 +103,30 @@ final class MeetingDetector: ObservableObject {
             // on launch and, mid-recording, a bogus "meeting ended → stop
             // recording?" the moment that window went away. Teams is
             // therefore detected by mic capture only (macOS 14.4+).
+            helperBundlePrefixes: [],
             meetingTitleHints: []
-        )
+        ),
+        // Google Meet runs inside a browser. Mic capture detects
+        // which browser is actively using the microphone; helper
+        // prefixes catch the subprocess that actually captures audio.
+        App(
+            bundleID: "meet.google.com",
+            displayName: "Google Meet (Chrome, Safari, Arc, Island)",
+            appBundleIDs: [
+                "com.google.Chrome",
+                "com.apple.Safari",
+                "company.thebrowser.Browser",
+                "io.island.Island",
+            ],
+            captureBundlePrefixes: [],
+            helperBundlePrefixes: [
+                "com.google.chrome",
+                "com.apple.webkit",
+                "company.thebrowser",
+                "io.island",
+            ],
+            meetingTitleHints: ["meet.google.com", "meet -"]
+        ),
     ]
 
     /// Fired exactly once per meeting — the first poll that sees a
@@ -158,7 +207,33 @@ final class MeetingDetector: ObservableObject {
         var activeMeetings: Set<String> = []
         for app in Self.supportedApps {
             let inMeeting: Bool
-            if let capturing {
+            if app.captureBundlePrefixes.isEmpty {
+                // Browser-based meetings (Google Meet, etc.): detect
+                // via mic capture — the browser (or its helper) is
+                // actively capturing the microphone during a call.
+                //
+                // Window-title matching would be more precise but macOS
+                // 26 (Tahoe) hides titles from CGWindowListCopyWindowInfo
+                // even with Screen Recording permission, making it
+                // unreliable. Mic capture is the only cross-version
+                // signal that works.
+                //
+                // Case-insensitive prefix: browser helpers use a
+                // lowercased bundle ID (e.g. Arc's mic-capture process
+                // is "company.thebrowser.browser.helper").
+                if let capturing {
+                    let allPrefixes = app.appBundleIDs.map { $0.lowercased() }
+                        + app.helperBundlePrefixes.map { $0.lowercased() }
+                    inMeeting = capturing.contains { bid in
+                        let lowered = bid.lowercased()
+                        return allPrefixes.contains { lowered.hasPrefix($0) }
+                    }
+                } else {
+                    // No mic-capture API (older macOS): fall back to
+                    // title-only detection.
+                    inMeeting = isRunning(app) && hasMeetingWindow(for: app, includeOffScreen: true)
+                }
+            } else if let capturing {
                 inMeeting = app.captureBundlePrefixes.contains { prefix in
                     capturing.contains { $0.hasPrefix(prefix) }
                 }
@@ -229,7 +304,7 @@ final class MeetingDetector: ObservableObject {
 
     private func isRunning(_ app: App) -> Bool {
         NSWorkspace.shared.runningApplications
-            .contains { $0.bundleIdentifier == app.bundleID }
+            .contains { bid in app.appBundleIDs.contains(bid.bundleIdentifier ?? "") }
     }
 
     // MARK: - Primary signal: per-process mic capture (Core Audio)
@@ -297,15 +372,22 @@ final class MeetingDetector: ObservableObject {
     /// Recording permission, window titles for other processes come back
     /// nil — in that case we conservatively return false. An app with no
     /// hints opts out of this fallback entirely.
-    private func hasMeetingWindow(for app: App) -> Bool {
+    ///
+    /// `includeOffScreen` broadens the search to minimized and off-screen
+    /// windows. Used for title-only apps (browsers) where the user may
+    /// minimize the browser during a call — `.optionOnScreenOnly` would
+    /// miss the Meet tab and falsely end the meeting.
+    private func hasMeetingWindow(for app: App, includeOffScreen: Bool = false) -> Bool {
         guard !app.meetingTitleHints.isEmpty else { return false }
 
         let runningPIDs = NSWorkspace.shared.runningApplications
-            .filter { $0.bundleIdentifier == app.bundleID }
+            .filter { bid in app.appBundleIDs.contains(bid.bundleIdentifier ?? "") }
             .map { $0.processIdentifier }
         guard !runningPIDs.isEmpty else { return false }
 
-        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        let options: CGWindowListOption = includeOffScreen
+            ? [.excludeDesktopElements]
+            : [.optionOnScreenOnly, .excludeDesktopElements]
         guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]]
         else { return false }
         for window in info {

--- a/Mila/Audio/MeetingDetector.swift
+++ b/Mila/Audio/MeetingDetector.swift
@@ -22,6 +22,22 @@ import OSLog
 /// on-screen window titles via `CGWindowListCopyWindowInfo` (needs Screen
 /// Recording permission for titles; silently skipped without it).
 ///
+/// **Browser-hosted meetings (Google Meet).** Meet has no app of its own —
+/// it is a tab in Chrome, Safari, Arc or Island — so the entry lists the
+/// browsers that host it (`appBundleIDs`) and the helper processes they
+/// actually capture under (`helperBundlePrefixes`). It rides the same two
+/// signals in the same order, which has one consequence worth stating
+/// plainly: **mic capture proves a browser is in a live audio session, not
+/// that the session is Google Meet.** A Slack huddle or WhatsApp Web call
+/// in a supported browser reads as a Meet meeting on the primary path. That
+/// is accepted deliberately — the prompt it produces is a 10-second
+/// auto-dismissing offer to transcribe a call the user really is in, and the
+/// alternative (title matching as the primary signal) trades it for a worse
+/// failure: a window title only ever reflects the *frontmost tab*, so
+/// switching tabs mid-call would read as the meeting having ended and offer
+/// to stop a recording that should keep running. See the notes on
+/// `helperBundlePrefixes` for the identity trap this creates.
+///
 /// Detection is a low-frequency poll (every 3 s), not an event
 /// subscription — neither the audio nor the window signal posts a "user
 /// joined a meeting" notification.
@@ -61,6 +77,16 @@ final class MeetingDetector: ObservableObject {
         /// `company.thebrowser.browser.helper`). Checked alongside
         /// `appBundleIDs` during mic-capture matching (case-insensitive).
         /// Empty for native apps that capture under their own prefix.
+        ///
+        /// **Keep every prefix here as long as the app it identifies.** A
+        /// prefix is matched against *all* mic-capturing processes on the
+        /// machine, Mila's own included: Mila is `io.island.whisper.…` and
+        /// captures the mic both while recording and while the Settings VU
+        /// meter is live, so a prefix of `io.island` (rather than
+        /// `io.island.Island` for the Island browser) makes Mila detect
+        /// *itself* as a meeting and prompt the user about a call that is
+        /// just their own audio settings pane.
+        /// `MeetingDetectorBrowserDetectionTests` pins this.
         let helperBundlePrefixes: [String]
         /// Lowercased window-title substrings. For native apps (Zoom,
         /// Teams) this is a fallback when the mic-capture API is
@@ -74,6 +100,17 @@ final class MeetingDetector: ObservableObject {
         /// the fallback never claims a meeting for it (the Core Audio
         /// signal remains, and no detection beats a false one).
         let meetingTitleHints: [String]
+
+        /// True for an entry that lives inside another app (a browser tab)
+        /// rather than owning a process of its own — it captures under a
+        /// host's bundle ID, so it declares no `captureBundlePrefixes`.
+        ///
+        /// Only the window-title path needs to know: a browser window
+        /// minimized during a call must still count, or the fallback reads a
+        /// minimized Meet tab as the meeting having ended. A native app's
+        /// meeting window is its own, so the narrower on-screen-only search
+        /// stays for those (unchanged behaviour for Zoom).
+        var isBrowserHosted: Bool { captureBundlePrefixes.isEmpty }
     }
 
     /// Supported meeting apps. Adding a new app (e.g. Google Meet) is just
@@ -106,25 +143,46 @@ final class MeetingDetector: ObservableObject {
             helperBundlePrefixes: [],
             meetingTitleHints: []
         ),
-        // Google Meet runs inside a browser. Mic capture detects
-        // which browser is actively using the microphone; helper
-        // prefixes catch the subprocess that actually captures audio.
+        // Google Meet runs inside a browser, so the entry names the browsers
+        // that host it and rides the same mic-capture signal as the native
+        // apps: whichever of them is actively capturing the microphone (in
+        // its own process or a helper) is in a call.
+        //
+        // `bundleID` is synthetic — no process has this ID. It is the
+        // silence/snooze key and the badge key, and it deliberately does not
+        // name a browser, because silencing "Google Meet" must not silence
+        // every recording made from Chrome.
         App(
             bundleID: "meet.google.com",
-            displayName: "Google Meet (Chrome, Safari, Arc, Island)",
+            displayName: "Google Meet",
             appBundleIDs: [
                 "com.google.Chrome",
                 "com.apple.Safari",
                 "company.thebrowser.Browser",
+                // The Island browser. NOT `io.island` — see the warning on
+                // `helperBundlePrefixes`; that prefix also owns Mila.
                 "io.island.Island",
             ],
             captureBundlePrefixes: [],
-            helperBundlePrefixes: [
-                "com.google.chrome",
-                "com.apple.webkit",
-                "company.thebrowser",
-                "io.island",
-            ],
+            // Just the one. Chrome, Arc and Island capture under a `.helper`
+            // subprocess (`com.google.Chrome.helper`,
+            // `company.thebrowser.browser.helper`) which their own bundle ID
+            // above already prefixes, so listing those again adds nothing —
+            // and listing them *shorter* than the browser's own ID (say
+            // `company.thebrowser`, which also owns Dia) only widens what
+            // counts as Meet. Safari is the exception that needs an entry:
+            // its capture process is `com.apple.WebKit.GPU`, which
+            // `com.apple.Safari` does not prefix. It is also the broadest
+            // prefix here — a WKWebView capturing audio inside some *other*
+            // app would read as Meet.
+            helperBundlePrefixes: ["com.apple.webkit"],
+            // `Meet - <code>` is the in-call window title; the bare URL shows
+            // while the page loads. Reached only on macOS < 14.4 (no
+            // per-process audio API), which is why `meet -` is tolerable
+            // despite also matching a page titled e.g. "Track Meet -
+            // Results": on 14.4+ this list is never consulted. Deliberately
+            // no `google meet` hint — that is the *lobby* title, where the
+            // user has not joined anything yet.
             meetingTitleHints: ["meet.google.com", "meet -"]
         ),
     ]
@@ -207,42 +265,63 @@ final class MeetingDetector: ObservableObject {
         var activeMeetings: Set<String> = []
         for app in Self.supportedApps {
             let inMeeting: Bool
-            if app.captureBundlePrefixes.isEmpty {
-                // Browser-based meetings (Google Meet, etc.): detect
-                // via mic capture — the browser (or its helper) is
-                // actively capturing the microphone during a call.
-                //
-                // Window-title matching would be more precise but macOS
-                // 26 (Tahoe) hides titles from CGWindowListCopyWindowInfo
-                // even with Screen Recording permission, making it
-                // unreliable. Mic capture is the only cross-version
-                // signal that works.
-                //
-                // Case-insensitive prefix: browser helpers use a
-                // lowercased bundle ID (e.g. Arc's mic-capture process
-                // is "company.thebrowser.browser.helper").
-                if let capturing {
-                    let allPrefixes = app.appBundleIDs.map { $0.lowercased() }
-                        + app.helperBundlePrefixes.map { $0.lowercased() }
-                    inMeeting = capturing.contains { bid in
-                        let lowered = bid.lowercased()
-                        return allPrefixes.contains { lowered.hasPrefix($0) }
-                    }
-                } else {
-                    // No mic-capture API (older macOS): fall back to
-                    // title-only detection.
-                    inMeeting = isRunning(app) && hasMeetingWindow(for: app, includeOffScreen: true)
-                }
-            } else if let capturing {
-                inMeeting = app.captureBundlePrefixes.contains { prefix in
-                    capturing.contains { $0.hasPrefix(prefix) }
-                }
+            if let capturing {
+                inMeeting = Self.micCaptureIndicatesMeeting(app, capturing: capturing)
             } else {
-                inMeeting = isRunning(app) && hasMeetingWindow(for: app)
+                // No mic-capture API (macOS < 14.4): the window title is all
+                // there is. Both guards short-circuit before
+                // `windowTitles(for:)`, so an app that isn't running — or
+                // that opted out of this path by declaring no hints, like
+                // Teams — costs no window enumeration on a 3-second poll.
+                inMeeting = isRunning(app)
+                    && !app.meetingTitleHints.isEmpty
+                    && Self.titleIndicatesMeeting(
+                        app,
+                        titles: windowTitles(for: app, includeOffScreen: app.isBrowserHosted))
             }
             if inMeeting { activeMeetings.insert(app.bundleID) }
         }
         processActiveMeetings(activeMeetings)
+    }
+
+    // MARK: - Pure matching (the two signals, without the world)
+
+    /// True iff one of the processes currently capturing mic input belongs to
+    /// `app` — its own bundle ID, its host app's, or one of the helper
+    /// subprocesses it captures through.
+    ///
+    /// Pure and `static` on purpose: this is the decision that says "you are
+    /// in a meeting", and it is the one part of the detector that can be
+    /// tested exhaustively without Core Audio, a browser, or a microphone.
+    /// Matching is prefix-based (an app may capture under a helper ID) and
+    /// case-insensitive on both sides — bundle IDs are conventionally
+    /// lowercase but nothing enforces it, the same reason
+    /// `MeetingApp.matching(bundleID:)` lowercases.
+    ///
+    /// Because a prefix match is open-ended to the right, every prefix has to
+    /// be long enough to name one app and no more; `io.island` would claim
+    /// Mila itself. `MeetingDetectorBrowserDetectionTests` holds that line.
+    static func micCaptureIndicatesMeeting(_ app: App, capturing: Set<String>) -> Bool {
+        let prefixes = (app.captureBundlePrefixes + app.appBundleIDs + app.helperBundlePrefixes)
+            .map { $0.lowercased() }
+        return capturing.contains { bundleID in
+            let lowered = bundleID.lowercased()
+            return prefixes.contains { lowered.hasPrefix($0) }
+        }
+    }
+
+    /// True iff one of `titles` looks like one of `app`'s meeting windows.
+    /// `titles` are the raw window titles as `CGWindowListCopyWindowInfo`
+    /// reports them; hints are lowercased substrings, so the comparison
+    /// lowercases the title. An app with no hints opts out entirely (Teams),
+    /// which is why an empty hint list must never be read as "match
+    /// anything".
+    static func titleIndicatesMeeting(_ app: App, titles: [String]) -> Bool {
+        guard !app.meetingTitleHints.isEmpty else { return false }
+        return titles.contains { title in
+            let lower = title.lowercased()
+            return app.meetingTitleHints.contains { lower.contains($0) }
+        }
     }
 
     /// Test seam: drive the state machine directly with a set of "in a
@@ -367,39 +446,42 @@ final class MeetingDetector: ObservableObject {
 
     // MARK: - Fallback signal: window title (older macOS)
 
-    /// True iff a window owned by an app with the given bundle ID has a
-    /// title containing one of `app.meetingTitleHints`. Without Screen
-    /// Recording permission, window titles for other processes come back
-    /// nil — in that case we conservatively return false. An app with no
-    /// hints opts out of this fallback entirely.
+    /// Titles of the windows owned by any of `app.appBundleIDs`. Without
+    /// Screen Recording permission, window titles for other processes come
+    /// back nil, so this returns an empty array and the caller detects
+    /// nothing — the same conservative outcome as before, just expressed as
+    /// "no evidence" rather than "no meeting".
+    ///
+    /// Split from the hint matching (`titleIndicatesMeeting`) so the matching
+    /// half is a pure function tests can drive with realistic titles; this
+    /// half is the part that needs a real WindowServer.
     ///
     /// `includeOffScreen` broadens the search to minimized and off-screen
-    /// windows. Used for title-only apps (browsers) where the user may
-    /// minimize the browser during a call — `.optionOnScreenOnly` would
-    /// miss the Meet tab and falsely end the meeting.
-    private func hasMeetingWindow(for app: App, includeOffScreen: Bool = false) -> Bool {
-        guard !app.meetingTitleHints.isEmpty else { return false }
-
+    /// windows, for browser-hosted meetings where the user may minimize the
+    /// browser during a call — `.optionOnScreenOnly` would miss the Meet tab
+    /// and falsely end the meeting.
+    ///
+    /// Titles are user content (a tab title names a document, a client, a
+    /// meeting) and are deliberately never logged — see
+    /// `bugbot-rules/no-user-content-in-logs.md`.
+    private func windowTitles(for app: App, includeOffScreen: Bool = false) -> [String] {
         let runningPIDs = NSWorkspace.shared.runningApplications
-            .filter { bid in app.appBundleIDs.contains(bid.bundleIdentifier ?? "") }
+            .filter { app.appBundleIDs.contains($0.bundleIdentifier ?? "") }
             .map { $0.processIdentifier }
-        guard !runningPIDs.isEmpty else { return false }
+        guard !runningPIDs.isEmpty else { return [] }
 
         let options: CGWindowListOption = includeOffScreen
             ? [.excludeDesktopElements]
             : [.optionOnScreenOnly, .excludeDesktopElements]
         guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]]
-        else { return false }
-        for window in info {
+        else { return [] }
+
+        return info.compactMap { window in
             guard let pid = window[kCGWindowOwnerPID as String] as? Int32,
-                  runningPIDs.contains(pid) else { continue }
+                  runningPIDs.contains(pid) else { return nil }
             guard let title = window[kCGWindowName as String] as? String,
-                  !title.isEmpty else { continue }
-            let lower = title.lowercased()
-            if app.meetingTitleHints.contains(where: { lower.contains($0) }) {
-                return true
-            }
+                  !title.isEmpty else { return nil }
+            return title
         }
-        return false
     }
 }

--- a/Mila/Models/MeetingApp.swift
+++ b/Mila/Models/MeetingApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum MeetingApp: String, CaseIterable {
     case zoom
     case teams
+    case googleMeet
 
     struct Info {
         let displayName: String
@@ -44,6 +45,17 @@ enum MeetingApp: String, CaseIterable {
                 badgeColor: Color(red: 0.384, green: 0.388, blue: 0.651), // #6264A7
                 bundleIDPrefixes: ["com.microsoft.teams"],
                 matchSubstring: "microsoft teams"
+            )
+        case .googleMeet:
+            return Info(
+                displayName: "Google Meet",
+                badgeColor: Color(red: 0.0, green: 0.682, blue: 0.478), // #00AE7A
+                bundleIDPrefixes: [
+                    "meet.google.com",
+                    "com.google.chrome", "com.apple.safari",
+                    "company.thebrowser", "io.island"
+                ],
+                matchSubstring: "meet.google.com"
             )
         }
     }

--- a/Mila/Models/MeetingApp.swift
+++ b/Mila/Models/MeetingApp.swift
@@ -50,11 +50,25 @@ enum MeetingApp: String, CaseIterable {
             return Info(
                 displayName: "Google Meet",
                 badgeColor: Color(red: 0.0, green: 0.682, blue: 0.478), // #00AE7A
-                bundleIDPrefixes: [
-                    "meet.google.com",
-                    "com.google.chrome", "com.apple.safari",
-                    "company.thebrowser", "io.island"
-                ],
+                // Only the synthetic ID `MeetingDetector` uses for Meet —
+                // deliberately NOT the browsers that host it. A browser's
+                // bundle ID says the recording came from a browser, not that
+                // it came from a Google Meet call, so listing
+                // `com.apple.safari` here would badge every Safari
+                // system-audio capture — YouTube, a podcast, anything — as a
+                // Meet meeting, and `io.island` would badge one as Meet
+                // because Mila's own ID (`io.island.whisper.…`) starts with
+                // it. `MeetingAppTests` pins Safari to no meeting app for
+                // exactly this reason.
+                //
+                // The honest consequence: a browser capture the user started
+                // by hand gets the generic source icon rather than a guess.
+                // This case exists to keep the detector↔badge identity
+                // invariant (`MeetingDetectorAppsTests`) satisfiable — every
+                // detector entry must resolve to a badge — and it is no less
+                // reachable than Zoom's is from an auto-started recording,
+                // which persists no app identity at all.
+                bundleIDPrefixes: ["meet.google.com"],
                 matchSubstring: "meet.google.com"
             )
         }

--- a/MilaTests/MeetingAppTests.swift
+++ b/MilaTests/MeetingAppTests.swift
@@ -67,5 +67,37 @@ final class MeetingAppTests: XCTestCase {
     func test_zoom_and_teams_cases_exist_with_expected_display_names() {
         XCTAssertEqual(MeetingApp.zoom.info.displayName, "Zoom")
         XCTAssertEqual(MeetingApp.teams.info.displayName, "Microsoft Teams")
+        XCTAssertEqual(MeetingApp.googleMeet.info.displayName, "Google Meet")
+    }
+
+    /// Google Meet's only bundle-ID prefix is the detector's synthetic
+    /// `meet.google.com`, so a recording that came from a detected Meet call
+    /// still gets the Meet badge.
+    func test_matching_bundle_id_finds_google_meet_by_its_synthetic_id() {
+        XCTAssertEqual(MeetingApp.matching(bundleID: "meet.google.com"), .googleMeet)
+        XCTAssertEqual(MeetingApp.matching(bundleID: "MEET.GOOGLE.COM"), .googleMeet)
+    }
+
+    /// The browsers that *host* Meet must never be listed as Meet's bundle-ID
+    /// prefixes. A browser's bundle ID says the recording came from a browser,
+    /// not that it came from a Google Meet call, so listing them would badge
+    /// every Chrome or Safari system-audio capture as a Meet meeting — and
+    /// `io.island` would badge one as Meet because Mila's own bundle ID
+    /// (`io.island.whisper.IslandWhisper`) starts with it.
+    ///
+    /// `test_matching_bundle_id_rejects_lookalike_identifiers` above already
+    /// pins Safari; this covers the rest of the browsers and Mila itself.
+    func test_host_browsers_are_not_badged_as_google_meet() {
+        for bundleID in ["com.google.Chrome", "com.apple.Safari",
+                         "company.thebrowser.Browser", "io.island.Island",
+                         "io.island.whisper.IslandWhisper"] {
+            XCTAssertNil(
+                MeetingApp.matching(bundleID: bundleID),
+                """
+                \(bundleID) is a browser (or Mila itself), not evidence of a \
+                Google Meet call — it must not carry the Meet badge.
+                """
+            )
+        }
     }
 }

--- a/MilaTests/MeetingDetectorAppsTests.swift
+++ b/MilaTests/MeetingDetectorAppsTests.swift
@@ -8,15 +8,19 @@ import XCTest
 @MainActor
 final class MeetingDetectorAppsTests: XCTestCase {
 
-    func test_every_supported_app_declares_a_capture_prefix() {
+    func test_every_supported_app_has_a_detection_path() {
         for app in MeetingDetector.supportedApps {
-            XCTAssertFalse(
-                app.captureBundlePrefixes.isEmpty,
+            // Native apps (Zoom, Teams) use captureBundlePrefixes.
+            // Browser apps use their own bundleID for mic-capture
+            // matching (case-insensitive prefix against helper
+            // processes) plus title hints as a fallback on older macOS.
+            let hasCapturePrefixes = !app.captureBundlePrefixes.isEmpty
+            let hasTitleFallback = !app.meetingTitleHints.isEmpty
+            XCTAssertTrue(
+                hasCapturePrefixes || hasTitleFallback,
                 """
-                \(app.displayName) has no captureBundlePrefixes, so the \
-                primary signal (Core Audio per-process mic capture) can \
-                never fire for it. Window titles are a fallback, never the \
-                main detection path.
+                \(app.displayName) has neither captureBundlePrefixes nor \
+                meetingTitleHints — it can never be detected by any path.
                 """
             )
         }
@@ -45,6 +49,9 @@ final class MeetingDetectorAppsTests: XCTestCase {
 
     func test_canonical_bundle_id_is_covered_by_its_own_capture_prefixes() {
         for app in MeetingDetector.supportedApps {
+            // Browser apps have empty captureBundlePrefixes — they use
+            // their bundleID directly for case-insensitive mic matching.
+            guard !app.captureBundlePrefixes.isEmpty else { continue }
             XCTAssertTrue(
                 app.captureBundlePrefixes.contains { app.bundleID.hasPrefix($0) },
                 """

--- a/MilaTests/MeetingDetectorAppsTests.swift
+++ b/MilaTests/MeetingDetectorAppsTests.swift
@@ -8,22 +8,48 @@ import XCTest
 @MainActor
 final class MeetingDetectorAppsTests: XCTestCase {
 
-    func test_every_supported_app_has_a_detection_path() {
+    /// Every app must be reachable by the PRIMARY signal (Core Audio
+    /// per-process mic capture). Window titles remain a fallback, never the
+    /// main detection path — the same invariant this test has always held,
+    /// widened only in *where* the bundle IDs may come from.
+    ///
+    /// Native apps (Zoom, Teams) declare `captureBundlePrefixes`. A
+    /// browser-hosted entry (Google Meet) declares none, because it captures
+    /// under a host browser's ID — so for it the primary signal is
+    /// `appBundleIDs` plus `helperBundlePrefixes`. An entry with all three
+    /// empty can only ever be detected on macOS < 14.4, which is not a
+    /// feature anyone would ship on purpose.
+    func test_every_supported_app_is_reachable_by_mic_capture() {
         for app in MeetingDetector.supportedApps {
-            // Native apps (Zoom, Teams) use captureBundlePrefixes.
-            // Browser apps use their own bundleID for mic-capture
-            // matching (case-insensitive prefix against helper
-            // processes) plus title hints as a fallback on older macOS.
-            let hasCapturePrefixes = !app.captureBundlePrefixes.isEmpty
-            let hasTitleFallback = !app.meetingTitleHints.isEmpty
-            XCTAssertTrue(
-                hasCapturePrefixes || hasTitleFallback,
+            let micCaptureIDs =
+                app.captureBundlePrefixes + app.appBundleIDs + app.helperBundlePrefixes
+            XCTAssertFalse(
+                micCaptureIDs.isEmpty,
                 """
-                \(app.displayName) has neither captureBundlePrefixes nor \
-                meetingTitleHints — it can never be detected by any path.
+                \(app.displayName) declares no bundle IDs for the mic-capture \
+                path, so the primary signal can never fire for it. Window \
+                titles are a fallback (macOS < 14.4), never the main \
+                detection path.
                 """
             )
         }
+    }
+
+    /// Google Meet is not an app — it is a tab. The entry has to name the
+    /// browsers that host it, or `isRunning` / the window-title fallback have
+    /// nothing to look at, and the mic-capture path has no prefix to match.
+    func test_google_meet_names_the_browsers_that_host_it() throws {
+        let meet = try XCTUnwrap(
+            MeetingDetector.supportedApps.first { $0.bundleID == "meet.google.com" },
+            "Google Meet (meet.google.com) is not a supported app"
+        )
+        for browser in ["com.google.Chrome", "com.apple.Safari",
+                        "company.thebrowser.Browser", "io.island.Island"] {
+            XCTAssertTrue(meet.appBundleIDs.contains(browser),
+                          "Google Meet does not list \(browser) as a host browser")
+        }
+        XCTAssertTrue(meet.captureBundlePrefixes.isEmpty,
+                      "A browser-hosted entry captures under its host's ID, not its own")
     }
 
     /// The live detector (Core Audio bundle IDs) and the saved-recording

--- a/MilaTests/MeetingDetectorBrowserDetectionTests.swift
+++ b/MilaTests/MeetingDetectorBrowserDetectionTests.swift
@@ -1,0 +1,336 @@
+import XCTest
+@testable import Mila
+
+/// Behaviour tests for the two signals that decide "you are in a meeting",
+/// driven directly through the pure matchers
+/// (`MeetingDetector.micCaptureIndicatesMeeting` /
+/// `.titleIndicatesMeeting`) so no Core Audio, browser, microphone or Screen
+/// Recording permission is involved.
+///
+/// `MeetingDetectorAppsTests` guards the *shape* of the app table and
+/// `MeetingStopPromptTests` the start/end state machine; this file covers the
+/// step between them — turning a set of mic-capturing bundle IDs, or a list of
+/// window titles, into a detection.
+///
+/// Google Meet is the reason this file exists. Meet has no app of its own, so
+/// its entry matches four host browsers and their helper processes, and both
+/// the matching and the *non*-matching cases need pinning: a prefix broad
+/// enough to catch a browser's helper is also broad enough to catch the wrong
+/// app entirely.
+@MainActor
+final class MeetingDetectorBrowserDetectionTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private static let meetID = "meet.google.com"
+    private static let zoomID = "us.zoom.xos"
+    private static let teamsID = "com.microsoft.teams2"
+
+    /// Mila's own bundle ID (`project.yml`: `PRODUCT_BUNDLE_IDENTIFIER`).
+    /// Hard-coded rather than read from `Bundle.main`, whose identifier under
+    /// the test host is the host app's — the point is to pin the literal
+    /// string the shipping app runs as.
+    private static let milaBundleID = "io.island.whisper.IslandWhisper"
+
+    private func supportedApp(_ bundleID: String) throws -> MeetingDetector.App {
+        try XCTUnwrap(
+            MeetingDetector.supportedApps.first { $0.bundleID == bundleID },
+            "\(bundleID) is not in MeetingDetector.supportedApps"
+        )
+    }
+
+    /// The bundle ID each browser's mic capture actually surfaces under.
+    /// Browsers hand capture to a helper subprocess, so these are the IDs
+    /// Core Audio reports — not the browsers' own.
+    private let browserCaptureIDs: [(browser: String, capturingBundleID: String)] = [
+        ("Chrome", "com.google.Chrome.helper (Renderer)"),
+        ("Safari", "com.apple.WebKit.GPU"),
+        ("Arc", "company.thebrowser.browser.helper"),
+        ("Island", "io.island.Island.helper"),
+    ]
+
+    /// A Google Meet call as each browser titles its window: Chromium-based
+    /// browsers append their own name, Safari and Arc show the page title
+    /// alone. `Meet - <meeting code>` is the in-call title; the raw URL shows
+    /// up in place of a title while the page is still loading.
+    private let meetWindowTitles: [(browser: String, title: String)] = [
+        ("Chrome", "Meet - abc-defg-hij - Google Chrome"),
+        ("Safari", "Meet - abc-defg-hij"),
+        ("Arc", "Meet - abc-defg-hij"),
+        ("Island", "Meet - abc-defg-hij - Island"),
+        ("Chrome, still loading", "meet.google.com/abc-defg-hij - Google Chrome"),
+    ]
+
+    // MARK: - Mic capture: Google Meet in each browser
+
+    /// The primary path on macOS 14.4+. Each supported browser, capturing
+    /// under its real helper bundle ID, must read as a Meet meeting.
+    func test_google_meet_is_detected_when_any_supported_browser_captures_the_mic() throws {
+        let meet = try supportedApp(Self.meetID)
+        for (browser, capturingBundleID) in browserCaptureIDs {
+            XCTAssertTrue(
+                MeetingDetector.micCaptureIndicatesMeeting(
+                    meet, capturing: [capturingBundleID]),
+                """
+                \(browser) capturing the mic as \(capturingBundleID) was not \
+                read as a Google Meet call — Meet in \(browser) would never \
+                prompt.
+                """
+            )
+        }
+    }
+
+    /// A browser capturing under its own bundle ID (rather than a helper)
+    /// counts too — which one is used varies by browser and version.
+    func test_google_meet_is_detected_when_the_browser_itself_captures() throws {
+        let meet = try supportedApp(Self.meetID)
+        for bundleID in ["com.google.Chrome", "com.apple.Safari",
+                         "company.thebrowser.Browser", "io.island.Island"] {
+            XCTAssertTrue(
+                MeetingDetector.micCaptureIndicatesMeeting(meet, capturing: [bundleID]),
+                "\(bundleID) capturing the mic should read as a Google Meet call"
+            )
+        }
+    }
+
+    /// The regression that matters most, and the reason this file exists.
+    ///
+    /// Mila captures the microphone itself — while recording, and also while
+    /// the Settings ▸ Audio Input VU meter is live (`InputLevelMonitor` opens
+    /// its own `AVAudioEngine` input tap when Mila is *not* recording). Its
+    /// bundle ID is `io.island.whisper.IslandWhisper`, so a Meet helper prefix
+    /// of `io.island` — rather than `io.island.Island` for the Island browser
+    /// — makes Mila detect *itself*: opening Mila's own audio settings pops a
+    /// "Google Meet meeting detected — start transcribing?" prompt, and a mic
+    /// drop mid-recording pops "meeting ended — stop recording?".
+    ///
+    /// No entry may claim Mila, by any of its three prefix lists.
+    func test_mila_capturing_its_own_mic_is_never_a_meeting() {
+        for app in MeetingDetector.supportedApps {
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(
+                    app, capturing: [Self.milaBundleID]),
+                """
+                \(app.displayName) claims Mila's own bundle ID \
+                (\(Self.milaBundleID)) as a meeting. Mila captures the mic \
+                while recording and while the Settings VU meter runs, so this \
+                prompts the user about their own audio settings pane. Narrow \
+                the prefix (`io.island.Island`, not `io.island`).
+                """
+            )
+        }
+    }
+
+    /// Nothing capturing ⇒ nothing detected. The empty set is the state the
+    /// poll sees most of the time, so it must not match a zero-length prefix
+    /// or an empty prefix list.
+    func test_nothing_capturing_detects_nothing() {
+        for app in MeetingDetector.supportedApps {
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(app, capturing: []),
+                "\(app.displayName) detected a meeting with no process capturing audio"
+            )
+        }
+    }
+
+    /// Negative control on the *host* dimension: a browser capturing the mic
+    /// must not be read as a Zoom or Teams call, and the native apps must not
+    /// be read as Meet. Without this, "is anything capturing?" would pass the
+    /// browser tests above just as well.
+    func test_capture_by_one_app_is_not_attributed_to_another() throws {
+        let meet = try supportedApp(Self.meetID)
+        let zoom = try supportedApp(Self.zoomID)
+        let teams = try supportedApp(Self.teamsID)
+
+        for (browser, capturingBundleID) in browserCaptureIDs {
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(
+                    zoom, capturing: [capturingBundleID]),
+                "\(browser) (\(capturingBundleID)) was read as a Zoom meeting"
+            )
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(
+                    teams, capturing: [capturingBundleID]),
+                "\(browser) (\(capturingBundleID)) was read as a Teams meeting"
+            )
+        }
+
+        for nativeID in ["us.zoom.CptHost", "com.microsoft.teams2"] {
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(meet, capturing: [nativeID]),
+                "\(nativeID) was read as a Google Meet call"
+            )
+        }
+    }
+
+    /// Unrelated mic users must not register as any meeting — including apps
+    /// whose IDs merely *resemble* a supported one. `net.us.zoom.fake` and
+    /// `io.islandapp.Browser` are the prefix-anchoring cases: a `contains`
+    /// match would let the first through, and an `io.island` prefix (the bug
+    /// pinned above) would let the second through. A Slack huddle is the
+    /// realistic non-Meet call — a live audio session that is emphatically
+    /// not Google Meet.
+    func test_unrelated_mic_users_are_not_meetings() {
+        let strangers: Set<String> = [
+            "com.apple.Terminal",
+            "com.tinyspeck.slackmacgap",
+            "net.us.zoom.fake",
+            "com.google.GoogleDrive",
+            "com.island.something.else",
+            "io.islandapp.Browser",
+            "com.brave.Browser",
+        ]
+        for app in MeetingDetector.supportedApps {
+            XCTAssertFalse(
+                MeetingDetector.micCaptureIndicatesMeeting(app, capturing: strangers),
+                "\(app.displayName) matched one of: \(strangers.sorted().joined(separator: ", "))"
+            )
+        }
+    }
+
+    /// Matching is case-insensitive on both sides: bundle IDs are
+    /// conventionally lowercase, nothing enforces it, and the helper prefixes
+    /// are written lowercase.
+    func test_capture_matching_is_case_insensitive() throws {
+        let meet = try supportedApp(Self.meetID)
+        let zoom = try supportedApp(Self.zoomID)
+        XCTAssertTrue(
+            MeetingDetector.micCaptureIndicatesMeeting(
+                meet, capturing: ["COM.GOOGLE.CHROME.HELPER"]),
+            "An upper-cased Chrome helper ID should still match"
+        )
+        XCTAssertTrue(
+            MeetingDetector.micCaptureIndicatesMeeting(zoom, capturing: ["US.ZOOM.XOS"]),
+            "An upper-cased Zoom ID should still match"
+        )
+    }
+
+    /// The pre-existing signal still works — this feature must not have
+    /// narrowed it while widening the table.
+    func test_native_apps_are_still_detected_by_their_own_capture() throws {
+        let zoom = try supportedApp(Self.zoomID)
+        let teams = try supportedApp(Self.teamsID)
+        XCTAssertTrue(
+            MeetingDetector.micCaptureIndicatesMeeting(zoom, capturing: ["us.zoom.CptHost"]),
+            "Zoom's helper process must still be detected"
+        )
+        XCTAssertTrue(
+            MeetingDetector.micCaptureIndicatesMeeting(teams, capturing: ["com.microsoft.teams2"]),
+            "Teams must still be detected by mic capture"
+        )
+    }
+
+    // MARK: - Window titles: the macOS < 14.4 fallback
+
+    /// The fallback path. A Meet call in each browser, titled the way that
+    /// browser titles it, must be recognised.
+    func test_google_meet_is_detected_from_each_browsers_window_title() throws {
+        let meet = try supportedApp(Self.meetID)
+        for (browser, title) in meetWindowTitles {
+            XCTAssertTrue(
+                MeetingDetector.titleIndicatesMeeting(meet, titles: [title]),
+                "\(browser)'s in-call window title \"\(title)\" was not recognised as Meet"
+            )
+        }
+    }
+
+    /// A Meet call in one window among several ordinary ones still counts —
+    /// the user has other windows open.
+    func test_a_meet_window_among_other_windows_is_detected() throws {
+        let meet = try supportedApp(Self.meetID)
+        let titles = [
+            "Inbox (12) - name@example.com - Google Chrome",
+            "Meet - abc-defg-hij - Google Chrome",
+            "Untitled - TextEdit",
+        ]
+        XCTAssertTrue(
+            MeetingDetector.titleIndicatesMeeting(meet, titles: titles),
+            "A Meet window alongside other windows should still be detected"
+        )
+    }
+
+    /// Negative control for the title path: ordinary browsing must not read
+    /// as a call. "Meet the team" is the deliberately deceptive one — a page
+    /// whose title starts with the word *meet* — and it must not match,
+    /// because the hint is `meet -` (the `Meet - <code>` in-call shape), not
+    /// a bare `meet`. Nor may a support article *about* Meet match.
+    func test_ordinary_browser_windows_are_not_meetings() throws {
+        let meet = try supportedApp(Self.meetID)
+        let innocent = [
+            "Inbox (12) - name@example.com - Google Chrome",
+            "Meet the team - Acme Corp - Google Chrome",
+            "Meeting notes.md - Obsidian",
+            "google.com - Google Chrome",
+            "YouTube - Google Chrome",
+            "New Tab - Google Chrome",
+            "Google Meet: how to join a call - Support - Safari",
+        ]
+        for title in innocent {
+            XCTAssertFalse(
+                MeetingDetector.titleIndicatesMeeting(meet, titles: [title]),
+                "\"\(title)\" was read as an active Google Meet call"
+            )
+        }
+        XCTAssertFalse(
+            MeetingDetector.titleIndicatesMeeting(meet, titles: innocent),
+            "No window in an ordinary browsing session is a Meet call"
+        )
+    }
+
+    /// No windows at all (the Screen Recording permission is missing, so
+    /// titles come back empty) must read as "no meeting", never as a match.
+    func test_no_window_titles_detects_nothing() {
+        for app in MeetingDetector.supportedApps {
+            XCTAssertFalse(
+                MeetingDetector.titleIndicatesMeeting(app, titles: []),
+                """
+                \(app.displayName) reported a meeting from an empty title \
+                list — that is the no-Screen-Recording-permission case, and \
+                it must fail closed.
+                """
+            )
+        }
+    }
+
+    /// An app that declares no hints opts out of the title path entirely, and
+    /// an empty hint list must never be read as "match anything". Teams is
+    /// the case: every Teams window is titled "… | Microsoft Teams", so no
+    /// hint can tell a call from the app merely being open.
+    func test_teams_opts_out_of_title_detection() throws {
+        let teams = try supportedApp(Self.teamsID)
+        XCTAssertTrue(teams.meetingTitleHints.isEmpty,
+                      "Teams is deliberately title-hint-free")
+        XCTAssertFalse(
+            MeetingDetector.titleIndicatesMeeting(
+                teams,
+                titles: ["Chat | Microsoft Teams", "Calendar | Microsoft Teams"]),
+            "Teams must not be detected from a window title"
+        )
+    }
+
+    /// Zoom's own title hint still works, and is still specific to a meeting
+    /// window rather than the app being open.
+    func test_zoom_title_detection_is_unchanged() throws {
+        let zoom = try supportedApp(Self.zoomID)
+        XCTAssertTrue(
+            MeetingDetector.titleIndicatesMeeting(zoom, titles: ["Zoom Meeting"]),
+            "Zoom's meeting window title must still be recognised"
+        )
+        XCTAssertFalse(
+            MeetingDetector.titleIndicatesMeeting(zoom, titles: ["Zoom Workplace"]),
+            "Zoom's idle window must not read as a meeting"
+        )
+    }
+
+    // MARK: - Browser-hosted flag
+
+    /// `isBrowserHosted` drives whether minimized windows are searched. Meet
+    /// needs them (minimizing the browser mid-call must not end the meeting);
+    /// the native apps keep the narrower on-screen-only search they had.
+    func test_only_browser_hosted_entries_search_minimized_windows() throws {
+        XCTAssertTrue(try supportedApp(Self.meetID).isBrowserHosted,
+                      "Google Meet is hosted in a browser, so minimized windows must count")
+        XCTAssertFalse(try supportedApp(Self.zoomID).isBrowserHosted)
+        XCTAssertFalse(try supportedApp(Self.teamsID).isBrowserHosted)
+    }
+}

--- a/MilaTests/MeetingStopPromptTests.swift
+++ b/MilaTests/MeetingStopPromptTests.swift
@@ -187,4 +187,37 @@ final class MeetingStopPromptTests: XCTestCase {
         XCTAssertEqual(ended.count, 2,
                        "Re-joining and ending a second meeting should fire meetingEnded again")
     }
+
+    // MARK: - Browser (title-only) detection
+
+    /// Apps with empty `captureBundlePrefixes` (browsers running Google
+    /// Meet) are detected by window title only. Verify they exist in
+    /// `supportedApps` and that the state machine handles them the same
+    /// way as mic-capture apps.
+    func test_browser_apps_have_title_hints_and_empty_capture_prefixes() {
+        let browsers = MeetingDetector.supportedApps.filter {
+            $0.captureBundlePrefixes.isEmpty
+        }
+        XCTAssertFalse(browsers.isEmpty,
+                       "At least one browser should be in supportedApps for Google Meet")
+        for app in browsers {
+            XCTAssertFalse(app.meetingTitleHints.isEmpty,
+                           "\(app.displayName) has empty prefixes but also empty title hints — it can never be detected")
+        }
+    }
+
+    func test_browser_app_triggers_meeting_started_via_state_machine() throws {
+        let detector = MeetingDetector(endConfirmationPolls: 2)
+        var started: [MeetingDetector.App] = []
+        let cancellable = detector.meetingStarted.sink { started.append($0) }
+        defer { cancellable.cancel() }
+
+        let meet = try XCTUnwrap(MeetingDetector.supportedApps.first {
+            $0.bundleID == "meet.google.com"
+        })
+        detector.simulatePollForTesting(activeBundleIDs: [meet.bundleID])
+
+        XCTAssertEqual(started.map(\.bundleID), [meet.bundleID],
+                       "A browser app should trigger meetingStarted the same as any other app")
+    }
 }


### PR DESCRIPTION
Closes #21

## Credit: this feature is @noamleibovitch's work

**Google Meet detection was designed and written by @noamleibovitch. This PR
relays it — it supersedes #214, which is where the work actually happened.**
His commit is cherry-picked unmodified, so he is the `Author` on it; everything
I added sits in a single commit on top, and it is bug fixes plus tests, not the
feature.

> **On the `Co-authored-by` trailer.** My commit credits
> `67009220+noamleibovitch@users.noreply.github.com` rather than the address on
> his commits: `git log` on #214 reports `noam@example.com` for both of them — a
> placeholder in his local git config, which would not link to his account. The
> cherry-picked commit keeps that address verbatim as its `Author`; the trailer
> on mine uses his GitHub noreply address so at least one of the two resolves.

Relayed rather than merged for the usual reason (the #129 → #164 and #198 → #204
precedent): a fork PR can't get an automated review under the contributor's own
quota, and its CI needs per-run approval on every run.

## Scope: one of #214's two commits is relayed

#214's branch carries two commits. Only the first is here:

- **`31a1b39` feat(meetings): detect Google Meet…** — relayed. It is what the PR
  title, the PR body and #21 describe.
- **`99e19de` feat(speakers): on-demand voice embedding from any recording** —
  **not relayed.** It is an unrelated second feature (a new
  `SpeakerDiarizer.embedSpeakers` inline-Python path plus batch voice matching in
  `MilaApp`, +222 lines across the diarization pipeline), it is not mentioned
  anywhere in #214's description — which in fact says "No changes to the
  transcription pipeline" — it has no linked issue of its own, and it touches the
  one area of this codebase where review is least optional. It deserves its own
  PR against its own issue, not a free ride on a meeting-detection review.
  @noamleibovitch — the commit is untouched on your branch; please open it
  separately and I'll review it properly.

## What & why

Google Meet joins Zoom and Microsoft Teams in `MeetingDetector.supportedApps`.
Meet has no app of its own, so the entry names the browsers that host it
(Chrome, Safari, Arc, Island) plus the helper processes they capture under, and
`MeetingApp` gains a `.googleMeet` badge case.

Mechanically, three things changed in the detector: entries gained
`appBundleIDs` / `helperBundlePrefixes` so a meeting can be hosted by another
app; the poll loop learned to match an entry that declares no
`captureBundlePrefixes` of its own; and the window-title fallback can search
minimized windows, so minimizing a browser mid-call is not read as the call
ending.

## The window-title rationale does not survive review — because the code does not implement it

Worth reading before the diff, since **#214's stated design and #214's code are
opposites.**

The PR body and commit message say:

> Google Meet runs inside a browser, so mic-capture detection would trigger on
> any tab with microphone access. Use window-title matching instead.

The code does the reverse: for browser-hosted entries it matches **mic capture**
whenever the Core Audio per-process API is available, and consults window titles
only when that API is missing — i.e. macOS < 14.4, below which almost no user
sits (the app's floor is 14.0). A comment inside the diff gives the real reason
("macOS 26 hides titles from `CGWindowListCopyWindowInfo`… mic capture is the
only cross-version signal"), so this looks like a mid-PR change of direction
that the description never caught up with.

**I kept the code's design, not the body's, and I think that is the right call —
but not for the reason the comment gives.** What I could verify:

- **Title matching cannot work as a primary signal here, and the reason is not
  Tahoe.** A window title reflects only the **frontmost tab**. Switch away from
  the Meet tab to take notes and the title is gone, so a title-primary detector
  reads a live call as ended and offers to **stop a recording that should keep
  running** — mid-meeting, which is the worst moment to be wrong.
  `includeOffScreen` does not help: it fixes minimized *windows*, not background
  *tabs*. That is a verifiable property of window titles; the Tahoe claim is one
  I cannot check from here (no macOS in this environment) and it is not needed.
- **Titles also need Screen Recording (TCC), which Mila otherwise does not
  require.** Nothing in `Mila/Resources/Mila.entitlements` or `Info.plist` asks
  for it, and `CGWindowListCopyWindowInfo` returns titles only with it granted —
  so on the title path, detection silently does nothing for most users. Mic
  capture (`kAudioProcessPropertyIsRunningInput`) needs no permission and shows
  no prompt.
- **The cost is real and is stated in the code now:** mic capture proves *a
  browser is in a live audio session*, not *that the session is Meet*. A Slack
  huddle, WhatsApp Web call or Discord tab in a supported browser reads as a
  Meet meeting. The false-positive surface is genuinely wider than Zoom's or
  Teams', and this trades the false-positive class the PR body was worried about
  for a false-negative class that is worse.
- **What makes that acceptable rather than a blocker:** the prompt is a
  10-second auto-dismissing offer (`autoDismissSeconds = 10` in
  `MeetingPromptOverlay`), it never acts on its own, `handleMeetingStart` is
  suppressed while already recording, and it is per-app silenceable. When it
  misfires, the user is in *some* call and Mila offered to transcribe it. Judged
  against this repo's own standard — "no detection beats a false one", from the
  Teams entry — a browser capturing the mic is a much narrower claim than
  "Teams is open", which is what that comment refused.

**The label is the part I would still change, and I have deliberately left it
for you.** The signal supports "you're in a browser call"; the UI says "Google
Meet meeting detected". I shortened `displayName` from
`"Google Meet (Chrome, Safari, Arc, Island)"` to `"Google Meet"` (that string is
interpolated into "X meeting detected", where the parenthetical read badly) but
did not rename the concept, because #21 asks for Google Meet specifically and
renaming it is a product call, not a bug fix.

Two smaller things I could not verify and would want a second pair of eyes on:

- **The Island browser's bundle ID is assumed to be `io.island.Island`.** If the
  shipping ID differs, Island detection silently never fires — and this is the
  one entry nobody outside the org can check.
- **`com.apple.webkit` is the broadest prefix in the table.** It is required
  (Safari captures as `com.apple.WebKit.GPU`, which `com.apple.Safari` does not
  prefix) but it also matches a `WKWebView` capturing audio inside some *other*
  app, which would then read as Meet.

## What I fixed on top

### 1. Mila detected *itself* as a Google Meet call

`helperBundlePrefixes` contained `io.island`. Mila's own bundle ID is
`io.island.whisper.IslandWhisper`, which that prefix matches.

Mila captures the microphone while recording **and while the Settings ▸ Audio
Input VU meter is live** — `InputLevelMonitor` opens its own `AVAudioEngine`
input tap when Mila is *not* recording. So `bundleIDsCapturingMicInput()` reports
Mila to the detector, the Meet entry matched it, and **opening Mila's own audio
settings pane was enough to pop "Google Meet meeting detected — start
transcribing?"**. The other end of it: a mic drop while recording (device switch,
the meter fighting the recorder) would clear the streak and pop "meeting ended —
stop recording?" over a live recording.

Fixed by narrowing to `io.island.Island` (via `appBundleIDs`), which does not
prefix Mila. While there, the other helper prefixes were redundant or worse:
`com.google.chrome` duplicated the browser's own ID exactly, and
`company.thebrowser` was *shorter* than Arc's own ID (it also owns Dia). Since
matching is prefix-based, a browser's own bundle ID already covers its `.helper`
children, so only Safari needs an entry.

### 2. The badge change turned two existing tests red

`MeetingApp.googleMeet` listed the host browsers in `bundleIDPrefixes` — a field
documented as "the authoritative signal". A browser's bundle ID is not evidence
of a Meet call, and two tests already on `main` say so:

- `MeetingAppTests.test_matching_bundle_id_rejects_lookalike_identifiers` pins
  `com.apple.Safari` to *no* meeting app.
- `RecordingTests.test_detected_meeting_app_falls_back_when_bundle_id_unknown`
  uses `com.apple.Safari` as its *unknown* bundle ID and expects the appName pass
  to win; it would have resolved `.googleMeet` instead.

Beyond the red, the user-visible effect: **every** Safari or Chrome system-audio
capture — YouTube, a podcast, a lecture — would have been badged "Google Meet",
and `io.island` would have badged one because Mila's own ID starts with it. Meet
now claims only the detector's synthetic `meet.google.com`; a hand-started
browser capture gets the generic source icon instead of a guess.

### 3. The new matching logic was unreachable from tests

It lived inline in `pollOnce()` behind Core Audio and `CGWindowListCopyWindowInfo`,
so neither the four-browser matching nor the self-match above could be exercised
at all. Extracted two pure statics — `micCaptureIndicatesMeeting` and
`titleIndicatesMeeting` — leaving the impure halves (`bundleIDsCapturingMicInput`,
the new `windowTitles(for:includeOffScreen:)`) as the only parts that need a real
machine. That also collapsed the browser/native branch in `pollOnce`: both classes
now match against the union of their bundle-ID lists, so there is one matcher
rather than two that can drift apart. `includeOffScreen` moved onto
`App.isBrowserHosted`, so Zoom keeps its on-screen-only search unchanged.

Window titles are user content and are still never logged, per
`bugbot-rules/no-user-content-in-logs.md` — the new `windowTitles(for:)` returns
them to the matcher and no `Logger` call touches them. The only interpolated
values in this file remain hard-coded `displayName`s and bundle IDs, which are
correctly `privacy: .public`.

## How it was tested

**Not built and not run.** This environment is Linux with no Xcode, no
`xcodebuild` and no Swift toolchain at all, so verification here was careful
reading plus CI. Every symbol referenced in the new tests was grepped for
existence, and the new file mirrors the idioms of the two neighbouring test files
(`@MainActor final class`, `XCTUnwrap` for table lookups, message-carrying
assertions). **CI's `unit-and-ui-tests` is the first thing that compiles this.**

New `MilaTests/MeetingDetectorBrowserDetectionTests.swift` — 13 tests, each
paired with a negative control so the positives mean something:

| Test | Fails on `main` because |
|---|---|
| Meet detected from each browser's **helper capture ID** (Chrome `com.google.Chrome.helper`, Safari `com.apple.WebKit.GPU`, Arc `company.thebrowser.browser.helper`, Island `io.island.Island.helper`) | there is no Meet entry to unwrap, and no matcher to call |
| Meet detected from each browser's **in-call window title** (`Meet - abc-defg-hij - Google Chrome`, Safari/Arc bare, `… - Island`, plus the still-loading `meet.google.com/…` form) | same |
| Meet detected when the browser captures under **its own** ID | same |

Negative controls, in the same file:

- **`test_mila_capturing_its_own_mic_is_never_a_meeting`** — the regression for
  fix 1, and it fails on #214's own code, not just on `main`.
- a browser is never read as Zoom or Teams, and neither native app is read as
  Meet (without this, "is *anything* capturing?" would pass every positive above)
- lookalike and unrelated mic users match nothing: `net.us.zoom.fake`,
  `io.islandapp.Browser` (which an `io.island` prefix *would* match),
  `com.brave.Browser`, and a Slack huddle — the realistic non-Meet call
- ordinary browsing titles are not calls: `Meet the team - Acme Corp`, a support
  article *about* Meet, Gmail, YouTube, New Tab
- an empty title list (no Screen Recording permission) and an empty capture set
  both fail closed
- Teams still opts out of the title path entirely; Zoom's own title hint and
  helper capture still work

`MeetingAppTests` gains the badge cases (Meet resolves from `meet.google.com`;
the four browsers **and** Mila's own ID resolve to nothing).
`MeetingDetectorAppsTests`'s `test_every_supported_app_has_a_detection_path` is
restored to the strength it had on `main`: #214 had weakened it to accept a title
fallback *in place of* the primary signal, and it now requires every entry to be
reachable by mic capture — which for a browser-hosted entry means `appBundleIDs`.

Not verified: no run against a real Meet call in any of the four browsers, and
the Island bundle ID above.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not
      possible in this environment (no Xcode/Swift); left to CI**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] README changelog — N/A, entries are written per release, not per PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how meeting start/stop prompts fire, with intentional false positives when supported browsers capture the mic; prefix rules must stay tight to avoid self-detection or over-broad WebKit matching.
> 
> **Overview**
> Adds **Google Meet** to live meeting detection and recording badges alongside Zoom and Teams. Meet is modeled as a **browser-hosted** entry (synthetic `meet.google.com` identity) that matches mic capture from Chrome, Safari, Arc, and Island—including helper processes such as Safari’s WebKit GPU—and falls back to window-title hints only when the Core Audio per-process API is unavailable.
> 
> **`MeetingDetector`** grows `appBundleIDs`, `helperBundlePrefixes`, and `isBrowserHosted`; unifies detection through testable pure matchers `micCaptureIndicatesMeeting` and `titleIndicatesMeeting`; and for browser-hosted apps can include **minimized** windows in the title fallback so a minimized browser mid-call does not look like the meeting ended. On macOS 14.4+, Meet is inferred when a listed browser is capturing the mic (any tab with live audio may surface as “Google Meet,” by design).
> 
> **`MeetingApp`** adds `.googleMeet` with badge matching on the synthetic `meet.google.com` ID only—not host browser bundle IDs—so generic browser captures are not mislabeled.
> 
> Relay fixes on top narrow Island prefix matching so **Mila’s own mic** (settings VU meter / recording) is not detected as Meet, and add **`MeetingDetectorBrowserDetectionTests`** plus updated config/badge invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359c8c303b0249763e4767619a9d96b051b50788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->