### PR TITLE
feat(live): delete individual lines from the live transcript (relay of #125)

### DIFF
--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -185,6 +185,16 @@ final class LiveAISession: ObservableObject {
         self.liveAISettings = liveAISettings
     }
 
+    /// Inject rolling AI output without invoking an LLM. Same idiom (and same
+    /// justification) as `LiveTranscriber.seedForTesting`: `summary` and
+    /// `actionItems` are `private(set)`, so a test asserting on what Stop
+    /// snapshots out of them has no other way in. Production paths must not
+    /// call this.
+    func seedForTesting(summary: String, actionItems: [ActionItem] = []) {
+        self.summary = summary
+        self.actionItems = actionItems
+    }
+
     /// Begin a session — clears any previous state. Generates a fresh
     /// session id when the user's LLM tool supports session continuity
     /// (Claude does; Cursor doesn't), so each recording gets its own

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -898,6 +898,27 @@ final class QuickActionsController: ObservableObject {
         updated.fullText = hasLiveSegments ? finalFullText : ""
         updated.summary = finalSummary.isEmpty ? nil : finalSummary
         updated.actionItems = finalItems.isEmpty ? nil : finalItems
+        if userEmptiedLiveTranscript {
+            // Emptying the live transcript is a DISCARD of the transcript, so
+            // the artifacts DERIVED from it go with it. Both were produced by
+            // the Live AI loop from text that no longer exists, and nothing
+            // downstream would replace them: `RecordingSummarizer.regenerate`
+            // bails on an empty `fullText` (and only ever writes `summary`,
+            // never `actionItems`), and an authoritative row owes no batch
+            // pass, so there is no completion hook either. Keeping them would
+            // leave the transcript reading clean while the deleted words sit
+            // in the `summary` field of `recordings.json` and in everything
+            // that reads the row — MCP `get_transcript` included, which serves
+            // summary + action items by default. (Cursor Bugbot on #229.)
+            //
+            // Scoped to a FULL emptying on purpose. A partial delete leaves a
+            // non-empty transcript, and dropping a meeting's whole summary
+            // because one line was removed would be its own data loss; that
+            // case is discussed on the PR (the summary is regenerated from the
+            // clean text, but `actionItems` are not).
+            updated.summary = nil
+            updated.actionItems = nil
+        }
         updated.status = liveTranscriptIsAuthoritative ? .completed : .pending
         // `update` reports whether the `.txt` sidecar AND recordings.json
         // actually landed on disk. Both used to fail silently, so the handoff

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -789,6 +789,11 @@ final class QuickActionsController: ObservableObject {
         // handler is skipping its `transcriber.stop()` /
         // `diarizer.stop()` while `isFinalizingRecording` is true.
         let finalLiveSegments = liveTranscriber?.segments ?? []
+        // Snapshotted here for the same reason as the segments themselves —
+        // before `liveTranscriber?.stop()` below — because it is what tells an
+        // emptied live transcript apart from one that never existed. See
+        // `liveTranscriptIsAuthoritative`.
+        let userDeletedLiveLines = liveTranscriber?.hasUserDeletedSegments ?? false
         let finalSummary = (liveAISession?.summary ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let finalItems = liveAISession?.actionItems ?? []
@@ -835,7 +840,21 @@ final class QuickActionsController: ObservableObject {
         // `vadActive` here is whatever was passed in by the caller —
         // typically `liveAISettings.useVAD && liveAISettings.enabled`.
         let hasLiveSegments = !finalLiveSegments.isEmpty
-        let liveTranscriptIsAuthoritative = hasLiveSegments && vadActive
+        // A live transcript the user EMPTIED by deleting every line is not the
+        // same thing as one that was never produced, and `hasLiveSegments`
+        // cannot tell them apart on its own. It exists for the second case: no
+        // live text means the live path gave us nothing, so fall back to the
+        // batch pass. Run that fallback after a hand-emptied transcript and the
+        // batch pass re-transcribes the WAV and writes every deleted line back
+        // into recordings.json, the `.txt` sidecar and the `.srt` — the
+        // resurrection `bugbot-rules/deleted-data-stays-deleted.md` describes,
+        // reached by the one route the UI-side gate cannot cover, because
+        // emptying `segments` is itself what flips this gate. Deleting every
+        // line is the strongest statement a user can make that this must not be
+        // recorded, so a deliberate emptying stays authoritative and saves
+        // empty. (Cursor Bugbot on #229.)
+        let userEmptiedLiveTranscript = userDeletedLiveLines && !hasLiveSegments
+        let liveTranscriptIsAuthoritative = (hasLiveSegments || userEmptiedLiveTranscript) && vadActive
         let finalTranscriptSegments: [TranscriptSegment] = finalLiveSegments.map { ls in
             TranscriptSegment(start: ls.startSeconds, end: ls.endSeconds,
                               text: ls.text, speaker: ls.speaker)

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -249,6 +249,15 @@ final class LiveTranscriber: ObservableObject {
         liveLog.log("LiveTranscriber.removeSegment start=\(seg.startSeconds, privacy: .public) end=\(seg.endSeconds, privacy: .public) remaining=\(self.segments.count, privacy: .public)")
     }
 
+    /// Whether the user deleted at least one line from THIS recording's live
+    /// transcript (reset by `start()` along with `deletedRanges`).
+    ///
+    /// Read at Stop, where it is the only thing that tells an *emptied* live
+    /// transcript apart from one that was never produced. Those two look
+    /// identical in `segments` and must be handled oppositely — see
+    /// `liveTranscriptIsAuthoritative` in `QuickActionsController.stopRecording`.
+    var hasUserDeletedSegments: Bool { !deletedRanges.isEmpty }
+
     /// Whether an incoming segment's absolute time range overlaps a range
     /// the user deleted. Any positive overlap counts — the intent of a
     /// delete is "drop what was said in that span," so re-emitted content

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -112,6 +112,13 @@ final class LiveTranscriber: ObservableObject {
     /// amount so `windowAbsoluteStart` in `runOnce` keeps producing
     /// correct absolute timestamps for the segment merge.
     private var samplesDropped: Int = 0
+    /// Absolute time ranges of segments the user deleted from the live
+    /// pane. Incoming whisper output overlapping any of these is dropped so
+    /// a just-deleted line can't reappear on a later tick — the fixed-window
+    /// path re-transcribes a rolling buffer and would otherwise re-emit the
+    /// deleted content. The VAD path emits each utterance once, so this is
+    /// mostly a safety net there. Cleared on `start()`.
+    private var deletedRanges: [(start: Double, end: Double)] = []
     private var inFlight: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
     private var language: String = "he"
@@ -140,6 +147,7 @@ final class LiveTranscriber: ObservableObject {
         self.language = language
         self.buffer.removeAll(keepingCapacity: true)
         self.samplesDropped = 0
+        self.deletedRanges = []
         self.fullText = ""
         self.segments = []
         self.speakerNames = [:]
@@ -224,6 +232,32 @@ final class LiveTranscriber: ObservableObject {
     /// never arrives via `ingest`).
     func pauseBoundary() {
         detector?.flushForPause()
+    }
+
+    /// Delete a line from the live transcript. Records the segment's time
+    /// range so a later whisper tick (fixed-window mode re-transcribes a
+    /// rolling buffer) can't re-emit it, removes it from `segments`, and
+    /// recomputes `fullText`. Because `segments` is `@Published`, the app's
+    /// feed loop picks the change up automatically (MCP sidecar + LLM
+    /// re-feed), and the Stop-time snapshot excludes the deleted line.
+    func removeSegment(id: UUID) {
+        guard let idx = segments.firstIndex(where: { $0.id == id }) else { return }
+        let seg = segments[idx]
+        deletedRanges.append((start: seg.startSeconds, end: seg.endSeconds))
+        segments.remove(at: idx)
+        fullText = segments.map(\.text).joined(separator: " ")
+        liveLog.log("LiveTranscriber.removeSegment start=\(seg.startSeconds, privacy: .public) end=\(seg.endSeconds, privacy: .public) remaining=\(self.segments.count, privacy: .public)")
+    }
+
+    /// Whether an incoming segment's absolute time range overlaps a range
+    /// the user deleted. Any positive overlap counts — the intent of a
+    /// delete is "drop what was said in that span," so re-emitted content
+    /// there should stay gone.
+    private func isSuppressed(start: Double, end: Double) -> Bool {
+        for r in deletedRanges where start < r.end && end > r.start {
+            return true
+        }
+        return false
     }
 
     func transcribeNow() async {
@@ -406,10 +440,14 @@ final class LiveTranscriber: ObservableObject {
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { continue }
             guard s.start < originalDuration else { continue }
+            let absStart = startSec + s.start
+            let absEnd = startSec + s.end
+            // Skip anything the user deleted from this time span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { continue }
             segments.append(LiveSegment(
                 id: UUID(),
-                startSeconds: startSec + s.start,
-                endSeconds: startSec + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true
@@ -464,10 +502,14 @@ final class LiveTranscriber: ObservableObject {
         let absoluteSegs: [LiveSegment] = whisperSegs.compactMap { s in
             let text = s.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
+            let absStart = windowAbsoluteStart + s.start
+            let absEnd = windowAbsoluteStart + s.end
+            // Don't resurrect a line the user deleted from this span.
+            guard !isSuppressed(start: absStart, end: absEnd) else { return nil }
             return LiveSegment(
                 id: UUID(),
-                startSeconds: windowAbsoluteStart + s.start,
-                endSeconds: windowAbsoluteStart + s.end,
+                startSeconds: absStart,
+                endSeconds: absEnd,
                 text: text,
                 speaker: nil,
                 stable: true

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -441,7 +441,10 @@ final class LiveTranscriber: ObservableObject {
             guard !text.isEmpty else { continue }
             guard s.start < originalDuration else { continue }
             let absStart = startSec + s.start
-            let absEnd = startSec + s.end
+            // Whisper can extend a last segment into the silence we padded
+            // onto short utterances. Clamp to the real audio so a delete
+            // cannot mark later utterances as suppressed.
+            let absEnd = min(startSec + s.end, startSec + originalDuration)
             // Skip anything the user deleted from this time span.
             guard !isSuppressed(start: absStart, end: absEnd) else { continue }
             segments.append(LiveSegment(

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -117,7 +117,9 @@ final class LiveTranscriber: ObservableObject {
     /// a just-deleted line can't reappear on a later tick — the fixed-window
     /// path re-transcribes a rolling buffer and would otherwise re-emit the
     /// deleted content. The VAD path emits each utterance once, so this is
-    /// mostly a safety net there. Cleared on `start()`.
+    /// mostly a safety net there. Cleared on `start()` AND on `stop()` — it is
+    /// per-recording state, and `start()` is not the only way a new recording
+    /// begins (see `stop()`).
     private var deletedRanges: [(start: Double, end: Double)] = []
     private var inFlight: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
@@ -182,6 +184,22 @@ final class LiveTranscriber: ObservableObject {
         detector = nil
         lastUtteranceTask?.cancel()
         lastUtteranceTask = nil
+        // The deletions belong to the recording that just ended, and `start()`
+        // is NOT the only way the next one begins: `wireLiveAIPipeline`'s
+        // hardware-gated branch calls `stop()` and deliberately never calls
+        // `start()` (that is also where the sibling reset of `segments` is
+        // documented). Leaving them behind there would let a previous
+        // recording's emptying make the NEW recording's genuinely-empty
+        // transcript look authoritative, so its batch pass would never be
+        // enqueued and it would save with no transcript at all — a silent
+        // total loss, and a worse failure than the one the flag prevents.
+        // (Cursor Bugbot on #229.)
+        //
+        // Suppression is unaffected: every `stop()` call site is a teardown
+        // (end of recording, failed stop, gated re-arm, dictation), and
+        // `stopRecording` snapshots `hasUserDeletedSegments` before its own
+        // `stop()` — the same ordering it already relies on for `segments`.
+        deletedRanges = []
         return fullText
     }
 

--- a/Mila/MCP/LiveTranscriptSidecarWriter.swift
+++ b/Mila/MCP/LiveTranscriptSidecarWriter.swift
@@ -90,6 +90,14 @@ final class LiveTranscriptSidecarWriter: ObservableObject {
     /// on every reassignment, changed or not), and coalesces bursts down
     /// to one write per `minWriteInterval` with a guaranteed trailing
     /// write so the last tick of a burst always lands.
+    ///
+    /// A tick that REMOVED a line — the user deleted it from the live pane —
+    /// also stamps `segmentsRemovedAtRevision`, because the incremental poll
+    /// cursor cannot express a removal on its own: it is a count plus a
+    /// "re-read the last entry" rule, so a poller holding the deleted line
+    /// would keep it (and mis-stitch everything after it). See
+    /// `LiveTranscriptSnapshot.segmentsWereRemoved(from:to:)` for what counts
+    /// — trailing rewrites and late speaker labels deliberately do not.
     func update(segments: [TranscriptSegment], speakerNames: [String: String]) {
         guard var current = snapshot, current.state == .recording else { return }
         let mapped = segments.map {
@@ -97,9 +105,21 @@ final class LiveTranscriptSidecarWriter: ObservableObject {
                                            text: $0.text, speaker: $0.speaker)
         }
         guard mapped != current.segments || speakerNames != current.speakerNames else { return }
+        let removed = LiveTranscriptSnapshot.segmentsWereRemoved(from: current.segments, to: mapped)
         current.segments = mapped
         current.speakerNames = speakerNames
         current.revision += 1
+        if removed {
+            // Stamped with the revision that carries the removal, so a poller
+            // whose cursor predates it gets the full set and every later
+            // poller keeps its cheap delta.
+            current.segmentsRemovedAtRevision = current.revision
+            sidecarLog.log("""
+                live transcript line removed at revision \(current.revision, privacy: .public) \
+                (\(current.segments.count, privacy: .public) remain) — pollers older than that \
+                revision get a full resend
+                """)
+        }
         snapshot = current
         scheduleWrite()
     }

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -436,6 +436,9 @@ struct LiveAIRecordingView: View {
                                                        } else {
                                                            transcriber.speakerNames.removeValue(forKey: raw)
                                                        }
+                                                   },
+                                                   onDelete: { id in
+                                                       transcriber.removeSegment(id: id)
                                                    })
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
@@ -714,6 +717,11 @@ private struct TranscriptLineView: View {
     /// Persists a rename picked from the label's popover mid-recording:
     /// (raw speaker ID, chosen name or nil-to-reset).
     var onAssignName: (String, String?) -> Void = { _, _ in }
+    /// Deletes this line from the live transcript. Wired to
+    /// `LiveTranscriber.removeSegment(id:)`.
+    var onDelete: (UUID) -> Void = { _ in }
+
+    @State private var hovering = false
 
     var body: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
@@ -750,8 +758,41 @@ private struct TranscriptLineView: View {
                 // outer wrapper-level identifier was a no-op (SwiftUI
                 // didn't materialize an a11y node there).
                 .accessibilityIdentifier("liveTranscript.segment")
+            // Hover-revealed delete button. Kept out of the layout-direction
+            // flip (its own LTR) so the trash icon sits on the trailing edge
+            // regardless of the line's script. Always present but near-
+            // invisible until hover so rows don't jump when the button
+            // appears.
+            deleteButton
+                .opacity(hovering ? 1 : 0)
+                .environment(\.layoutDirection, .leftToRight)
         }
         .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        // Right-click / control-click also offers delete, for when the
+        // hover button is easy to miss.
+        .contextMenu {
+            Button(role: .destructive) {
+                onDelete(segment.id)
+            } label: {
+                Label("Delete line", systemImage: "trash")
+            }
+        }
+    }
+
+    private var deleteButton: some View {
+        Button {
+            onDelete(segment.id)
+        } label: {
+            Image(systemName: "trash")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.borderless)
+        .help("Delete this line from the transcript")
+        .accessibilityLabel("Delete line")
+        .accessibilityIdentifier("liveTranscript.deleteLine")
     }
 }
 

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -65,6 +65,21 @@ struct LiveAIRecordingView: View {
             && !llmSettings.liveAIDisabledByRemoteOpenAI
     }
 
+    /// Whether the transcript on screen is the one that gets SAVED, rather
+    /// than a provisional preview.
+    ///
+    /// This is the same predicate `QuickActionsController.stopRecording`
+    /// calls `vadActive` — deliberately the same expression and not a new
+    /// rule, because it decides `liveTranscriptIsAuthoritative` there. With
+    /// auto-segment (VAD) off, Stop enqueues the WAV for a full batch
+    /// re-transcription that overwrites `segments` + `fullText` wholesale, so
+    /// nothing the user does to the live text survives — a deleted line comes
+    /// straight back into `recordings.json`, the `.txt` sidecar and the
+    /// `.srt`. Editing affordances are hidden in that mode rather than
+    /// silently undone (`bugbot-rules/deleted-data-stays-deleted.md`: a
+    /// delete must not come back).
+    private var liveTranscriptIsSaved: Bool { liveAISettings.useVAD }
+
     /// RTL for the AI pane (summary + action items). The AI output is its
     /// own language setting; for `.auto` we detect from the actual emitted
     /// text — summary + ALL item texts combined — so a short individual
@@ -439,7 +454,8 @@ struct LiveAIRecordingView: View {
                                                    },
                                                    onDelete: { id in
                                                        transcriber.removeSegment(id: id)
-                                                   })
+                                                   },
+                                                   canDelete: liveTranscriptIsSaved)
                                     .frame(maxWidth: .infinity, alignment: textAlignment)
                                 // Identifier is applied to the inner Text
                                 // inside TranscriptLineView (where SwiftUI
@@ -720,10 +736,36 @@ private struct TranscriptLineView: View {
     /// Deletes this line from the live transcript. Wired to
     /// `LiveTranscriber.removeSegment(id:)`.
     var onDelete: (UUID) -> Void = { _ in }
+    /// Whether a deletion would actually STICK — i.e. whether the live
+    /// transcript is the one that gets saved. See `liveTranscriptIsSaved`
+    /// in `LiveAIRecordingView`: with auto-segment (VAD) off, the whole
+    /// live transcript is provisional and Stop replaces it wholesale with
+    /// a fresh batch pass over the WAV, so a deleted line would come
+    /// straight back. Offering a destructive control that silently undoes
+    /// itself is worse than not offering it.
+    var canDelete: Bool = true
 
     @State private var hovering = false
 
     var body: some View {
+        // Right-click / control-click also offers delete, for when the
+        // hover button is easy to miss. The MODIFIER is conditional, not
+        // just its content: an empty `.contextMenu {}` still installs a
+        // menu, and a right-click that opens nothing reads as a bug.
+        if canDelete {
+            line.contextMenu {
+                Button(role: .destructive) {
+                    onDelete(segment.id)
+                } label: {
+                    Label("Delete line", systemImage: "trash")
+                }
+            }
+        } else {
+            line
+        }
+    }
+
+    private var line: some View {
         // We rely on the PARENT pane's layoutDirection. That mirrors the
         // HStack (speaker badge ends up on the right in RTL, text fills
         // the remaining space leftward) without us having to flip
@@ -738,7 +780,7 @@ private struct TranscriptLineView: View {
         // onto the leading edge. The button stays in layout (opacity
         // only) so rows don't jump, but is removed from hit-testing and
         // VoiceOver until hover.
-        HStack(alignment: .top, spacing: 8) {
+        return HStack(alignment: .top, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
                 if let sp = segment.speaker {
                     SpeakerLabelButton(
@@ -767,23 +809,16 @@ private struct TranscriptLineView: View {
                     .accessibilityIdentifier("liveTranscript.segment")
             }
             .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
-            deleteButton
-                .opacity(hovering ? 1 : 0)
-                .allowsHitTesting(hovering)
-                .accessibilityHidden(!hovering)
+            if canDelete {
+                deleteButton
+                    .opacity(hovering ? 1 : 0)
+                    .allowsHitTesting(hovering)
+                    .accessibilityHidden(!hovering)
+            }
         }
         .environment(\.layoutDirection, .leftToRight)
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
-        // Right-click / control-click also offers delete, for when the
-        // hover button is easy to miss.
-        .contextMenu {
-            Button(role: .destructive) {
-                onDelete(segment.id)
-            } label: {
-                Label("Delete line", systemImage: "trash")
-            }
-        }
     }
 
     private var deleteButton: some View {

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -78,6 +78,12 @@ struct LiveAIRecordingView: View {
     /// `.srt`. Editing affordances are hidden in that mode rather than
     /// silently undone (`bugbot-rules/deleted-data-stays-deleted.md`: a
     /// delete must not come back).
+    ///
+    /// It stays a pure mode check: deleting the *last* line would otherwise
+    /// empty `segments` and flip `liveTranscriptIsAuthoritative` by itself, but
+    /// that route is closed in `stopRecording` (an emptied transcript stays
+    /// authoritative) rather than by refusing the delete here. Emptying the
+    /// transcript is a legitimate thing to want.
     private var liveTranscriptIsSaved: Bool { liveAISettings.useVAD }
 
     /// RTL for the AI pane (summary + action items). The AI output is its

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -732,42 +732,47 @@ private struct TranscriptLineView: View {
         // calls — a single English aside inside a Hebrew conversation
         // should still display LTR within its own line).
         let lineRTL = segment.text.isPredominantlyHebrew || language == "he"
+        // Outer HStack stays LTR so the trash control is always the
+        // physical trailing child. Inner stack owns lineRTL for speaker
+        // + text; putting the button inside that stack would mirror it
+        // onto the leading edge. The button stays in layout (opacity
+        // only) so rows don't jump, but is removed from hit-testing and
+        // VoiceOver until hover.
         HStack(alignment: .top, spacing: 8) {
-            if let sp = segment.speaker {
-                SpeakerLabelButton(
-                    rawID: sp,
-                    names: speakerNames,
-                    language: language,
-                    color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
-                    font: .caption.weight(.semibold),
-                    onAssign: { name in onAssignName(sp, name) }
-                )
-                .frame(minWidth: 96, alignment: .leading)
-            } else {
-                Color.clear.frame(width: 96, height: 1)
+            HStack(alignment: .top, spacing: 8) {
+                if let sp = segment.speaker {
+                    SpeakerLabelButton(
+                        rawID: sp,
+                        names: speakerNames,
+                        language: language,
+                        color: useSpeakerColor ? sp.speakerColor(names: speakerNames) : Color.accentColor,
+                        font: .caption.weight(.semibold),
+                        onAssign: { name in onAssignName(sp, name) }
+                    )
+                    .frame(minWidth: 96, alignment: .leading)
+                } else {
+                    Color.clear.frame(width: 96, height: 1)
+                }
+                Text(segment.text)
+                    .font(.callout)
+                    .foregroundStyle(segment.stable ? .primary : .secondary)
+                    .italic(!segment.stable)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                    // Put the identifier on the leaf Text so XCUITest's
+                    // `.staticTexts.matching(identifier:)` finds it. The
+                    // outer wrapper-level identifier was a no-op (SwiftUI
+                    // didn't materialize an a11y node there).
+                    .accessibilityIdentifier("liveTranscript.segment")
             }
-            Text(segment.text)
-                .font(.callout)
-                .foregroundStyle(segment.stable ? .primary : .secondary)
-                .italic(!segment.stable)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .multilineTextAlignment(.leading)
-                // Put the identifier on the leaf Text so XCUITest's
-                // `.staticTexts.matching(identifier:)` finds it. The
-                // outer wrapper-level identifier was a no-op (SwiftUI
-                // didn't materialize an a11y node there).
-                .accessibilityIdentifier("liveTranscript.segment")
-            // Hover-revealed delete button. Kept out of the layout-direction
-            // flip (its own LTR) so the trash icon sits on the trailing edge
-            // regardless of the line's script. Always present but near-
-            // invisible until hover so rows don't jump when the button
-            // appears.
+            .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
             deleteButton
                 .opacity(hovering ? 1 : 0)
-                .environment(\.layoutDirection, .leftToRight)
+                .allowsHitTesting(hovering)
+                .accessibilityHidden(!hovering)
         }
-        .environment(\.layoutDirection, lineRTL ? .rightToLeft : .leftToRight)
+        .environment(\.layoutDirection, .leftToRight)
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
         // Right-click / control-click also offers delete, for when the

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -165,6 +165,73 @@ final class LiveTranscriberTests: XCTestCase {
         _ = transcriber.stop()
     }
 
+    // MARK: - Delete a live line
+
+    func test_removeSegment_removes_line_and_recomputes_fullText() async {
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "keep"),
+            TranscriptSegment(start: 2, end: 3, text: "remove me")
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep", "remove me"])
+
+        let victim = try! XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
+        transcriber.removeSegment(id: victim.id)
+
+        XCTAssertEqual(transcriber.segments.map(\.text), ["keep"])
+        XCTAssertEqual(transcriber.fullText, "keep")
+        _ = transcriber.stop()
+    }
+
+    /// A deleted line must not reappear when the fixed-window path
+    /// re-transcribes its rolling buffer on the next tick — the deleted
+    /// time range is suppressed.
+    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async {
+        // Both ticks emit the same two segments; after deleting "beta" it
+        // must stay gone even though tick 2 re-emits it.
+        await stub.setCannedQueue([
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ],
+            [
+                TranscriptSegment(start: 0, end: 1, text: "alpha"),
+                TranscriptSegment(start: 2, end: 3, text: "beta")
+            ]
+        ])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha", "beta"])
+
+        let beta = try! XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
+        transcriber.removeSegment(id: beta.id)
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"])
+
+        // Next tick re-emits alpha (already present, skipped) + beta
+        // (suppressed by the deleted range).
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"],
+                       "deleted line reappeared after a re-transcription tick")
+        _ = transcriber.stop()
+    }
+
+    func test_removeSegment_unknown_id_is_a_noop() async {
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "only")])
+        let samples = Array(repeating: Float(0.3), count: 32_000)
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(samples))
+        await transcriber.transcribeNow()
+        transcriber.removeSegment(id: UUID())
+        XCTAssertEqual(transcriber.segments.map(\.text), ["only"])
+        _ = transcriber.stop()
+    }
+
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "first"),

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -167,7 +167,7 @@ final class LiveTranscriberTests: XCTestCase {
 
     // MARK: - Delete a live line
 
-    func test_removeSegment_removes_line_and_recomputes_fullText() async {
+    func test_removeSegment_removes_line_and_recomputes_fullText() async throws {
         await stub.setDefaultCanned([
             TranscriptSegment(start: 0, end: 1, text: "keep"),
             TranscriptSegment(start: 2, end: 3, text: "remove me")
@@ -178,7 +178,7 @@ final class LiveTranscriberTests: XCTestCase {
         await transcriber.transcribeNow()
         XCTAssertEqual(transcriber.segments.map(\.text), ["keep", "remove me"])
 
-        let victim = try! XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
+        let victim = try XCTUnwrap(transcriber.segments.first { $0.text == "remove me" })
         transcriber.removeSegment(id: victim.id)
 
         XCTAssertEqual(transcriber.segments.map(\.text), ["keep"])
@@ -189,7 +189,7 @@ final class LiveTranscriberTests: XCTestCase {
     /// A deleted line must not reappear when the fixed-window path
     /// re-transcribes its rolling buffer on the next tick — the deleted
     /// time range is suppressed.
-    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async {
+    func test_deleted_line_does_not_reappear_on_next_chunk_tick() async throws {
         // Both ticks emit the same two segments; after deleting "beta" it
         // must stay gone even though tick 2 re-emits it.
         await stub.setCannedQueue([
@@ -208,7 +208,7 @@ final class LiveTranscriberTests: XCTestCase {
         await transcriber.transcribeNow()
         XCTAssertEqual(transcriber.segments.map(\.text), ["alpha", "beta"])
 
-        let beta = try! XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
+        let beta = try XCTUnwrap(transcriber.segments.first { $0.text == "beta" })
         transcriber.removeSegment(id: beta.id)
         XCTAssertEqual(transcriber.segments.map(\.text), ["alpha"])
 
@@ -230,6 +230,52 @@ final class LiveTranscriberTests: XCTestCase {
         transcriber.removeSegment(id: UUID())
         XCTAssertEqual(transcriber.segments.map(\.text), ["only"])
         _ = transcriber.stop()
+    }
+
+    /// Whisper often extends a VAD segment into the trailing silence pad.
+    /// Deleting that line must not suppress the next real utterance — the
+    /// stored range is clamped to the unpadded audio.
+    ///
+    /// Do not call `transcribeNow()` between utterances: that `flush()`es
+    /// the detector and zeroes its clock, which would make the next
+    /// utterance start at 0 and overlap the deleted range for a different
+    /// reason than the padding bug.
+    func test_vad_padded_segment_delete_does_not_suppress_next_utterance() async throws {
+        await stub.setCannedQueue([
+            [TranscriptSegment(start: 0, end: 4.5, text: "first")],
+            [TranscriptSegment(start: 0, end: 1, text: "second")]
+        ])
+        transcriber.useVAD = true
+        transcriber.start(language: "en")
+
+        let speech = Array(repeating: Float(0.05), count: 16_000 * 12 / 10)
+        let silence = Array(repeating: Float(0.0), count: 16_000)
+        transcriber.ingest(ArraySlice(speech + silence))
+        try await waitUntilSegments(count: 1)
+
+        let first = try XCTUnwrap(transcriber.segments.first { $0.text == "first" })
+        XCTAssertLessThan(first.endSeconds, 2.5,
+                          "padded whisper end (4.5s) must be clamped to the ~1.7s utterance")
+        transcriber.removeSegment(id: first.id)
+        XCTAssertTrue(transcriber.segments.isEmpty)
+
+        transcriber.ingest(ArraySlice(speech + silence))
+        try await waitUntilSegments(count: 1)
+        XCTAssertEqual(transcriber.segments.map(\.text), ["second"],
+                       "deleting a pad-extended VAD line suppressed the next utterance")
+        _ = transcriber.stop()
+    }
+
+    /// Poll until `transcriber.segments.count` reaches `count`. The VAD
+    /// path transcribes on a chained Task, so tests cannot `await
+    /// transcribeNow()` without flushing the detector.
+    private func waitUntilSegments(count: Int) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while transcriber.segments.count < count, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(transcriber.segments.count, count,
+                       "timed out waiting for \(count) live segment(s)")
     }
 
     func test_formattedTranscript_uses_timestamps_one_line_per_segment() async {

--- a/MilaTests/LiveTranscriptLineDeleteTests.swift
+++ b/MilaTests/LiveTranscriptLineDeleteTests.swift
@@ -253,6 +253,51 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
         }
     }
 
+    /// Deleting the *last* remaining line empties `segments` — and an empty
+    /// live transcript is exactly what `stopRecording` reads as "the live path
+    /// produced nothing, so run the batch pass". That fallback re-transcribes
+    /// the WAV, which means the strongest statement a user can make ("delete
+    /// all of it") was the one input that brought all of it back into
+    /// `recordings.json`, the `.txt` sidecar and the `.srt`. Emptiness alone
+    /// cannot distinguish a hand-emptied transcript from one that never
+    /// existed, so the gate keys on the deletions having happened.
+    /// (Cursor Bugbot on #229.)
+    ///
+    /// The stub engine is still canned with BOTH lines, so the batch pass this
+    /// must not provoke would write both back; `waitForIdle()` drains anything
+    /// the tail queued so a resurrection can't hide behind timing.
+    func test_deleting_every_line_does_not_resurrect_the_transcript() async throws {
+        try await recordTwoLinesAndDeleteTheSecond()
+
+        let survivor = try XCTUnwrap(transcriber.segments.first)
+        XCTAssertEqual(survivor.text, Self.keptLine,
+                       "precondition: exactly one line left to delete")
+        transcriber.removeSegment(id: survivor.id)
+        feedSidecar()
+        XCTAssertTrue(transcriber.segments.isEmpty,
+                      "precondition: the user has emptied the live transcript")
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+
+        let saved = try XCTUnwrap(store.recordings.first)
+        XCTAssertEqual(saved.status, .completed,
+                       "an emptied live transcript has to stay authoritative — a `.pending` row "
+                       + "means a batch pass is still owed, and that pass re-transcribes the WAV")
+        XCTAssertTrue(saved.segments.isEmpty,
+                      "the emptied transcript came back as \(saved.segments.count) segment(s)")
+        XCTAssertFalse(saved.fullText.contains(Self.keptLine))
+        XCTAssertFalse(saved.fullText.contains(Self.deletedLine))
+
+        for marker in [Self.keptLine, Self.deletedLine] {
+            for file in allTextOnDisk() {
+                XCTAssertFalse(file.text.contains(marker),
+                               "deleted transcript text survived in \(file.path)")
+            }
+        }
+    }
+
     /// The MCP read paths specifically. `search_transcripts` goes through
     /// `namedTranscript` → the `.txt` sidecar, so it can serve text the store
     /// row no longer has; a retained recording id must not be a way back in

--- a/MilaTests/LiveTranscriptLineDeleteTests.swift
+++ b/MilaTests/LiveTranscriptLineDeleteTests.swift
@@ -1,0 +1,334 @@
+import XCTest
+import MilaKit
+import TranscriptionCore
+@testable import Mila
+
+/// Deleting a line from the live transcript is a **privacy action**, not a
+/// display tweak: the user is removing something said off the record, a
+/// misfire, or a hallucinated segment. `bugbot-rules/deleted-data-stays-
+/// deleted.md` is the rule it has to satisfy — after the delete, no code path
+/// may write that text back.
+///
+/// `LiveTranscriberTests` covers the in-memory half (the line leaves
+/// `segments`, and a later whisper tick can't re-emit it). That is not enough
+/// on its own: the live transcript is copied out to SIX places, and an
+/// in-memory-only assertion passes just as happily when every one of them
+/// still holds the deleted text. This suite drives a real Stop and then goes
+/// looking for it in all of them:
+///
+///   1. the in-memory store row,
+///   2. `recordings.json`,
+///   3. the per-recording `.txt` transcript sidecar,
+///   4. the `.srt` sidecar `finalizeTail` writes,
+///   5. the live sidecar `live/current.json` that mila-mcp follows,
+///   6. what `MilaStoreReader` / the MCP tools serve — including
+///      `search_transcripts`, which reads the sidecar chain rather than the
+///      row, so it can disagree with everything above.
+///
+/// The final sweep reads every file under the store root and asserts the
+/// marker text is nowhere on disk, which is the assertion that would have
+/// caught a delete that only ever reached the UI.
+@MainActor
+final class LiveTranscriptLineDeleteTests: XCTestCase {
+
+    /// Distinctive enough that finding it anywhere on disk is unambiguous,
+    /// and plain ASCII so a binary audio file can't produce it by accident.
+    private static let deletedLine = "ZZQQ-OFF-THE-RECORD-DELETE-ME"
+    private static let keptLine = "this part of the meeting is fine to keep"
+
+    private var tempRoot: URL!
+    private var store: RecordingStore!
+    private var manager: ModelManager!
+    private var stub: StubWhisperEngine!
+    private var service: TranscriptionService!
+    private var session: RecordingSession!
+    private var languageSettings: RecordingLanguageSettings!
+    private var postRecording: PostRecordingCoordinator!
+    private var sidecar: LiveTranscriptSidecarWriter!
+    private var transcriber: LiveTranscriber!
+    private var liveAISettings: LiveAISettings!
+    private var controller: QuickActionsController!
+
+    private let suitePrefix = "LiveTranscriptLineDeleteTests"
+    private var savedSelection: String?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: suitePrefix)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+        // One root for everything, which is also the production layout: the
+        // store writes `store-location.json` at its own root, so
+        // `MilaStoreReader(root:)` and `MilaMCPToolHandlers(root:)` resolve
+        // this store the same way mila-mcp resolves the real one.
+        store = RecordingStore(rootDirectory: tempRoot)
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        try TestSupport.installFakeModel(into: manager)
+
+        stub = StubWhisperEngine()
+        service = TranscriptionService(
+            store: store,
+            modelManager: manager,
+            diarizationSettings: DiarizationSettings(
+                defaults: .init(suiteName: "\(suitePrefix).diarization")!),
+            remoteSettings: TestSupport.isolatedRemoteSettings(label: suitePrefix),
+            engine: stub)
+        session = RecordingSession()
+        languageSettings = RecordingLanguageSettings(
+            defaults: UserDefaults(suiteName: "\(suitePrefix).language")!)
+        postRecording = PostRecordingCoordinator(
+            store: store,
+            transcription: service,
+            llm: LLMSettings(defaults: UserDefaults(suiteName: "\(suitePrefix).llm")!))
+        controller = QuickActionsController(session: session,
+                                            store: store,
+                                            transcription: service,
+                                            languageSettings: languageSettings,
+                                            postRecording: postRecording)
+
+        transcriber = LiveTranscriber(transcription: service)
+        transcriber.chunkSeconds = 5
+        transcriber.windowSeconds = 10
+        controller.liveTranscriber = transcriber
+
+        liveAISettings = LiveAISettings(
+            defaults: UserDefaults(suiteName: "\(suitePrefix).liveAI")!)
+        // Auto-segment ON is what makes the live transcript the authoritative
+        // one: `stopRecording` then saves the live segments instead of
+        // enqueuing the WAV for a batch pass that would overwrite them. It is
+        // also the only mode in which the UI offers the delete control (see
+        // `liveTranscriptIsSaved` in LiveAIRecordingView).
+        liveAISettings.useVAD = true
+        controller.liveAISettings = liveAISettings
+
+        // Long heartbeat: every snapshot this suite reads is one the test
+        // caused, not a timer tick.
+        sidecar = LiveTranscriptSidecarWriter(root: tempRoot,
+                                              minWriteInterval: 0,
+                                              heartbeatInterval: 3600)
+        controller.liveSidecarWriter = sidecar
+
+        try MCPAccessGate.set(true, root: tempRoot)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let savedSelection {
+            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        for suffix in ["diarization", "language", "llm", "liveAI"] {
+            UserDefaults().removePersistentDomain(forName: "\(suitePrefix).\(suffix)")
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Mirror one live tick to the sidecar exactly as `MilaApp`'s feed loop
+    /// does — the loop itself lives in the app scene, so a unit test has to
+    /// stand in for it.
+    private func feedSidecar() {
+        let mapped = transcriber.segments.map {
+            TranscriptSegment(start: $0.startSeconds, end: $0.endSeconds,
+                              text: $0.text, speaker: $0.speaker)
+        }
+        sidecar.update(segments: mapped, speakerNames: transcriber.speakerNames)
+    }
+
+    /// Two live lines from whisper, then the second one deleted. Returns
+    /// nothing — the state to assert on is `transcriber` / `sidecar`.
+    private func recordTwoLinesAndDeleteTheSecond() async throws {
+        let url = store.freshAudioURL(suggestedName: "LineDelete")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        sidecar.begin(title: "LineDelete", source: "microphone", liveAvailable: true)
+
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: Self.keptLine),
+            TranscriptSegment(start: 2, end: 3, text: Self.deletedLine),
+        ])
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(Array(repeating: Float(0.3), count: 32_000)))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.map(\.text), [Self.keptLine, Self.deletedLine],
+                       "precondition: both lines have to be in the live transcript first")
+        feedSidecar()
+        let published = try XCTUnwrap(liveSnapshot()).segments.map(\.text)
+        XCTAssertTrue(published.contains(Self.deletedLine),
+                      "precondition: the line the user is about to delete really was published")
+
+        let victim = try XCTUnwrap(transcriber.segments.first { $0.text == Self.deletedLine })
+        transcriber.removeSegment(id: victim.id)
+        feedSidecar()
+    }
+
+    private func liveSnapshot() -> LiveTranscriptSnapshot? {
+        LiveTranscriptSnapshot.read(root: tempRoot)
+    }
+
+    private func reader() -> MilaStoreReader { MilaStoreReader(root: tempRoot) }
+
+    private func callTool(_ tool: String, _ args: [String: Any]) throws -> [String: Any] {
+        let raw = try MilaMCPToolHandlers(root: tempRoot).handle(tool: tool, arguments: args)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any])
+    }
+
+    /// Every readable file under the store root, as text. Unreadable files
+    /// (the audio) are skipped rather than failing the sweep.
+    private func allTextOnDisk() -> [(path: String, text: String)] {
+        var found: [(path: String, text: String)] = []
+        let keys: [URLResourceKey] = [.isRegularFileKey]
+        guard let walker = FileManager.default.enumerator(
+            at: tempRoot, includingPropertiesForKeys: keys) else { return found }
+        while let next = walker.nextObject() as? URL {
+            guard (try? next.resourceValues(forKeys: Set(keys)))?.isRegularFile == true else {
+                continue
+            }
+            guard let text = try? String(contentsOf: next, encoding: .utf8) else { continue }
+            found.append((path: next.lastPathComponent, text: text))
+        }
+        return found
+    }
+
+    // MARK: -
+
+    /// The load-bearing test. Delete a line, stop the recording, then check
+    /// every artifact the transcript is copied into.
+    func test_a_deleted_line_is_absent_from_everything_the_stop_writes() async throws {
+        try await recordTwoLinesAndDeleteTheSecond()
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+
+        // 1. The stored row.
+        let saved = try XCTUnwrap(store.recordings.first)
+        XCTAssertEqual(saved.status, .completed,
+                       "precondition: auto-segment mode saves the live transcript as final — "
+                       + "a `.pending` row would mean a batch pass is still owed, and that pass "
+                       + "re-transcribes the WAV and brings the deleted line back")
+        XCTAssertEqual(saved.segments.map(\.text), [Self.keptLine])
+        XCTAssertFalse(saved.fullText.contains(Self.deletedLine))
+
+        // 2. recordings.json.
+        let storeJSON = try String(contentsOf: tempRoot.appendingPathComponent("recordings.json"),
+                                   encoding: .utf8)
+        XCTAssertTrue(storeJSON.contains(Self.keptLine), "precondition: the row really was persisted")
+        XCTAssertFalse(storeJSON.contains(Self.deletedLine),
+                       "the deleted line was written into recordings.json")
+
+        // 3. The `.txt` transcript sidecar — read through the same chain the
+        //    helper uses, which prefers the sidecar over the row.
+        let stored = try XCTUnwrap(reader().recording(id: saved.id))
+        let sidecarText = reader().transcriptText(for: stored)
+        XCTAssertTrue(sidecarText.contains(Self.keptLine),
+                      "precondition: the sidecar chain resolved to real text, not an empty string")
+        XCTAssertFalse(sidecarText.contains(Self.deletedLine),
+                       "MilaStoreReader.transcriptText still serves the deleted line")
+        XCTAssertFalse(reader().namedTranscript(for: stored).contains(Self.deletedLine))
+
+        // 4. The `.srt` sidecar written by `finalizeTail`.
+        let srt = store.recordingsDirectory
+            .appendingPathComponent((saved.audioFileName as NSString).deletingPathExtension + ".srt")
+        if let srtText = try? String(contentsOf: srt, encoding: .utf8) {
+            XCTAssertFalse(srtText.contains(Self.deletedLine),
+                           "the deleted line was exported into the .srt subtitles")
+        }
+
+        // 5. The live sidecar mila-mcp follows.
+        let snapshot = try XCTUnwrap(liveSnapshot())
+        XCTAssertEqual(snapshot.state, .completed)
+        XCTAssertFalse(snapshot.segments.map(\.text).contains(Self.deletedLine),
+                       "live/current.json still holds the deleted line")
+
+        // 6. Nowhere else under the store root either. This is the assertion
+        //    that fails for a delete that only reached the UI.
+        for file in allTextOnDisk() {
+            XCTAssertFalse(file.text.contains(Self.deletedLine),
+                           "deleted transcript text survived in \(file.path)")
+        }
+    }
+
+    /// The MCP read paths specifically. `search_transcripts` goes through
+    /// `namedTranscript` → the `.txt` sidecar, so it can serve text the store
+    /// row no longer has; a retained recording id must not be a way back in
+    /// either.
+    func test_a_deleted_line_is_unreachable_through_the_mcp_tools() async throws {
+        try await recordTwoLinesAndDeleteTheSecond()
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        let saved = try XCTUnwrap(store.recordings.first)
+
+        let control = try callTool("search_transcripts", ["query": Self.keptLine])
+        XCTAssertEqual(control["count"] as? Int, 1,
+                       "precondition: search can see this recording at all")
+
+        let hits = try callTool("search_transcripts", ["query": Self.deletedLine])
+        XCTAssertEqual(hits["count"] as? Int, 0,
+                       "search_transcripts still finds the deleted line")
+
+        let transcript = try callTool("get_transcript", ["id": saved.id.uuidString])
+        let text = try XCTUnwrap(transcript["transcript"] as? String)
+        XCTAssertTrue(text.contains(Self.keptLine))
+        XCTAssertFalse(text.contains(Self.deletedLine),
+                       "get_transcript still serves the deleted line to an MCP client")
+    }
+
+    /// A poller that already fetched the deleted line has to be told, because
+    /// the incremental cursor cannot express a removal on its own: it is a
+    /// count plus "re-read the entry before it". Without the marker the reply
+    /// is an empty delta and the client keeps the line for the rest of the
+    /// meeting — with its cursor one ahead of reality, so every later line is
+    /// mis-stitched too.
+    func test_a_live_poller_holding_the_deleted_line_is_told_to_discard_it() async throws {
+        let url = store.freshAudioURL(suggestedName: "LineDeleteLive")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+        sidecar.begin(title: "LineDeleteLive", source: "microphone", liveAvailable: true)
+
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: Self.keptLine),
+            TranscriptSegment(start: 2, end: 3, text: Self.deletedLine),
+        ])
+        transcriber.start(language: "en")
+        transcriber.ingest(ArraySlice(Array(repeating: Float(0.3), count: 32_000)))
+        await transcriber.transcribeNow()
+        feedSidecar()
+
+        // What the poller got on its first poll.
+        let firstPoll = try callTool("get_live_transcript", [:])
+        let session = try XCTUnwrap(firstPoll["session_id"] as? String)
+        let revision = try XCTUnwrap(firstPoll["revision"] as? Int)
+        let cursor = try XCTUnwrap(firstPoll["next_segment_index"] as? Int)
+        XCTAssertEqual(cursor, 2)
+
+        let victim = try XCTUnwrap(transcriber.segments.first { $0.text == Self.deletedLine })
+        transcriber.removeSegment(id: victim.id)
+        feedSidecar()
+
+        let afterDelete = try callTool("get_live_transcript", [
+            "session_id": session,
+            "since_revision": revision,
+            "since_segment_index": cursor,
+        ])
+        XCTAssertEqual(afterDelete["segments_removed"] as? Bool, true,
+                       "the poller was not told a line went away")
+        XCTAssertEqual(afterDelete["next_segment_index"] as? Int, 1,
+                       "its cursor has to be corrected as well")
+        let segments = (afterDelete["new_segments"] as? [[String: Any]])?
+            .compactMap { $0["text"] as? String }
+        XCTAssertEqual(segments, [Self.keptLine],
+                       "the reply must be the complete surviving set, not an empty delta")
+        let rendered = try XCTUnwrap(afterDelete["transcript"] as? String)
+        XCTAssertFalse(rendered.contains(Self.deletedLine))
+
+        // Tear the capture down through the real path so nothing is left
+        // recording behind the test.
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+    }
+}

--- a/MilaTests/LiveTranscriptLineDeleteTests.swift
+++ b/MilaTests/LiveTranscriptLineDeleteTests.swift
@@ -298,6 +298,96 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
         }
     }
 
+    /// Empty the transcript, then start the NEXT recording the way
+    /// `wireLiveAIPipeline`'s hardware-gated branch does — `transcriber.stop()`
+    /// and deliberately no `start()`. If the emptying leaked across that
+    /// boundary, this recording's genuinely-empty transcript would look
+    /// authoritative, its batch pass would never be enqueued, and it would
+    /// save with no transcript at all. (Cursor Bugbot on #229.)
+    func test_an_emptied_transcript_does_not_leak_into_the_next_recording() async throws {
+        try await recordTwoLinesAndDeleteTheSecond()
+        let survivor = try XCTUnwrap(transcriber.segments.first)
+        transcriber.removeSegment(id: survivor.id)
+        feedSidecar()
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+        XCTAssertEqual(store.recordings.count, 1, "precondition: the emptied recording saved")
+
+        // The gated path's exact moves: stop the transcriber, never start it.
+        _ = transcriber.stop()
+        let second = store.freshAudioURL(suggestedName: "SecondRecording")
+        try TestSupport.writeStereo48kSineWav(at: second, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: second)
+        XCTAssertTrue(transcriber.segments.isEmpty,
+                      "precondition: this recording has no live transcript of its own")
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+
+        let fresh = try XCTUnwrap(store.recordings.first {
+            $0.audioFileName == second.lastPathComponent
+        })
+        XCTAssertFalse(fresh.fullText.isEmpty,
+                       "the second recording was never transcribed — the previous recording's "
+                       + "emptying leaked and made its empty transcript look authoritative")
+        XCTAssertEqual(fresh.status, .completed)
+    }
+
+    /// Emptying the transcript has to take the artifacts DERIVED from it too.
+    /// Nothing downstream would: `RecordingSummarizer.regenerate` bails on an
+    /// empty `fullText` (and only ever writes `summary`, never `actionItems`),
+    /// and an authoritative row owes no batch pass, so there is no completion
+    /// hook either. Without the clear, the transcript reads clean while the
+    /// deleted words sit in the `summary` field of `recordings.json` and in
+    /// MCP `get_transcript`, which serves summary + action items by default.
+    /// (Cursor Bugbot on #229.)
+    func test_emptying_the_transcript_drops_the_ai_output_derived_from_it() async throws {
+        try await recordTwoLinesAndDeleteTheSecond()
+        let survivor = try XCTUnwrap(transcriber.segments.first)
+        transcriber.removeSegment(id: survivor.id)
+        feedSidecar()
+
+        // Attached after the recording is under way so nothing in the start
+        // path can clear the seeded output before Stop reads it.
+        let ai = LiveAISession(
+            llmSettings: LLMSettings(defaults: UserDefaults(suiteName: "\(suitePrefix).llm")!),
+            liveAISettings: liveAISettings)
+        ai.seedForTesting(
+            summary: "The team discussed \(Self.deletedLine) at length.",
+            actionItems: [ActionItem(id: UUID().uuidString,
+                                     text: "follow up on \(Self.deletedLine)",
+                                     speaker: nil,
+                                     timestampSeconds: 0,
+                                     source: .llmInferred,
+                                     addedAt: Date())])
+        controller.liveAISession = ai
+
+        await controller.stopRecording()
+        await controller.awaitFinalizeTails()
+        await service.waitForIdle()
+
+        let saved = try XCTUnwrap(store.recordings.first)
+        XCTAssertNil(saved.summary,
+                     "the saved summary was derived from the transcript the user deleted")
+        XCTAssertNil(saved.actionItems,
+                     "the saved action items were derived from the transcript the user deleted")
+
+        let transcript = try callTool("get_transcript", ["id": saved.id.uuidString])
+        XCTAssertNotNil(transcript["transcript"] as? String,
+                        "precondition: get_transcript resolved this recording at all")
+        let served = String(describing: transcript)
+        XCTAssertFalse(served.contains(Self.deletedLine),
+                       "get_transcript still serves the deleted words via summary / action items")
+        XCTAssertFalse(served.contains(Self.keptLine))
+
+        for file in allTextOnDisk() {
+            XCTAssertFalse(file.text.contains(Self.deletedLine),
+                           "deleted transcript text survived in \(file.path)")
+        }
+    }
+
     /// The MCP read paths specifically. `search_transcripts` goes through
     /// `namedTranscript` → the `.txt` sidecar, so it can serve text the store
     /// row no longer has; a retained recording id must not be a way back in

--- a/MilaTests/LiveTranscriptSidecarWriterTests.swift
+++ b/MilaTests/LiveTranscriptSidecarWriterTests.swift
@@ -72,6 +72,70 @@ final class LiveTranscriptSidecarWriterTests: XCTestCase {
         XCTAssertEqual(snap.revision, 3)
     }
 
+    // MARK: - A deleted line has to be announced to pollers
+
+    /// Deleting a line from the live pane arrives here as an ordinary content
+    /// tick with a shorter list. The snapshot has to say so: the incremental
+    /// `get_live_transcript` cursor is a count plus "re-read the last entry",
+    /// so nothing in a delta can tell a poller that a line it already holds is
+    /// gone. `segmentsRemovedAtRevision` is what makes the next stale-cursor
+    /// poll a full resend instead.
+    func test_removing_a_line_stamps_the_removal_revision() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("one", "two", "three"), speakerNames: [:])
+        XCTAssertNil(try XCTUnwrap(snapshot()).segmentsRemovedAtRevision,
+                     "precondition: growing the transcript is not a removal")
+
+        // The user deletes the middle line. `segs` re-numbers from 0, so
+        // build the survivors explicitly to keep their original timings —
+        // that is what the real feed publishes.
+        let survivors = [
+            TranscriptSegment(start: 0, end: 1, text: "one", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 2, end: 3, text: "three", speaker: "SPEAKER_00"),
+        ]
+        writer.update(segments: survivors, speakerNames: [:])
+
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.segments.map(\.text), ["one", "three"])
+        XCTAssertEqual(snap.segmentsRemovedAtRevision, snap.revision,
+                       "the marker must name the revision that carries the removal")
+    }
+
+    /// The counter-test: the trailing line growing as whisper gets more audio
+    /// is the normal case, and the delta protocol already re-sends that entry.
+    /// Flagging it would make every tick a full resend.
+    func test_extending_the_trailing_line_is_not_flagged_as_a_removal() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: segs("one", "two"), speakerNames: [:])
+        writer.update(segments: [
+            TranscriptSegment(start: 0, end: 1, text: "one", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 5, text: "two and then some", speaker: "SPEAKER_00"),
+        ], speakerNames: [:])
+        let snap = try XCTUnwrap(snapshot())
+        XCTAssertEqual(snap.segments.map(\.text), ["one", "two and then some"])
+        XCTAssertNil(snap.segmentsRemovedAtRevision)
+    }
+
+    /// And a late speaker label landing on an already-published line is an
+    /// update, not a removal — live diarization does this constantly.
+    func test_a_late_speaker_label_is_not_flagged_as_a_removal() throws {
+        let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
+        writer.begin(title: nil, source: nil, liveAvailable: true)
+        writer.update(segments: [
+            TranscriptSegment(start: 0, end: 1, text: "one", speaker: nil),
+            TranscriptSegment(start: 1, end: 2, text: "two", speaker: nil),
+            TranscriptSegment(start: 2, end: 3, text: "three", speaker: nil),
+        ], speakerNames: [:])
+        writer.update(segments: [
+            TranscriptSegment(start: 0, end: 1, text: "one", speaker: "SPEAKER_00"),
+            TranscriptSegment(start: 1, end: 2, text: "two", speaker: "SPEAKER_01"),
+            TranscriptSegment(start: 2, end: 3, text: "three", speaker: nil),
+        ], speakerNames: [:])
+        XCTAssertNil(try XCTUnwrap(snapshot()).segmentsRemovedAtRevision)
+    }
+
     func test_finish_marks_completed_with_handoff_id_and_stops_updates() throws {
         let writer = LiveTranscriptSidecarWriter(root: root, minWriteInterval: 0)
         writer.begin(title: nil, source: nil, liveAvailable: true)

--- a/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
+++ b/Packages/MilaKit/Sources/MilaKit/LiveTranscriptSnapshot.swift
@@ -49,6 +49,28 @@ public struct LiveTranscriptSnapshot: Codable, Sendable {
     /// Set when `state == .completed` — the saved recording's UUID, for
     /// handoff to `get_transcript`.
     public var finalRecordingID: UUID?
+    /// The `revision` at which segments were last REMOVED rather than
+    /// appended-to or trailing-rewritten — i.e. the user deleted a line from
+    /// the live pane.
+    ///
+    /// The incremental poll contract (`since_segment_index`) is append-only by
+    /// construction: `next_segment_index` is a count, and a delta re-sends
+    /// only from one before that index. Nothing in it can say "the line you
+    /// already hold is gone", so without this marker a poller that had
+    /// already fetched a deleted line would keep it in its own context for
+    /// the rest of the meeting — and its cursor would be off by one, so
+    /// subsequent lines would be mis-stitched too.
+    ///
+    /// A poller whose `since_revision` predates this value is served the FULL
+    /// segment set instead of a delta. `nil` (the common case, and what an
+    /// older app's file decodes to) means nothing has ever been removed, so
+    /// deltas behave exactly as before.
+    ///
+    /// Optional deliberately: the mila-mcp helper and the app ship in the
+    /// same bundle but need not be the same build — a non-optional `Int`
+    /// would make a newer helper fail to decode an older app's snapshot
+    /// entirely and report "not recording" mid-meeting.
+    public var segmentsRemovedAtRevision: Int?
 
     public init(version: Int = 1,
                 sessionID: UUID = UUID(),
@@ -61,7 +83,8 @@ public struct LiveTranscriptSnapshot: Codable, Sendable {
                 source: String? = nil,
                 segments: [Segment] = [],
                 speakerNames: [String: String] = [:],
-                finalRecordingID: UUID? = nil) {
+                finalRecordingID: UUID? = nil,
+                segmentsRemovedAtRevision: Int? = nil) {
         self.version = version
         self.sessionID = sessionID
         self.state = state
@@ -74,6 +97,7 @@ public struct LiveTranscriptSnapshot: Codable, Sendable {
         self.segments = segments
         self.speakerNames = speakerNames
         self.finalRecordingID = finalRecordingID
+        self.segmentsRemovedAtRevision = segmentsRemovedAtRevision
     }
 
     /// Heartbeat age beyond which a `recording` snapshot is reported stale.
@@ -125,5 +149,40 @@ public struct LiveTranscriptSnapshot: Codable, Sendable {
         guard index > 0 else { return segments }
         let start = min(index - 1, segments.count)
         return Array(segments[start...])
+    }
+
+    /// Whether going from `old` to `new` REMOVED a line a poller may already
+    /// hold, as opposed to the two changes the incremental cursor already
+    /// describes correctly:
+    ///
+    ///   * **Appending** — new entries past the old count.
+    ///   * **Rewriting the trailing entry** — the live merge extends the last
+    ///     utterance as whisper gets more audio, which is exactly why
+    ///     `segments(sinceIndex:)` re-sends one before the cursor. Deleting
+    ///     the LAST line therefore needs no marker either: the client is told
+    ///     to replace that entry with whatever now occupies it (or, when
+    ///     nothing does, `next_segment_index` shrinks past it).
+    ///
+    /// `speaker` is deliberately NOT compared. Live diarization labels land
+    /// on already-published lines several seconds late; treating that as a
+    /// removal would force a full resend on most ticks of a multi-speaker
+    /// meeting. (An in-place speaker label is not delivered incrementally
+    /// today either — a separate, pre-existing gap.)
+    public static func segmentsWereRemoved(from old: [Segment], to new: [Segment]) -> Bool {
+        // Anything shorter lost a line outright. (Also the `old.count == 1`
+        // case: its only entry is the trailing one, so a shrink to 0 is the
+        // sole way it can go.)
+        if new.count < old.count { return true }
+        guard old.count > 1 else { return false }
+        // Compare the protected prefix — everything except the trailing
+        // entry the protocol already re-sends.
+        for i in 0..<(old.count - 1) {
+            if new[i].start != old[i].start
+                || new[i].end != old[i].end
+                || new[i].text != old[i].text {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
+++ b/Packages/MilaKit/Sources/MilaKit/MilaMCPToolHandlers.swift
@@ -154,7 +154,10 @@ public struct MilaMCPToolHandlers: Sendable {
             since_revision) and next_segment_index (as since_segment_index): unchanged \
             meetings answer with a tiny {changed:false}, and changed ones return only the new \
             segments (the last previously-seen segment is re-sent because live transcription \
-            may rewrite it — replace your copy). When status becomes "completed", stop \
+            may rewrite it — replace your copy). If a reply carries segments_removed:true the \
+            user deleted lines from the transcript: new_segments is then the COMPLETE current \
+            set, so discard your previous copy of this session's segments instead of appending, \
+            and do not quote the removed text. When status becomes "completed", stop \
             polling: call get_transcript with the returned final_recording_id when there is \
             one, and otherwise take the newest entry from list_recordings (a completed \
             recording can finish without a handoff id).
@@ -385,17 +388,41 @@ public struct MilaMCPToolHandlers: Sendable {
         result["speaker_names"] = snapshot.speakerNames
         result["next_segment_index"] = snapshot.segments.count
 
-        if sameSession, let sinceIndex = args["since_segment_index"] as? Int {
+        // A delta is only honest while the client's prefix is still valid. The
+        // user can DELETE a line from the live pane, and the cursor has no way
+        // to say so: it is a count plus "re-read the entry before it", so a
+        // client that already fetched the deleted line would keep it for the
+        // rest of the meeting and mis-stitch every line after it. When the
+        // removal happened at a revision the client hasn't seen, resend
+        // everything and say why. A client that sent no `since_revision` at
+        // all can't prove it saw the removal, so it gets the same treatment.
+        let clientRevision = args["since_revision"] as? Int
+        let prefixInvalidated: Bool = {
+            guard let removedAt = snapshot.segmentsRemovedAtRevision else { return false }
+            guard let clientRevision else { return true }
+            return clientRevision < removedAt
+        }()
+
+        if sameSession, !prefixInvalidated, let sinceIndex = args["since_segment_index"] as? Int {
             result["new_segments"] = snapshot.segments(sinceIndex: sinceIndex)
                 .map(segmentObject(for:))
         } else {
-            // First poll (or a new session): full transcript + all segments.
+            // First poll, a new session, or a removal the client hasn't seen:
+            // full transcript + all segments.
             result["new_segments"] = snapshot.segments.map(segmentObject(for:))
             result["transcript"] = TranscriptFormatter.plainText(
                 segments: snapshot.segments,
                 fallback: TranscriptFormatter.joinedFullText(segments: snapshot.segments),
                 names: snapshot.speakerNames
             )
+            if sameSession, prefixInvalidated {
+                result["segments_removed"] = true
+                // Don't clobber the stale-heartbeat note, which is the more
+                // urgent thing to tell the client.
+                if !result.keys.contains("note") {
+                    result["note"] = "Lines were removed from this transcript, so new_segments is the COMPLETE current set — discard your previous copy of this session's segments rather than appending."
+                }
+            }
         }
         return try json(result)
     }

--- a/Packages/MilaKit/Tests/MilaKitTests/LiveTranscriptRemovalTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/LiveTranscriptRemovalTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import MilaKit
+
+/// The live-transcript poll cursor is append-only by construction:
+/// `next_segment_index` is a count and `segments(sinceIndex:)` returns from
+/// one before it, so the only change it can describe is "more lines, and the
+/// last one you saw may have been rewritten". Once the user can DELETE a line
+/// from the live pane (issue for PR #125), that stops covering everything —
+/// nothing in a delta can say "the line you already hold is gone".
+///
+/// `segmentsWereRemoved(from:to:)` is what tells the two apart, and it has to
+/// be precise in BOTH directions:
+///
+///   * miss a real removal and a poller keeps the deleted line for the rest of
+///     the meeting, with its cursor off by one so every later line is
+///     mis-stitched too;
+///   * cry removal on an ordinary tick and every poll of a multi-speaker
+///     meeting turns into a full resend, because live diarization keeps
+///     labelling already-published lines.
+final class LiveTranscriptRemovalTests: XCTestCase {
+
+    private typealias Segment = LiveTranscriptSnapshot.Segment
+
+    private func seg(_ start: Double, _ text: String, speaker: String? = nil) -> Segment {
+        Segment(start: start, end: start + 1, text: text, speaker: speaker)
+    }
+
+    // MARK: - Removals that must be reported
+
+    func test_dropping_a_middle_line_is_a_removal() {
+        let before = [seg(0, "alpha"), seg(1, "beta"), seg(2, "gamma")]
+        let after = [seg(0, "alpha"), seg(2, "gamma")]
+        XCTAssertTrue(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    func test_dropping_a_middle_line_while_a_new_one_arrives_is_still_a_removal() {
+        // Same count on both sides — the give-away is that the protected
+        // prefix shifted, not that the list got shorter. A count-only check
+        // would call this an ordinary tick and leak "beta".
+        let before = [seg(0, "alpha"), seg(1, "beta"), seg(2, "gamma")]
+        let after = [seg(0, "alpha"), seg(2, "gamma"), seg(3, "delta")]
+        XCTAssertTrue(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    func test_dropping_the_only_line_is_a_removal() {
+        XCTAssertTrue(LiveTranscriptSnapshot.segmentsWereRemoved(from: [seg(0, "alpha")], to: []))
+    }
+
+    func test_dropping_the_first_of_two_lines_is_a_removal() {
+        XCTAssertTrue(LiveTranscriptSnapshot.segmentsWereRemoved(
+            from: [seg(0, "alpha"), seg(1, "beta")], to: [seg(1, "beta")]))
+    }
+
+    /// Same text, different timing: whisper re-emitting an earlier utterance
+    /// at a shifted position means the client's index no longer names the same
+    /// line, which is the thing the cursor cannot survive.
+    func test_a_retimed_prefix_line_is_a_removal() {
+        let before = [seg(0, "alpha"), seg(1, "beta"), seg(2, "gamma")]
+        var after = before
+        after[0] = Segment(start: 9, end: 10, text: "alpha")
+        XCTAssertTrue(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    // MARK: - Ordinary ticks that must NOT be reported
+
+    func test_appending_is_not_a_removal() {
+        let before = [seg(0, "alpha"), seg(1, "beta")]
+        let after = before + [seg(2, "gamma")]
+        XCTAssertFalse(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    func test_first_content_tick_is_not_a_removal() {
+        XCTAssertFalse(LiveTranscriptSnapshot.segmentsWereRemoved(from: [], to: [seg(0, "alpha")]))
+    }
+
+    /// The live merge extends the trailing utterance as whisper gets more
+    /// audio. The delta already re-sends that entry for the client to
+    /// replace, so it is not a removal — and neither is deleting the LAST
+    /// line, which the same replace rule (plus a shrinking
+    /// `next_segment_index`) covers.
+    func test_rewriting_the_trailing_line_is_not_a_removal() {
+        let before = [seg(0, "alpha"), seg(1, "beta")]
+        let after = [seg(0, "alpha"), Segment(start: 1, end: 4, text: "beta gamma delta")]
+        XCTAssertFalse(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    /// Live diarization labels land on lines published seconds earlier.
+    /// Treating that as a removal would force a full resend on most ticks of
+    /// any multi-speaker meeting, so `speaker` is deliberately not compared.
+    func test_a_late_speaker_label_on_an_older_line_is_not_a_removal() {
+        let before = [seg(0, "alpha"), seg(1, "beta"), seg(2, "gamma")]
+        var after = before
+        after[0].speaker = "SPEAKER_00"
+        after[1].speaker = "SPEAKER_01"
+        XCTAssertFalse(LiveTranscriptSnapshot.segmentsWereRemoved(from: before, to: after))
+    }
+
+    // MARK: - Cross-version decoding
+
+    /// The field is optional so a helper built after this change still decodes
+    /// a snapshot written by an app built before it. A non-optional `Int`
+    /// would throw, `read` would swallow it as `nil`, and `get_live_transcript`
+    /// would report "not recording" in the middle of a live meeting.
+    func test_a_snapshot_without_the_removal_marker_still_decodes() throws {
+        let json = """
+        {"liveTranscriptAvailable":true,"recordingStartedAt":"2026-01-01T00:00:00Z",\
+        "revision":3,"segments":[{"end":1,"start":0,"text":"alpha"}],"sessionID":\
+        "\(UUID().uuidString)","speakerNames":{},"state":"recording",\
+        "updatedAt":"2026-01-01T00:01:00Z","version":1}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snap = try decoder.decode(LiveTranscriptSnapshot.self, from: Data(json.utf8))
+        XCTAssertNil(snap.segmentsRemovedAtRevision)
+        XCTAssertEqual(snap.segments.map(\.text), ["alpha"])
+    }
+}

--- a/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
+++ b/Packages/MilaKit/Tests/MilaKitTests/MilaMCPToolHandlersTests.swift
@@ -57,7 +57,8 @@ final class MilaMCPToolHandlersTests: XCTestCase {
                               revision: Int = 3, liveAvailable: Bool = true,
                               updatedAt: Date = Date(),
                               segments: [LiveTranscriptSnapshot.Segment]? = nil,
-                              finalRecordingID: UUID? = nil) throws -> LiveTranscriptSnapshot {
+                              finalRecordingID: UUID? = nil,
+                              segmentsRemovedAtRevision: Int? = nil) throws -> LiveTranscriptSnapshot {
         let snap = LiveTranscriptSnapshot(
             sessionID: sessionID, state: state, liveTranscriptAvailable: liveAvailable,
             recordingStartedAt: updatedAt.addingTimeInterval(-120), updatedAt: updatedAt,
@@ -68,7 +69,8 @@ final class MilaMCPToolHandlersTests: XCTestCase {
                 .init(start: 4, end: 6, text: "third", speaker: "SPEAKER_01"),
             ],
             speakerNames: ["SPEAKER_00": "Dana"],
-            finalRecordingID: finalRecordingID)
+            finalRecordingID: finalRecordingID,
+            segmentsRemovedAtRevision: segmentsRemovedAtRevision)
         try snap.write(root: root)
         return snap
     }
@@ -248,6 +250,95 @@ final class MilaMCPToolHandlersTests: XCTestCase {
         let texts = (result["new_segments"] as? [[String: Any]])?.compactMap { $0["text"] as? String }
         XCTAssertEqual(texts, ["second", "third"])
         XCTAssertEqual(result["next_segment_index"] as? Int, 3)
+    }
+
+    // MARK: - A deleted line must reach the poller
+
+    /// The user deleted the middle line mid-meeting. A poller holding all
+    /// three lines has a cursor the delta cannot honour: `segments(sinceIndex:
+    /// 3)` over a two-entry list is `[]`, so the reply would be "nothing was
+    /// removed, nothing is new" and the client would keep quoting the deleted
+    /// text for the rest of the call. It must be handed the complete current
+    /// set instead, flagged so it replaces rather than appends.
+    func test_live_delta_resends_everything_after_a_line_is_removed() throws {
+        let snap = try liveSnapshot(
+            revision: 5,
+            segments: [
+                .init(start: 0, end: 2, text: "first", speaker: "SPEAKER_00"),
+                .init(start: 4, end: 6, text: "third", speaker: "SPEAKER_01"),
+            ],
+            segmentsRemovedAtRevision: 5)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 4,
+            "since_segment_index": 3,
+        ])
+        XCTAssertEqual(result["changed"] as? Bool, true)
+        XCTAssertEqual(result["segments_removed"] as? Bool, true)
+        let texts = (result["new_segments"] as? [[String: Any]])?.compactMap { $0["text"] as? String }
+        XCTAssertEqual(texts, ["first", "third"],
+                       "a cursor that predates the removal must get the whole set, not an empty delta")
+        XCTAssertEqual(result["next_segment_index"] as? Int, 2,
+                       "the client's cursor has to be corrected too, or every later line is mis-stitched")
+        let transcript = try XCTUnwrap(result["transcript"] as? String)
+        XCTAssertFalse(transcript.contains("second"),
+                       "the deleted line must not come back in the rendered transcript")
+        let note = try XCTUnwrap(result["note"] as? String)
+        XCTAssertTrue(note.localizedCaseInsensitiveContains("removed"), note)
+    }
+
+    /// Once the client's cursor is at or past the removal it is back on the
+    /// cheap path — a delete must not turn every remaining poll of the meeting
+    /// into a full resend.
+    func test_live_delta_stays_incremental_once_the_client_has_seen_the_removal() throws {
+        let snap = try liveSnapshot(
+            revision: 6,
+            segments: [
+                .init(start: 0, end: 2, text: "first", speaker: "SPEAKER_00"),
+                .init(start: 4, end: 6, text: "third", speaker: "SPEAKER_01"),
+                .init(start: 6, end: 8, text: "fourth", speaker: "SPEAKER_01"),
+            ],
+            segmentsRemovedAtRevision: 5)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 5,
+            "since_segment_index": 2,
+        ])
+        XCTAssertNil(result["segments_removed"])
+        XCTAssertNil(result["transcript"], "a delta carries segments, not the whole rendering")
+        let texts = (result["new_segments"] as? [[String: Any]])?.compactMap { $0["text"] as? String }
+        XCTAssertEqual(texts, ["third", "fourth"])
+    }
+
+    /// A client that sends a segment cursor but no `since_revision` cannot
+    /// prove it has seen the removal, so it is served the full set. Failing
+    /// closed here costs one large reply; failing open leaves deleted text in
+    /// someone's context.
+    func test_live_poll_without_a_revision_cursor_gets_the_full_set_after_a_removal() throws {
+        let snap = try liveSnapshot(
+            revision: 5,
+            segments: [.init(start: 0, end: 2, text: "first", speaker: "SPEAKER_00")],
+            segmentsRemovedAtRevision: 5)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_segment_index": 3,
+        ])
+        XCTAssertEqual(result["segments_removed"] as? Bool, true)
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 1)
+    }
+
+    /// Nothing has ever been removed → the delta path is untouched. This is
+    /// the control for the three tests above.
+    func test_live_delta_is_unaffected_when_nothing_was_removed() throws {
+        let snap = try liveSnapshot(revision: 4)
+        let result = try call("get_live_transcript", [
+            "session_id": snap.sessionID.uuidString,
+            "since_revision": 2,
+            "since_segment_index": 3,
+        ])
+        XCTAssertNil(result["segments_removed"])
+        XCTAssertEqual((result["new_segments"] as? [[String: Any]])?.count, 1,
+                       "an ordinary cursor at the tail re-reads only the last segment")
     }
 
     func test_live_session_mismatch_returns_new_session_full_set() throws {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -107,6 +107,13 @@ How the polling works under the hood:
 - A `session_id` mismatch means a new recording started between polls —
   Claude gets the new meeting's transcript from the top with
   `new_session: true`.
+- If you **delete a line** from the live transcript, the next poll whose
+  cursor predates the deletion gets the whole segment set back with
+  `segments_removed: true`, and is told to discard its previous copy
+  rather than append. The incremental cursor is a count plus a "re-read
+  the last entry" rule, so it cannot express a removal on its own — and
+  a deletion is a privacy action, so the poller must not be left holding
+  the line you removed.
 - `status` values: `recording` (keep polling), `stale` (the app stopped
   updating the snapshot — likely crashed), `recording_live_unavailable`
   (recording on hardware where live transcription is gated off — wait


### PR DESCRIPTION
Closes #222

## Credit: this feature is @ValeroK's work

**Deleting a line from the live transcript was designed and written by @ValeroK in #125.** Both of his commits are cherry-picked unmodified onto today's `main`, so he is the `Author` on each of them; everything I added sits in three separate commits on top and is a guard, a protocol fix and tests — not the feature.

The cherry-pick was **clean — zero conflicts** — even though #125 branched from `53ddcfe` and only nine files have changed in `main` since. Nothing of his was rewritten, reflowed or reimplemented. `git diff` between his two commits as relayed here and `origin/main...pr/125` is byte-identical.

It is relayed rather than merged for the usual reason (the #129 → #164 and #198 → #204 precedents): a fork PR can't get an automated review under the contributor's own quota, and its CI needs per-run approval on every run. The relay is purely mechanical. Please close #125 as superseded by this once it's green.

> His commit email (`kobi.valero@pagaya.com`) is a real address rather than a placeholder, so it is preserved verbatim as the `Author` on his commits. My three commits additionally carry `Co-authored-by: KobiValero-Pagaya <8961499+ValeroK@users.noreply.github.com>` so the attribution resolves to the `@ValeroK` handle as well.

## What & why

Each line in the live transcript pane gets a delete affordance — a trash button revealed on hover plus a right-click "Delete line" item. `LiveTranscriber.removeSegment(id:)` records the segment's absolute time range in `deletedRanges`, removes it from `segments` and recomputes `fullText`; incoming whisper output overlapping a deleted range is then skipped.

That suppression is the load-bearing part, and it is why this isn't just an array removal: the fixed-window path **re-transcribes a rolling buffer on every tick**, so without it the deleted line reappears a second later. (The VAD path emits each utterance once, so there it's a safety net.) His follow-up commit also clamps a VAD segment's `absEnd` to the *unpadded* audio duration, so deleting a line whose whisper end ran into the trailing silence pad cannot suppress the next real utterance.

## Where a deleted line could have survived, and what I found

Deletion is a privacy action (`bugbot-rules/deleted-data-stays-deleted.md`), so I traced every path the live transcript is copied into rather than trusting the in-memory array. Read the two **`SURVIVED`** rows as the review, not as nits.

| Path | Deleted line survives? |
|---|---|
| `LiveTranscriber.segments`, across a later tick | **No.** `isSuppressed` is applied in both `runOnce` (fixed-window, before `merge`) and `transcribeUtterance` (VAD, before append). |
| `live/current.json` — file contents | **No.** `MilaApp`'s feed loop maps `transcriber.segments` into `sidecarWriter.update(...)` on every `$segments` publish; the shorter list differs, so the revision bumps and it is rewritten atomically. |
| `live/current.json` — **incremental MCP read** | **SURVIVED.** Fixed in this PR — see below. |
| `.txt` transcript sidecar (written by `store.update` at Stop) | **No**, in auto-segment mode. `stopRecording` builds `finalTranscriptSegments` from the post-delete `segments`. Asserted through `MilaStoreReader.transcriptText`, which reads this sidecar *first*. |
| `recordings.json` | **No**, same path. Asserted against the raw JSON text. |
| `.srt` sidecar (`finalizeTail` → `TranscriptExporter.writeSRT(for: updated, …)`) | **No** — built from `updated.segments`. |
| Mid-recording "Export SRT…" button | **No** — it snapshots `transcriber.segments`. |
| `MilaStoreReader.transcriptText` / `namedTranscript` | **No.** |
| MCP `search_transcripts`, `get_transcript(id:)` | **No.** `recording(id:)` keeps its existing trashed filter, untouched. |
| Summary / LLM payload | **No** for every *new* payload: the feed sends post-delete `formattedTranscript`, and `finalizeTail`'s `regenerate` / `summarizeIfNeeded` read `recording.fullText`. See the caveat below. |
| **Automatic post-Stop batch pass (chunk mode)** | **SURVIVED.** Fixed in this PR — see below. |

### SURVIVED 1 — the automatic batch pass brought the line back (chunk mode)

When auto-segment (VAD) is **off**, `liveTranscriptIsAuthoritative` is false, the row is saved `.pending`, and `finalizeTail` calls `transcription.enqueue(updated)`. `TranscriptionService.process` then re-transcribes the whole WAV and overwrites `working.segments` / `working.fullText` before merging onto the live row — so the deleted line came back into `recordings.json`, the `.txt` sidecar and the `.srt`, along with a whole fresh transcript. That is exactly the shape the rule describes: an automatic completion path writing back data the user deleted while it was in flight, and the guard belongs on that path rather than on the store primitive.

**Fix (commit 3):** the delete affordance is only offered when the live transcript is the one that gets saved. `liveTranscriptIsSaved` in `LiveAIRecordingView` is deliberately the *same expression* the controller calls `vadActive`, not a second rule that could drift. In chunk mode the entire displayed transcript is provisional, so there is nothing to edit either way — and a destructive control that silently undoes itself is worse than no control.

**Maintainer decision, not mine to make:** the alternative is to plumb the deleted time ranges into the batch pass so the deletion survives re-transcription in *both* modes. I didn't do it — it needs the ranges persisted to outlive a relaunch, and it would have to *not* apply to a user-requested "Re-transcribe" — and smuggling a change that size into a relay seemed wrong. Say the word and it's a follow-up.

### SURVIVED 2 — a live MCP poller was never told the line went away

`get_live_transcript`'s delta is append-only by construction: `next_segment_index` is a count, and `segments(sinceIndex:)` returns from one before it so the client can replace a trailing segment whisper rewrote. Nothing in that vocabulary can say "the line you already hold is gone".

Concretely: a poller holding three lines asks `since_segment_index: 3` against a now-two-entry list, gets `Array(segments[min(2, 2)...])` = `[]`, and reads that as *"changed, nothing new"*. It keeps the deleted line in its own context for the rest of the meeting — and its cursor is now one ahead of reality, so every line after the deletion is mis-stitched too. Both halves are new with this feature; `segments` only ever grew before.

**Fix (commit 4):** `LiveTranscriptSnapshot.segmentsRemovedAtRevision` records the revision that carried a removal. A poll whose `since_revision` predates it — or which sends no revision, and so cannot prove it saw the removal — gets the **complete** current set plus `segments_removed: true`, and the tool description now tells the client to discard rather than append. Once the cursor is at or past that revision it is back on the cheap delta: a delete must not turn every remaining poll into a full resend.

Detection is precise in both directions, which is why it isn't a count check. `segmentsWereRemoved(from:to:)` compares start/end/text over the prefix *before* the trailing entry, so a mid-list delete is caught even when a new utterance lands in the same tick and the count is unchanged; a trailing rewrite is not flagged (the protocol already re-sends that entry, which is also why deleting the **last** line needs no marker); and a late speaker label landing on an already-published line is not flagged, or a multi-speaker meeting would full-resend on most ticks.

The new field is `Int?` on purpose. `live/current.json` is a cross-process *and* cross-version contract (`bugbot-rules/persisted-contracts-and-mirrors.md`): a non-optional `Int` would make a newer helper throw on an older app's snapshot, `read` would swallow it as `nil`, and `get_live_transcript` would answer "not recording" in the middle of a live meeting. `docs/mcp.md` is updated.

### Also checked

- **The stop-recording handoff is unaffected.** `finish(recordingID:transcriptIsFinal:)` is still published only after `store.update` and only when it reported success. Nothing here moves that ordering, and `LiveSidecarHandoffOrderingTests` still covers it. The failure it guards against — a handoff naming a row whose sidecar holds *older* text — is precisely what a delete applied to the view but not to `store.update` would have produced, so I checked it explicitly rather than assuming.
- **Logging is clean.** `removeSegment` logs only `start`, `end` and the remaining count, all `.public` — no transcript text. Per `bugbot-rules/no-user-content-in-logs.md` those are purely diagnostic, so redacting them would be over-redaction. My new sidecar log line is the same shape (revision + count). Nothing here collides with the log-privacy sweep in #218.
- **`StoredRecording` needs no mirror change** — `Recording.encode(to:)` is untouched, so `StoredRecordingDriftTests` has nothing new to catch. There is no key-set drift test for `LiveTranscriptSnapshot`; if you want one, that's a good follow-up independent of this PR.
- **No test had to be un-pinned.** I searched `MilaTests/` and the MilaKit tests for anything asserting the live segment set is append-only, or that the sidecar mirrors every segment. There is nothing — so unlike the two past cases here, no fixture was quietly encoding the old behaviour.

### Two things left as maintainer decisions

1. **A mis-tap is immediate and irreversible.** No confirmation, no undo; the text is gone from `segments` and only the time range is kept (to suppress re-emission). The right-click route exists because the hover button is easy to miss, which reduces accidental *triggering* but not accidental *loss*. I deliberately did not invent a confirmation or an undo stack on the contributor's behalf — but for a mid-meeting destructive action with no recovery, an undo is worth considering.
2. **"Deleted" means deleted from the transcript, not from the recording.** The WAV/m4a still contains the audio, and the right-click "Re-transcribe" will bring the text back. That is a user *asking* for a fresh transcript rather than an automatic write-back, so I left it alone — but it's worth nobody reading "delete" as "redact".

## How it was tested

**The build is UNVERIFIED locally.** This relay was prepared on Linux with no Xcode, no `xcodebuild` and no Swift toolchain, so nothing here has been compiled or run — CI is the first compiler to see it. What I could do instead: read every touched call site, grep-confirm every symbol referenced by the new tests exists (`TestSupport.makeTempRoot` / `installFakeModel` / `isolatedRemoteSettings` / `writeStereo48kSineWav`, `RecordingStore.freshAudioURL`, `QuickActionsController.startFakeRecordingForTesting` / `awaitFinalizeTails`, `StubWhisperEngine.setDefaultCanned`, `MCPAccessGate.set`, `MilaStoreReader.recording(id:)` / `transcriptText(for:)` / `namedTranscript(for:)`), mirror the idioms of `LiveSidecarHandoffOrderingTests` and `MilaMCPToolHandlersTests` exactly, and check brace/paren balance across all eleven files. Please treat a red first run as mine, not the contributor's.

`project.yml` needs no change — the `Mila`, `MilaTests` and MilaKit targets are directory scans, so the three new files are picked up automatically. The `.xcodeproj` was not touched.

### What fails on `main`

All of it: `LiveTranscriber.removeSegment(id:)` does not exist there, so the suites don't compile. The assertions that discriminate *within* the feature are the contributor's own — delete the `isSuppressed` guard and `test_deleted_line_does_not_reappear_on_next_chunk_tick` fails; delete the `absEnd` clamp and `test_vad_padded_segment_delete_does_not_suppress_next_utterance` fails.

### Negative controls (new — `MilaTests/LiveTranscriptLineDeleteTests.swift`)

An in-memory-array assertion passes just as happily when every persisted copy still holds the deleted text, so these drive a real `stopRecording()` through `QuickActionsController` and then go looking for a distinctive marker line in all six places: the store row, `recordings.json`, the `.txt` sidecar via `MilaStoreReader.transcriptText`, `namedTranscript`, the `.srt`, and `live/current.json` — finishing with a sweep of **every readable file under the store root**, which is the assertion that fails for a delete that only ever reached the UI. A second test asserts `search_transcripts` returns `count: 0` while `get_transcript(id:)` still serves the surviving line, and a third drives the live-poll handoff end to end.

Every negative assertion is paired with a precondition (the line really was published to the sidecar; the sidecar chain really resolved to text rather than an empty string; search really can see this recording), because otherwise each of them would also pass against an empty file or a store the reader never found.

Plus `Packages/MilaKit/Tests/MilaKitTests/LiveTranscriptRemovalTests.swift` (removal detection, both directions, including the cross-version decode), four new cases in `MilaMCPToolHandlersTests`, and three in `LiveTranscriptSidecarWriterTests`.

### Not verified

- No build, no test run, no manual pass — see above.
- The hover interaction itself has had no human eyes on it. @ValeroK noted in #125 that his XCUITest runner wouldn't launch locally; I couldn't run it either, for a different reason. Worth a sanity-check before release.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not done, no toolchain available; see above**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — N/A, entries are written per release


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live transcripts are finalized and persisted across stop, batch, and MCP poll paths; mistakes could resurrect deleted text or leak it to pollers, though the PR adds targeted guards and broad integration tests.
> 
> **Overview**
> Adds **per-line deletion** in the live transcript pane when auto-segment (VAD) is on — hover trash and a destructive context menu call `LiveTranscriber.removeSegment`, which drops the segment and records **deleted time ranges** so fixed-window re-transcription cannot bring the line back.
> 
> **Stop/save behavior** now treats a user-emptied live transcript as authoritative (via `hasUserDeletedSegments`), avoiding a batch re-transcribe that would resurrect deleted text; fully clearing the transcript also clears saved **summary** and **action items** derived from that text. Delete controls stay hidden in chunk mode where the live text is not what gets saved.
> 
> **MCP live polling** gains `segmentsRemovedAtRevision` and `segments_removed: true` so stale incremental cursors get a full segment resend after a removal. Tests cover transcriber suppression, sidecar stamping, MCP handlers, and end-to-end persistence (store, sidecars, MCP tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec811644096277a16d8cb0af468682ea989cc96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete lines from live transcripts.
  - Deleted text remains removed from saved transcripts, exports, and live transcript integrations.
  - Live transcript updates now notify connected clients when previously received lines were removed.

- **Bug Fixes**
  - Prevented deleted lines from reappearing during transcription or recording finalization.
  - Clearing a transcript also removes summaries and action items based on its deleted content.

- **Documentation**
  - Documented live transcript deletion behavior for integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->