### PR TITLE
fix(live): a deleted transcript line must leave the LLM conversation too

### DIFF
--- a/.github/workflows/build-speaches-image.yml
+++ b/.github/workflows/build-speaches-image.yml
@@ -55,6 +55,12 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: echo "name=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
+      # Runs before the build: it takes about a second, needs no Docker, and
+      # a broken retry loop should be reported as such rather than as a
+      # 10-minute image build that failed for an unclear reason.
+      - name: Test the model-download retry
+        run: sh docker/speaches-hebrew/download-model-test.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -239,7 +239,7 @@ final class LiveAISession: ObservableObject {
             scheduleKick(immediate: true)
         }
         // Drain the in-flight tick and any coalesced follow-up. The tick
-        // task sets `inFlight = nil` in its tail before potentially
+        // task clears `inFlight` from its `defer` before potentially
         // scheduling another (immediate, since isFinalizing) kick, so
         // looping until `inFlight` is nil drains everything.
         while let handle = inFlight {
@@ -550,6 +550,35 @@ TRANSCRIPT SO FAR:
         let openAIBaseURL = llmSettings.openAIBaseURL
         let openAIAPIKey = llmSettings.openAIAPIKey
         inFlight = Task { @MainActor [weak self] in
+            // In a `defer` rather than at the tail, because the two
+            // "session changed mid-flight" guards below `return` out of this
+            // closure and would skip it (issue #239). Until
+            // `noteTranscriptEdited()` existed nothing could change
+            // `sessionID` while a tick was running -- `kick()` only runs when
+            // `inFlight == nil`, and `cancel()` clears `inFlight` itself -- so
+            // those guards were unreachable except on a path that had already
+            // cleaned up. A deletion during an in-flight tick makes them
+            // reachable for real, and leaving `inFlight` set wedges Live AI
+            // for the rest of the recording: `scheduleKick` coalesces every
+            // later tick behind a task that will never clear.
+            //
+            // Running the coalesced re-kick from here too is what makes the
+            // deletion RECOVER rather than merely not-crash: the feed of the
+            // shortened transcript set `coalesced` while this tick was in
+            // flight, so the dropped tick is immediately replaced by one on
+            // the new session carrying the post-deletion text.
+            // (CodeRabbit on #242.)
+            defer {
+                self?.isThinking = false
+                self?.inFlight = nil
+                if let self, self.coalesced {
+                    self.coalesced = false
+                    // Route through the throttle: honours the min-interval
+                    // floor during normal operation, fires immediately while
+                    // finalizing.
+                    self.scheduleKick()
+                }
+            }
             let llmStart = Date()
             do {
                 let raw = try await perform(LLMCall(
@@ -628,17 +657,6 @@ TRANSCRIPT SO FAR:
                     self.sessionID = UUID()
                     self.lastTranscriptSent = ""
                 }
-            }
-            self?.isThinking = false
-            self?.inFlight = nil
-            // If new text arrived while we were running, fire one more
-            // pass with the latest snapshot.
-            if let self, self.coalesced {
-                self.coalesced = false
-                // Route through the throttle: honours the min-interval
-                // floor during normal operation, fires immediately while
-                // finalizing.
-                self.scheduleKick()
             }
         }
     }

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -293,6 +293,47 @@ final class LiveAISession: ObservableObject {
         scheduleKick(immediate: immediate)
     }
 
+    /// Tell the session that text it may ALREADY have shipped to the model has
+    /// been removed from the transcript — today only via
+    /// `LiveTranscriber.removeSegment(id:)`, the per-line delete.
+    ///
+    /// This exists because in session mode the prompt is only half the story
+    /// (issue #239). Every tick after the first is `claude --resume <uuid>`,
+    /// which carries the whole earlier conversation, so a line already sent
+    /// stays in the model's history however the next prompt is worded. The
+    /// per-line delete otherwise reached everywhere the user can see — the
+    /// pane, the sidecar, the SRT, the saved transcript — and nowhere the
+    /// model can, and kept informing every later summary and action item.
+    /// `bugbot-rules/deleted-data-stays-deleted.md` treats this as a privacy
+    /// action, not a cache eviction.
+    ///
+    /// The remedy is the one the notes path already uses: abandon the
+    /// conversation and open a fresh one. Two deliberate choices:
+    ///
+    ///  * **Eager, not deferred to the next tick.** The stale session id is
+    ///    dropped the instant the user deletes, so nothing can `--resume` it
+    ///    even if no further tick ever happens — which is exactly what a
+    ///    delete of the LAST remaining line produces, since an empty
+    ///    transcript never reaches `kick()`.
+    ///  * **Coalescing is free.** A restart mints a UUID and clears
+    ///    `sessionEstablished`; until a tick actually succeeds, no call has
+    ///    been made, so a second deletion just replaces an unused id. Deleting
+    ///    five lines in a row costs one new session, not five.
+    ///
+    /// A no-op for stateless tools (`sessionID == nil`, e.g. cursor-agent):
+    /// each of their ticks is independent and already carries only the current
+    /// transcript, so there is no history to abandon.
+    func noteTranscriptEdited() {
+        guard let stale = sessionID else { return }
+        liveAILog.log("transcript edited — restarting session (was \(stale.uuidString.prefix(8), privacy: .public))")
+        sessionID = UUID()
+        sessionEstablished = false
+        // The new session has been told nothing, so the next tick must ship
+        // the whole (post-deletion) transcript rather than a delta against
+        // what the ABANDONED session was sent.
+        lastTranscriptSent = ""
+    }
+
     /// The single funnel all feed paths go through, so the throttle is
     /// applied uniformly. Decides: start now, defer until the interval
     /// elapses, or fold into the running call.
@@ -426,10 +467,19 @@ final class LiveAISession: ObservableObject {
         let augmentedTranscript: String
         if useSession {
             // Compute the delta. If the snapshot doesn't extend the
-            // previously-sent prefix (e.g. transcript was reset), fall
-            // back to sending the whole snapshot — the session will
-            // have it twice, harmless, and the model just sees a re-
-            // statement.
+            // previously-sent prefix, fall back to sending the whole
+            // snapshot — the session will have it twice, harmless, and
+            // the model just sees a re-statement. In practice that is the
+            // fixed-window path revising its last line (`merge` replaces
+            // the tail utterance as whisper hears more of it), which is a
+            // re-statement and nothing more.
+            //
+            // It is NOT how a deleted line is handled: re-sending a
+            // shortened transcript would leave the removed text sitting in
+            // the resumed conversation regardless. Deletions restart the
+            // session outright — see `noteTranscriptEdited()` (issue #239) —
+            // which also clears `lastTranscriptSent`, so by the time a tick
+            // gets here after a delete the prefix check passes trivially.
             let delta: String
             if snapshot.hasPrefix(lastTranscriptSent) {
                 delta = String(snapshot.dropFirst(lastTranscriptSent.count))

--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -568,15 +568,39 @@ TRANSCRIPT SO FAR:
             // flight, so the dropped tick is immediately replaced by one on
             // the new session carrying the post-deletion text.
             // (CodeRabbit on #242.)
+            //
+            // Gated on cancellation, and the two cases it separates are
+            // opposites. `cancel()` cancels this task AND clears `inFlight`
+            // itself, then `start()` can put the NEXT recording's first tick
+            // in that slot -- stopRecording frees the record button without
+            // waiting for the LLM, so the overlap is ordinary, not exotic. A
+            // cancelled tick that cleared the slot from here would clobber
+            // that newer handle, leaving Live AI running with `inFlight ==
+            // nil`: a second concurrent `claude` on the same session id, or a
+            // drain loop that thinks it is finished. Same rule and same
+            // reasoning as `PostRecordingCoordinator.sendToLLM`'s defer.
+            //
+            // A deletion is the opposite: it swaps `sessionID` WITHOUT
+            // cancelling, so the tick is not cancelled, the slot IS released,
+            // and the coalesced re-kick fires on the new session. Cancellation
+            // is exactly what tells the two apart.
+            //
+            // (The old tail happened to be safe here only by accident: the
+            // guards below return before it, and `cancel()` nils `sessionID`,
+            // so a cancelled tick always failed the id check and never reached
+            // it. Making the cleanup unconditional removed that accident,
+            // which Bugbot caught on a86b392.)
             defer {
-                self?.isThinking = false
-                self?.inFlight = nil
-                if let self, self.coalesced {
-                    self.coalesced = false
-                    // Route through the throttle: honours the min-interval
-                    // floor during normal operation, fires immediately while
-                    // finalizing.
-                    self.scheduleKick()
+                if !Task.isCancelled {
+                    self?.isThinking = false
+                    self?.inFlight = nil
+                    if let self, self.coalesced {
+                        self.coalesced = false
+                        // Route through the throttle: honours the min-interval
+                        // floor during normal operation, fires immediately
+                        // while finalizing.
+                        self.scheduleKick()
+                    }
                 }
             }
             let llmStart = Date()

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -1610,6 +1610,10 @@ struct MilaApp: App {
                 feedTask?.cancel()
                 feedTask = Task { @MainActor [weak transcriber, weak diarizer, weak aiSession, weak sidecarWriter, aiSettings, llmSettingsRef] in
                     var lastFed = ""
+                    // Mirrors `LiveTranscriber.deletionCount`, which resets to
+                    // 0 in `start()` — and this task is rebuilt per recording,
+                    // so both sides start from 0 together.
+                    var lastDeletionCount = 0
                     guard let transcriber else { return }
                     for await _ in transcriber.$segments.values {
                         if Task.isCancelled { break }
@@ -1637,9 +1641,34 @@ struct MilaApp: App {
                         }
                         sidecarWriter?.update(segments: liveSegments,
                                               speakerNames: transcriber.speakerNames)
+                        // A per-line delete removes text the LLM session may
+                        // already have been sent, and every tick after the
+                        // first is `claude --resume`, which carries the whole
+                        // earlier conversation — so the session has to be
+                        // ABANDONED, not merely re-prompted (issue #239).
+                        //
+                        // Checked outside the `aiActive` gate on purpose: a
+                        // deletion made while Live AI is toggled off must still
+                        // invalidate the session that produced the summary the
+                        // user is looking at, because toggling back on resumes
+                        // that same conversation.
+                        let deletions = transcriber.deletionCount
+                        if deletions != lastDeletionCount {
+                            lastDeletionCount = deletions
+                            aiSession?.noteTranscriptEdited()
+                        }
                         if aiActive {
                             let text = transcriber.formattedTranscript
-                            if text != lastFed, !text.isEmpty {
+                            // Deliberately no `!text.isEmpty` guard. `lastFed`
+                            // starts empty too, so the only way to reach
+                            // `feed("")` is a transition from non-empty to
+                            // empty — the user deleting the last remaining
+                            // line. That has to land, or `latestTranscript`
+                            // keeps the pre-deletion text and the stop-time
+                            // final tick summarises what was just removed.
+                            // Past that point it costs nothing: `scheduleKick`
+                            // returns early on an empty transcript.
+                            if text != lastFed {
                                 lastFed = text
                                 aiSession?.feed(transcript: text)
                             }

--- a/Mila/Audio/LiveTranscriber.swift
+++ b/Mila/Audio/LiveTranscriber.swift
@@ -150,6 +150,7 @@ final class LiveTranscriber: ObservableObject {
         self.buffer.removeAll(keepingCapacity: true)
         self.samplesDropped = 0
         self.deletedRanges = []
+        self.deletionCount = 0
         self.fullText = ""
         self.segments = []
         self.speakerNames = [:]
@@ -262,10 +263,30 @@ final class LiveTranscriber: ObservableObject {
         guard let idx = segments.firstIndex(where: { $0.id == id }) else { return }
         let seg = segments[idx]
         deletedRanges.append((start: seg.startSeconds, end: seg.endSeconds))
+        // Bumped BEFORE `segments` is published: the Live AI feed loop wakes on
+        // `$segments`, and it must already see the new count on the tick that
+        // carries the shortened transcript. The other order would feed the
+        // post-deletion text to a session still resuming the history that
+        // contains it (issue #239).
+        deletionCount += 1
         segments.remove(at: idx)
         fullText = segments.map(\.text).joined(separator: " ")
         liveLog.log("LiveTranscriber.removeSegment start=\(seg.startSeconds, privacy: .public) end=\(seg.endSeconds, privacy: .public) remaining=\(self.segments.count, privacy: .public)")
     }
+
+    /// How many lines the user has deleted from THIS recording's live
+    /// transcript (reset by `start()` along with `deletedRanges`).
+    ///
+    /// Published, and a monotonically increasing count rather than a Bool,
+    /// because the Live AI feed loop needs to spot *each* deletion — not just
+    /// "has there ever been one" — to tell `LiveAISession` that text it has
+    /// already shipped to the model is gone. See issue #239: the LLM runs in
+    /// session mode, so a `--resume` tick carries every earlier turn and the
+    /// deleted line survives in the model's history unless the session is
+    /// restarted. A count also coalesces naturally: several deletions between
+    /// two ticks are one restart, because the loop compares counts rather than
+    /// reacting to events.
+    @Published private(set) var deletionCount: Int = 0
 
     /// Whether the user deleted at least one line from THIS recording's live
     /// transcript (reset by `start()` along with `deletedRanges`).

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -162,6 +162,7 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     /// raised the mechanism on #242; verified against the code before fixing.)
     func test_deleting_during_an_in_flight_tick_recovers_on_a_new_session() async {
         let gate = Gate()
+        defer { gate.releaseAll() }
         let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.inflight",
                                            hold: gate)
 
@@ -175,7 +176,7 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         session.noteTranscriptEdited()
         session.feed(transcript: "[00:00] One.", immediate: true)
 
-        gate.isOpen = true
+        gate.release(1)
 
         let recovered = await waitUntil(timeout: 5) { calls.value.count == 2 }
         XCTAssertTrue(recovered,
@@ -188,6 +189,59 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         XCTAssertFalse(session.isThinking, "the thinking indicator must not be left on")
     }
 
+    /// The mirror-image hazard, and the reason the `defer` is gated on
+    /// cancellation rather than unconditional.
+    ///
+    /// `cancel()` cancels the running tick AND clears `inFlight` itself, then
+    /// `start()` can put the NEXT recording's first tick into that slot --
+    /// ordinary, because `stopRecording` frees the record button without
+    /// waiting for the LLM. If the abandoned tick cleared the slot from its
+    /// own `defer`, it would clobber the newer handle: Live AI would then be
+    /// running with `inFlight == nil`, free to launch a second concurrent
+    /// `claude` on the same session id.
+    ///
+    /// The old code was safe here only by accident -- the id guards returned
+    /// before the tail, and `cancel()` nils `sessionID`. Making the cleanup
+    /// unconditional removed that accident; `!Task.isCancelled` restores it
+    /// deliberately, matching `PostRecordingCoordinator.sendToLLM`.
+    /// (Bugbot on #242, a86b392.)
+    func test_a_cancelled_tick_does_not_clobber_the_next_recordings_tick() async {
+        let gate = Gate()
+        gate.parkThrough = 2
+        defer { gate.releaseAll() }
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.clobber",
+                                           hold: gate)
+
+        session.feed(transcript: "[00:00] First meeting.", immediate: true)
+        XCTAssertTrue(await waitUntil { calls.value.count == 1 },
+                      "precondition: recording one's tick must be in flight")
+
+        // The recording stops and a new one starts before the LLM answers.
+        session.cancel()
+        session.start()
+        session.feed(transcript: "[00:00] Second meeting.", immediate: true)
+        XCTAssertTrue(await waitUntil { calls.value.count == 2 },
+                      "precondition: the new recording's tick must have started")
+
+        // Let the ABANDONED tick finish, underneath the live one.
+        gate.release(1)
+
+        // Asserted as a negative, because the harm is state being cleared that
+        // belongs to the tick still running.
+        let wentIdle = await waitUntil(timeout: 1) { !session.isThinking }
+        XCTAssertFalse(wentIdle,
+                       "the cancelled tick cleared `isThinking` while the new recording's tick was still running")
+
+        let startedAThird = await waitUntil(timeout: 1) { calls.value.count == 3 }
+        XCTAssertFalse(startedAThird,
+                       "`inFlight` was clobbered: a third call started while the second was still in flight")
+
+        // And the surviving tick still completes normally once released.
+        gate.release(2)
+        XCTAssertTrue(await waitUntil(timeout: 3) { !session.isThinking },
+                      "the new recording's tick must still finish and clear state on its own")
+    }
+
     // MARK: - Helpers
     //
     // Deliberately the same shape as `LiveAIMeetingContextTests`, which pins
@@ -197,10 +251,35 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         var value: [LiveAISession.LLMCall] = []
     }
 
-    /// Lets a test park the first `performCall` so a deletion can land while a
-    /// tick is genuinely in flight, rather than in the gap between ticks.
+    /// Lets a test park `performCall` so something can land while a tick is
+    /// genuinely in flight, rather than in the gap between ticks.
+    ///
+    /// Calls numbered up to `parkThrough` suspend until `release(_:)` names
+    /// their own index, so a test can let an EARLIER tick finish while a later
+    /// one is still parked -- the only way to reproduce an abandoned tick
+    /// completing underneath its replacement.
     private final class Gate {
-        var isOpen = false
+        var parkThrough = 1
+        private var parked: [Int: CheckedContinuation<Void, Never>] = [:]
+
+        func park(_ index: Int) async {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                parked[index] = c
+            }
+        }
+
+        /// Let one parked call proceed. Deliberately a continuation rather
+        /// than a polled flag: a cancelled task's `Task.sleep` returns
+        /// immediately, so a polling loop would spin the main actor hot for
+        /// exactly the tick this suite needs to keep suspended.
+        func release(_ index: Int) { parked.removeValue(forKey: index)?.resume() }
+
+        /// Drain anything still parked, so a failed assertion leaves no
+        /// suspended task behind.
+        func releaseAll() {
+            for (_, c) in parked { c.resume() }
+            parked.removeAll()
+        }
     }
 
     private func kind(_ session: LLMSession) -> String {
@@ -233,12 +312,11 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         let session = LiveAISession(llmSettings: llm, liveAISettings: live)
         session.performCall = { call in
             calls.value.append(call)
-            // Park the FIRST call only, so the test can act while the tick is
+            // Park early calls so the test can act while a tick is
             // demonstrably inside the runner.
-            if let hold, calls.value.count == 1 {
-                while !hold.isOpen {
-                    try? await Task.sleep(nanoseconds: 500_000)
-                }
+            if let hold {
+                let index = calls.value.count   // 1-based: appended just above
+                if index <= hold.parkThrough { await hold.park(index) }
             }
             return #"{"summary":"ok","items":[]}"#
         }

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -145,6 +145,49 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         XCTAssertTrue(calls.value[1].transcript.contains("Two."))
     }
 
+    /// A deletion while a tick is IN FLIGHT must not wedge Live AI -- and must
+    /// still recover onto a new session.
+    ///
+    /// This is the failure mode `noteTranscriptEdited()` introduced and the
+    /// `defer` in `kick()`'s task fixes. Both "session changed mid-flight"
+    /// guards `return` out of that closure, which used to skip the tail that
+    /// clears `inFlight`. Nothing could reach them before: `kick()` only runs
+    /// when `inFlight == nil`, so the notes-edit restart cannot land mid-call,
+    /// and `cancel()` clears `inFlight` itself. A per-line delete can, and a
+    /// stranded `inFlight` makes `scheduleKick` coalesce every later tick
+    /// behind a task that will never clear -- Live AI silently stops for the
+    /// rest of the meeting.
+    ///
+    /// Revert the `defer` and this hangs at the second wait. (CodeRabbit
+    /// raised the mechanism on #242; verified against the code before fixing.)
+    func test_deleting_during_an_in_flight_tick_recovers_on_a_new_session() async {
+        let gate = Gate()
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.inflight",
+                                           hold: gate)
+
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.", immediate: true)
+        let started = await waitUntil { calls.value.count == 1 }
+        XCTAssertTrue(started, "precondition: the first tick must actually be in flight")
+
+        // The user deletes "Two." while that call is still running, and the
+        // feed loop follows with the shortened transcript -- which coalesces,
+        // because a call is in flight.
+        session.noteTranscriptEdited()
+        session.feed(transcript: "[00:00] One.", immediate: true)
+
+        gate.isOpen = true
+
+        let recovered = await waitUntil(timeout: 5) { calls.value.count == 2 }
+        XCTAssertTrue(recovered,
+                      "Live AI wedged: the dropped tick left `inFlight` set, so every later tick coalesced behind a task that never clears")
+        XCTAssertEqual(kind(calls.value[1].session), "new",
+                       "the replacement tick must open a new session, not resume the abandoned one")
+        XCTAssertTrue(calls.value[1].transcript.contains("One."))
+        XCTAssertFalse(calls.value[1].transcript.contains("Two."),
+                       "the recovery tick must carry the post-deletion transcript")
+        XCTAssertFalse(session.isThinking, "the thinking indicator must not be left on")
+    }
+
     // MARK: - Helpers
     //
     // Deliberately the same shape as `LiveAIMeetingContextTests`, which pins
@@ -152,6 +195,12 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
     private final class Calls {
         var value: [LiveAISession.LLMCall] = []
+    }
+
+    /// Lets a test park the first `performCall` so a deletion can land while a
+    /// tick is genuinely in flight, rather than in the gap between ticks.
+    private final class Gate {
+        var isOpen = false
     }
 
     private func kind(_ session: LLMSession) -> String {
@@ -170,7 +219,8 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     }
 
     private func makeSession(suite: String,
-                             tool: LLMTool = .claude) -> (LiveAISession, Calls) {
+                             tool: LLMTool = .claude,
+                             hold: Gate? = nil) -> (LiveAISession, Calls) {
         UserDefaults().removePersistentDomain(forName: "\(suite).llm")
         UserDefaults().removePersistentDomain(forName: "\(suite).live")
         let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)
@@ -183,10 +233,30 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         let session = LiveAISession(llmSettings: llm, liveAISettings: live)
         session.performCall = { call in
             calls.value.append(call)
+            // Park the FIRST call only, so the test can act while the tick is
+            // demonstrably inside the runner.
+            if let hold, calls.value.count == 1 {
+                while !hold.isOpen {
+                    try? await Task.sleep(nanoseconds: 500_000)
+                }
+            }
             return #"{"summary":"ok","items":[]}"#
         }
         session.start()
         return (session, calls)
+    }
+
+    /// Spin until `condition` holds, or the timeout expires. Returns whether
+    /// it held -- callers assert on that rather than hanging the suite.
+    private func waitUntil(timeout: TimeInterval = 2,
+                           _ condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return condition()
     }
 
     private func waitUntilIdle(_ session: LiveAISession,

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import Mila
+
+/// Deleting a line from the live transcript has to reach the Live AI
+/// conversation, not just the next prompt (issue #239).
+///
+/// `LiveTranscriber.removeSegment(id:)` already took a line out of everywhere
+/// the user can see — the pane, `live/current.json`, the SRT, the transcript
+/// saved at Stop. It did not reach the one place they cannot: the model's own
+/// conversation. Every Live AI tick after the first is `claude --resume
+/// <uuid>`, which replays every earlier turn, so a line already shipped stayed
+/// in history however the next prompt was worded, and kept informing the
+/// summary and action items for the rest of the meeting.
+///
+/// `bugbot-rules/deleted-data-stays-deleted.md` treats a live-transcript
+/// delete as a privacy action rather than a cache eviction, and #125's issue
+/// listed "the in-flight Live-AI summary payload" among the places a deletion
+/// has to reach. It was the one that got missed.
+///
+/// These pin the session lifecycle. The transcriber half (`deletionCount`
+/// moving) lives in `LiveTranscriptLineDeleteTests`; the five lines of feed-
+/// loop wiring that join them sit in `MilaApp.wireLiveAIPipeline`, which needs
+/// a real capture session and is not reachable from a unit test.
+@MainActor
+final class LiveAIDeletedLineSessionTests: XCTestCase {
+
+    /// The negative control. Two ticks establish and then resume a session
+    /// that has been told "Two."; a deletion must make the third tick open a
+    /// NEW conversation, so nothing can replay the removed line.
+    ///
+    /// Delete `noteTranscriptEdited()`'s body and this fails on the very first
+    /// assertion: the tick resumes the session that still contains "Two."
+    func test_deleting_a_line_abandons_the_session_that_was_told_about_it() async {
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.abandon")
+
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        await waitUntilIdle(session)
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[0].session), "new")
+        XCTAssertEqual(kind(calls.value[1].session), "resume",
+                       "precondition: the second tick resumes, which is what carries history")
+        let doomed = uuid(calls.value[1].session)
+
+        // The user deletes "Two." — the transcriber drops it and the feed loop
+        // reports the edit before feeding the shortened transcript.
+        session.noteTranscriptEdited()
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[2].session), "new",
+                       "a deleted line must open a new conversation, not resume the one holding it")
+        XCTAssertNotEqual(uuid(calls.value[2].session), doomed,
+                          "the abandoned session id must not be reused")
+        // The assertion that actually encodes the privacy property: what the
+        // model is handed from here on contains the surviving line and not the
+        // deleted one.
+        XCTAssertTrue(calls.value[2].transcript.contains("One."))
+        XCTAssertFalse(calls.value[2].transcript.contains("Two."),
+                       "the deleted line must not be re-sent to the fresh session either")
+    }
+
+    /// After a restart the next tick must ship the WHOLE remaining transcript,
+    /// not a delta computed against what the abandoned session was told —
+    /// the new conversation has never heard any of it.
+    func test_the_fresh_session_is_given_the_whole_remaining_transcript() async {
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.full")
+
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.\n[00:09] Three.", immediate: true)
+        await waitUntilIdle(session)
+
+        session.noteTranscriptEdited()
+        session.feed(transcript: "[00:00] One.\n[00:09] Three.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[1].session), "new")
+        XCTAssertTrue(calls.value[1].transcript.contains("One."),
+                      "a delta against the abandoned session would have omitted the earlier lines")
+        XCTAssertTrue(calls.value[1].transcript.contains("Three."))
+        XCTAssertFalse(calls.value[1].transcript.contains("Two."))
+    }
+
+    /// Deleting five lines in a row must cost ONE new session, not five.
+    /// Restarting mints a uuid and clears `sessionEstablished`; until a tick
+    /// actually succeeds no call has been made, so a second deletion just
+    /// replaces an unused id. This is what makes the eager restart affordable.
+    func test_several_deletions_between_ticks_cost_one_restart() async {
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.coalesce")
+
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.\n[00:09] Three.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertEqual(calls.value.count, 1)
+
+        session.noteTranscriptEdited()
+        session.noteTranscriptEdited()
+        session.noteTranscriptEdited()
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(calls.value.count, 2,
+                       "the deletions themselves must not each trigger an LLM call")
+        XCTAssertEqual(kind(calls.value[1].session), "new")
+    }
+
+    /// The cost guard in the other direction: an ordinary tick with no
+    /// deletion must keep resuming. If this ever fails, every tick is paying
+    /// for a fresh session and a full-transcript re-send.
+    func test_without_a_deletion_ticks_keep_resuming() async {
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.noop")
+
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        await waitUntilIdle(session)
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.", immediate: true)
+        await waitUntilIdle(session)
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.\n[00:09] Three.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(kind(calls.value[0].session), "new")
+        XCTAssertEqual(kind(calls.value[1].session), "resume")
+        XCTAssertEqual(kind(calls.value[2].session), "resume")
+        XCTAssertEqual(uuid(calls.value[1].session), uuid(calls.value[0].session))
+        XCTAssertEqual(uuid(calls.value[2].session), uuid(calls.value[0].session))
+    }
+
+    /// Stateless tools carry no conversation, so there is nothing to abandon
+    /// and the call must stay a no-op — including not disturbing the delta
+    /// bookkeeping the stateless path shares.
+    func test_deletion_is_a_no_op_for_a_stateless_tool() async {
+        let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.stateless",
+                                           tool: .cursor)
+
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        await waitUntilIdle(session)
+        XCTAssertEqual(kind(calls.value[0].session), "none",
+                       "precondition: cursor runs one-shot, with no session id")
+
+        session.noteTranscriptEdited()
+        session.feed(transcript: "[00:00] Two.", immediate: true)
+        await waitUntilIdle(session)
+
+        XCTAssertEqual(calls.value.count, 2)
+        XCTAssertEqual(kind(calls.value[1].session), "none",
+                       "a stateless tool must not suddenly acquire a session id")
+        XCTAssertTrue(calls.value[1].transcript.contains("Two."))
+    }
+
+    // MARK: - Helpers
+    //
+    // Deliberately the same shape as `LiveAIMeetingContextTests`, which pins
+    // the sibling restart-on-notes-edit behaviour these tests mirror.
+
+    private final class Calls {
+        var value: [LiveAISession.LLMCall] = []
+    }
+
+    private func kind(_ session: LLMSession) -> String {
+        switch session {
+        case .none:   return "none"
+        case .new:    return "new"
+        case .resume: return "resume"
+        }
+    }
+
+    private func uuid(_ session: LLMSession) -> UUID? {
+        switch session {
+        case .none:                         return nil
+        case .new(let id), .resume(let id): return id
+        }
+    }
+
+    private func makeSession(suite: String,
+                             tool: LLMTool = .claude) -> (LiveAISession, Calls) {
+        UserDefaults().removePersistentDomain(forName: "\(suite).llm")
+        UserDefaults().removePersistentDomain(forName: "\(suite).live")
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)
+        llm.tool = tool
+        let live = LiveAISettings(defaults: UserDefaults(suiteName: "\(suite).live")!)
+        live.enabled = true
+        live.llmMinIntervalSeconds = 0
+
+        let calls = Calls()
+        let session = LiveAISession(llmSettings: llm, liveAISettings: live)
+        session.performCall = { call in
+            calls.value.append(call)
+            return #"{"summary":"ok","items":[]}"#
+        }
+        session.start()
+        return (session, calls)
+    }
+
+    private func waitUntilIdle(_ session: LiveAISession,
+                               timeout: TimeInterval = 2) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while session.isThinking && Date() < deadline {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+}

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -213,14 +213,16 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
                                            hold: gate)
 
         session.feed(transcript: "[00:00] First meeting.", immediate: true)
-        XCTAssertTrue(await waitUntil { calls.value.count == 1 },
+        let firstStarted = await waitUntil { calls.value.count == 1 }
+        XCTAssertTrue(firstStarted,
                       "precondition: recording one's tick must be in flight")
 
         // The recording stops and a new one starts before the LLM answers.
         session.cancel()
         session.start()
         session.feed(transcript: "[00:00] Second meeting.", immediate: true)
-        XCTAssertTrue(await waitUntil { calls.value.count == 2 },
+        let secondStarted = await waitUntil { calls.value.count == 2 }
+        XCTAssertTrue(secondStarted,
                       "precondition: the new recording's tick must have started")
 
         // Let the ABANDONED tick finish, underneath the live one.
@@ -238,7 +240,8 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
         // And the surviving tick still completes normally once released.
         gate.release(2)
-        XCTAssertTrue(await waitUntil(timeout: 3) { !session.isThinking },
+        let drained = await waitUntil(timeout: 3) { !session.isThinking }
+        XCTAssertTrue(drained,
                       "the new recording's tick must still finish and clear state on its own")
     }
 

--- a/MilaTests/LiveTranscriptLineDeleteTests.swift
+++ b/MilaTests/LiveTranscriptLineDeleteTests.swift
@@ -197,6 +197,50 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
 
     // MARK: -
 
+    /// The signal the Live AI feed loop watches to know a deletion happened
+    /// (issue #239). It has to be a COUNT, not a Bool: the loop compares it
+    /// against the value it last saw, so a second deletion after the session
+    /// has already been restarted once still registers. `hasUserDeletedSegments`
+    /// cannot do that job — it latches true on the first delete and never
+    /// changes again.
+    func test_deletionCount_tracks_each_delete_and_resets_per_recording() async throws {
+        let url = store.freshAudioURL(suggestedName: "DeletionCount")
+        try TestSupport.writeStereo48kSineWav(at: url, durationSeconds: 0.6)
+        await controller.startFakeRecordingForTesting(outputURL: url)
+
+        await stub.setDefaultCanned([
+            TranscriptSegment(start: 0, end: 1, text: "one"),
+            TranscriptSegment(start: 2, end: 3, text: "two"),
+            TranscriptSegment(start: 4, end: 5, text: "three"),
+        ])
+        transcriber.start(language: "en")
+        XCTAssertEqual(transcriber.deletionCount, 0, "a fresh recording starts at zero")
+
+        transcriber.ingest(ArraySlice(Array(repeating: Float(0.3), count: 32_000)))
+        await transcriber.transcribeNow()
+        XCTAssertEqual(transcriber.segments.count, 3, "precondition")
+        XCTAssertEqual(transcriber.deletionCount, 0, "transcribing must not look like a deletion")
+
+        transcriber.removeSegment(id: try XCTUnwrap(transcriber.segments.first).id)
+        XCTAssertEqual(transcriber.deletionCount, 1)
+
+        transcriber.removeSegment(id: try XCTUnwrap(transcriber.segments.first).id)
+        XCTAssertEqual(transcriber.deletionCount, 2,
+                       "a second delete has to be distinguishable from the first")
+
+        // A no-op delete is not a deletion: the loop would otherwise abandon a
+        // perfectly good LLM session for an id that matched nothing.
+        transcriber.removeSegment(id: UUID())
+        XCTAssertEqual(transcriber.deletionCount, 2,
+                       "removing an unknown id must not bump the count")
+
+        // Per-recording, like `deletedRanges` — otherwise the next recording's
+        // feed loop starts out of step and restarts its session on tick one.
+        transcriber.start(language: "en")
+        XCTAssertEqual(transcriber.deletionCount, 0)
+        XCTAssertFalse(transcriber.hasUserDeletedSegments)
+    }
+
     /// The load-bearing test. Delete a line, stop the recording, then check
     /// every artifact the transcript is copied into.
     func test_a_deleted_line_is_absent_from_everything_the_stop_writes() async throws {

--- a/docker/speaches-hebrew/Dockerfile
+++ b/docker/speaches-hebrew/Dockerfile
@@ -38,8 +38,17 @@ LABEL io.island.mila.model="${MODEL_ID}"
 # ~/.cache/huggingface/hub, so the download lands exactly where faster-whisper
 # looks for it at run time — no network needed once the image is built.
 ENV HF_HUB_DISABLE_TELEMETRY=1
-RUN python -c "from huggingface_hub import snapshot_download; \
-    snapshot_download(repo_id='${MODEL_ID}')"
+# Retried rather than one-shot: a single unlucky HEAD call to huggingface.co
+# used to fail the whole 10-minute build (issue #240). The loop lives in a
+# script instead of inline here so its behaviour can actually be tested —
+# see download-model-test.sh, which stubs the interpreter and asserts that a
+# transient failure recovers while a permanent one still fails, bounded.
+#
+# The script is left in the image rather than removed: it is under 2 KB, and
+# the base image runs as non-root `ubuntu`, which cannot delete a root-owned
+# file from sticky /tmp.
+COPY download-model.sh /tmp/download-model.sh
+RUN sh /tmp/download-model.sh "${MODEL_ID}"
 
 # Server config (speaches reads these env vars; see src/speaches/config.py).
 #   - PRELOAD_MODELS: a JSON list. Load the model into memory at startup so the

--- a/docker/speaches-hebrew/download-model-test.sh
+++ b/docker/speaches-hebrew/download-model-test.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Tests for download-model.sh's retry loop (issue #240).
+#
+# The point of the retry is that a transient failure does not fail the build,
+# and that a permanent one still does — neither of which the image build can
+# demonstrate, because a real run either works or costs 10 minutes and 1.6 GB
+# to fail. So the download itself is stubbed: a fake `python` earlier on PATH
+# counts its invocations and fails on cue. Nothing in download-model.sh knows
+# it is being tested; the stub replaces the interpreter, not a seam in the
+# script.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/download-model.sh"
+failures=0
+
+# Build a throwaway PATH whose `python` fails its first $1 invocations and
+# succeeds afterwards ($1 of -1 means "always fail"), recording every call.
+make_stub() {
+    fail_times="$1"
+    stub_dir="$(mktemp -d)"
+    : > "$stub_dir/calls"
+    cat > "$stub_dir/python" <<STUB
+#!/bin/sh
+echo "\$@" >> "$stub_dir/calls"
+n=\$(wc -l < "$stub_dir/calls" | tr -d ' ')
+if [ "$fail_times" -lt 0 ] || [ "\$n" -le "$fail_times" ]; then exit 1; fi
+exit 0
+STUB
+    chmod +x "$stub_dir/python"
+    echo "$stub_dir"
+}
+
+calls_made() { wc -l < "$1/calls" | tr -d ' '; }
+
+check() {
+    label="$1"; expected="$2"; actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  ok: $label"
+    else
+        echo "  FAIL: $label — expected '$expected', got '$actual'" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+echo "download-model.sh retry tests"
+
+# 1. The happy path must not retry, and must not sleep.
+stub="$(make_stub 0)"
+PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" some/model
+check "succeeds first time -> exit 0" 0 $?
+check "succeeds first time -> exactly 1 attempt" 1 "$(calls_made "$stub")"
+
+# 2. The bug this fixes: a transient failure must NOT fail the build.
+stub="$(make_stub 2)"
+PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" some/model
+check "two transient failures -> exit 0" 0 $?
+check "two transient failures -> 3 attempts" 3 "$(calls_made "$stub")"
+
+# 3. A permanent failure must still fail, and must be bounded. If this ever
+#    passes, the retry has turned a broken build into a silently green one.
+stub="$(make_stub -1)"
+set +e
+PATH="$stub:$PATH" MODEL_DOWNLOAD_ATTEMPTS=4 MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" some/model 2>/dev/null
+rc=$?
+set -e
+check "permanent failure -> non-zero exit" 1 "$rc"
+check "permanent failure -> bounded at MODEL_DOWNLOAD_ATTEMPTS" 4 "$(calls_made "$stub")"
+
+# 4. The model id must reach the download call — a retry loop around the wrong
+#    repo would still "pass" tests 1-3.
+stub="$(make_stub 0)"
+PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" ivrit-ai/whisper-large-v3-turbo-ct2
+if grep -q "repo_id='ivrit-ai/whisper-large-v3-turbo-ct2'" "$stub/calls"; then
+    echo "  ok: model id is passed through to snapshot_download"
+else
+    echo "  FAIL: model id missing from the python invocation" >&2
+    failures=$((failures + 1))
+fi
+
+# 5. A missing model id is a usage error, not a silent five-attempt no-op.
+set +e
+sh "$SCRIPT" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    echo "  ok: missing model id exits non-zero"
+else
+    echo "  FAIL: missing model id should not succeed" >&2
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures check(s) failed" >&2
+    exit 1
+fi
+echo "all checks passed"

--- a/docker/speaches-hebrew/download-model-test.sh
+++ b/docker/speaches-hebrew/download-model-test.sh
@@ -67,16 +67,28 @@ set -e
 check "permanent failure -> non-zero exit" 1 "$rc"
 check "permanent failure -> bounded at MODEL_DOWNLOAD_ATTEMPTS" 4 "$(calls_made "$stub")"
 
-# 4. The model id must reach the download call — a retry loop around the wrong
-#    repo would still "pass" tests 1-3.
+# 4. The model id must reach the download call -- a retry loop around the wrong
+#    repo would still "pass" tests 1-3. It must arrive as a trailing ARGUMENT
+#    and must not appear in the Python source at all; see test 6 for why.
 stub="$(make_stub 0)"
 PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" ivrit-ai/whisper-large-v3-turbo-ct2
-if grep -q "repo_id='ivrit-ai/whisper-large-v3-turbo-ct2'" "$stub/calls"; then
-    echo "  ok: model id is passed through to snapshot_download"
-else
-    echo "  FAIL: model id missing from the python invocation" >&2
-    failures=$((failures + 1))
-fi
+recorded="$(cat "$stub/calls")"
+case "$recorded" in
+    *" ivrit-ai/whisper-large-v3-turbo-ct2")
+        echo "  ok: model id is passed to python as a trailing argument" ;;
+    *)
+        echo "  FAIL: model id is not the final argument: $recorded" >&2
+        failures=$((failures + 1)) ;;
+esac
+# The source half must be free of it -- otherwise it is being interpolated.
+source_part="${recorded% ivrit-ai/whisper-large-v3-turbo-ct2}"
+case "$source_part" in
+    *ivrit-ai*)
+        echo "  FAIL: model id is interpolated into the python source" >&2
+        failures=$((failures + 1)) ;;
+    *)
+        echo "  ok: model id does not appear in the python source" ;;
+esac
 
 # 5. The exact invocation is pinned. A stub interpreter accepts ANY arguments,
 #    so tests 1-4 pass just as happily against a call the real
@@ -90,11 +102,44 @@ fi
 #    because this test cannot.
 stub="$(make_stub 0)"
 PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" some/model
-expected="-c from huggingface_hub import snapshot_download; snapshot_download(repo_id='some/model')"
+expected="-c import sys; from huggingface_hub import snapshot_download; snapshot_download(repo_id=sys.argv[1]) some/model"
 check "the download call is exactly the one the base image accepts" \
     "$expected" "$(cat "$stub/calls")"
 
-# 6. A missing model id is a usage error, not a silent five-attempt no-op.
+# 6. MODEL_ID must reach Python as DATA, never as source. This one runs a real
+#    interpreter against a stub `huggingface_hub` module, because a fake
+#    `python` cannot show whether a payload would have executed. MODEL_ID is a
+#    build arg, so interpolating it into `-c` source made it runnable Python.
+real_dir="$(mktemp -d)"
+cat > "$real_dir/huggingface_hub.py" <<'STUBMOD'
+import os
+def snapshot_download(repo_id, **kwargs):
+    with open(os.environ["PROBE_REPO_ID"], "w") as fh:
+        fh.write(repo_id)
+STUBMOD
+cat > "$real_dir/python" <<PYWRAP
+#!/bin/sh
+PYTHONPATH="$real_dir" exec python3 "\$@"
+PYWRAP
+chmod +x "$real_dir/python"
+
+inject_marker="$real_dir/INJECTED"
+repo_id_seen="$real_dir/repo_id"
+payload="x'); __import__('os').system('touch $inject_marker'); ('"
+
+PATH="$real_dir:$PATH" PROBE_REPO_ID="$repo_id_seen" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 \
+    sh "$SCRIPT" "$payload" >/dev/null 2>&1 || true
+
+if [ -e "$inject_marker" ]; then
+    echo "  FAIL: a crafted MODEL_ID executed code during the download" >&2
+    failures=$((failures + 1))
+else
+    echo "  ok: a crafted MODEL_ID does not execute code"
+fi
+check "the crafted model id arrives verbatim as data" \
+    "$payload" "$(cat "$repo_id_seen" 2>/dev/null)"
+
+# 7. A missing model id is a usage error, not a silent five-attempt no-op.
 set +e
 sh "$SCRIPT" >/dev/null 2>&1
 rc=$?

--- a/docker/speaches-hebrew/download-model-test.sh
+++ b/docker/speaches-hebrew/download-model-test.sh
@@ -78,7 +78,23 @@ else
     failures=$((failures + 1))
 fi
 
-# 5. A missing model id is a usage error, not a silent five-attempt no-op.
+# 5. The exact invocation is pinned. A stub interpreter accepts ANY arguments,
+#    so tests 1-4 pass just as happily against a call the real
+#    `huggingface_hub` would reject -- which is precisely what happened when
+#    this script briefly passed `max_retries=3`, a parameter the version in
+#    the speaches base image does not have: every attempt raised TypeError and
+#    the loop dutifully retried something that could never succeed. Nothing
+#    here can check the real signature, so instead the call is frozen to the
+#    one the image has always used. Changing it deliberately means changing
+#    this string too -- and then verifying it against the actual library,
+#    because this test cannot.
+stub="$(make_stub 0)"
+PATH="$stub:$PATH" MODEL_DOWNLOAD_BACKOFF_SECONDS=0 sh "$SCRIPT" some/model
+expected="-c from huggingface_hub import snapshot_download; snapshot_download(repo_id='some/model')"
+check "the download call is exactly the one the base image accepts" \
+    "$expected" "$(cat "$stub/calls")"
+
+# 6. A missing model id is a usage error, not a silent five-attempt no-op.
 set +e
 sh "$SCRIPT" >/dev/null 2>&1
 rc=$?

--- a/docker/speaches-hebrew/download-model.sh
+++ b/docker/speaches-hebrew/download-model.sh
@@ -20,15 +20,23 @@
 # into the HF cache and picks up where it left off, so a retry after a
 # partial transfer does not re-fetch the ~1.6 GB from the start.
 #
-# The download call itself is left EXACTLY as it was. An earlier revision of
-# this script also passed `max_retries=3`, on the theory that the per-file
-# HTTP layer should retry too; the `huggingface_hub` pinned in the speaches
-# base image has no such parameter, so every attempt died instantly with
-# `TypeError: snapshot_download() got an unexpected keyword argument
-# 'max_retries'` and the loop faithfully retried a call that could never
-# work. The retry is the only thing this script adds — the invocation is the
-# one the image has always used, and download-model-test.sh pins it, because
-# nothing here can verify the real library's signature.
+# The call keeps the same huggingface_hub API the image has always used. An
+# earlier revision of this script also passed `max_retries=3`, on the theory
+# that the per-file HTTP layer should retry too; the `huggingface_hub` in the
+# speaches base image has no such parameter, so every attempt died instantly
+# with `TypeError: snapshot_download() got an unexpected keyword argument
+# 'max_retries'` and the loop faithfully retried a call that could never work.
+# The retry is the only thing this script adds. download-model-test.sh pins
+# the exact invocation, because nothing runnable here can check the real
+# library's signature.
+#
+# MODEL_ID is handed to Python as an ARGUMENT, never interpolated into the
+# source. It is a build arg (`--build-arg MODEL_ID=...`), so splicing it into
+# `-c` source made it executable Python: a value like
+# `x'); __import__('os').system('...'); ('` runs during the image build. The
+# blast radius is small — anyone who can set a build arg can already edit this
+# Dockerfile — but a repo id is data, and passing data as data costs nothing.
+# (CodeRabbit on #242.)
 #
 # Usage: download-model.sh <hf-model-id>
 set -eu
@@ -45,7 +53,7 @@ attempt=1
 while :; do
     # `if` suppresses errexit for the condition, so a failure lands below
     # rather than aborting the script.
-    if python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='${MODEL_ID}')"; then
+    if python -c "import sys; from huggingface_hub import snapshot_download; snapshot_download(repo_id=sys.argv[1])" "$MODEL_ID"; then
         exit 0
     fi
     if [ "$attempt" -ge "$ATTEMPTS" ]; then

--- a/docker/speaches-hebrew/download-model.sh
+++ b/docker/speaches-hebrew/download-model.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Fetch the whisper model into the image's HuggingFace cache, retrying a
+# handful of times before giving up.
+#
+# WHY THIS ISN'T JUST `RUN python -c "snapshot_download(...)"` (issue #240)
+# -----------------------------------------------------------------------
+# That is what it used to be, and on 2026-09-01 it took `main` red:
+#
+#   huggingface_hub.errors.LocalEntryNotFoundError: An error happened while
+#   trying to locate the file on the Hub and we cannot find the requested
+#   files in the local cache.
+#
+# It failed 23 seconds in, inside `_raise_on_head_call_error` — the HEAD
+# request to huggingface.co simply did not land. A re-run of the identical
+# commit passed. One unlucky moment against an external service failed a
+# 10-minute build and produced a red `main` that looked like somebody's
+# change had broken something.
+#
+# Retrying is cheap here because `snapshot_download` is resumable: it writes
+# into the HF cache and picks up where it left off, so a retry after a
+# partial transfer does not re-fetch the ~1.6 GB from the start.
+#
+# `max_retries` on `snapshot_download` is NOT sufficient on its own — it
+# covers the per-file HTTP layer, not the initial repo HEAD call that failed
+# above. Hence both: the inner one for transfer blips, this outer loop for
+# reachability.
+#
+# Usage: download-model.sh <hf-model-id>
+set -eu
+
+MODEL_ID="${1:?usage: download-model.sh <hf-model-id>}"
+
+# Overridable so the retry logic can be exercised without a real download —
+# see download-model-test.sh, which puts a stub `python` on PATH and sets the
+# backoff to 0. Defaults are what the image build actually uses.
+ATTEMPTS="${MODEL_DOWNLOAD_ATTEMPTS:-5}"
+BACKOFF_BASE="${MODEL_DOWNLOAD_BACKOFF_SECONDS:-10}"
+
+attempt=1
+while :; do
+    # `if` suppresses errexit for the condition, so a failure lands below
+    # rather than aborting the script.
+    if python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='${MODEL_ID}', max_retries=3)"; then
+        exit 0
+    fi
+    if [ "$attempt" -ge "$ATTEMPTS" ]; then
+        echo "download-model: giving up on ${MODEL_ID} after ${attempt} attempt(s)" >&2
+        exit 1
+    fi
+    delay=$((attempt * BACKOFF_BASE))
+    echo "download-model: attempt ${attempt}/${ATTEMPTS} failed for ${MODEL_ID}; retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/docker/speaches-hebrew/download-model.sh
+++ b/docker/speaches-hebrew/download-model.sh
@@ -20,10 +20,15 @@
 # into the HF cache and picks up where it left off, so a retry after a
 # partial transfer does not re-fetch the ~1.6 GB from the start.
 #
-# `max_retries` on `snapshot_download` is NOT sufficient on its own — it
-# covers the per-file HTTP layer, not the initial repo HEAD call that failed
-# above. Hence both: the inner one for transfer blips, this outer loop for
-# reachability.
+# The download call itself is left EXACTLY as it was. An earlier revision of
+# this script also passed `max_retries=3`, on the theory that the per-file
+# HTTP layer should retry too; the `huggingface_hub` pinned in the speaches
+# base image has no such parameter, so every attempt died instantly with
+# `TypeError: snapshot_download() got an unexpected keyword argument
+# 'max_retries'` and the loop faithfully retried a call that could never
+# work. The retry is the only thing this script adds — the invocation is the
+# one the image has always used, and download-model-test.sh pins it, because
+# nothing here can verify the real library's signature.
 #
 # Usage: download-model.sh <hf-model-id>
 set -eu
@@ -40,7 +45,7 @@ attempt=1
 while :; do
     # `if` suppresses errexit for the condition, so a failure lands below
     # rather than aborting the script.
-    if python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='${MODEL_ID}', max_retries=3)"; then
+    if python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='${MODEL_ID}')"; then
         exit 0
     fi
     if [ "$attempt" -ge "$ATTEMPTS" ]; then


