### PR TITLE
ci: pin the speaches base image to a digest dependabot can refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,19 @@ updates:
       - dependency-name: "swift-actions/setup-swift"
         versions: [">= 3.a, < 4"]
 
+  # The speaches base image behind the Hebrew remote-transcription E2E.
+  #
+  # This entry did nothing at all for its first months: the Dockerfile said
+  # `FROM ghcr.io/speaches-ai/speaches:${SPEACHES_TAG}`, and dependabot's
+  # Dockerfile parser does not resolve ARGs — its FROM regex wants a literal
+  # tag, and a FROM line with neither tag nor digest is skipped, so there was
+  # no dependency to update and never a PR (issue #243).
+  #
+  # So: the FROM in docker/speaches-hebrew/Dockerfile must stay a LITERAL
+  # `image:tag@sha256:digest`. The digest is the pin; the tag is what
+  # dependabot compares versions on (a tag with no version in it — `latest-cpu`
+  # — can never be bumped). Re-introducing a variable there re-breaks this
+  # silently, since an inert ecosystem entry looks exactly like a quiet one.
   - package-ecosystem: "docker"
     directory: "/docker/speaches-hebrew"
     schedule:

--- a/docker/speaches-hebrew/Dockerfile
+++ b/docker/speaches-hebrew/Dockerfile
@@ -22,10 +22,52 @@
 # build time so the container is fully self-contained and needs no network at
 # run time (important for hermetic CI). Override with --build-arg MODEL_ID=... .
 
-ARG SPEACHES_TAG=latest-cpu
-FROM ghcr.io/speaches-ai/speaches:${SPEACHES_TAG}
+# BASE IMAGE — pinned to a digest, refreshed by dependabot (issue #243)
+# ----------------------------------------------------------------------
+# We inherit this image's ENTIRE Python environment: huggingface_hub,
+# faster-whisper, ctranslate2, the lot. It used to be `latest-cpu`, so that
+# environment could change between two builds of an unchanged Dockerfile —
+# and did: #242 called `snapshot_download(max_retries=3)`, a parameter that
+# does not exist in the huggingface_hub this image ships, and the build broke
+# for reasons nothing in this repo could explain. With a pin, the contract is
+# knowable: as of this digest the base is speaches 0.8.3 (upstream commit
+# c78b77d), whose uv.lock — installed with `uv sync --frozen` — gives
+# huggingface_hub 0.33.4, faster-whisper 1.1.1, ctranslate2 4.5.0.
+#
+# WHY tag AND digest, not one or the other
+#   - The digest is the pin. A tag, semver or not, is mutable at the
+#     registry's discretion; upstream re-points `latest-cpu` on every release.
+#     `sha256:21e3df…` is the only form that cannot move under us.
+#   - The tag is not decoration. Docker resolves by digest and ignores it, but
+#     dependabot keys its version search on the tag, and only a tag with a
+#     comparable version can move: `latest-cpu` has none, so dependabot could
+#     never bump it. `0.8.3-cpu` parses as version 0.8.3 + suffix `-cpu`, and
+#     dependabot only compares tags with a matching suffix — so it will offer
+#     `0.9.0-cpu` and never a `-cuda` or `-rc` tag. It also tells a human
+#     reading the diff what they are actually on.
+#
+# WHY NOT `ARG SPEACHES_TAG` + `FROM …:${SPEACHES_TAG}` (what this replaced)
+#   Dependabot's Dockerfile parser does not resolve ARGs. Its FROM regex wants
+#   a literal tag (`[\w][\w.-]{0,127}`), `${SPEACHES_TAG}` cannot match it, and
+#   a FROM line with neither tag nor digest is skipped outright. The `docker`
+#   entry in .github/dependabot.yml has existed since #95 and has never opened
+#   a PR — it had nothing to parse. Keep this line literal or it goes inert
+#   again, silently.
+#
+# REFRESH PATH (a pin that freezes security updates is its own hazard)
+#   1. Dependabot, weekly, with the 7-day cooldown in .github/dependabot.yml:
+#      new upstream release -> a `docker:` PR bumping tag + digest together.
+#      A same-tag digest refresh (upstream re-pushing patched bytes under
+#      `0.8.3-cpu`) is also something dependabot can propose, but whether it
+#      does is governed by a server-side dependabot experiment we cannot
+#      observe from here — do not rely on it as the only path.
+#   2. Manual: `Build Speaches Hebrew Image` has a `workflow_dispatch` for
+#      exactly this, and any bump lands as a reviewable PR that rebuilds the
+#      image and runs the Hebrew E2E against it.
+FROM ghcr.io/speaches-ai/speaches:0.8.3-cpu@sha256:21e3df06d842fb7802ab470dd77c25f0e8c0d22950e8d8c6ae886e851af53ef8
 
