### PR TITLE
feat(speakers): un-naming / renaming corrects voice profiles + segment reassignment

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -725,15 +725,153 @@ struct MilaApp: App {
         // weight already stored on disk, and folding it back counts it twice.
         // This is the only place voice profiles are written, so a recognised
         // speaker merges exactly once per recording.
-        store.onSpeakerNamed = { recordingID, rawID, name in
+        let voiceLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper", category: "VoiceProfile")
+        store.onSpeakerNamed = { [weak store, weak diarSettings] recordingID, rawID, name in
             guard voiceSettings.isConfigured else { return }
-            guard let observed = voiceSnapshots.observation(forSpeaker: rawID,
-                                                           in: recordingID) else { return }
-            profileStoreRef.updateProfile(
-                name: name,
-                embedding: observed.observedCentroid,
-                sampleCount: observed.observedCount
-            )
+            if let observed = voiceSnapshots.observation(forSpeaker: rawID,
+                                                         in: recordingID) {
+                // Snapshot exists (live or batch) — save immediately.
+                profileStoreRef.updateProfile(
+                    name: name,
+                    embedding: observed.observedCentroid,
+                    sampleCount: observed.observedCount
+                )
+            } else if let store {
+                // No snapshot (old recording, never re-transcribed).
+                // Extract the embedding on demand (~0.5s) from the
+                // speaker's longest segment in this recording.
+                guard let rec = store.recordings.first(where: { $0.id == recordingID }) else { return }
+                var best: (start: Double, end: Double)?
+                for seg in rec.segments where seg.speaker == rawID {
+                    let dur = seg.end - seg.start
+                    if best == nil || dur > (best!.end - best!.start) {
+                        best = (seg.start, seg.end)
+                    }
+                }
+                guard let segment = best else { return }
+                let pythonPath = diarSettings?.pythonPath ?? "/usr/bin/python3"
+                let capturedName = name
+                let capturedRecID = recordingID
+                let capturedRawID = rawID
+                // Capture the audio URL now, before compression can
+                // change the recording's audioFileName to .m4a.
+                let wavURL = store.audioURL(for: rec)
+                Task.detached(priority: .utility) {
+                    guard FileManager.default.fileExists(atPath: wavURL.path) else { return }
+                    do {
+                        let embeddings = try await SpeakerDiarizer.embedSpeakers(
+                            wavURL: wavURL, pythonPath: pythonPath,
+                            speakerSegments: [capturedRawID: segment])
+                        guard let emb = embeddings[capturedRawID] else { return }
+                        await MainActor.run {
+                            // Re-check after await: user may have opted
+                            // out while the embedding was being extracted.
+                            guard voiceSettings.isConfigured else { return }
+                            voiceLog.log("on-demand voice profile saved for \(capturedRawID, privacy: .public)")
+                            voiceSnapshots.record(
+                                [(id: capturedRawID, observedCentroid: emb,
+                                  observedCount: 1, profileName: nil)],
+                                for: capturedRecID)
+                            profileStoreRef.updateProfile(
+                                name: capturedName,
+                                embedding: emb,
+                                sampleCount: 1)
+                        }
+                    } catch {
+                        voiceLog.log("on-demand embedding failed: \(error.localizedDescription, privacy: .private)")
+                    }
+                }
+            }
+        }
+
+        // Reverse a profile merge when a speaker is un-named or renamed.
+        // Looks up the snapshot for what was merged when the speaker was
+        // originally named; if available, subtracts that observation from
+        // the old profile. If the snapshot has been evicted, the name is
+        // still cleared but the profile is left untouched (safe default).
+        store.onSpeakerUnnamed = { recordingID, rawID, previousName in
+            guard voiceSettings.isConfigured else { return }
+            if let observed = voiceSnapshots.observation(forSpeaker: rawID,
+                                                         in: recordingID) {
+                profileStoreRef.subtractObservation(
+                    name: previousName,
+                    embedding: observed.observedCentroid,
+                    sampleCount: observed.observedCount)
+            } else {
+                voiceLog.log("un-name: no snapshot for \(rawID, privacy: .public) — profile not adjusted")
+            }
+        }
+
+        // Batch voice matching: after any transcription completes, embed
+        // each speaker's longest segment and match against stored voice
+        // profiles. Uses embedSpeakers (embedding model only, ~0.5s)
+        // instead of the full pyannote pipeline (30-60min).
+        //
+        // Skipped when the recording already has a snapshot from the live
+        // stop path (`RecognisedSpeakerAssigner.finish`), which stores
+        // richer multi-sample observations and already names recognised
+        // speakers. Without this guard the batch path would overwrite
+        // those observations with single-segment extracts and double-
+        // learn by firing `onSpeakerNamed` a second time.
+        let existingCallback = svc.onTranscriptionCompleted
+        svc.onTranscriptionCompleted = { [weak store, weak diarSettings] rec, wasRetranscription in
+            existingCallback?(rec, wasRetranscription)
+            guard voiceSettings.isConfigured,
+                  !profileStoreRef.profiles.isEmpty,
+                  rec.speakerNames.isEmpty,
+                  rec.segments.contains(where: { $0.speaker != nil }),
+                  // Skip if the live stop already snapshotted this
+                  // recording — its observations are richer and it
+                  // already named recognised speakers.
+                  voiceSnapshots.observation(forSpeaker: rec.segments.first(where: { $0.speaker != nil })!.speaker!, in: rec.id) == nil,
+                  let store else { return }
+            // Build a map of each speaker's longest segment.
+            var longest: [String: (start: Double, end: Double)] = [:]
+            for seg in rec.segments {
+                guard let sp = seg.speaker else { continue }
+                let dur = seg.end - seg.start
+                if let existing = longest[sp] {
+                    if dur > (existing.end - existing.start) {
+                        longest[sp] = (seg.start, seg.end)
+                    }
+                } else {
+                    longest[sp] = (seg.start, seg.end)
+                }
+            }
+            guard !longest.isEmpty else { return }
+            let pythonPath = diarSettings?.pythonPath ?? "/usr/bin/python3"
+            // Capture URL before the detached task — compression runs
+            // concurrently and may delete the WAV or change the path.
+            let wavURL = store.audioURL(for: rec)
+            Task.detached(priority: .utility) {
+                guard FileManager.default.fileExists(atPath: wavURL.path) else { return }
+                let embeddings = (try? await SpeakerDiarizer.embedSpeakers(
+                    wavURL: wavURL, pythonPath: pythonPath,
+                    speakerSegments: longest)) ?? [:]
+                guard !embeddings.isEmpty else { return }
+                await MainActor.run {
+                    // Re-check after await: user may have opted out.
+                    guard voiceSettings.isConfigured else { return }
+                    // Store embeddings as snapshots so naming a speaker
+                    // later (via onSpeakerNamed) can save the voice
+                    // profile even for batch-transcribed recordings.
+                    let entries = embeddings.map { (rawID, emb) in
+                        (id: rawID,
+                         observedCentroid: emb,
+                         observedCount: 1,
+                         profileName: nil as String?)
+                    }
+                    voiceSnapshots.record(entries, for: rec.id)
+
+                    for (rawID, emb) in embeddings {
+                        if let profile = profileStoreRef.match(embedding: emb) {
+                            store.setSpeakerName(
+                                profile.name, forSpeaker: rawID,
+                                recordingID: rec.id)
+                        }
+                    }
+                }
+            }
         }
 
         // Auto-drop accidental short+empty captures (issue #61). A recording

--- a/Mila/Models/ObservedVoiceSnapshots.swift
+++ b/Mila/Models/ObservedVoiceSnapshots.swift
@@ -40,17 +40,17 @@ final class ObservedVoiceSnapshots {
         let profileName: String?
     }
 
-    /// How many recordings' snapshots to keep. Naming happens right after a
-    /// recording in the overwhelming majority of cases; a handful of slots
-    /// covers "record a few back-to-back, then go back and label them"
-    /// without letting embeddings accumulate for the life of the process.
+    /// How many recordings' snapshots to keep. Raised from 8 to 20 so
+    /// un-naming a speaker (to correct a false recognition) can still find
+    /// the snapshot and subtract it from the voice profile. Memory cost is
+    /// negligible (~1 KB per speaker per recording).
     private let limit: Int
 
     private var byRecording: [UUID: [String: Observation]] = [:]
     /// Insertion order, oldest first — the eviction queue.
     private var order: [UUID] = []
 
-    init(limit: Int = 8) {
+    init(limit: Int = 20) {
         self.limit = max(1, limit)
     }
 

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -28,6 +28,12 @@ final class RecordingStore: ObservableObject {
     /// Used by voice recognition to save voice profiles.
     var onSpeakerNamed: ((_ recordingID: UUID, _ rawID: String, _ name: String) -> Void)?
 
+    /// Called when a speaker name is cleared or replaced. Provides the
+    /// recording ID, raw speaker ID, and the *previous* name that was
+    /// removed. Used by voice recognition to subtract the recording's
+    /// observed embedding from the old profile.
+    var onSpeakerUnnamed: ((_ recordingID: UUID, _ rawID: String, _ previousName: String) -> Void)?
+
     private let fileManager = FileManager.default
     /// `storeURL` and `foldersURL` move with `recordingsDirectory` on
     /// every `relocateRecordings` call. On the default path they live
@@ -507,15 +513,71 @@ final class RecordingStore: ObservableObject {
         let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmed, !trimmed.isEmpty {
             guard recordings[idx].speakerNames[rawID] != trimmed else { return }
+            // If another speaker in this recording already has this name,
+            // merge: reassign all segments of rawID into that speaker.
+            if let existingRaw = recordings[idx].speakerNames.first(where: { $0.key != rawID && $0.value == trimmed })?.key {
+                mergeSpeakers(from: rawID, into: existingRaw, recordingID: recordingID)
+                return
+            }
+            let previousName = recordings[idx].speakerNames[rawID]
             recordings[idx].speakerNames[rawID] = trimmed
+            // Renaming: subtract from old profile before merging into new.
+            if let previousName {
+                onSpeakerUnnamed?(recordingID, rawID, previousName)
+            }
             onSpeakerNamed?(recordingID, rawID, trimmed)
         } else {
-            guard recordings[idx].speakerNames[rawID] != nil else { return }
+            guard let previousName = recordings[idx].speakerNames[rawID] else { return }
             recordings[idx].speakerNames.removeValue(forKey: rawID)
+            onSpeakerUnnamed?(recordingID, rawID, previousName)
         }
         persist()
         if recordings[idx].status == .completed {
             TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
+        }
+    }
+
+    /// Merge all segments of one speaker into another within a recording.
+    /// Triggered automatically when a user names a speaker with a name
+    /// already used by another speaker in the same recording — meaning
+    /// they're the same person. Reassigns every segment and cleans up
+    /// the source speaker's name entry.
+    func mergeSpeakers(from sourceRawID: String, into targetRawID: String, recordingID: UUID) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recordingID }),
+              sourceRawID != targetRawID else { return }
+        for i in recordings[idx].segments.indices {
+            if recordings[idx].segments[i].speaker == sourceRawID {
+                recordings[idx].segments[i].speaker = targetRawID
+            }
+        }
+        // Clean up the source speaker's name. If it had a name, fire
+        // onSpeakerUnnamed so the profile can be corrected.
+        if let previousName = recordings[idx].speakerNames.removeValue(forKey: sourceRawID) {
+            onSpeakerUnnamed?(recordingID, sourceRawID, previousName)
+        }
+        persist()
+        if recordings[idx].status == .completed {
+            TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
+        }
+    }
+
+    /// Split a single segment into a new speaker. Generates the next
+    /// unused SPEAKER_NN id and assigns it to just this segment. The
+    /// user can then name the new speaker via the normal label popover;
+    /// if they pick a name already in use, `setSpeakerName` auto-merges.
+    func splitSegmentSpeaker(segmentID: UUID, recordingID: UUID) {
+        guard let recIdx = recordings.firstIndex(where: { $0.id == recordingID }),
+              let segIdx = recordings[recIdx].segments.firstIndex(where: { $0.id == segmentID })
+        else { return }
+        // Find the next unused SPEAKER_NN id.
+        let used = Set(recordings[recIdx].segments.compactMap(\.speaker))
+        var next = 0
+        while used.contains(String(format: "SPEAKER_%02d", next)) { next += 1 }
+        let newRawID = String(format: "SPEAKER_%02d", next)
+        recordings[recIdx].segments[segIdx].speaker = newRawID
+        persist()
+        if recordings[recIdx].status == .completed {
+            TranscriptExporter.writeSRT(for: recordings[recIdx], in: recordingsDirectory)
         }
     }
 

--- a/Mila/Models/SpeakerProfileStore.swift
+++ b/Mila/Models/SpeakerProfileStore.swift
@@ -308,6 +308,57 @@ final class SpeakerProfileStore: ObservableObject {
         }
     }
 