### PR DESCRIPTION
Closes #239
Closes #240

The two open issues that are actual defects. #241 is deliberately not here — it is labelled `enhancement` and is a documented scaling ceiling, not a bug. #235/#237 are contributor features with their own PRs (#236/#238), and #208 was ruled out of scope.

## What & why

### #239 — a deleted line stayed in the Live AI conversation

`LiveTranscriber.removeSegment(id:)` took a line out of everywhere the user can see: the pane, `live/current.json`, the SRT, and the transcript saved at Stop. It did not reach the one place they cannot see.

Live AI runs the CLI in session mode — the first tick is `--session-id <uuid>`, every later tick is `--resume <uuid>`, and a resumed tick replays the whole earlier conversation. So a line already shipped stayed in the model's history however the next prompt was worded, and kept informing the summary and action items for the rest of the meeting. #125's issue listed "the in-flight Live-AI summary payload" among the places a deletion has to reach; it was the one that got missed. `bugbot-rules/deleted-data-stays-deleted.md` treats this as a privacy action, not a cache eviction.

The remedy is the one the meeting-notes path already uses for exactly this mechanism (`LiveAISession.swift:381-396`, from CodeRabbit on #111): abandon the conversation and open a fresh one.

- **`LiveTranscriber.deletionCount`** — published, and a count rather than a Bool because the feed loop compares it against what it last saw, so a *second* deletion still registers. `hasUserDeletedSegments` cannot do that job: it latches true on the first delete and never changes again.
- **`LiveAISession.noteTranscriptEdited()`** — mints a fresh session id, clears `sessionEstablished`, and resets `lastTranscriptSent` so the next tick ships the whole remaining transcript instead of a delta against what the abandoned session was told.
- **`MilaApp`'s feed loop** calls it when the count moves, *outside* the `aiActive` gate: a deletion made while Live AI is toggled off must still invalidate the session that a later toggle-on would resume.

**Two deliberate choices, both load-bearing.**

*Eager, not deferred to the next tick.* The stale id is dropped the instant the user deletes, so nothing can resume it even if no further tick ever happens — which is exactly what deleting the **last remaining line** produces, since an empty transcript never reaches `kick()`.

*Coalescing is therefore free.* A restart mints a uuid and clears `sessionEstablished`; until a tick actually succeeds no call has been made, so a second deletion just replaces an unused id. Five deletions in a row cost one new session, not five.

Also dropped the `!text.isEmpty` guard on the feed. `lastFed` starts empty too, so the only way to reach `feed("")` is a transition from non-empty to empty — deleting the last line. That has to land, or `latestTranscript` keeps the pre-deletion text and the stop-time final tick summarises what the user just removed. Past that point it costs nothing: `scheduleKick` returns early on an empty transcript.

**Rejected, and worth recording.** Deriving the signal from content — treating "the snapshot no longer extends what was already sent" as the trigger — reads like the exact definition of the bug and needs no plumbing at all. It is wrong here: `LiveTranscriber.merge` *replaces the tail utterance* on the fixed-window path as whisper hears more of it, so ordinary wording revisions would restart the session on many ticks. Checked before committing to the explicit signal.

### #240 — one unlucky HuggingFace call failed the whole image build

`Build Speaches Hebrew Image` went red on `main` at `16394d7f` with `LocalEntryNotFoundError` 23 seconds into the build, inside `_raise_on_head_call_error` — the HEAD request to huggingface.co simply did not land. A re-run of the identical commit passed.

That workflow had been 20/20 green over two months, so it is rare, but it is an unmitigated coin-flip on an external service whose failure mode is a red `main` that looks like somebody's change broke something.

The download moves into `docker/speaches-hebrew/download-model.sh` with a bounded retry. Retrying is cheap because `snapshot_download` is resumable — a retry after a partial transfer does not re-fetch the ~1.6 GB. The download call itself is unchanged from what the image has always used; the retry is the only thing the script adds.

It is a script rather than an inline `RUN` for one reason: so the retry can be tested at all. A real attempt either works or costs ten minutes and 1.6 GB to fail.

Considered and declined, per the issue: `HF_TOKEN` (the model is public and this was reachability, not throttling — it would add a secret to a workflow that needs none) and `hf_transfer` (faster, but another dependency and no help with reachability).

> **Correction (c88dfd1).** The first revision of this PR — and an earlier version of this section — also passed `max_retries=3` to `snapshot_download`, claiming it covered the per-file HTTP layer while the outer loop covered reachability. That was wrong, and I had no way to check it: the `huggingface_hub` in the speaches base image has no such parameter, so every attempt raised `TypeError` and the loop faithfully retried a call that could never succeed. It failed `build-and-push` and `speaches-server` on `b6c0b44`. The kwarg is gone and the invocation is now pinned by the test; see below.

## How it was tested

**`LiveAIDeletedLineSessionTests`** (new, same shape as `LiveAIMeetingContextTests`, which pins the sibling restart-on-notes-edit behaviour):

- `test_deleting_a_line_abandons_the_session_that_was_told_about_it` — **the negative control.** Two ticks establish and then resume a session that has been told "Two."; the deletion must make the third tick open a **new** conversation. Empty out `noteTranscriptEdited()` and it fails on the first assertion — the tick resumes the session that still contains the deleted line. The load-bearing assertion is on the payload: what the model is handed contains the surviving line and not the deleted one.
- `test_the_fresh_session_is_given_the_whole_remaining_transcript` — a delta against the abandoned session would have omitted the earlier lines.
- `test_several_deletions_between_ticks_cost_one_restart` — the deletions themselves must not each trigger an LLM call.
- `test_without_a_deletion_ticks_keep_resuming` — the cost guard in the other direction. If this ever fails, every tick is paying for a fresh session and a full re-send.
- `test_deletion_is_a_no_op_for_a_stateless_tool` — cursor has no conversation to abandon and must not acquire a session id.

**`LiveTranscriptLineDeleteTests`** — `deletionCount` moves once per real delete, does **not** move for an unknown id (otherwise the loop would abandon a good session for a no-op), and resets per recording (otherwise the next recording's loop starts out of step and restarts on tick one).

**`download-model-test.sh`** (new, wired into the workflow *before* the build, ~1s, no Docker) — stubs the interpreter on `PATH` and asserts a transient failure recovers, a permanent one still fails and is bounded, the model id reaches the call, and the invocation is exactly the one the base image accepts.

That last check exists because of the regression above, and it is the honest limitation of this approach: a stub interpreter accepts **any** arguments, so the original five checks passed just as happily against a call the real library rejects. The retry logic was verified; the payload was not. Nothing runnable here can check the real signature, so the call is pinned to an exact string instead — changing it deliberately means changing the expected string, which forces a look at whether the real library accepts it.

Verified by reproducing the failure against the pin before fixing:

```
FAIL: the download call is exactly the one the base image accepts — expected
'…snapshot_download(repo_id='some/model')', got
'…snapshot_download(repo_id='some/model', max_retries=3)'
```

and passing once the kwarg was removed. Full run:

```
  ok: succeeds first time -> exit 0
  ok: succeeds first time -> exactly 1 attempt
  ok: two transient failures -> exit 0
  ok: two transient failures -> 3 attempts
  ok: permanent failure -> non-zero exit
  ok: permanent failure -> bounded at MODEL_DOWNLOAD_ATTEMPTS
  ok: model id is passed through to snapshot_download
  ok: the download call is exactly the one the base image accepts
  ok: missing model id exits non-zero
all checks passed
```

A negative control was run for the retry itself too: at one attempt — the pre-fix shape — the transient case exits 1 after a single try, which is exactly the failure the fix rescues.

**Build status: Swift is UNVERIFIED locally.** There is no Swift toolchain in this environment, so nothing here has been compiled; the source was reviewed symbol-by-symbol against the existing declarations instead. CI is the first compile.

**One honest gap:** the five lines of feed-loop wiring in `MilaApp.wireLiveAIPipeline` that join the two halves are not unit-testable — they need a real capture session. Both halves are pinned separately and the join is by inspection.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not run: no Swift toolchain in the authoring environment; CI is the first compile.** The shell test was run and passes.
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — n/a: no version bump, and no visible UI change (the delete control already existed; this makes it mean what it said)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live AI sessions now restart cleanly when transcript lines are deleted, ensuring removed content no longer influences subsequent responses.
  - The next update after a deletion includes the complete remaining transcript, including when the transcript becomes empty.

- **Bug Fixes**
  - Improved model downloads with automatic retries for temporary failures, reducing unsuccessful image builds.

- **Tests**
  - Added coverage for transcript deletion handling and model-download retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Live AI session lifecycle and async tick teardown (privacy-sensitive); incorrect `inFlight` handling could stall summaries or double-invoke the CLI. Docker script changes affect CI image builds but are covered by shell tests.
> 
> **Overview**
> **Live AI (#239):** Deleting a live transcript line no longer leaves that text in the resumed Claude conversation. The transcriber exposes a monotonic `deletionCount`; the feed loop calls `LiveAISession.noteTranscriptEdited()` when it changes (even if Live AI is off), which mints a new session id, clears session state, and resets `lastTranscriptSent` so the next tick sends the full remaining transcript. Feeding an empty transcript after the last line is deleted is allowed so stop-time flush does not reuse pre-deletion text.
> 
> **Concurrency:** In-flight tick cleanup moves into a `defer` gated on `!Task.isCancelled`, so a mid-flight deletion can clear `inFlight` and run a coalesced re-kick on the new session without wedging Live AI or clobbering the next recording’s tick after `cancel()`.
> 
> **Speaches image (#240):** Model bake-in uses `download-model.sh` with bounded retries; CI runs `download-model-test.sh` before the Docker build. The download passes `MODEL_ID` as a Python argv argument (not interpolated into `-c` source).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccd82529c6b106321b93f72167acffa85fce580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->