### PR TITLE
feat(speakers): on-demand voice embedding from any recording

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -725,15 +725,153 @@ struct MilaApp: App {
         // weight already stored on disk, and folding it back counts it twice.
         // This is the only place voice profiles are written, so a recognised
         // speaker merges exactly once per recording.
-        store.onSpeakerNamed = { recordingID, rawID, name in
+        let voiceLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceProfile")
+        store.onSpeakerNamed = { [weak store, weak diarSettings] recordingID, rawID, name in
             guard voiceSettings.isConfigured else { return }
-            guard let observed = voiceSnapshots.observation(forSpeaker: rawID,
-                                                           in: recordingID) else { return }
-            profileStoreRef.updateProfile(
-                name: name,
-                embedding: observed.observedCentroid,
-                sampleCount: observed.observedCount
-            )
+            if let observed = voiceSnapshots.observation(forSpeaker: rawID,
+                                                         in: recordingID) {
+                // Snapshot exists (live or batch) — save immediately.
+                profileStoreRef.updateProfile(
+                    name: name,
+                    embedding: observed.observedCentroid,
+                    sampleCount: observed.observedCount
+                )
+            } else if let store {
+                // No snapshot (old recording, never re-transcribed).
+                // Extract the embedding on demand (~0.5s) from the
+                // speaker's longest segment in this recording.
+                guard let rec = store.recordings.first(where: { $0.id == recordingID }) else { return }
+                var best: (start: Double, end: Double)?
+                for seg in rec.segments where seg.speaker == rawID {
+                    let dur = seg.end - seg.start
+                    if best == nil || dur > (best!.end - best!.start) {
+                        best = (seg.start, seg.end)
+                    }
+                }
+                guard let segment = best else { return }
+                let pythonPath = diarSettings?.pythonPath ?? "/usr/bin/python3"
+                let capturedName = name
+                let capturedRecID = recordingID
+                let capturedRawID = rawID
+                // Capture the audio URL now, before compression can
+                // change the recording's audioFileName to .m4a.
+                let wavURL = store.audioURL(for: rec)
+                Task.detached(priority: .utility) {
+                    guard FileManager.default.fileExists(atPath: wavURL.path) else { return }
+                    do {
+                        let embeddings = try await SpeakerDiarizer.embedSpeakers(
+                            wavURL: wavURL, pythonPath: pythonPath,
+                            speakerSegments: [capturedRawID: segment])
+                        guard let emb = embeddings[capturedRawID] else { return }
+                        await MainActor.run {
+                            // Re-check after await: user may have opted
+                            // out while the embedding was being extracted.
+                            guard voiceSettings.isConfigured else { return }
+                            voiceLog.log("on-demand voice profile saved for \(capturedRawID, privacy: .public)")
+                            voiceSnapshots.record(
+                                [(id: capturedRawID, observedCentroid: emb,
+                                  observedCount: 1, profileName: nil)],
+                                for: capturedRecID)
+                            profileStoreRef.updateProfile(
+                                name: capturedName,
+                                embedding: emb,
+                                sampleCount: 1)
+                        }
+                    } catch {
+                        voiceLog.log("on-demand embedding failed: \(error.localizedDescription, privacy: .private)")
+                    }
+                }
+            }
+        }
+
+        // Reverse a profile merge when a speaker is un-named or renamed.
+        // Looks up the snapshot for what was merged when the speaker was
+        // originally named; if available, subtracts that observation from
+        // the old profile. If the snapshot has been evicted, the name is
+        // still cleared but the profile is left untouched (safe default).
+        store.onSpeakerUnnamed = { recordingID, rawID, previousName in
+            guard voiceSettings.isConfigured else { return }
+            if let observed = voiceSnapshots.observation(forSpeaker: rawID,
+                                                         in: recordingID) {
+                profileStoreRef.subtractObservation(
+                    name: previousName,
+                    embedding: observed.observedCentroid,
+                    sampleCount: observed.observedCount)
+            } else {
+                voiceLog.log("un-name: no snapshot for \(rawID, privacy: .public) — profile not adjusted")
+            }
+        }
+
+        // Batch voice matching: after any transcription completes, embed
+        // each speaker's longest segment and match against stored voice
+        // profiles. Uses embedSpeakers (embedding model only, ~0.5s)
+        // instead of the full pyannote pipeline (30-60min).
+        //
+        // Skipped when the recording already has a snapshot from the live
+        // stop path (`RecognisedSpeakerAssigner.finish`), which stores
+        // richer multi-sample observations and already names recognised
+        // speakers. Without this guard the batch path would overwrite
+        // those observations with single-segment extracts and double-
+        // learn by firing `onSpeakerNamed` a second time.
+        let existingCallback = svc.onTranscriptionCompleted
+        svc.onTranscriptionCompleted = { [weak store, weak diarSettings] rec, wasRetranscription in
+            existingCallback?(rec, wasRetranscription)
+            guard voiceSettings.isConfigured,
+                  !profileStoreRef.profiles.isEmpty,
+                  rec.speakerNames.isEmpty,
+                  rec.segments.contains(where: { $0.speaker != nil }),
+                  // Skip if the live stop already snapshotted this
+                  // recording — its observations are richer and it
+                  // already named recognised speakers.
+                  voiceSnapshots.observation(forSpeaker: rec.segments.first(where: { $0.speaker != nil })!.speaker!, in: rec.id) == nil,
+                  let store else { return }
+            // Build a map of each speaker's longest segment.
+            var longest: [String: (start: Double, end: Double)] = [:]
+            for seg in rec.segments {
+                guard let sp = seg.speaker else { continue }
+                let dur = seg.end - seg.start
+                if let existing = longest[sp] {
+                    if dur > (existing.end - existing.start) {
+                        longest[sp] = (seg.start, seg.end)
+                    }
+                } else {
+                    longest[sp] = (seg.start, seg.end)
+                }
+            }
+            guard !longest.isEmpty else { return }
+            let pythonPath = diarSettings?.pythonPath ?? "/usr/bin/python3"
+            // Capture URL before the detached task — compression runs
+            // concurrently and may delete the WAV or change the path.
+            let wavURL = store.audioURL(for: rec)
+            Task.detached(priority: .utility) {
+                guard FileManager.default.fileExists(atPath: wavURL.path) else { return }
+                let embeddings = (try? await SpeakerDiarizer.embedSpeakers(
+                    wavURL: wavURL, pythonPath: pythonPath,
+                    speakerSegments: longest)) ?? [:]
+                guard !embeddings.isEmpty else { return }
+                await MainActor.run {
+                    // Re-check after await: user may have opted out.
+                    guard voiceSettings.isConfigured else { return }
+                    // Store embeddings as snapshots so naming a speaker
+                    // later (via onSpeakerNamed) can save the voice
+                    // profile even for batch-transcribed recordings.
+                    let entries = embeddings.map { (rawID, emb) in
+                        (id: rawID,
+                         observedCentroid: emb,
+                         observedCount: 1,
+                         profileName: nil as String?)
+                    }
+                    voiceSnapshots.record(entries, for: rec.id)
+
+                    for (rawID, emb) in embeddings {
+                        if let profile = profileStoreRef.match(embedding: emb) {
+                            store.setSpeakerName(
+                                profile.name, forSpeaker: rawID,
+                                recordingID: rec.id)
+                        }
+                    }
+                }
+            }
         }
 
         // Auto-drop accidental short+empty captures (issue #61). A recording

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -356,6 +356,120 @@ enum SpeakerDiarizer {
         return try JSONDecoder().decode([SpeakerTurn].self, from: result.stdout)
     }
 
+    /// Embed specific speaker segments from an already-diarized recording.
+    /// Unlike `diarize` (which runs the full pyannote pipeline), this loads
+    /// ONLY the embedding model and extracts centroids from known speaker
+    /// segments. Takes ~0.4s to load + ~0.04s per speaker vs. 30-60+
+    /// minutes for full diarization.
+    ///
+    /// `speakerSegments` maps raw speaker IDs to their (start, end) time
+    /// ranges — typically the longest segment per speaker from the
+    /// already-completed transcription.
+    static func embedSpeakers(
+        wavURL: URL,
+        pythonPath: String,
+        speakerSegments: [String: (start: Double, end: Double)]
+    ) async throws -> [String: [Float]] {
+        guard let modelsPath = bundledModelsPath else { return [:] }
+        guard !speakerSegments.isEmpty else { return [:] }
+        var pythonInputURL = wavURL
+        var tempWAVToCleanUp: URL?
+        if wavURL.pathExtension.lowercased() != "wav" {
+            pythonInputURL = try AudioCompressor.decodeToTempWAV(wavURL)
+            tempWAVToCleanUp = pythonInputURL
+        }
+        defer {
+            if let temp = tempWAVToCleanUp { try? FileManager.default.removeItem(at: temp) }
+        }
+        let resolvedPython = resolvePython(userConfigured: pythonPath)
+        let extraEnv = pythonEnvironment()
+
+        // Encode speaker segments as JSON for the Python script.
+        let segmentsJSON = try JSONSerialization.data(
+            withJSONObject: speakerSegments.mapValues { ["start": $0.start, "end": $0.end] },
+            options: [])
+        let segmentsArg = String(data: segmentsJSON, encoding: .utf8) ?? "{}"
+
+        let script = """
+        import json, sys, os, types
+
+        try:
+            import speechbrain.utils.importutils as _sbiu
+            _orig_ensure = _sbiu.LazyModule.ensure_module
+            def _safe_ensure(self, *a, **kw):
+                try:
+                    return _orig_ensure(self, *a, **kw)
+                except ImportError:
+                    self.lazy_module = types.ModuleType(self.target)
+                    return self.lazy_module
+            _sbiu.LazyModule.ensure_module = _safe_ensure
+        except Exception:
+            pass
+
+        import torch
+        _orig_torch_load = torch.load
+        def _patched_torch_load(*args, **kwargs):
+            kwargs["weights_only"] = False
+            return _orig_torch_load(*args, **kwargs)
+        torch.load = _patched_torch_load
+
+        import soundfile as sf
+        import tempfile
+        from pyannote.audio import Pipeline
+
+        wav_path = sys.argv[1]
+        models_dir = sys.argv[2]
+        segments = json.loads(sys.argv[3])
+
+        config_path = os.path.join(models_dir, "config.yaml")
+        with open(config_path) as f:
+            config_text = f.read().replace("__MODELS_DIR__", models_dir)
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(config_text)
+        tmp.close()
+
+        try:
+            pipeline = Pipeline.from_pretrained(tmp.name)
+            embedder = getattr(pipeline, "_embedding", None)
+            if embedder is None:
+                json.dump({}, sys.stdout)
+                sys.exit(0)
+
+            samples, sr = sf.read(wav_path, dtype="float32")
+            if samples.ndim > 1:
+                samples = samples.mean(axis=1)
+
+            embeddings = {}
+            for sp, seg in segments.items():
+                start_sample = int(seg["start"] * sr)
+                end_sample = int(seg["end"] * sr)
+                chunk = samples[start_sample:end_sample]
+                if len(chunk) < sr * 0.3:
+                    continue
+                wave = torch.from_numpy(chunk).unsqueeze(0).unsqueeze(0)
+                emb = embedder(wave)
+                if hasattr(emb, 'detach'):
+                    arr = emb.detach().cpu().numpy().flatten()
+                else:
+                    import numpy
+                    arr = numpy.array(emb).flatten()
+                embeddings[sp] = arr.tolist()
+
+            json.dump(embeddings, sys.stdout)
+        finally:
+            os.unlink(tmp.name)
+        """
+
+        let result = try await runPython(
+            path: resolvedPython,
+            arguments: ["-c", script, pythonInputURL.path, modelsPath, segmentsArg],
+            environment: extraEnv
+        )
+        guard result.exitCode == 0, !result.stdout.isEmpty else { return [:] }
+        return (try? JSONDecoder().decode([String: [Float]].self, from: result.stdout)) ?? [:]
+    }
+
     struct VerifyResult: Codable {
         let pyannoteInstalled: Bool
         let torchInstalled: Bool


### PR DESCRIPTION
Closes #235

## Summary

- Adds `SpeakerDiarizer.embedSpeakers()` — loads only the pyannote embedding model (~0.4s) to extract voice centroids from known speaker segments, bypassing the full diarization pipeline (30-60min)
- When naming a speaker on an old recording with no snapshot, extracts the embedding on demand and saves the voice profile
- After any transcription completes, embeds all speakers and auto-matches against stored voice profiles for immediate auto-tagging

## Test plan

- [ ] Name a speaker on an old recording (never re-transcribed) — verify voice profile is created (~0.5s delay)
- [ ] Re-transcribe a recording with known speakers — verify they are auto-tagged
- [ ] Verify live recording flow is unchanged (snapshot path still preferred over on-demand)
- [ ] Verify opt-out (`voiceSettings.isConfigured = false`) blocks both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how voice fingerprints are created, merged, and reversed across async Python subprocesses and persisted profiles; guards reduce double-learning and opt-out races but incorrect matching or profile math would affect speaker identity data.
> 
> **Overview**
> Adds a **fast embedding path** (`SpeakerDiarizer.embedSpeakers`) that runs only the pyannote embedding model on known segment time ranges (~sub-second) instead of full diarization.
> 
> **Naming speakers** still uses live/batch snapshots when present; otherwise it **extracts an embedding on demand** from the speaker’s longest segment in that recording (background utility task), records a snapshot, and updates the voice profile. Audio URLs are captured before compression can swap WAV for M4A, and `voiceSettings.isConfigured` is re-checked after the async work.
> 
> **Un-naming or renaming** now calls `onSpeakerUnnamed`, which **subtracts the merged observation** from the previous profile when a per-recording snapshot still exists (no adjustment if the snapshot was evicted).
> 
> After **transcription completes**, a chained hook (when voice recognition is on, profiles exist, and the recording has no names yet) embeds each speaker’s longest segment, **stores batch snapshots**, and **auto-applies stored profile names** via `setSpeakerName`. It **skips** recordings that already have live-stop snapshots so richer observations are not overwritten and profiles are not double-merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0a51c84b0f3a79ec3ef8a6767e038dc8696616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved speaker identification by creating voice profiles automatically when a live or batch match is unavailable.
  - Added automatic voice matching after transcription completes.
  - Speaker names are now applied to recordings based on the closest stored voice profiles.
  - Renaming or removing a speaker name now correctly updates associated voice profile data.

- **Bug Fixes**
  - Improved handling of recordings and speaker segments that previously lacked usable voice-matching data.
  - Added more reliable processing across supported audio formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->