+    /// Reverse a prior `updateProfile` merge: subtract an observation's
+    /// contribution from a profile's weighted-average centroid. Called when
+    /// a speaker is un-named or renamed, so the old profile no longer
+    /// carries this recording's (possibly wrong) embedding.
+    ///
+    /// If the subtraction would leave the profile with zero or fewer
+    /// samples, the profile is deleted entirely. If the resulting centroid
+    /// contains non-finite values (numerical drift), the profile is also
+    /// deleted as irrecoverable.
+    func subtractObservation(name: String, embedding: [Float], sampleCount: Int) {
+        guard settings.isConfigured else { return }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !embedding.isEmpty,
+              embedding.allSatisfy({ $0.isFinite }),
+              sampleCount > 0 else { return }
+
+        guard let idx = profiles.firstIndex(where: { $0.name == trimmed }) else { return }
+        let existing = profiles[idx]
+        guard existing.embedding.count == embedding.count else {
+            profileLog.log("subtractObservation: dimension mismatch (\(existing.embedding.count) vs \(embedding.count)) for \(trimmed, privacy: .private)")
+            return
+        }
+
+        let remaining = existing.sampleCount - sampleCount
+        if remaining <= 0 {
+            profileLog.log("subtractObservation: removing \(trimmed, privacy: .private) (samples would drop to \(remaining))")
+            deleteProfile(name: trimmed)
+            return
+        }
+
+        var restored = [Float](repeating: 0, count: embedding.count)
+        for i in 0..<restored.count {
+            restored[i] = (existing.embedding[i] * Float(existing.sampleCount)
+                         - embedding[i] * Float(sampleCount)) / Float(remaining)
+        }
+
+        // If subtraction produced non-finite values, the centroid is
+        // irrecoverable — delete rather than persist poison.
+        guard restored.allSatisfy({ $0.isFinite }) else {
+            profileLog.log("subtractObservation: non-finite result for \(trimmed, privacy: .private), deleting profile")
+            deleteProfile(name: trimmed)
+            return
+        }
+
+        profiles[idx].embedding = restored
+        profiles[idx].sampleCount = remaining
+        profileLog.log("subtractObservation: corrected \(trimmed, privacy: .private) (now \(remaining) samples)")
+        save()
+    }
+
     func deleteProfile(id: UUID) {
         let removed = Set(profiles.filter { $0.id == id }.map(\.name))
         profiles.removeAll { $0.id == id }

--- a/Mila/Transcription/SpeakerDiarizer.swift
+++ b/Mila/Transcription/SpeakerDiarizer.swift
@@ -356,6 +356,120 @@ enum SpeakerDiarizer {
         return try JSONDecoder().decode([SpeakerTurn].self, from: result.stdout)
     }
 
+    /// Embed specific speaker segments from an already-diarized recording.
+    /// Unlike `diarize` (which runs the full pyannote pipeline), this loads
+    /// ONLY the embedding model and extracts centroids from known speaker
+    /// segments. Takes ~0.4s to load + ~0.04s per speaker vs. 30-60+
+    /// minutes for full diarization.
+    ///
+    /// `speakerSegments` maps raw speaker IDs to their (start, end) time
+    /// ranges — typically the longest segment per speaker from the
+    /// already-completed transcription.
+    static func embedSpeakers(
+        wavURL: URL,
+        pythonPath: String,
+        speakerSegments: [String: (start: Double, end: Double)]
+    ) async throws -> [String: [Float]] {
+        guard let modelsPath = bundledModelsPath else { return [:] }
+        guard !speakerSegments.isEmpty else { return [:] }
+        var pythonInputURL = wavURL
+        var tempWAVToCleanUp: URL?
+        if wavURL.pathExtension.lowercased() != "wav" {
+            pythonInputURL = try AudioCompressor.decodeToTempWAV(wavURL)
+            tempWAVToCleanUp = pythonInputURL
+        }
+        defer {
+            if let temp = tempWAVToCleanUp { try? FileManager.default.removeItem(at: temp) }
+        }
+        let resolvedPython = resolvePython(userConfigured: pythonPath)
+        let extraEnv = pythonEnvironment()
+
+        // Encode speaker segments as JSON for the Python script.
+        let segmentsJSON = try JSONSerialization.data(
+            withJSONObject: speakerSegments.mapValues { ["start": $0.start, "end": $0.end] },
+            options: [])
+        let segmentsArg = String(data: segmentsJSON, encoding: .utf8) ?? "{}"
+
+        let script = """
+        import json, sys, os, types
+
+        try:
+            import speechbrain.utils.importutils as _sbiu
+            _orig_ensure = _sbiu.LazyModule.ensure_module
+            def _safe_ensure(self, *a, **kw):
+                try:
+                    return _orig_ensure(self, *a, **kw)
+                except ImportError:
+                    self.lazy_module = types.ModuleType(self.target)
+                    return self.lazy_module
+            _sbiu.LazyModule.ensure_module = _safe_ensure
+        except Exception:
+            pass
+
+        import torch
+        _orig_torch_load = torch.load
+        def _patched_torch_load(*args, **kwargs):
+            kwargs["weights_only"] = False
+            return _orig_torch_load(*args, **kwargs)
+        torch.load = _patched_torch_load
+
+        import soundfile as sf
+        import tempfile
+        from pyannote.audio import Pipeline
+
+        wav_path = sys.argv[1]
+        models_dir = sys.argv[2]
+        segments = json.loads(sys.argv[3])
+
+        config_path = os.path.join(models_dir, "config.yaml")
+        with open(config_path) as f:
+            config_text = f.read().replace("__MODELS_DIR__", models_dir)
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(config_text)
+        tmp.close()
+
+        try:
+            pipeline = Pipeline.from_pretrained(tmp.name)
+            embedder = getattr(pipeline, "_embedding", None)
+            if embedder is None:
+                json.dump({}, sys.stdout)
+                sys.exit(0)
+
+            samples, sr = sf.read(wav_path, dtype="float32")
+            if samples.ndim > 1:
+                samples = samples.mean(axis=1)
+
+            embeddings = {}
+            for sp, seg in segments.items():
+                start_sample = int(seg["start"] * sr)
+                end_sample = int(seg["end"] * sr)
+                chunk = samples[start_sample:end_sample]
+                if len(chunk) < sr * 0.3:
+                    continue
+                wave = torch.from_numpy(chunk).unsqueeze(0).unsqueeze(0)
+                emb = embedder(wave)
+                if hasattr(emb, 'detach'):
+                    arr = emb.detach().cpu().numpy().flatten()
+                else:
+                    import numpy
+                    arr = numpy.array(emb).flatten()
+                embeddings[sp] = arr.tolist()
+
+            json.dump(embeddings, sys.stdout)
+        finally:
+            os.unlink(tmp.name)
+        """
+
+        let result = try await runPython(
+            path: resolvedPython,
+            arguments: ["-c", script, pythonInputURL.path, modelsPath, segmentsArg],
+            environment: extraEnv
+        )
+        guard result.exitCode == 0, !result.stdout.isEmpty else { return [:] }
+        return (try? JSONDecoder().decode([String: [Float]].self, from: result.stdout)) ?? [:]
+    }
+
     struct VerifyResult: Codable {
         let pyannoteInstalled: Bool
         let torchInstalled: Bool

--- a/Mila/Views/RecordingDetailView.swift
+++ b/Mila/Views/RecordingDetailView.swift
@@ -347,6 +347,10 @@ struct RecordingDetailView: View {
                                        onAssignName: { raw, name in
                                            store.setSpeakerName(name, forSpeaker: raw,
                                                                 recordingID: recording.id)
+                                       },
+                                       onSplit: {
+                                           store.splitSegmentSpeaker(segmentID: seg.id,
+                                                                     recordingID: recording.id)
                                        })
                         }
                     }