-# Redeclare after FROM so it's visible in the build stage.
+# Declared after FROM so it's visible in this build stage — an ARG before FROM
+# only reaches the FROM line itself.
 ARG MODEL_ID=ivrit-ai/whisper-large-v3-turbo-ct2
 
 LABEL org.opencontainers.image.source="https://github.com/island-io/mila"


### PR DESCRIPTION
Closes #243

## What & why

`docker/speaches-hebrew/Dockerfile` built on `FROM ghcr.io/speaches-ai/speaches:${SPEACHES_TAG}` with `SPEACHES_TAG=latest-cpu`. The whole Python environment the image inherits — `huggingface_hub`, `faster-whisper`, `ctranslate2` — could therefore change between two builds of an unchanged Dockerfile, which is the root cause behind the #242 failure: `snapshot_download(max_retries=3)` raised `TypeError` because the parameter doesn't exist in whatever `huggingface_hub` the base shipped that day, and no pinned version existed to check the call against.

This pins it to **`ghcr.io/speaches-ai/speaches:0.8.3-cpu@sha256:21e3df06…`** and documents the tradeoff and the refresh path in the Dockerfile, so the next reader doesn't re-derive it.

### The two decisions the issue asked for

**1. Digest, carried alongside a versioned tag — both, not either.**

The digest is the actual pin: a tag is mutable at the registry's discretion, and upstream re-points `latest-cpu` on every release. But the tag is not decoration — Docker resolves by digest and ignores it, while dependabot keys its *version* search on the tag, and only a tag with a comparable version can move. `latest-cpu` has no version component, so dependabot could never bump it even if it parsed the line. `0.8.3-cpu` parses as version `0.8.3` + suffix `-cpu`, and dependabot only compares tags whose suffix matches, so it will offer `0.9.0-cpu` and never a `-cuda` or an `-rc` tag. It also tells a human reading the diff what they're on.

`0.8.3-cpu` is the newest **stable** CPU tag upstream publishes (`0.9.0-rc.1…rc.3` exist; dependabot filters pre-releases out from a stable pin, and so did I).

**2. The refresh path is dependabot — and it was already configured and doing nothing.**

`.github/dependabot.yml` has had a `docker` ecosystem entry on `/docker/speaches-hebrew` since #95. It has never opened a PR, and it never could: dependabot's Dockerfile parser does not resolve `ARG`s. Its `FROM` regex wants a literal tag (`[\w][\w.-]{0,127}`), `${SPEACHES_TAG}` cannot match it, and a `FROM` line with neither tag nor digest is dropped (`version_from` returns nil → `next unless version`). So the entry had nothing to parse — an inert ecosystem entry looks exactly like a quiet one, which is why this went unnoticed for months.

With a literal `tag@digest` the line parses and dependabot manages it weekly under the 7-day cooldown already configured there. Both the Dockerfile and `dependabot.yml` now carry a note that the `FROM` must stay literal, since reintroducing a variable would silently re-break it.

### The security tradeoff, stated plainly

A pin freezes security updates to the base image, so it's only safe with a refresh path. Two exist here, and I'd rather be honest about the strength of each:

- **New upstream releases → a dependabot PR** that bumps tag and digest together. This is the path I'm confident in.
- **A same-tag digest refresh** (upstream re-pushing patched bytes under `0.8.3-cpu`) is something dependabot's checker *can* propose, but whether it does is gated by a server-side dependabot experiment (`docker_digest_only_update_suppression`) that suppresses digest-only bumps for comparable tags. I cannot observe that flag's state from outside, so I have **not** claimed it as a guarantee — the Dockerfile comment says as much.
- **Manual:** `Build Speaches Hebrew Image` already exposes `workflow_dispatch` for exactly this, and any bump arrives as a reviewable PR that rebuilds the image and runs the Hebrew E2E against it.

