### PR TITLE
fix(llm): wait for speaker finalization before sending a transcript

### DIFF
--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -87,7 +87,18 @@ final class PostRecordingCoordinator: ObservableObject {
     /// caller hands us an empty transcript we poll the store until the
     /// recording lands in a terminal state. Generous bound: a long file
     /// can still be transcribing minutes after the user walks away.
+    ///
+    /// One budget covers BOTH halves of "is this transcript final" — the
+    /// text and then the speaker labels (issue #211) — rather than two
+    /// stacked timeouts that could add up to twice the advertised bound.
     var transcriptWaitTimeout: TimeInterval = 600
+
+    /// Shown while a send is parked waiting for the offline speaker pass to
+    /// re-key `SPEAKER_NN`. A named constant because it is the difference
+    /// between "the app is thinking" and an unexplained delay before
+    /// "Sending to Claude…", and the tests assert on the same string the
+    /// user reads. (Issue #211.)
+    static let waitingForSpeakersStatus = "Waiting for speaker identification…"
 
     init(store: RecordingStore,
          transcription: TranscriptionService,
@@ -146,8 +157,8 @@ final class PostRecordingCoordinator: ObservableObject {
     /// the meantime. (Issue #34.)
     ///
     /// The transcript is usually still being finalized at add time, so we
-    /// reuse `awaitTranscript` (the same poller "Send to <LLM>" uses) to wait
-    /// for it before invoking the CLI.
+    /// reuse `awaitFinalTranscript` (the same poller "Send to <LLM>" uses) to
+    /// wait for it — text and speaker labels both — before invoking the CLI.
     private func armAutoSuggestTitle(for recording: Recording) {
         guard llm.isConfigured, llm.nameGenerationEnabled else { return }
         let id = recording.id
@@ -181,8 +192,14 @@ final class PostRecordingCoordinator: ObservableObject {
                 if !Task.isCancelled { self?.clearLLM(for: id) }
             }
             guard let self else { return }
-            guard let transcript = await self.awaitTranscript(for: id,
-                                                              timeout: waitTimeout) else {
+            // Same wait as the Send path, and for the same reason (issue
+            // #211): a title generated from the live diarizer's
+            // over-segmented speakers is less wrong than a summary built on
+            // them, but it is the same stale input. Silent here — this job
+            // runs unattended on every recording, so a banner explaining a
+            // wait the user never asked for would be noise.
+            guard let transcript = await self.awaitFinalTranscript(
+                for: id, timeout: waitTimeout, announceSpeakerWait: false) else {
                 return  // discarded, timed out, or empty transcript
             }
             if Task.isCancelled { return }
@@ -290,13 +307,15 @@ final class PostRecordingCoordinator: ObservableObject {
     /// dismiss BEFORE calling this, so the call genuinely runs in the
     /// background — the user can close the sheet and walk away.
     ///
-    /// `transcript` is whatever the caller had at click time. When the
-    /// user fires before transcription finishes it'll be empty; in that
-    /// case we wait for the recording to reach a terminal state and pull
-    /// the finished transcript out of the store ourselves, rather than
-    /// blocking the UI behind a disabled button. (The sheet used to gate
-    /// the button on `transcriptReady` for exactly this reason — now the
-    /// readiness wait lives here so "Send" is always pressable.)
+    /// `transcript` is whatever the caller had at click time. We do not send
+    /// it: we wait for the recording to be genuinely final — transcribed AND
+    /// past the offline speaker pass — and read the text back out of the
+    /// store, rather than blocking the UI behind a disabled button. (The
+    /// sheet used to gate the button on `transcriptReady` for exactly this
+    /// reason — now the readiness wait lives here so "Send" is always
+    /// pressable.) The click-time text is the fallback for a row the store
+    /// cannot answer for at all; see `awaitFinalTranscript` for why it can no
+    /// longer be a shortcut past the wait (issue #211).
     ///
     /// Idempotent per id: a second send for the same recording cancels and
     /// replaces the first (no use case for two competing CLI calls writing
@@ -349,21 +368,39 @@ final class PostRecordingCoordinator: ObservableObject {
                 if let self, !Task.isCancelled { self.sendTasks[recordingID] = nil }
             }
             guard let self else { return }
-            // Resolve the transcript: use the click-time snapshot if it
-            // already has text, otherwise wait for transcription to finish.
+            // Resolve the transcript from the STORE, waiting until it is
+            // final in both senses — the text has been produced, and the
+            // speaker labels on it will not be re-keyed again.
+            //
+            // The click-time snapshot is no longer a shortcut past that wait,
+            // only a fallback for when the store cannot answer at all (the
+            // row was discarded, or was never there). It has to be: on the
+            // live/VAD path the snapshot is ALWAYS non-empty — the sheet is
+            // showing the live transcript — so preferring it made the wait
+            // unreachable on the one path that has the race (issue #211).
+            // And it is a snapshot of the pre-re-diarize labels by
+            // construction, so even a correct wait would have sent stale
+            // text if we then used it instead of re-reading.
             let resolved: String
-            if transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                guard let waited = await self.awaitTranscript(for: recordingID,
-                                                              timeout: timeout) else {
-                    if Task.isCancelled { return }
-                    self.postStatus("\(toolName): no transcript to send.", isError: true)
-                    return
-                }
-                resolved = waited
-            } else {
+            if let final = await self.awaitFinalTranscript(for: recordingID,
+                                                           timeout: timeout,
+                                                           announceSpeakerWait: true) {
+                resolved = final
+            } else if !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 resolved = transcript
+            } else {
+                if Task.isCancelled { return }
+                self.postStatus("\(toolName): no transcript to send.", isError: true)
+                return
             }
             if Task.isCancelled { return }
+            // Re-assert the banner now the waiting is over. The click-time
+            // "Sending to …" may have auto-cleared minutes ago (a long
+            // transcription, then the speaker pass), and the speaker wait
+            // clears its own message on the way out — so without this the
+            // last thing the user saw is nothing at all, right at the point
+            // the CLI actually starts.
+            self.postStatus("Sending to \(toolName)…")
             do {
                 // OpenAI-compatible runs need the model name threaded (the
                 // HTTP path can't pick its own). Issue celarent7/mila#3.
@@ -385,10 +422,13 @@ final class PostRecordingCoordinator: ObservableObject {
                     false,
                     nil,
                     .action,
-                    // Resolved here, after the transcript wait: the `.srt` is
-                    // written at the end of the transcription pass, so asking
-                    // any earlier would find nothing and fall back to inline
-                    // for every send fired mid-recording.
+                    // Resolved here, after the transcript AND speaker waits:
+                    // the `.srt` is written at the end of the transcription
+                    // pass — and, on the live path, only after the offline
+                    // re-diarize inside `finalizeTail` — so asking any earlier
+                    // would find nothing and fall back to inline for every
+                    // send fired mid-recording or straight after Stop
+                    // (issue #211).
                     byPath ? self.transcriptReferences(for: recordingID) : .inline)
                 let preview = output
                     .replacingOccurrences(of: "\n", with: " ")
@@ -447,32 +487,136 @@ final class PostRecordingCoordinator: ObservableObject {
                                     audio: store.audioURL(for: rec)))
     }
 
+    /// The transcript to hand an LLM for `recordingID`, once it is genuinely
+    /// final — in BOTH senses:
+    ///
+    ///  1. the text exists and the recording has left `.pending`/`.running`;
+    ///  2. its speaker labels will not change again (issue #211).
+    ///
+    /// Step 2 exists because on the live/VAD path the row is already
+    /// `.completed` when Stop returns, while the offline re-diarize that
+    /// fixes the live diarizer's over-segmentation runs afterwards in
+    /// `QuickActionsController.finalizeTail`. Everything sent in that window
+    /// carries one person split across several `SPEAKER_NN`, with names on
+    /// the wrong turns, and nothing reconciles the CLI's answer once the good
+    /// labels land.
+    ///
+    /// Order matters: the speaker check comes SECOND. A send fired mid-
+    /// recording sees no marker yet — the tail that publishes it has not been
+    /// reached — so checking speakers first would sail straight through.
+    /// Waiting for the terminal status first lands us past the marker's
+    /// publication, which happens in the same main-actor run as the
+    /// `store.update` that flips the status.
+    ///
+    /// Both halves share one `deadline`, so the caller's `timeout` is the
+    /// total bound rather than a per-phase one. Returns nil if the recording
+    /// disappears, ends up with no text, or the wait times out / is
+    /// cancelled; the wait honours task cancellation so `cancelAndDiscard`
+    /// unblocks it immediately.
+    private func awaitFinalTranscript(for recordingID: UUID,
+                                      timeout: TimeInterval,
+                                      announceSpeakerWait: Bool) async -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        guard let text = await awaitTranscript(for: recordingID, until: deadline) else {
+            return nil
+        }
+        guard await awaitSpeakerFinalization(for: recordingID,
+                                             until: deadline,
+                                             announce: announceSpeakerWait) else {
+            // Nothing was pending, so the text above already carries final
+            // labels — and no wait was paid.
+            return text
+        }
+        // The offline pass re-keys every `SPEAKER_NN` and moves
+        // `speakerNames` onto the new ids, so the text read before the wait
+        // is stale by construction. Re-read.
+        return storedTranscript(for: recordingID) ?? text
+    }
+
     /// Poll the store until `recordingID` has a non-empty transcript and
     /// has left the in-progress states (`.pending` / `.running`), then
     /// return the speaker-aware plain text. Returns nil if the recording
-    /// disappears, ends up with no text, or the wait times out / is
+    /// disappears, ends up with no text, or `deadline` passes / the task is
     /// cancelled. The wait is cheap (a short sleep between checks) and
     /// honours task cancellation so `cancelAndDiscard` unblocks it
     /// immediately.
     private func awaitTranscript(for recordingID: UUID,
-                                 timeout: TimeInterval) async -> String? {
-        let deadline = Date().addingTimeInterval(timeout)
+                                 until deadline: Date) async -> String? {
         while Date() < deadline {
             if Task.isCancelled { return nil }
             guard let rec = store.recordings.first(where: { $0.id == recordingID }) else {
                 return nil  // discarded out from under us
             }
             if rec.status != .pending && rec.status != .running {
-                let text = TranscriptFormatter.plainText(segments: rec.segments,
-                                                         fallback: rec.fullText,
-                                                         names: rec.speakerNames)
-                return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ? nil
-                    : text
+                return storedTranscript(for: recordingID)
             }
             try? await Task.sleep(nanoseconds: 250_000_000)
         }
         return nil
+    }
+
+    /// Park until the offline speaker pass for `recordingID` is done, so the
+    /// caller reads the CLEANED labels rather than the live diarizer's
+    /// over-segmented ones.
+    ///
+    /// Returns `true` when there was something to wait for — the caller must
+    /// then re-read the transcript, because the pass re-keys the speaker ids.
+    /// Returns `false` when nothing was pending, which is the common case and
+    /// costs NOTHING: diarization off, a recording the live pass already
+    /// pinned at ≤ `QuickActionsController.maxLiveSpeakersToSkipRediarize`
+    /// speakers, or a batch-transcribed recording (whose diarization happens
+    /// inside the transcription pass, before it leaves `.pending`).
+    ///
+    /// `announce` drives the user-visible banner, and only the interactive
+    /// Send path passes it — the unattended auto-title job must not narrate a
+    /// wait the user never asked for.
+    private func awaitSpeakerFinalization(for recordingID: UUID,
+                                          until deadline: Date,
+                                          announce: Bool) async -> Bool {
+        guard transcription.isAwaitingSpeakerFinalization(recordingID) else { return false }
+        // Set directly rather than through `postStatus`, which auto-clears
+        // after a few seconds. This banner has to stay up for as long as the
+        // pass runs — a minute or more on a long meeting — and re-posting the
+        // same string cannot outrun its own pending clear, which matches on
+        // the message text. Cleared on the way out (below) so a cancelled or
+        // timed-out send never strands it.
+        if announce {
+            activityStatus = Self.waitingForSpeakersStatus
+            activityIsError = false
+        }
+        defer {
+            if announce, activityStatus == Self.waitingForSpeakersStatus {
+                activityStatus = nil
+            }
+        }
+        while Date() < deadline {
+            if Task.isCancelled { return true }
+            // Gone from the store: nothing will ever release the marker for a
+            // row that no longer exists, so stop waiting. A user-initiated
+            // discard has already cancelled this task (`cancelAndDiscard`),
+            // and the caller re-checks cancellation before it sends.
+            guard store.recordings.contains(where: { $0.id == recordingID }) else { return true }
+            guard transcription.isAwaitingSpeakerFinalization(recordingID) else { return true }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        // Timed out. Fall through rather than failing the send: the labels
+        // may be imperfect, but a summary the user asked for beats no summary
+        // at all, and the bound is what keeps this from hanging forever.
+        return true
+    }
+
+    /// The recording's speaker-aware plain text as the store holds it right
+    /// now, or nil when the row is gone or has no text. The single place the
+    /// transcript is rendered from a stored row, so the pre-wait read and the
+    /// post-wait re-read cannot drift apart.
+    private func storedTranscript(for recordingID: UUID) -> String? {
+        guard let rec = store.recordings.first(where: { $0.id == recordingID }) else {
+            return nil
+        }
+        let text = TranscriptFormatter.plainText(segments: rec.segments,
+                                                 fallback: rec.fullText,
+                                                 names: rec.speakerNames)
+        return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : text
     }
 
     /// The Cancel button in the rename sheet: throw away EVERYTHING related

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -1081,6 +1081,33 @@ final class QuickActionsController: ObservableObject {
         liveSpeakerCount > maxLiveSpeakersToSkipRediarize
     }
 
+    /// Whether `finalizeTail` is going to re-key this recording's speaker
+    /// labels — and therefore whether anything that feeds the transcript to
+    /// an LLM ("Send to Claude", the background auto-title job) must wait
+    /// before it can trust them. Issue #211.
+    ///
+    /// All three conditions matter:
+    ///  * `liveTranscriptIsAuthoritative` — the batch path diarizes inside
+    ///    the transcription pass and only then leaves `.pending`, so its
+    ///    labels are already final when the row goes terminal.
+    ///  * `diarizationConfigured` — with the feature off `rediarizeSegments`
+    ///    returns immediately and nothing re-keys anything, so a user who
+    ///    has it off must not pay a wait.
+    ///  * `shouldRediarize` — at or below `maxLiveSpeakersToSkipRediarize`
+    ///    the offline pass is skipped entirely, so a short recording pays
+    ///    no wait either.
+    ///
+    /// Pure + `static` for the same reason `shouldRediarize` is: the gate
+    /// has to be assertable without a pyannote subprocess, which CI cannot
+    /// spin up.
+    static func willFinalizeSpeakers(liveTranscriptIsAuthoritative: Bool,
+                                     liveSpeakerCount: Int,
+                                     diarizationConfigured: Bool) -> Bool {
+        liveTranscriptIsAuthoritative
+            && diarizationConfigured
+            && shouldRediarize(liveSpeakerCount: liveSpeakerCount)
+    }
+
     /// The HEAVY, live-singleton-free tail of finalization, run as a
     /// detached, id-keyed background task so the record button (freed in
     /// `stopRecording` once the live pipeline is drained) stays usable
@@ -1100,12 +1127,43 @@ final class QuickActionsController: ObservableObject {
     /// pure store + service work and is the part this PR decoupled.
     func finalizeTail(for recording: Recording, liveTranscriptIsAuthoritative: Bool) {
         let id = recording.id
+        // Bound to a local, and captured strongly by the task below (which
+        // holds `self` weakly): the `defer` there MUST be able to release the
+        // speaker-finalization marker even on the paths where `self` has gone
+        // away, or a waiting send is parked on a pass that can never finish.
+        // The service holds no reference back here, so this is not a cycle.
+        let transcription = self.transcription
+        // Whether the offline pass will re-key the speakers is decided HERE,
+        // synchronously, and published before this function returns — not
+        // inside the task below. `stopRecording` runs from the
+        // `store.update(updated)` that flips the row to `.completed` all the
+        // way to this call without a single suspension point, so no other
+        // main-actor work (a "Send to Claude" among it) can observe the row
+        // as finished while the marker is still missing. Deciding inside the
+        // task would reopen exactly the gap issue #211 describes: the row
+        // already terminal, the pass not yet started, nothing to wait on.
+        let liveSpeakerCount = Set(recording.segments.compactMap(\.speaker)).count
+        let willRediarize = Self.willFinalizeSpeakers(
+            liveTranscriptIsAuthoritative: liveTranscriptIsAuthoritative,
+            liveSpeakerCount: liveSpeakerCount,
+            diarizationConfigured: transcription.isDiarizationConfigured)
+        if willRediarize { transcription.beginSpeakerFinalization(id) }
         // Replace (and cancel) any previous tail for the same id —
         // defensive; ids are unique per recording so this shouldn't
         // collide in practice.
         finalizeTasks[id]?.cancel()
         finalizeTasks[id] = Task { @MainActor [weak self] in
-            defer { self?.finalizeTasks[id] = nil }
+            defer {
+                self?.finalizeTasks[id] = nil
+                // Belt and braces. The marker is released explicitly below,
+                // the moment the labels and the `.srt` carrying them are on
+                // disk — well before the summarizer and the transcode this
+                // task also runs. This catches the routes that never reach
+                // that line (cancellation, an early return) so a send can
+                // never be parked on a pass that will not finish. `remove`
+                // is idempotent.
+                transcription.endSpeakerFinalization(id)
+            }
             guard let self else { return }
             var updated = recording
             if liveTranscriptIsAuthoritative {
@@ -1125,8 +1183,12 @@ final class QuickActionsController: ObservableObject {
                 // ≤3 speakers is almost certainly correct, so we finalize
                 // with the live labels as-is and skip the heavy pyannote
                 // subprocess (saves seconds of post-record delay).
-                let liveSpeakerCount = Set(updated.segments.compactMap(\.speaker)).count
-                if Self.shouldRediarize(liveSpeakerCount: liveSpeakerCount) {
+                //
+                // `willRediarize` was computed (and published as the
+                // speaker-finalization marker) before this task existed, so
+                // the decision a waiting send is gated on and the work
+                // actually done here can never disagree.
+                if willRediarize {
                     // Re-fetch before writing: the user may have renamed the
                     // recording (rename sheet) while this tail was running, so
                     // we update only the segments rather than clobbering the row.
@@ -1164,6 +1226,13 @@ final class QuickActionsController: ObservableObject {
                 // enabled + configured conditions. `summarizeIfNeeded` covers
                 // the Live-AI-off case under the normal auto-summary gate.
                 TranscriptExporter.writeSRT(for: updated, in: self.store.recordingsDirectory)
+                // Speakers are settled and the `.srt` that carries them is on
+                // disk, so release anything parked on this recording's labels
+                // — a background "Send to Claude", the auto-title job — now,
+                // rather than making it also sit out the summarizer LLM call
+                // and the m4a transcode below, neither of which touches the
+                // transcript's speakers. (Issue #211.)
+                self.transcription.endSpeakerFinalization(id)
                 // Mark this fresh completion pending for Obsidian export (if
                 // enabled) BEFORE kicking the summarizer, since a skip fires
                 // the completion hook synchronously.

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -56,6 +56,30 @@ final class TranscriptionService: ObservableObject {
     /// implying the transcript is still being produced. `nil` when no
     /// re-diarize is in flight.
     @Published private(set) var diarizingRecordingID: UUID?
+
+    /// Recording ids whose SPEAKER LABELS are not final yet, because the
+    /// offline re-diarize pass for them is about to run or is running.
+    ///
+    /// Deliberately wider in time than `diarizingRecordingID`, and that is
+    /// the entire point. `diarizingRecordingID` only lights up once
+    /// `rediarizeSegments` is already executing inside
+    /// `QuickActionsController.finalizeTail`'s detached task; this set is
+    /// published SYNCHRONOUSLY by `finalizeTail` itself, in the same
+    /// main-actor run as the `store.update` that flips the row to
+    /// `.completed`. The gap between those two is the window issue #211
+    /// describes: the recording already reads as finished, its labels are
+    /// still the live diarizer's over-segmented ones, and a "Send to Claude"
+    /// fired in that gap ships them to the CLI — silently and permanently,
+    /// since nothing reconciles the CLI's answer once the good labels land.
+    ///
+    /// A set, not a single id, because the tail is id-keyed: the user can
+    /// start a new recording while a previous one is still finalizing.
+    ///
+    /// In-memory on purpose. The failure mode of losing it (app relaunch, a
+    /// crash mid-pass) is that nothing waits — today's behaviour — whereas a
+    /// persisted flag orphaned by a crash would park every future send on
+    /// that recording until the timeout.
+    @Published private(set) var speakerFinalizationPendingIDs: Set<UUID> = []
     @Published private(set) var progress: Double = 0
     @Published var lastError: String?
 
@@ -455,6 +479,41 @@ final class TranscriptionService: ObservableObject {
             serviceLog.error("transcribeOnceSegments: FAILED model=\(model.name, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             return []
         }
+    }
+
+    // MARK: - Speaker finalization marker (issue #211)
+
+    /// Whether the offline speaker pipeline is enabled AND ready to run.
+    ///
+    /// A read-only passthrough to `DiarizationSettings.isConfigured`, which
+    /// this service already owns privately. Exposed so
+    /// `QuickActionsController.finalizeTail` can decide whether the offline
+    /// pass is going to happen *before* it spawns the tail — without the
+    /// controller growing a second reference to the same settings object,
+    /// and without anything downstream having to guess. Users with
+    /// diarization off never publish a marker, so nothing waits for them.
+    var isDiarizationConfigured: Bool { diarizationSettings.isConfigured }
+
+    /// Publish "the speaker labels for `recordingID` are not final yet".
+    ///
+    /// Called by `QuickActionsController.finalizeTail` before it spawns the
+    /// detached tail, so there is no instant in which the row reads
+    /// `.completed` with no marker while the offline pass is still to come.
+    func beginSpeakerFinalization(_ recordingID: UUID) {
+        speakerFinalizationPendingIDs.insert(recordingID)
+    }
+
+    /// Release the marker. Idempotent: the tail clears it the moment the
+    /// labels (and the `.srt` that carries them) are written, and again from
+    /// its `defer`, so a cancelled or failed tail cannot strand a send.
+    func endSpeakerFinalization(_ recordingID: UUID) {
+        speakerFinalizationPendingIDs.remove(recordingID)
+    }
+
+    /// True while `recordingID`'s speaker labels may still be re-keyed by the
+    /// offline pass. Callers that feed a transcript to an LLM wait on this.
+    func isAwaitingSpeakerFinalization(_ recordingID: UUID) -> Bool {
+        speakerFinalizationPendingIDs.contains(recordingID)
     }
 
     /// Re-run the OFFLINE speaker diarizer on an already-transcribed

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TranscriptionCore
+import MilaKit
 @testable import Mila
 
 /// Tests for `PostRecordingCoordinator`'s background "Send to <LLM>"
@@ -251,6 +252,197 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         XCTAssertFalse(coordinator.isSending(rec.id))
     }
 
+    // MARK: - Fired before the offline speaker pass lands (issue #211)
+
+    /// NEGATIVE CONTROL for issue #211.
+    ///
+    /// The user stops a meeting and hits Send immediately. On the live/VAD
+    /// path the row is ALREADY `.completed` at that instant — `stopRecording`
+    /// writes it before spinning off `finalizeTail` — but the labels on it are
+    /// the live diarizer's over-segmented ones: one person split across four
+    /// `SPEAKER_NN`, with the name the user typed stuck to only the first.
+    /// The offline pass that collapses them lands seconds later.
+    ///
+    /// Before the fix the send took two shortcuts that both landed on the
+    /// stale text: the click-time snapshot was used verbatim whenever it was
+    /// non-empty (always, on this path), and even falling through,
+    /// `awaitTranscript` only waited for the status to leave
+    /// `.pending`/`.running` — which it already had.
+    ///
+    /// The assertion is deliberately on the PAYLOAD, not on the plumbing:
+    /// what reaches the runner must carry the POST-remap labels. Remove the
+    /// speaker wait, or the re-read that follows it, and this fails — the
+    /// captured transcript comes back full of `SPEAKER_01`…`SPEAKER_03`.
+    func test_send_waits_for_speaker_finalization_and_sends_the_remapped_labels() async throws {
+        var captured: String?
+        var callCount = 0
+        let coordinator = makeCoordinator(label: "speakers.\(#function)") {
+            _, _, transcript, _, _, _, _, _, _, _, _, _, _, _ in
+            captured = transcript
+            callCount += 1
+            return "ANSWER"
+        }
+
+        let rec = addCompletedRecording(
+            text: "one two three four",
+            segments: [seg(0, 1, "one", "SPEAKER_00"),
+                       seg(1, 2, "two", "SPEAKER_01"),
+                       seg(2, 3, "three", "SPEAKER_02"),
+                       seg(3, 4, "four", "SPEAKER_03")],
+            speakerNames: ["SPEAKER_00": "Ada"])
+        // Exactly what the sheet would hand `sendToLLM` at click time.
+        let clickTime = TranscriptFormatter.plainText(segments: rec.segments,
+                                                      fallback: rec.fullText,
+                                                      names: rec.speakerNames)
+        XCTAssertTrue(clickTime.contains("SPEAKER_03"),
+                      "Sanity: the click-time snapshot carries the live diarizer's labels")
+
+        // `finalizeTail` has published the marker and the pyannote pass is
+        // running — the window a Send fired right after Stop lands in.
+        service.beginSpeakerFinalization(rec.id)
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude,
+                              prompt: "Summarize", transcript: clickTime,
+                              summary: "", executableOverride: nil)
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+        XCTAssertEqual(callCount, 0,
+                       "The send must not reach the CLI while the speaker labels are still being re-keyed")
+        XCTAssertEqual(coordinator.activityStatus,
+                       PostRecordingCoordinator.waitingForSpeakersStatus,
+                       "The wait must be explained, not just felt as an unexplained delay")
+
+        // The offline pass lands: four speakers collapse to one, and
+        // `SpeakerNameRemapper` carries the name onto the surviving id.
+        var current = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        current.segments = [seg(0, 1, "one", "SPEAKER_00"),
+                            seg(1, 2, "two", "SPEAKER_00"),
+                            seg(2, 3, "three", "SPEAKER_00"),
+                            seg(3, 4, "four", "SPEAKER_00")]
+        current.speakerNames = ["SPEAKER_00": "Ada"]
+        store.update(current)
+        service.endSpeakerFinalization(rec.id)
+
+        try await waitFor(callCount > 0)
+        let sent = try XCTUnwrap(captured)
+        XCTAssertFalse(sent.contains("SPEAKER_01"),
+                       "The CLI must not receive the pre-re-diarize labels — got: \(sent)")
+        XCTAssertFalse(sent.contains("SPEAKER_02"))
+        XCTAssertFalse(sent.contains("SPEAKER_03"))
+        XCTAssertTrue(sent.contains("Ada: one two three four"),
+                      "The remapped name must cover every turn — got: \(sent)")
+    }
+
+    /// The counterpart, so the fix cannot degenerate into "always sleep".
+    ///
+    /// A recording the live pass already pinned at ≤
+    /// `maxLiveSpeakersToSkipRediarize` speakers skips the offline pass
+    /// entirely, so `finalizeTail` publishes no marker and the send must pay
+    /// NOTHING for the new wait.
+    ///
+    /// Discriminating by construction: nothing in this test ever calls
+    /// `endSpeakerFinalization`, and `transcriptWaitTimeout` is shortened to
+    /// 3s. An unconditional wait would therefore park the send for the full
+    /// timeout and blow the 1s assertion window.
+    func test_send_does_not_wait_when_the_recording_skipped_rediarization() async throws {
+        var captured: String?
+        var callCount = 0
+        let coordinator = makeCoordinator(label: "nowait.\(#function)") {
+            _, _, transcript, _, _, _, _, _, _, _, _, _, _, _ in
+            captured = transcript
+            callCount += 1
+            return "ANSWER"
+        }
+        coordinator.transcriptWaitTimeout = 3
+
+        let rec = addCompletedRecording(
+            text: "hello there",
+            segments: [seg(0, 1, "hello", "SPEAKER_00"),
+                       seg(1, 2, "there", "SPEAKER_01")],
+            speakerNames: [:])
+        XCTAssertFalse(service.isAwaitingSpeakerFinalization(rec.id),
+                       "Sanity: a recording that skipped re-diarization carries no marker")
+
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude,
+                              prompt: "Summarize", transcript: "hello there",
+                              summary: "", executableOverride: nil)
+
+        try await waitFor(callCount > 0, timeoutSeconds: 1)
+        XCTAssertNotEqual(coordinator.activityStatus,
+                          PostRecordingCoordinator.waitingForSpeakersStatus,
+                          "Nothing was pending, so no speaker wait should ever have been announced")
+        XCTAssertEqual(captured, "SPEAKER_00: hello\nSPEAKER_01: there")
+    }
+
+    /// The marker is per-recording: one recording still finalizing must not
+    /// hold up a send for a different, already-final one.
+    func test_speaker_wait_is_scoped_to_the_recording_being_sent() async throws {
+        var callCount = 0
+        let coordinator = makeCoordinator(label: "scoped.\(#function)") {
+            _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
+            callCount += 1
+            return "ANSWER"
+        }
+        coordinator.transcriptWaitTimeout = 3
+
+        let other = addCompletedRecording(text: "other meeting")
+        service.beginSpeakerFinalization(other.id)
+        defer { service.endSpeakerFinalization(other.id) }
+
+        let rec = addCompletedRecording(text: "this meeting")
+        coordinator.sendToLLM(recordingID: rec.id, tool: .claude,
+                              prompt: "Summarize", transcript: "this meeting",
+                              summary: "", executableOverride: nil)
+
+        try await waitFor(callCount > 0, timeoutSeconds: 1)
+    }
+
+    /// The background auto-title job shares the wait (issue #211, point 4) —
+    /// a title built from over-segmented speakers is the same stale input.
+    /// It must NOT announce the wait, though: it runs unattended on every
+    /// recording, so a banner would be noise for something the user never
+    /// asked for.
+    func test_auto_title_waits_for_speaker_finalization_without_a_banner() async throws {
+        let suiteName = "PostRecordingCoordinatorSendTests.titleWait.\(#function)"
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: suiteName)!,
+                              apiKeyKeychainKey: suiteName)
+        llm.tool = .claude
+        llm.nameGenerationEnabled = true
+
+        var captured: String?
+        var callCount = 0
+        let coordinator = PostRecordingCoordinator(
+            store: store, transcription: service, llm: llm,
+            runLLM: { _, _, transcript, _, _, _, _, _, _, _, _, _, _, _ in
+                captured = transcript
+                callCount += 1
+                return "A Tidy Title"
+            })
+
+        let rec = addCompletedRecording(
+            text: "one two",
+            segments: [seg(0, 1, "one", "SPEAKER_00"),
+                       seg(1, 2, "two", "SPEAKER_01")],
+            speakerNames: [:])
+        service.beginSpeakerFinalization(rec.id)
+
+        coordinator.present(rec)
+        try await Task.sleep(nanoseconds: 400_000_000)
+        XCTAssertEqual(callCount, 0, "The auto-title job must wait for the speaker pass too")
+        XCTAssertNil(coordinator.activityStatus,
+                     "The unattended title job must not post a banner about the wait")
+
+        var current = try XCTUnwrap(store.recordings.first { $0.id == rec.id })
+        current.segments = [seg(0, 1, "one", "SPEAKER_00"), seg(1, 2, "two", "SPEAKER_00")]
+        store.update(current)
+        service.endSpeakerFinalization(rec.id)
+
+        try await waitFor(callCount > 0)
+        XCTAssertEqual(captured, "SPEAKER_00: one two",
+                       "The title must be generated from the post-remap transcript")
+    }
+
     // MARK: - OpenAI-compatible model threading (issue celarent7/mila#3)
 
     /// `sendToLLM` must thread `openAIModelName` as the `model` argument for
@@ -474,16 +666,43 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
     }
 
     /// Add a `.completed` recording with the given transcript text, with a
-    /// placeholder audio file so `RecordingStore.add` is happy.
-    private func addCompletedRecording(text: String) -> Recording {
+    /// placeholder audio file so `RecordingStore.add` is happy. `segments` /
+    /// `speakerNames` let a test stage a diarized row — the shape the issue
+    /// #211 tests need.
+    private func addCompletedRecording(text: String,
+                                       segments: [TranscriptSegment] = [],
+                                       speakerNames: [String: String] = [:]) -> Recording {
         let audioURL = store.freshAudioURL(suggestedName: "Send")
         try? Data("not-audio".utf8).write(to: audioURL)
         var rec = Recording(title: "Send", source: .microphone,
                             audioFileName: audioURL.lastPathComponent,
                             fullText: text)
         rec.status = .completed
+        rec.segments = segments
+        rec.speakerNames = speakerNames
         store.add(rec)
         return rec
+    }
+
+    /// One utterance, labeled by the diarizer.
+    private func seg(_ start: Double, _ end: Double,
+                     _ text: String, _ speaker: String) -> TranscriptSegment {
+        TranscriptSegment(start: start, end: end, text: text, speaker: speaker)
+    }
+
+    /// A coordinator with an injected `runLLM` seam, so the assertions can
+    /// read exactly what the CLI would have been handed without spawning one.
+    private func makeCoordinator(
+        label: String,
+        runLLM: @escaping PostRecordingCoordinator.RunLLM
+    ) -> PostRecordingCoordinator {
+        let suiteName = "PostRecordingCoordinatorSendTests.\(label)"
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: suiteName)!,
+                              apiKeyKeychainKey: suiteName)
+        llm.tool = .claude
+        return PostRecordingCoordinator(store: store, transcription: service,
+                                        llm: llm, runLLM: runLLM)
     }
 
     private func waitForBanner(containing needle: String,

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -458,6 +458,84 @@ final class QuickActionsControllerTests: XCTestCase {
         XCTAssertTrue(QuickActionsController.shouldRediarize(liveSpeakerCount: 7))
     }
 
+    // MARK: - Speaker-finalization gate (issue #211)
+
+    /// `willFinalizeSpeakers` is what decides whether a "Send to Claude"
+    /// fired the instant the recording stopped has to wait. It must be true
+    /// in exactly the case the offline pass actually runs — otherwise either
+    /// the send races the pass (too permissive) or every recording pays a
+    /// wait it doesn't need (too strict).
+    func test_willFinalizeSpeakers_only_when_the_offline_pass_will_run() {
+        XCTAssertTrue(QuickActionsController.willFinalizeSpeakers(
+            liveTranscriptIsAuthoritative: true,
+            liveSpeakerCount: 4,
+            diarizationConfigured: true),
+                      "Authoritative live transcript, over-segmented, diarization ready — the pass runs, so a send must wait")
+
+        XCTAssertFalse(QuickActionsController.willFinalizeSpeakers(
+            liveTranscriptIsAuthoritative: true,
+            liveSpeakerCount: 3,
+            diarizationConfigured: true),
+                       "At the skip threshold the pass never runs — a short recording must pay no wait")
+
+        XCTAssertFalse(QuickActionsController.willFinalizeSpeakers(
+            liveTranscriptIsAuthoritative: true,
+            liveSpeakerCount: 7,
+            diarizationConfigured: false),
+                       "Diarization off — nothing re-keys the labels, so nothing changes for that user")
+
+        XCTAssertFalse(QuickActionsController.willFinalizeSpeakers(
+            liveTranscriptIsAuthoritative: false,
+            liveSpeakerCount: 7,
+            diarizationConfigured: true),
+                       "The batch path diarizes inside the transcription pass, before the row leaves .pending")
+    }
+
+    /// The marker has to be published SYNCHRONOUSLY by `finalizeTail`, not
+    /// from inside its detached task: `stopRecording` flips the row to
+    /// `.completed` and calls `finalizeTail` in one uninterrupted main-actor
+    /// run, so a send can only ever observe "still transcribing" or
+    /// "finalizing speakers" — never the gap between them (issue #211).
+    ///
+    /// This test drives the gate's OFF side end-to-end, which is the side CI
+    /// can run: with diarization unconfigured no marker is published, so a
+    /// user who has the feature off waits for nothing. (The ON side needs a
+    /// pyannote subprocess; `willFinalizeSpeakers` above pins it purely.)
+    func test_finalize_tail_publishes_no_speaker_marker_when_diarization_is_off() async throws {
+        try FileManager.default.createDirectory(at: store.recordingsDirectory,
+                                                withIntermediateDirectories: true)
+        let url = store.recordingsDirectory.appendingPathComponent("speaker-marker.wav")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        let recording = Recording(
+            title: "marker-recording",
+            duration: 0.6,
+            source: .microphone,
+            audioFileName: url.lastPathComponent,
+            status: .completed,
+            language: languageSettings.current.rawValue,
+            // Over-segmented enough that `shouldRediarize` alone would say yes.
+            segments: [TranscriptSegment(start: 0, end: 1, text: "a", speaker: "SPEAKER_00"),
+                       TranscriptSegment(start: 1, end: 2, text: "b", speaker: "SPEAKER_01"),
+                       TranscriptSegment(start: 2, end: 3, text: "c", speaker: "SPEAKER_02"),
+                       TranscriptSegment(start: 3, end: 4, text: "d", speaker: "SPEAKER_03")],
+            fullText: "a b c d"
+        )
+        store.add(recording)
+        XCTAssertFalse(service.isDiarizationConfigured,
+                       "Sanity: the test suite runs with diarization unconfigured")
+
+        controller.isFinalizingRecording = false
+        controller.finalizeTail(for: recording, liveTranscriptIsAuthoritative: true)
+
+        // Checked BEFORE awaiting the tail — this is the synchronous window.
+        XCTAssertFalse(service.isAwaitingSpeakerFinalization(recording.id),
+                       "Diarization is off, so nothing will re-key the labels and nothing must wait")
+
+        await controller.awaitFinalizeTails()
+        XCTAssertFalse(service.isAwaitingSpeakerFinalization(recording.id),
+                       "The marker must not be left set after the tail finishes")
+    }
+
     func test_user_bug_repro_second_recording_after_first_started_transcribing() async throws {
         let first = tempRoot.appendingPathComponent("recording-A.wav")
         let second = tempRoot.appendingPathComponent("recording-B.wav")


### PR DESCRIPTION
Closes #211

## What & why

Stop a meeting, hit **Send to Claude** immediately, and the CLI gets the *live* diarizer's over-segmented speakers — one person split across several `SPEAKER_NN`, names on the wrong turns. Wait a few minutes and the same recording sends correctly. Nothing in the UI explained the difference.

Confirmed the mechanism against today's `main` (`e472466`), symbol by symbol:

- `QuickActionsController.stopRecording` sets `updated.status = liveTranscriptIsAuthoritative ? .completed : .pending` and calls `store.update(updated)` **before** `finalizeTail(...)`, whose re-diarize branch runs `TranscriptionService.rediarizeSegments` (the pyannote subprocess) and re-keys every `SPEAKER_NN` through `SpeakerNameRemapper.remap`.
- That pass only runs when the live pass minted more than `maxLiveSpeakersToSkipRediarize` (3) speakers — i.e. exactly when the live labels are worst.
- `PostRecordingCoordinator.sendToLLM` used the click-time `transcript` snapshot whenever non-empty; on the live path it always is.
- Falling through, `awaitTranscript` only waited for `rec.status != .pending && != .running` — already true.
- With `actionDeliversTranscriptByPath` on, `TranscriptExporter.writeSRT` runs *after* the re-diarize, so an early send found nothing and `LLMRunner.effectiveDelivery` fell back to the same stale inline text.

The failure is silent and permanent: the CLI has already answered from the bad labels, the store later gets the good ones, and nothing reconciles the two.

### The four decisions the issue calls out

**1. The gate mechanism — a published finalizing-ids set, *not* a field on `Recording`.**

`TranscriptionService` gains `speakerFinalizationPendingIDs: Set<UUID>` plus `beginSpeakerFinalization` / `endSpeakerFinalization` / `isAwaitingSpeakerFinalization`. `diarizingRecordingID` is genuinely insufficient — it only lights up once `rediarizeSegments` is executing, leaving the gap the issue describes. The new marker is published **synchronously by `finalizeTail` before it spawns the detached task**, and `stopRecording` runs from `store.update(updated)` all the way to `finalizeTail(...)` with **no suspension point**, so that whole stretch is one uninterrupted main-actor run. A send can observe "still transcribing" or "finalizing speakers" — never the gap between them.

I deliberately did **not** add a field to `Recording`. Cost/benefit:

- It would have to be mirrored in MilaKit's `StoredRecording` (per `CLAUDE.md`, with `StoredRecordingDriftTests` as the tripwire) and kept lenient for older `mila-mcp` builds — a cross-process/cross-version contract change for an in-process, in-flight signal.
- Worse, it has a bad failure mode a persisted flag cannot avoid: a crash or a force-quit mid-pass leaves the row permanently marked "not finalized", so **every future send on that recording waits out the full timeout**. The in-memory set fails the safe way — after a relaunch nothing is pending, which is exactly today's behaviour.
- The `.srt` race the issue hoped to fix "for free" is fixed here anyway: the marker is released *after* `writeSRT`, so by the time a send proceeds the sidecar is on disk. (For the ≤3-speaker case no marker is published at all — see decision 3 — so that path keeps today's graceful `.reference` → `.inline` fallback, which is harmless there because the inline text already carries final labels.)

`QuickActionsController.willFinalizeSpeakers(liveTranscriptIsAuthoritative:liveSpeakerCount:diarizationConfigured:)` is the pure, static decision function (mirroring `shouldRediarize`, for the same "CI cannot spin up pyannote" reason). The tail now branches on the *same* value it published, so the gate and the work can never disagree. `TranscriptionService.isDiarizationConfigured` is a read-only passthrough to `DiarizationSettings.isConfigured`, which the service already owns — no new settings reference in the controller or the coordinator.

**2. The click-time snapshot is demoted from shortcut to fallback.**

`sendToLLM` now always resolves through `awaitFinalTranscript`, which (a) waits for the row to leave `.pending`/`.running`, (b) waits for speaker finalization, then (c) **re-reads from the store** so it picks up the remapped `speakerNames`. The click-time text is used only when the store cannot answer at all (row discarded, or never there) — which keeps `test_sendToLLM_inlines_when_the_recording_is_gone` honest.

Order matters and is documented in the code: the speaker check comes **second**. A send fired *mid-recording* sees no marker yet (the tail hasn't been reached), so checking speakers first would sail straight through; waiting for the terminal status first lands past the marker's publication.

**3. Bounded and visible, and free when nothing is pending.**

Both halves share **one** `transcriptWaitTimeout` (600s) deadline, so the advertised bound doesn't silently double. On timeout the send proceeds rather than failing — imperfect labels beat no summary.

The wait shows as `Waiting for speaker identification…` in the existing activity banner. It sets `activityStatus` **directly** rather than through `postStatus`: `postStatus` auto-clears after 5s and matches on the message text, so re-posting the same string can't outrun its own pending clear. It's cleared on the way out (`defer`) and the send re-asserts `Sending to <tool>…` before invoking the CLI.

A recording that skips re-diarization (≤3 live speakers), or a user with diarization off, publishes **no marker** and therefore pays **no wait** — the `guard` returns before anything sleeps or announces.

**4. `armAutoSuggestTitle` shares the wait.** Same `awaitFinalTranscript`, with `announceSpeakerWait: false` — that job runs unattended on every recording, so a banner about a wait the user never asked for would be noise.

## How it was tested

Cannot compile locally (Linux, no Swift toolchain) — CI is the compiler. Every symbol referenced was grep-confirmed against the tree.

**Does an existing test pin the buggy behaviour?** Searched `MilaTests/`, in particular `PostRecordingCoordinatorSendTests`. Nothing did: `test_send_waits_for_transcript_when_fired_early` asserts the *transcript* wait (empty snapshot, `.running` → `.completed`) and stays valid unchanged; the other send tests use recordings with no marker and are unaffected by construction. So no fixture had to change — but the shortcut they exercised (non-empty snapshot ⇒ send immediately) is now a store read, and they pin that it still returns immediately.

**Negative control** — `test_send_waits_for_speaker_finalization_and_sends_the_remapped_labels`: stages the exact race (a `.completed` row whose four live `SPEAKER_NN` are the over-segmented ones, `speakerNames` naming only the first, marker outstanding), fires Send with the real click-time snapshot, asserts the runner is **not** called and the banner explains why, then lands the offline result and asserts the captured payload contains **no** `SPEAKER_01`…`SPEAKER_03` and reads `Ada: one two three four`. The assertion is on the payload, not the plumbing: delete the speaker wait, or the post-wait re-read, and it fails with the pre-remap labels. (It cannot literally run against unfixed `main` because the fix introduces the seam it drives — but every assertion in it is false for the unfixed logic.)

**Counterpart** — `test_send_does_not_wait_when_the_recording_skipped_rediarization`: a ≤3-speaker recording, `transcriptWaitTimeout` shortened to 3s, and **nothing in the test ever releases a marker**; the send must reach the runner within 1s and must never have announced a wait. An "always sleep" fix blows the window.

Also added: `test_speaker_wait_is_scoped_to_the_recording_being_sent` (a different recording finalizing must not block this one), `test_auto_title_waits_for_speaker_finalization_without_a_banner` (decision 4, including "no banner"), `test_willFinalizeSpeakers_only_when_the_offline_pass_will_run` (all four combinations, pure), and `test_finalize_tail_publishes_no_speaker_marker_when_diarization_is_off` (drives the real `finalizeTail` and asserts synchronously, before awaiting the tail, that the off-side of the gate publishes nothing — the side CI can run without pyannote).

No test spawns a subprocess or sleeps on wall-clock beyond the existing idioms in these files.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — no macOS/Swift toolchain in this environment; relying on CI
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, the README changelog isn't maintained per-fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when LLM actions run relative to post-stop finalization and transcript content; logic is gated and tested, but incorrect marker lifecycle could delay sends or still ship stale labels on timeout.
> 
> **Overview**
> Fixes **#211**: on the live/VAD path, **Send to Claude** and background auto-title could run while the row was already `.completed` but **before** the offline re-diarize pass re-keyed `SPEAKER_NN`, so the CLI got over-segmented live labels permanently.
> 
> **Send / auto-title** now resolve the transcript through **`awaitFinalTranscript`**: wait until transcription is done, then (when needed) park on an in-memory **`speakerFinalizationPendingIDs`** marker, **re-read from the store**, and only then invoke the LLM. The click-time snapshot is a **fallback** when the store has no row—not a shortcut past the wait. One **`transcriptWaitTimeout`** covers both phases. Interactive sends show **`Waiting for speaker identification…`**; auto-title waits silently.
> 
> **`finalizeTail`** publishes the marker **synchronously** (via **`willFinalizeSpeakers`**) before the detached tail runs, and clears it right after **`.srt`** is written with final labels—so sends and path-based delivery don’t race stale text or missing sidecars. Recordings that skip re-diarize (diarization off, ≤3 live speakers, batch path) publish **no** marker and pay **no** extra wait.
> 
> Tests cover remapped payload, no-wait when skipped, per-recording scoping, and auto-title without a banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817613fc5a51ce1e2a4704d6ccac73694389aea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->