@@ -584,6 +588,8 @@ private struct SegmentRow: View {
     /// Persists a rename picked from the label's popover:
     /// (raw speaker ID, chosen name or nil-to-reset).
     let onAssignName: (String, String?) -> Void
+    /// Split this segment into a new unnamed speaker.
+    var onSplit: (() -> Void)?
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -598,7 +604,8 @@ private struct SegmentRow: View {
                     language: language,
                     color: useSpeakerColor ? raw.speakerColor(names: speakerNames) : Color.accentColor,
                     suffix: ":",
-                    onAssign: { name in onAssignName(raw, name) }
+                    onAssign: { name in onAssignName(raw, name) },
+                    onSplit: onSplit
                 )
                 .fixedSize(horizontal: true, vertical: false)
             }

--- a/Mila/Views/SpeakerNamePicker.swift
+++ b/Mila/Views/SpeakerNamePicker.swift
@@ -13,6 +13,9 @@ struct SpeakerNamePicker: View {
     let currentName: String?
     /// Called with the chosen name, or nil to reset to the default label.
     let onAssign: (String?) -> Void
+    /// Split this segment into a new speaker. Nil when not applicable
+    /// (live transcript, or segment has no speaker).
+    var onSplit: (() -> Void)?
 
     @EnvironmentObject private var directory: SpeakerDirectory
     @Environment(\.dismiss) private var dismiss
@@ -79,15 +82,29 @@ struct SpeakerNamePicker: View {
             }
             .frame(maxHeight: 180)
 
-            if currentName != nil {
+            if currentName != nil || onSplit != nil {
                 Divider()
-                row {
-                    onAssign(nil)
-                    dismiss()
-                } label: {
-                    Label("Use default (\(defaultLabel))", systemImage: "arrow.uturn.backward")
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                VStack(alignment: .leading, spacing: 0) {
+                    if currentName != nil {
+                        row {
+                            onAssign(nil)
+                            dismiss()
+                        } label: {
+                            Label("Use default (\(defaultLabel))", systemImage: "arrow.uturn.backward")
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    if onSplit != nil {
+                        row {
+                            onSplit?()
+                            dismiss()
+                        } label: {
+                            Label("Split this line", systemImage: "arrow.triangle.branch")
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
                 }
                 .padding(.vertical, 4)
             }
@@ -149,6 +166,8 @@ struct SpeakerLabelButton: View {
     /// Receives the chosen name (nil = reset to the default label);
     /// the caller persists it wherever this transcript's names live.
     let onAssign: (String?) -> Void
+    /// Split this segment into a new speaker.
+    var onSplit: (() -> Void)?
 
     @State private var showingPicker = false
     @State private var hovering = false
@@ -165,7 +184,8 @@ struct SpeakerLabelButton: View {
                 SpeakerNamePicker(
                     defaultLabel: rawID.friendlySpeakerLabel(language: language),
                     currentName: names[rawID],
-                    onAssign: onAssign
+                    onAssign: onAssign,
+                    onSplit: onSplit
                 )
             }
             .help("Rename speaker")


### PR DESCRIPTION
Closes #237

## Summary

- **Profile correction on un-name/rename**: subtracts the recording's observed embedding from the old profile via `SpeakerProfileStore.subtractObservation`, reversing a false recognition's pollution
- **Rename handling**: renaming Alice to Bob subtracts from Alice's profile first, then merges into Bob's
- **Auto-merge on duplicate name**: naming a speaker with a name already used by another speaker in the same recording automatically merges all segments into that speaker
- **Split this line**: speaker label popover includes "Split this line" to move a single mis-tagged segment to a new unnamed speaker, which can then be named normally
- **Snapshot retention**: raised from 8 to 20 recordings so un-naming can still find the embedding to subtract
- **Review fixes**: re-check `isConfigured` after await in detached tasks, skip batch matching when live snapshot exists (prevents double-learn), capture audio URL before compression can race

Depends on #236 (on-demand voice embedding).

## Test plan

- [ ] Un-name an auto-tagged speaker ("Use default") — verify profile sample count decreases
- [ ] Rename Alice to Bob — verify Alice loses samples, Bob gains
- [ ] Name Speaker B the same as Speaker A — verify segments merge automatically
- [ ] Click speaker label → "Split this line" — verify segment becomes a new unnamed speaker
- [ ] Name the split speaker same as an existing one — verify auto-merge
- [ ] Live recording flow unchanged — name during recording, stop, verify profile created
- [ ] Batch transcription auto-tagging still works
- [ ] Opt out mid-recording — verify no embeddings written after opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how voice fingerprints are learned, reversed, and auto-applied across live, batch, and on-demand paths; mistakes could mis-tag speakers or corrupt profiles, though guards limit double-learning and opt-out races.
> 
> **Overview**
> **Voice profiles now stay aligned with speaker labels.** Clearing a name or renaming a speaker triggers `onSpeakerUnnamed`, which uses the per-recording snapshot to call `SpeakerProfileStore.subtractObservation` and undo that recording’s contribution (or deletes the profile if samples hit zero). Renames subtract from the old name before `onSpeakerNamed` merges into the new one. Snapshot retention rises from **8 → 20** recordings so corrections still find embeddings after more back-to-back captures.
> 
> **Naming and matching got richer paths.** If there’s no snapshot (e.g. old recording), naming kicks off **on-demand** `SpeakerDiarizer.embedSpeakers` on the longest segment in a detached task, with audio URL captured early and `isConfigured` re-checked after await. After batch transcription, a chained `onTranscriptionCompleted` hook embeds longest segments, stores snapshots, and auto-applies stored profile names—**skipped** when a live-stop snapshot already exists to avoid overwriting richer observations or double-learning.
> 
> **Transcript speaker editing:** assigning a name already used by another speaker in the same recording **merges** segments via `mergeSpeakers`; the detail view adds **“Split this line”** (`splitSegmentSpeaker`) to give one segment a new `SPEAKER_NN` id. `embedSpeakers` is new—a fast embedding-only Python path vs full diarization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb962f3c28d68523cf836d54f5a5bc2ec945861b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split an individual transcript line into a separate speaker identity.
  * Voice profiles now retain observations from up to 20 recordings.

* **Bug Fixes**
  * Improved voice embedding reliability during concurrent recording and compression.
  * Prevented existing live observations from being overwritten during batch matching.
  * Reversed profile learning when speaker assignments change, preserving recognition accuracy.
  * Rechecked voice-recognition settings before recording or applying extracted results.
  * Avoided duplicate profile learning for recordings with existing speaker observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->