Also worth noting: this image is a CI fixture and a local-testing convenience, not something shipped to users, which is what makes "pinned, refreshed on a weekly PR cadence" the right point on that curve rather than "always latest".

## How it was tested

I can't build the image (no Docker here); CI does that on this PR — `Build Speaches Hebrew Image` and the Hebrew E2E's `speaches-server` job both build this Dockerfile from the checkout.

**Verified:**

- **The digest is real and is exactly what CI builds today.** Resolved against the ghcr manifest API: `latest-cpu`, `0.8.3-cpu`, `0.8-cpu`, `0-cpu` and `sha-c78b77d-cpu` all return the same OCI index digest `sha256:21e3df06d842fb7802ab470dd77c25f0e8c0d22950e8d8c6ae886e851af53ef8` (multi-arch: `linux/amd64` + `linux/arm64`, so the `platforms: linux/amd64` build is unaffected). This pin is therefore a no-op for today's build — it changes only whether it can drift.
- **The old line was invisible to dependabot and the new one isn't.** I transcribed dependabot-core's actual `FROM_LINE` / `IMAGE` / `REGISTRY` / `TAG` regexes and `version_from`, and ran them against both lines: the old one yields `tag=None digest=None` → skipped; the new one yields `tag=0.8.3-cpu`, `digest=21e3df06…`. Corroborated by the record — 9 dependabot PRs in this repo, all `ci:` (actions), zero `docker:`.
- **The inherited contract is now knowable**, which was the point of the issue: this digest is speaches 0.8.3, built from upstream commit `c78b77d`, whose `Dockerfile` installs with `uv sync --frozen` against a `uv.lock` pinning `huggingface_hub 0.33.4`, `faster-whisper 1.1.1`, `ctranslate2 4.5.0`. And `snapshot_download` in `huggingface_hub` v0.33.4 takes `max_workers` but no `max_retries` — the #242 `TypeError`, now checkable from the repo in ten seconds.
- `sh docker/speaches-hebrew/download-model-test.sh` passes locally (unchanged by this PR, but it's the first step of the image workflow).
- `.github/dependabot.yml` still parses as YAML with both ecosystems intact.

**Assumed / not verified:** that the packages in the running image match `uv.lock` — inferred from `--frozen`, not by executing the image (blob fetches from `pkg-containers.githubusercontent.com` are blocked in my environment, so no SBOM/layer inspection). Also unverified: dependabot's live behaviour on this pin, which can only be observed from the next weekly run.

**Not touched:** `download-model.sh` and its test were just fixed in #242 and need no changes here.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — not applicable/not run: this PR touches only the Docker base-image pin and dependabot config, no Swift sources. CI's image build and Hebrew E2E are the relevant checks.
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, CI-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/local Docker fixture only; pinning improves reproducibility with weekly Dependabot/manual refresh documented—no app runtime or auth changes.
> 
> **Overview**
> **Stops the Hebrew speaches E2E image from inheriting a drifting `latest-cpu` Python stack** by replacing `ARG SPEACHES_TAG` + parameterized `FROM` with a literal **`ghcr.io/speaches-ai/speaches:0.8.3-cpu@sha256:…`** pin (same bytes as today’s `latest-cpu`, but fixed).
> 
> That pin makes the inherited **`huggingface_hub` / faster-whisper / ctranslate2** contract reviewable and addresses the class of breakage in **#242** (build code assuming APIs that moved under an unpinned base).
> 
> **Turns on the existing Dependabot `docker` entry** for `docker/speaches-hebrew`: Dependabot cannot parse `FROM …:${ARG}`, so the weekly job had never opened PRs. The versioned **`-cpu` tag** is what Dependabot can bump; the **digest** is what Docker actually resolves. Comments in the Dockerfile and `.github/dependabot.yml` warn that the `FROM` must stay literal or updates go silent again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c526aa928ecf09e34f511d3dfa3ade2f640cc131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image reliability by pinning the Hebrew Docker image to a specific version and verified digest.
  * Enabled dependable tracking of future container image updates.
* **Documentation**
  * Added guidance explaining image pinning and the process for refreshing the pinned image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->