### PR TITLE
fix(llm): empty the shared LLM sandbox on the idle transitions

### DIFF
--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1389,20 +1389,30 @@ enum LLMRunner {
         // surprises users whose claude/cursor wrappers source nvm/asdf/etc.
         process.environment = childEnvironment(for: executable)
 
-        // CRITICAL: spawn in an empty directory Mila owns — never $HOME, `/`,
-        // or a user folder. macOS attributes any file access by the child
-        // process to *our* bundle ID, so if claude / cursor-agent walks the
-        // cwd looking for project files (which both do — particularly
+        // CRITICAL: spawn in a directory Mila owns that holds nothing — never
+        // $HOME, `/`, or a user folder. macOS attributes any file access by the
+        // child process to *our* bundle ID, so if claude / cursor-agent walks
+        // the cwd looking for project files (which both do — particularly
         // cursor-agent in `-f` mode), the user sees scary TCC prompts saying
         // "Mila would like to access Desktop / Downloads". Launching from an
-        // isolated, empty directory guarantees there's nothing for the LLM
-        // CLI to discover and reach for, so no permission prompts fire.
+        // isolated directory with nothing in it guarantees there's nothing for
+        // the LLM CLI to discover and reach for, so no permission prompts fire.
         //
         // The directory is SHARED and STABLE across every invocation — see
         // `sandboxDirectory()` for why (issue #181: claude derives its
         // `~/.claude/projects/<slug-of-cwd>` project directory from the cwd,
         // so a per-run cwd leaked a per-run project directory forever).
-        process.currentDirectoryURL = sandboxDirectory()
+        //
+        // Because it is shared, it is NOT empty by construction: a CLI that
+        // writes into its cwd leaves the file there for whoever comes next
+        // (issue #190). `acquireSandbox()` takes a reference-counted lease and
+        // empties the directory on the idle transitions, so a child that starts
+        // while nothing else is running still starts in an empty directory. The
+        // `defer` must span the child's whole life — the lease is what stops a
+        // concurrent invocation's sweep from deleting a file this one is using.
+        let sandbox = acquireSandbox()
+        defer { releaseSandbox(sandbox) }
+        process.currentDirectoryURL = sandbox
 
         // Close stdin immediately. Some CLIs (claude) read both stdin AND
         // argv; some (cursor-agent) ignore stdin entirely. We standardised
@@ -1540,9 +1550,10 @@ enum LLMRunner {
     /// Two requirements meet here, and a single stable directory is the only
     /// shape that satisfies both:
     ///
-    /// 1. **TCC isolation.** The child must start in an empty directory Mila
-    ///    owns, so a CLI that scans its cwd for project context finds nothing
-    ///    and no "Mila would like to access Desktop" prompts fire.
+    /// 1. **TCC isolation.** The child must start in a directory Mila owns
+    ///    that holds nothing, so a CLI that scans its cwd for project context
+    ///    finds nothing and no "Mila would like to access Desktop" prompts
+    ///    fire.
     /// 2. **One Claude Code project, not one per run** (issue #181). claude
     ///    stores its conversation transcripts in
     ///    `~/.claude/projects/<slug-of-cwd>/<session-uuid>.jsonl` — the
@@ -1568,8 +1579,45 @@ enum LLMRunner {
     /// temp directory and periodically purges it — either would fragment the
     /// project directory again over time.
     ///
-    /// The directory is created on demand and never removed: `Process.run()`
-    /// fails outright if `currentDirectoryURL` doesn't exist.
+    /// ## What "holds nothing" is worth, exactly (issue #190)
+    ///
+    /// Sharing the directory is what costs it emptiness: any CLI that writes a
+    /// regular file into its cwd leaves it there. So emptiness is not a
+    /// property of the path — it is maintained by `acquireSandbox()` /
+    /// `releaseSandbox(_:)`, which reference-count the invocations currently
+    /// inside and empty the directory on **both** idle transitions: before the
+    /// first child enters, and after the last one leaves. The guarantee that
+    /// buys, stated so a future reader doesn't have to infer it:
+    ///
+    ///   * A child that starts while no other invocation is running always
+    ///     starts in an empty directory. The entry sweep does not trust the
+    ///     exit sweep to have happened, so this holds for the first run after a
+    ///     crash or a force-quit too.
+    ///   * An artifact an invocation writes here is therefore visible only to
+    ///     invocations whose lifetime **overlaps** it. A later, non-overlapping
+    ///     call — a different recording's summary, a Settings → AI Provider
+    ///     test — never sees it.
+    ///
+    /// What it is **not**: a private directory per invocation. Concurrent
+    /// invocations (a Live AI tick and a one-shot Send) deliberately share this
+    /// one cwd, and no sweep may run while any of them is inside — deleting a
+    /// file a live child is using is the worse bug — so overlapping runs can
+    /// see each other's files for as long as they overlap. Giving each run its
+    /// own directory is not available as a fix: claude's project slug is a slug
+    /// of the **full** cwd path, so even a subdirectory of a stable parent
+    /// mints a fresh `~/.claude/projects/<slug>` per run, which is precisely
+    /// the leak #181 removed.
+    ///
+    /// Nothing durable lives here, so sweeping costs nothing: conversations are
+    /// in `~/.claude/projects/<slug>` (never touched, so `--resume` still
+    /// works) and workspace trust is granted per-invocation in argv
+    /// (`cursor-agent -f`, `gemini --skip-trust`), not by state in the cwd.
+    ///
+    /// The directory itself is created on demand and never removed — only its
+    /// contents are swept. `Process.run()` fails outright if
+    /// `currentDirectoryURL` doesn't exist, and the path *is* the claude
+    /// project identity, so remove-and-recreate would race a launching child
+    /// for no benefit.
     static func sandboxDirectory() -> URL {
         let url = sandboxDirectory(appSupportRoot: applicationSupportRoot())
         do {
@@ -1603,6 +1651,103 @@ enum LLMRunner {
         appSupportRoot
             .appendingPathComponent("Mila", isDirectory: true)
             .appendingPathComponent("llm-sandbox", isDirectory: true)
+    }
+
+    // MARK: - Shared-sandbox lifecycle (issue #190)
+
+    /// How many child processes are currently chdir'd into the shared sandbox.
+    /// Guarded by `sandboxLock`.
+    private static var sandboxTenants = 0
+
+    /// Guards `sandboxTenants` **and** the sweep, in one critical section: a
+    /// sweep that ran outside the lock could start while the count still read
+    /// zero and finish after a child had already been counted in and launched,
+    /// deleting a file from under it. `NSLock` rather than
+    /// `OSAllocatedUnfairLock` (used elsewhere in this file for the pipe
+    /// buffers) precisely because this one is held across file I/O, which
+    /// `os_unfair_lock` is documented not to be for; the held region is a
+    /// `contentsOfDirectory` plus a handful of `removeItem`s over a directory
+    /// that is empty in the common case. `ProcessHandle` at the bottom of this
+    /// file uses `NSLock` for the same reason.
+    private static let sandboxLock = NSLock()
+
+    /// Claim the shared working directory for one child process and return the
+    /// directory to chdir into. **Must** be paired with `releaseSandbox(_:)` —
+    /// use `defer`, and keep the lease open for the whole life of the child,
+    /// not just its launch.
+    ///
+    /// The sweep on the idle→busy transition is the one that carries the
+    /// guarantee in `sandboxDirectory()`'s doc comment: when nobody is inside,
+    /// anything in there is a leftover — from this session's last run, or from
+    /// a run whose release never happened because Mila was force-quit. Doing it
+    /// here rather than once at app launch is also what keeps the guarantee
+    /// keyed to the directory the child is *about to enter*, which matters
+    /// because `sandboxDirectory()` can resolve to the temp fallback.
+    static func acquireSandbox() -> URL {
+        let url = sandboxDirectory()
+        sandboxLock.lock()
+        defer { sandboxLock.unlock() }
+        if sandboxTenants == 0 { emptySandbox(at: url) }
+        sandboxTenants += 1
+        return url
+    }
+
+    /// Release the lease `acquireSandbox()` returned, sweeping if this was the
+    /// last invocation inside. Pass back the URL that acquire handed out rather
+    /// than re-resolving: on the temp-fallback path the two can differ, and the
+    /// directory worth emptying is the one the child actually ran in.
+    ///
+    /// Note the sweep can fire while a *grandchild* the CLI spawned and Mila
+    /// killed is still winding down (see the SIGTERM/SIGKILL grace in
+    /// `executeProcess`). That is the intended order: its output is already
+    /// being discarded, and leaving its scratch behind is the outcome this
+    /// issue is about.
+    static func releaseSandbox(_ url: URL) {
+        sandboxLock.lock()
+        defer { sandboxLock.unlock() }
+        // `max` rather than a precondition: an unbalanced release is a bug in
+        // this file, not a reason to abort a running app — and clamping keeps
+        // the count able to return to a state where sweeps still happen.
+        sandboxTenants = max(0, sandboxTenants - 1)
+        if sandboxTenants == 0 { emptySandbox(at: url) }
+    }
+
+    /// Delete the *contents* of the sandbox. Caller must hold `sandboxLock`
+    /// and must have established that no invocation is inside.
+    ///
+    /// Hidden entries included — `contentsOfDirectory` returns them unless
+    /// `.skipsHiddenFiles` is passed, and it deliberately is not. A CLI's own
+    /// dot-directory (`.claude/`, `.cursor/`) is exactly where a cached answer
+    /// about the user's meeting would sit, and sparing it would leave the fix
+    /// covering only the naive case.
+    ///
+    /// Best-effort by design: a single undeletable entry must not stop the
+    /// rest, and there is no caller that could usefully handle a throw here —
+    /// refusing to launch the LLM because a stale file wouldn't unlink would
+    /// trade a small privacy regression for a broken feature.
+    private static func emptySandbox(at url: URL) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: url,
+                                                        includingPropertiesForKeys: nil,
+                                                        options: []) else { return }
+        guard !entries.isEmpty else { return }
+        var failed = 0
+        for entry in entries {
+            do { try fm.removeItem(at: entry) } catch { failed += 1 }
+        }
+        // Counts only, never names: a file an LLM CLI wrote here is named after
+        // whatever it was asked about, and Mila derives those prompts from
+        // recordings. `error` when something survived — the guarantee above
+        // silently stops holding for that entry, and that must not need
+        // `--debug` to notice.
+        if failed > 0 {
+            llmRunnerLog.error("""
+                llm sandbox sweep incomplete entries=\(entries.count, privacy: .public) \
+                failed=\(failed, privacy: .public) — leftovers stay visible to the next invocation
+                """)
+        } else {
+            llmRunnerLog.debug("llm sandbox swept entries=\(entries.count, privacy: .public)")
+        }
     }
 
     /// `~/Library/Application Support`, with a temp-directory fallback so a

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -45,15 +45,21 @@ final class LLMRunnerTests: XCTestCase {
     /// scary prompts for any folder the LLM CLI happens to scan.
     func test_runner_spawns_child_in_isolated_empty_directory() async throws {
         // Script prints its cwd and counts the entries it sees there.
-        // Deliberately `ls` and not `ls -A`: since #181 the sandbox is shared
-        // and persistent, so an LLM CLI is free to leave its own dot-files
-        // (`.claude/`) behind. What must stay true is that the child sees no
-        // *user* content — which is what a visible-entry count proves, and it
-        // still fails loudly if the cwd ever became $HOME or a user folder.
+        //
+        // `ls -A`, hidden entries included (issue #190). Between #181 and #190
+        // this was a bare `ls`, on the grounds that a shared, persistent
+        // sandbox lets an LLM CLI leave its own dot-files (`.claude/`) behind
+        // — which made the count pass by luck rather than by construction, and
+        // spared exactly the directory a CLI would cache an answer about the
+        // user's meeting in. The runner now empties the sandbox on the idle
+        // transitions, so a run that starts with nothing else in flight — as
+        // this one does — must find the directory genuinely empty, dot-files
+        // and all. The cwd assertions below still fail loudly if it ever became
+        // $HOME or a user folder.
         let script = makeScript("""
             #!/bin/sh
             printf 'cwd=%s\\n' "$PWD"
-            printf 'entries=%s\\n' "$(ls 2>/dev/null | wc -l | tr -d ' ')"
+            printf 'entries=%s\\n' "$(ls -A 2>/dev/null | wc -l | tr -d ' ')"
             """)
         defer { try? FileManager.default.removeItem(at: script) }
         let out = try await LLMRunner.run(
@@ -73,6 +79,89 @@ final class LLMRunnerTests: XCTestCase {
         // And it must be the one directory Mila owns for this.
         XCTAssertTrue(out.contains("cwd=\(LLMRunner.sandboxDirectory().path)\n"),
                       "Child cwd is not the shared LLM sandbox: \(out)")
+    }
+
+    /// Issue #190. The shared cwd #181 introduced is not empty at the start of
+    /// a run: whatever the previous CLI wrote into it is still sitting there.
+    /// So an artifact derived from one recording's call — a scratch file, a
+    /// cached answer — was discoverable by an unrelated later call, including
+    /// one for a different recording.
+    ///
+    /// Deliberately probes for ONE uniquely-named marker instead of asserting
+    /// the directory is empty. Emptiness is a property of the whole directory
+    /// that a concurrent invocation is entitled to break (concurrent runs share
+    /// this cwd by design, and that is pinned by
+    /// `LLMSandboxDirectoryTests`), whereas "the file invocation A wrote is
+    /// gone before invocation B starts" is the property that actually matters
+    /// and holds no matter what else is in there.
+    ///
+    /// The writer re-checks its own marker with the same `[ -e ]` test before
+    /// exiting, so `ABSENT` from the reader cannot pass for the wrong reason —
+    /// a mis-quoted path or a write that never landed would show up as
+    /// `WROTE:ABSENT` and fail the first assertion instead of quietly making
+    /// the second one trivially true.
+    func test_artifact_from_one_invocation_is_not_visible_to_the_next() async throws {
+        let marker = "island-mila-leak-probe-\(UUID().uuidString).txt"
+        let writer = makeScript("""
+            #!/bin/sh
+            printf 'output derived from a meeting transcript' > "\(marker)"
+            if [ -e "\(marker)" ]; then printf 'WROTE:FOUND'; else printf 'WROTE:ABSENT'; fi
+            """)
+        let reader = makeScript("""
+            #!/bin/sh
+            if [ -e "\(marker)" ]; then printf 'PROBE:FOUND'; else printf 'PROBE:ABSENT'; fi
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: writer)
+            try? FileManager.default.removeItem(at: reader)
+        }
+
+        let wrote = try await LLMRunner.run(tool: .claude,
+                                            prompt: "x", transcript: "y",
+                                            executablePathOverride: writer.path,
+                                            timeout: 30)
+        XCTAssertEqual(wrote, "WROTE:FOUND",
+                       "the first invocation never wrote its marker, so the "
+                       + "probe below would prove nothing: \(wrote)")
+
+        let probe = try await LLMRunner.run(tool: .claude,
+                                            prompt: "x", transcript: "y",
+                                            executablePathOverride: reader.path,
+                                            timeout: 30)
+        XCTAssertEqual(probe, "PROBE:ABSENT",
+                       "a later invocation could read a file the previous one "
+                       + "left in the shared sandbox: \(probe)")
+    }
+
+    /// Negative control for the test above, in the shape the bug actually took
+    /// on disk: a file already sitting in the shared directory when a run
+    /// starts. Planted with `FileManager` rather than by a first run, so this
+    /// asserts the *entry* sweep specifically — the one that also covers what a
+    /// crashed or force-quit session left behind, where no release ever ran.
+    ///
+    /// Uses nothing but the pre-#190 API surface (`run`, `sandboxDirectory()`),
+    /// so it compiles against the unfixed runner and fails there: that runner
+    /// swept nothing, and the child would print `PROBE:FOUND`.
+    func test_leftover_in_the_shared_sandbox_is_gone_before_the_next_child_starts() async throws {
+        let name = "island-mila-stale-leftover-\(UUID().uuidString).txt"
+        let leftover = LLMRunner.sandboxDirectory().appendingPathComponent(name)
+        try Data("left behind by an earlier invocation".utf8).write(to: leftover)
+        defer { try? FileManager.default.removeItem(at: leftover) }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: leftover.path),
+                      "test setup failed: the leftover was never planted at \(leftover.path)")
+
+        let script = makeScript("""
+            #!/bin/sh
+            if [ -e "\(name)" ]; then printf 'PROBE:FOUND'; else printf 'PROBE:ABSENT'; fi
+            """)
+        defer { try? FileManager.default.removeItem(at: script) }
+        let out = try await LLMRunner.run(tool: .claude,
+                                          prompt: "x", transcript: "y",
+                                          executablePathOverride: script.path,
+                                          timeout: 30)
+        XCTAssertEqual(out, "PROBE:ABSENT",
+                       "the child could read a file an earlier run left in the "
+                       + "shared sandbox: \(out)")
     }
 
     /// The transcript travels in argv (via `composedPrompt`), not stdin —

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -69,6 +69,48 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         return url
     }
 
+    /// Writes `marker` into its cwd (the sandbox), signals `ready`, parks until
+    /// `barrier` appears, then reports whether its own file survived the wait.
+    /// `ready` and `barrier` both live OUTSIDE the sandbox so the handshake
+    /// itself writes nothing into the directory under test.
+    private func makeMarkerHolderScript(marker: String, ready: URL, barrier: URL) -> URL {
+        makeScript("""
+        #!/bin/sh
+        printf 'output derived from a meeting transcript' > "\(marker)"
+        : > "\(ready.path)"
+        i=0
+        while [ ! -f "\(barrier.path)" ] && [ $i -lt 1200 ]; do
+          i=$((i+1)); sleep 0.05
+        done
+        if [ -e "\(marker)" ]; then printf 'TICK:FOUND'; else printf 'TICK:ABSENT'; fi
+        """)
+    }
+
+    private func makeScript(_ body: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
+        try? body.write(to: url, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: url.path)
+        return url
+    }
+
+    /// Poll for a handshake file. `XCTFail` rather than a `throw` on expiry so
+    /// the failure names the file that never appeared instead of surfacing as
+    /// an opaque error out of the caller.
+    private func waitForFile(_ url: URL,
+                             timeout: TimeInterval,
+                             file: StaticString = #filePath,
+                             line: UInt = #line) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTFail("timed out after \(Int(timeout))s waiting for \(url.lastPathComponent)",
+                file: file, line: line)
+    }
+
     /// claude derives its `~/.claude/projects/<slug-of-cwd>` project directory
     /// from the process CWD. A per-invocation CWD therefore leaked a
     /// per-invocation project directory that nothing ever cleaned up (175
@@ -242,6 +284,101 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: LLMRunner.sandboxDirectory().path),
             "shared sandbox was torn down after the run")
+    }
+
+    /// Issue #190's hard constraint: the sweep that keeps the shared directory
+    /// clean must never delete a file a CONCURRENT invocation is using. Driven
+    /// through the lease API directly rather than through two child processes
+    /// so the overlap is exact and the test carries no subprocess timing — the
+    /// end-to-end twin is `test_a_oneshot_run_does_not_sweep_a_concurrent_tick`
+    /// below.
+    ///
+    /// Reads as the life of one Live AI tick with a one-shot Send landing on
+    /// top of it: the tick writes something, the Send starts and finishes
+    /// around it, and only when the last invocation leaves does the directory
+    /// get emptied.
+    func test_sweep_waits_for_the_last_concurrent_invocation() throws {
+        let first = LLMRunner.acquireSandbox()
+        var firstReleased = false
+        defer { if !firstReleased { LLMRunner.releaseSandbox(first) } }
+
+        let marker = first.appendingPathComponent(
+            "island-mila-inflight-\(UUID().uuidString).txt")
+        try Data("a file the running invocation is using".utf8).write(to: marker)
+        // Control for the three assertions below: they are only meaningful if
+        // the file was really there to begin with.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path),
+                      "test setup failed: nothing was written at \(marker.path)")
+
+        // A second invocation STARTING while the first is still inside must not
+        // sweep — this is the "deleted a file out from under a live child"
+        // case that rules out a naive sweep-before-each-run.
+        let second = LLMRunner.acquireSandbox()
+        var secondReleased = false
+        defer { if !secondReleased { LLMRunner.releaseSandbox(second) } }
+        XCTAssertEqual(second, first,
+                       "concurrent invocations must still share one cwd (#181)")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path),
+                      "a second invocation swept a file the first one is using")
+
+        // Nor may it sweep on the way out, while the first is still inside.
+        LLMRunner.releaseSandbox(second)
+        secondReleased = true
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path),
+                      "the sweep fired while an invocation was still running")
+
+        // Last one out empties the directory.
+        LLMRunner.releaseSandbox(first)
+        firstReleased = true
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path),
+                       "the shared sandbox kept an artifact after the last "
+                       + "invocation left: \(marker.path)")
+    }
+
+    /// The same property with real children, because the lease test cannot show
+    /// that `executeProcess` actually holds its lease for the whole life of the
+    /// child rather than just across the launch.
+    ///
+    /// A long-running invocation (the shape of a Live AI tick) writes a file
+    /// into the shared cwd and parks on a barrier; a one-shot call then starts
+    /// AND finishes around it. Neither the one-shot's entry nor its exit may
+    /// take the tick's file with it.
+    func test_a_oneshot_run_does_not_sweep_a_concurrent_tick() async throws {
+        let token = UUID().uuidString
+        let temp = FileManager.default.temporaryDirectory
+        let ready = temp.appendingPathComponent("island-mila-tick-ready-\(token)")
+        let barrier = temp.appendingPathComponent("island-mila-tick-barrier-\(token)")
+        let tick = makeMarkerHolderScript(marker: "island-mila-tick-artifact-\(token).txt",
+                                          ready: ready,
+                                          barrier: barrier)
+        let oneShot = makeCWDEchoScript()
+        defer {
+            for url in [ready, barrier, tick, oneShot] {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        async let live = LLMRunner.run(tool: .claude, prompt: "x", transcript: "y",
+                                       executablePathOverride: tick.path,
+                                       session: .new(UUID()), timeout: 120)
+        // Don't start the one-shot until the tick is genuinely inside with its
+        // file written — otherwise the two might not overlap at all and the
+        // test would pass without exercising anything.
+        try await waitForFile(ready, timeout: 60)
+
+        let oneShotCWD = try await LLMRunner.run(tool: .claude,
+                                                 prompt: "x", transcript: "y",
+                                                 executablePathOverride: oneShot.path,
+                                                 timeout: 60)
+        XCTAssertEqual(oneShotCWD, LLMRunner.sandboxDirectory().path,
+                       "the one-shot didn't run in the shared sandbox, so it "
+                       + "never had the chance to sweep the tick's file")
+
+        try Data().write(to: barrier)
+        let tickResult = try await live
+        XCTAssertEqual(tickResult, "TICK:FOUND",
+                       "a concurrent one-shot swept the running tick's file out "
+                       + "from under it: \(tickResult)")
     }
 
     /// `diagnose` (Settings → AI Provider "Test") is the third code path into


### PR DESCRIPTION
Closes #190

## What & why

#187 pointed every LLM invocation at one stable working directory (`~/Library/Application Support/Mila/llm-sandbox/`) because the `claude` CLI derives its project identity from a slug of the cwd, so a per-run cwd minted a fresh `~/.claude/projects/` directory each time and made those conversations unresumable. The cost was that the directory is no longer empty at the start of a run: any CLI that writes a regular file into its cwd leaves it there for the next invocation to find.

Scope, honestly: this is not an external exposure. The directory sits under the user's own Application Support, readable only by them, and Mila writes no transcripts there. The narrow concern is that content **derived** from one recording's LLM call could be discovered by an unrelated later call, including one for a different recording. Separately — and this is the part a future reader would have been misled by — `LLMRunner`'s doc comment still promised "an empty directory", which stopped being true in #187.

### The option chosen: reference-count the invocations, sweep on both idle transitions

`acquireSandbox()` / `releaseSandbox(_:)` track how many children are currently chdir'd into the sandbox and empty it when the count is (or reaches) zero — **before the first child enters, and after the last one leaves**. `executeProcess` takes the lease with a `defer` that spans the child's whole life, not just its launch.

Against the two things #187 deliberately preserves:

1. **The stable project path.** Only the directory's *contents* are removed; the directory itself is never deleted or recreated. The path is unchanged, so claude still resolves one `~/.claude/projects/<slug>` for every run and #181 stays fixed. Nothing durable lives in the cwd to lose: conversations are stored under `~/.claude/projects/<slug>` (never touched, `--resume` still works), and workspace trust is granted per-invocation in argv (`cursor-agent -f`, `gemini --skip-trust`), not by state in the working directory.
2. **Concurrent invocations.** A sweep can only run when the count is zero, so it can never delete a file a live child is using. A Live AI tick and a one-shot Send still share the one cwd for as long as they overlap; the one-shot's entry and exit are both no-ops for the sweep while the tick is inside. This is exactly the hazard that rules out a naive sweep-before-each-run, and it is pinned by two tests.

**Why entry as well as exit.** The exit sweep cannot be trusted to have happened — a crash or force-quit skips it. Sweeping on entry when idle is what makes "a child that starts while nothing else is running starts in an empty directory" hold unconditionally, and it subsumes a sweep-at-app-launch hook (considered and dropped: it would clear crash residue slightly earlier while adding a second entry point enforcing the same invariant). It also keys the sweep to the directory the child is *about to enter*, which matters on the temp-fallback path where `sandboxDirectory()` can resolve somewhere else.

Hidden entries are swept too (`contentsOfDirectory` without `.skipsHiddenFiles`). A CLI's own dot-directory — `.claude/`, `.cursor/` — is precisely where a cached answer about the user's meeting would sit; sparing it would leave the fix covering only the naive case.

### On the per-invocation-subdirectory option

The issue says a subdirectory of a stable parent does not work, and that holds when checked against the code. `LLMRunner.sandboxDirectory()`'s doc comment and the #181 report both describe the project directory as `~/.claude/projects/<slug-of-cwd>` — the slug is of the **full** cwd path, not of a parent — and `LLMSandboxDirectoryTests.test_sandbox_path_has_no_per_run_component` already pins "the path must contain nothing run-specific: no UUID, no PID, no timestamp". A per-run child directory is a per-run cwd path, so it re-mints a project directory per run. Rejected, and now recorded in the doc comment so the next reader doesn't re-derive it.

### What the corrected doc comment promises

`sandboxDirectory()` no longer claims empty isolation as a property of the path. It states the guarantee the reference count actually keeps:

* A child that starts while no other invocation is running always starts in an empty directory — including the first run after a crash, because the entry sweep does not trust the exit sweep to have happened.
* An artifact an invocation writes here is visible only to invocations whose lifetime **overlaps** it. A later, non-overlapping call — a different recording's summary, a Settings → AI Provider test — never sees it.
* It is explicitly **not** a private directory per invocation. Overlapping runs share the cwd by design and can see each other's files while they overlap, because no sweep may run while any of them is inside.

Failures are visible rather than silent: a sweep that cannot unlink something logs at `error` ("leftovers stay visible to the next invocation"), with counts only — never filenames, which are derived from what the CLI was asked about.

## How it was tested

Cannot build on this machine (Linux, no Xcode/Swift toolchain), so the build and suite are unverified until CI runs. Tests added/changed:

**`MilaTests/LLMRunnerTests.swift`**

* `test_artifact_from_one_invocation_is_not_visible_to_the_next` — the test the issue asks for. Invocation 1 writes a uniquely-named marker into its cwd and re-checks it with the same `[ -e ]` predicate before exiting; invocation 2 probes for it and must report `ABSENT`. It deliberately probes for **one named file rather than asserting the directory is empty**: emptiness is a whole-directory property a concurrent invocation is entitled to break, whereas "the file A wrote is gone before B starts" is the property that matters and holds regardless of what else is in there. The writer's self-check is what stops `ABSENT` passing for the wrong reason (a mis-quoted path, a write that never landed).
* `test_leftover_in_the_shared_sandbox_is_gone_before_the_next_child_starts` — **negative control**, in the shape the bug actually took on disk: a file planted directly into the shared directory with `FileManager`, i.e. what a crashed session (or, before this change, any earlier invocation) leaves behind. It uses nothing but pre-#190 API (`run`, `sandboxDirectory()`), so it compiles against the unfixed runner and **fails there** — that runner swept nothing and the child prints `PROBE:FOUND`. The end-to-end test above fails on today's code too, for the same reason.
* `test_runner_spawns_child_in_isolated_empty_directory` — **this is the test that pinned the current behaviour and had to change.** It counted visible entries only (`ls`, not `ls -A`), on the grounds that a shared sandbox lets a CLI leave dot-files behind. That made the count pass by luck rather than by construction, and spared exactly the directory a CLI would cache in. It now uses `ls -A`, because the idle sweep makes emptiness true by construction for a run that starts with nothing else in flight.

**`MilaTests/LLMSandboxDirectoryTests.swift`**

* `test_sweep_waits_for_the_last_concurrent_invocation` — the concurrency constraint, driven through the lease API directly so the overlap is exact and there is no subprocess timing in it: a file written by the first tenant survives a second tenant's `acquire` **and** its `release`, and is gone only once the last tenant leaves.
* `test_a_oneshot_run_does_not_sweep_a_concurrent_tick` — the same property with real children, which the lease test cannot show: a long-running invocation (Live AI tick shape, `session: .new`) writes into the cwd and parks on a barrier while a one-shot call starts and finishes around it; the tick's file must still be there when it wakes. Both handshake files live outside the sandbox so the synchronisation writes nothing into the directory under test.
* The existing `test_concurrent_runs_share_one_working_directory` and `test_runner_leaves_the_shared_directory_in_place` are unchanged and must keep passing — the shared-cwd property from #187 is preserved, and the directory itself is never removed.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — not possible in this environment; relying on CI
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, no user-visible behaviour change


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess cwd lifecycle with locked file sweeps during overlapping LLM invocations; mistakes could delete in-use files or leave cross-run artifacts, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **issue #190**: the stable shared LLM working directory (`llm-sandbox`) could retain scratch files or CLI dot-directories between runs, so a later unrelated invocation might see artifacts from an earlier recording.
> 
> **`LLMRunner`** now treats the sandbox with a reference-counted lease: `acquireSandbox()` / `releaseSandbox(_:)` sweep directory **contents** (including hidden entries) when the tenant count transitions on idle—before the first child enters and after the last one leaves. `executeProcess` holds that lease for the full child lifetime via `defer`, so concurrent Live AI and one-shot runs still share one cwd (#181) without a sweep deleting files a live process is using.
> 
> Documentation for `sandboxDirectory()` is updated to describe maintained emptiness rather than “empty by construction.” Failed sweeps log at error with counts only (no filenames).
> 
> Tests cover sequential isolation (`ls -A`), planted leftovers, lease/concurrency behavior, and an end-to-end overlapping tick vs one-shot scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462707a9fde48cdfe4e01ed72e5a3d6166a2655c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->