### PR TITLE
test(ci): bound the test-side timeouts that turn a flake into an unretryable red

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -91,6 +91,15 @@ jobs:
           # leaves room for the slowest legit test (the model-reenqueue test
           # awaits waitForIdle TWICE, up to 90s each under load) while still
           # bounding a true hang to minutes. Mirrors ci.yml's build-and-test.
+          #
+          # `tee` before `tail` (issue #208). `tail -200` alone is why nobody
+          # could diagnose the flakes in this job: a ~1000-test run emits
+          # thousands of lines, so the only thing that ever reached the log
+          # was the closing summary. A suite in the alphabetical middle could
+          # fail and its assertion message — the one line that says WHY —
+          # was gone before the log was written. Keep the whole thing on disk
+          # so the summary step below can mine it and the artifact carries it.
+          mkdir -p build
           xcodebuild -project Mila.xcodeproj \
             -scheme Mila \
             -configuration Debug \
@@ -102,7 +111,41 @@ jobs:
             -test-timeouts-enabled YES \
             -default-test-execution-time-allowance 240 \
             -maximum-test-execution-time-allowance 480 \
-            test 2>&1 | tail -200
+            test 2>&1 | tee build/unit-tests.log | tail -200
+
+      # Issue #208: with `-retry-tests-on-failure`, a green job can sit on top
+      # of a pile of failed executions — one run logged
+      # "Executed 929 tests ... 7 failures" followed by "** TEST SUCCEEDED **".
+      # Those recovered flakes are the trend worth watching, and today they are
+      # invisible unless someone downloads the raw log. Surface the count and
+      # the failure lines in the job summary, pass or fail.
+      - name: Summarise test failures
+        if: always()
+        run: |
+          log=build/unit-tests.log
+          [ -f "$log" ] || exit 0
+          # `|| true`: grep exits 1 when it matches nothing, which is the
+          # good case here and must not fail the step.
+          executions=$(grep -c "^Test Case .* failed (" "$log" || true)
+          {
+            echo "### Unit tests"
+            echo
+            echo "Failed test-case **executions**: ${executions:-0} (counts every retry iteration, so a green job can show a non-zero number — that is the point)."
+            echo
+            echo "<details><summary>Failure lines</summary>"
+            echo
+            echo '```'
+            # Three shapes, all of them things you cannot get from the tail:
+            # the per-case "failed" lines (one per retry iteration), the
+            # `file:line: error:` assertion messages, and the closing
+            # `Failing tests:` block plus its indented `Suite.test()` names.
+            # `[[:space:]]` not `\s` — BSD grep on the macOS runner has no
+            # `\s` in ERE.
+            grep -E "^Test Case .* failed \(|: error: |^Failing tests:|^[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*\(\)$" "$log" | head -200 || true
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run UI tests
         # XCUIApplication.launch() repeatedly fails on GitHub-hosted
@@ -129,5 +172,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult
-          path: build/Logs/Test/*.xcresult
+          # The raw xcodebuild log travels with the xcresult (issue #208): the
+          # bundle is ~115 MB and awkward to read, whereas the log answers
+          # "which assertion failed, and on which iteration" with a grep.
+          path: |
+            build/Logs/Test/*.xcresult
+            build/unit-tests.log
           retention-days: 7

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -127,6 +127,15 @@ jobs:
           # `|| true`: grep exits 1 when it matches nothing, which is the
           # good case here and must not fail the step.
           executions=$(grep -c "^Test Case .* failed (" "$log" || true)
+          # Print to STDOUT as well as the step summary. The summary is nice to
+          # look at but has no API, so it cannot be read back by anything but a
+          # human with a browser — which is how a whole CI round was spent on
+          # this PR unable to see an assertion message that had been captured.
+          # The job log IS retrievable, and this step's output is short enough
+          # to survive being at the end of it.
+          echo "===== failure lines from $log ====="
+          grep -E "^Test Case .* failed \(|: error: |^Failing tests:" "$log" | head -60 || true
+          echo "===== end failure lines ====="
           {
             echo "### Unit tests"
             echo

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -229,9 +229,22 @@ final class LLMRunnerTests: XCTestCase {
     /// Adopting a 300s bound under a 240s allowance is what takes the safety
     /// net away.
     ///
-    /// 30s matches every other spawning test here and keeps the worst case
-    /// (30s wait + 1s SIGTERM grace + 5s SIGKILL grace + 3s drain) an order of
-    /// magnitude inside the allowance.
+    /// 30s matches the other *synthetic* spawning tests here — the ones whose
+    /// child is a shell script — and keeps the worst case (30s wait + 1s
+    /// SIGTERM grace + 5s SIGKILL grace + 3s drain) an order of magnitude
+    /// inside the allowance.
+    ///
+    /// Two sets of deliberate exceptions, both still under 240s:
+    ///
+    ///   * `timeout: 1` in `test_timeout_fires_when_process_exceeds_limit`,
+    ///     `test_timeout_returns_even_when_grandchild_holds_pipes_open` and
+    ///     `test_diagnose_reports_timeout_without_throwing` — those exercise
+    ///     the timeout path itself, so the bound IS the thing under test.
+    ///   * `timeout: 120` in the three real-CLI smoke tests
+    ///     (`test_claude_cli_…`, `test_cursor_cli_…`, `test_gemini_cli_…`),
+    ///     which wait on a live model round-trip rather than a script. They
+    ///     auto-skip when the CLI isn't installed, so they don't run in CI at
+    ///     all — but 120s would fit the allowance even if they did.
     func test_runner_surfaces_nonzero_exit_code() async {
         // `/usr/bin/false` always exits 1.
         do {

--- a/MilaTests/LLMRunnerTests.swift
+++ b/MilaTests/LLMRunnerTests.swift
@@ -198,13 +198,48 @@ final class LLMRunnerTests: XCTestCase {
         return url
     }
 
+    /// ## Why every spawning test in this file passes an explicit `timeout:`
+    ///
+    /// Issue #208. Omitting it adopts `LLMRunner.defaultTimeout` — 300s, a
+    /// production number sized for a real LLM chewing on a real transcript.
+    /// CI runs this bundle with `-default-test-execution-time-allowance 240`
+    /// (`.github/workflows/ios-tests.yml`), so a 300s bound is LONGER than the
+    /// window XCTest gives the test. That inverts which watchdog fires first,
+    /// and the two outcomes are not equivalent:
+    ///
+    ///   * bound < allowance — the runner's own wait expires, it SIGTERMs
+    ///     (then SIGKILLs) the child, and `run` throws `.timedOut`. The test
+    ///     fails normally, with a message, and `-retry-tests-on-failure`
+    ///     re-runs it.
+    ///   * bound > allowance — XCTest kills the whole test HOST at 240s.
+    ///     There is no assertion failure to report and nothing to retry.
+    ///
+    /// The second shape is what took `main` red on aec65fc. The job printed
+    /// `Executed 1057 tests, with 7 tests skipped and 0 failures` and then,
+    /// with no explanation anywhere in the log,
+    /// `Failing tests: LLMRunnerTests.test_runner_surfaces_nonzero_exit_code()`.
+    /// (`IDETestOperationsObserverDebug` reported 378s elapsed for a session
+    /// whose surviving run took 97.7s — the missing ~280s is the killed first
+    /// attempt.) A red tick with no cause attached is exactly what #208 is
+    /// about, and this shape is unretryable by construction.
+    ///
+    /// This does not need the child to misbehave. `executeProcess` documents a
+    /// macOS 26 reaping race where `waitUntilExit` never returns even after
+    /// `SIGKILL`; the runner survives that *because* its wait is bounded.
+    /// Adopting a 300s bound under a 240s allowance is what takes the safety
+    /// net away.
+    ///
+    /// 30s matches every other spawning test here and keeps the worst case
+    /// (30s wait + 1s SIGTERM grace + 5s SIGKILL grace + 3s drain) an order of
+    /// magnitude inside the allowance.
     func test_runner_surfaces_nonzero_exit_code() async {
         // `/usr/bin/false` always exits 1.
         do {
             _ = try await LLMRunner.run(tool: .claude,
                                         prompt: "x",
                                         transcript: "y",
-                                        executablePathOverride: "/usr/bin/false")
+                                        executablePathOverride: "/usr/bin/false",
+                                        timeout: 30)
             XCTFail("Expected nonZeroExit error")
         } catch let error as LLMRunnerError {
             if case .nonZeroExit(let code, _) = error {
@@ -478,10 +513,17 @@ final class LLMRunnerTests: XCTestCase {
     }
 
     func test_diagnose_captures_nonzero_exit_without_throwing() async {
+        // Stated bound rather than the inherited default — see the note on
+        // `test_runner_surfaces_nonzero_exit_code` (issue #208). `diagnose`'s
+        // own default is 120s, which does still fit inside CI's 240s per-test
+        // allowance, so this one was not over the line; it is spelled out so
+        // the rule ("a spawning test states its bound") holds file-wide and
+        // the next person adding a case here has a pattern to copy.
         let result = await LLMRunner.diagnose(tool: .claude,
                                               prompt: "x",
                                               transcript: "y",
-                                              executablePathOverride: "/usr/bin/false")
+                                              executablePathOverride: "/usr/bin/false",
+                                              timeout: 30)
         XCTAssertFalse(result.succeeded)
         XCTAssertTrue(result.didLaunch)
         XCTAssertEqual(result.exitCode, 1)
@@ -530,11 +572,17 @@ final class LLMRunnerTests: XCTestCase {
     }
 
     func test_diagnose_appends_extra_args_to_command() async {
+        // Only `result.command` is under test, but the call still spawns
+        // `/usr/bin/true` — so it states a bound like every other spawning
+        // case here (issue #208). Same note as above: `diagnose` defaults to
+        // 120s, which fits the allowance; `run` defaults to 300s, which does
+        // not.
         let result = await LLMRunner.diagnose(tool: .claude,
                                               prompt: "x",
                                               transcript: "y",
                                               extraArgs: ["--model", "claude sonnet"],
-                                              executablePathOverride: "/usr/bin/true")
+                                              executablePathOverride: "/usr/bin/true",
+                                              timeout: 30)
         // The space-bearing arg must round-trip through shell quoting.
         XCTAssertTrue(result.command.contains("--model 'claude sonnet'"),
                       "command: \(result.command)")

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -210,6 +210,32 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                                              executablePathOverride: script.path,
                                              session: .new(UUID()),
                                              timeout: 30)
+        // Diagnostics, not a new contract (issue #208). This test failed once
+        // on PR #242 and passed on a rerun of the same code, and the reason is
+        // not recoverable from the CI log — so the next occurrence should at
+        // least name itself.
+        //
+        // Every assertion below is an equality between two script outputs,
+        // and `executeProcess` has a documented path that returns an EMPTY
+        // string from a successful run: on normal exit it waits up to 30s for
+        // the pipe readers to reach EOF and, when that expires, logs and
+        // returns whatever it buffered — exit code 0, `timedOut` false. On a
+        // loaded macos-26 VM that dispatch latency is real; the sibling
+        // `LLMRunnerTests` case notes 10-15s of it, and the 30s grace exists
+        // precisely because a tighter one "truncated perfectly good output
+        // mid-stream".
+        //
+        // Without this guard that failure mode is indistinguishable from a
+        // real regression when it hits one run ("" != "/path/…"), and is
+        // INVISIBLE when it hits all of them — four empty strings compare
+        // equal and the test passes having proven nothing. `oneShot` is the
+        // value every other assertion is measured against, so guarding it
+        // covers both. Mirrors the guard
+        // `test_two_oneshot_runs_share_one_working_directory` already has.
+        XCTAssertFalse(oneShot.isEmpty,
+                       "the child printed no cwd at all — the run produced no "
+                       + "output rather than the wrong output, so the "
+                       + "comparisons below prove nothing")
         XCTAssertEqual(newSession, oneShot)
         XCTAssertEqual(resumed, oneShot)
         XCTAssertEqual(other, oneShot,

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -42,6 +42,15 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     /// the last unbounded subprocess wait in the bundle.
     private static let gitCommandTimeout: TimeInterval = 60
 
+    /// How long to wait for the output pipes to reach EOF once `git` has
+    /// exited. Separate from `gitCommandTimeout` because it bounds a different
+    /// hazard: not a wedged `git`, but a reader work item that has not been
+    /// scheduled yet. `executeProcess` documents 10-15s of dispatch latency on
+    /// the macos-26 CI image and each `runGit` parks three blocking items on
+    /// the global queue, so this has to clear that comfortably — 5s did not,
+    /// and cost this suite a deterministic failure.
+    private static let pipeDrainTimeout: TimeInterval = 30
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let git = ProcessGitCommandRunner.gitExecutable() else {
@@ -213,10 +222,26 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         for (pipe, isStdout) in [(out, true), (err, false)] {
             drain.enter()
             DispatchQueue.global().async {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                lock.lock()
-                if isStdout { outData = data } else { errData = data }
-                lock.unlock()
+                // Append chunk-by-chunk rather than one `readDataToEndOfFile()`
+                // — the same shape as `ProcessGitCommandRunner.runSync`, and
+                // load-bearing now that the drain below is bounded.
+                //
+                // `readDataToEndOfFile()` assigns only once it has read
+                // EVERYTHING. Pair that with a bounded wait and an expiry
+                // leaves `outData` as the empty `Data()` it was initialised
+                // with, so a SUCCESSFUL git reports empty stdout: exit code 0,
+                // no output, no error. Callers assert on that stdout
+                // (`ls-tree`, `log --oneline`, `show`), so it is an invisible
+                // way to fail a test for a reason unrelated to what it tests.
+                // Appending as chunks arrive means whatever was read survives.
+                let handle = pipe.fileHandleForReading
+                while true {
+                    let chunk = handle.availableData   // blocks until data or EOF
+                    if chunk.isEmpty { break }
+                    lock.lock()
+                    if isStdout { outData.append(chunk) } else { errData.append(chunk) }
+                    lock.unlock()
+                }
                 drain.leave()
             }
         }
@@ -243,20 +268,43 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
             }
         }
         // Bounded too: EOF is not guaranteed even after exit, because a helper
-        // `git` spawned can inherit the pipes and outlive it. The readers are
-        // abandoned rather than waited out; they exit when the pipes close.
-        _ = drain.wait(timeout: .now() + 5)
-        // Take the lock: unlike the old unbounded `drain.wait()`, the readers
-        // are not guaranteed to be finished here.
+        // `git` spawned can inherit the pipes and outlive it.
+        //
+        // The bound is generous on purpose. 5s was too tight and it regressed
+        // this suite: `executeProcess` documents 10-15s of dispatch latency on
+        // this CI image, and each `runGit` now parks three blocking work items
+        // on the global queue, so a reader simply not being SCHEDULED inside 5s
+        // is ordinary here, not pathological.
+        let drained = drain.wait(timeout: .now() + .seconds(Int(Self.pipeDrainTimeout))) != .timedOut
+        // Take the lock: unlike an unbounded `drain.wait()`, the readers are
+        // not guaranteed to be finished here.
         lock.lock()
         let stdout = String(data: outData, encoding: .utf8) ?? ""
         let stderr = String(data: errData, encoding: .utf8) ?? ""
+        // Byte counts for the diagnostic below, snapshotted here: on the
+        // timed-out path the readers may still be appending, so reading
+        // `outData.count` outside the lock would itself be a data race.
+        let stdoutBytes = outData.count, stderrBytes = errData.count
         lock.unlock()
         if timedOut {
             throw NSError(domain: "git", code: -1, userInfo: [
                 NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) "
                     + "did not exit within \(Int(Self.gitCommandTimeout))s and was killed"
                     + " (stderr so far: \(stderr))"
+            ])
+        }
+        // A drain that expired means `stdout` may be TRUNCATED. Returning it
+        // would hand the caller a short answer that looks like a real one —
+        // `files.contains("a.md")` would simply be false — which is the
+        // silently-wrong outcome this whole branch exists to remove. Fail
+        // loudly instead, and say how much did arrive.
+        guard drained else {
+            throw NSError(domain: "git", code: -2, userInfo: [
+                NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) "
+                    + "exited but its pipes did not reach EOF within "
+                    + "\(Int(Self.pipeDrainTimeout))s — refusing to report "
+                    + "possibly-truncated output (\(stdoutBytes) bytes stdout, "
+                    + "\(stderrBytes) bytes stderr so far)"
             ])
         }
         if process.terminationStatus != 0 {

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -17,6 +17,31 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     /// so `tearDown` can put them back. `nil` value == the var was unset.
     private var savedEnvironment: [String: String?] = [:]
 
+    /// Per-`git`-invocation bound, for BOTH the setup helper below and the
+    /// production runner the tests drive (issue #208).
+    ///
+    /// Nothing here is slow: every command runs against a three-object local
+    /// repo and finishes in milliseconds, so 60s is ~4 orders of magnitude of
+    /// headroom and cannot fail a loaded runner. What it buys is the
+    /// difference between the two ways a wedged `git` can end.
+    ///
+    /// CI gives each test 240s (`-default-test-execution-time-allowance`, see
+    /// `.github/workflows/ios-tests.yml`). An unbounded wait therefore cannot
+    /// fail *as a test*: XCTest kills the whole test HOST first, which records
+    /// no assertion message and cannot be recovered by
+    /// `-retry-tests-on-failure`, so the job prints a bare `Failing tests: …`
+    /// line with no cause anywhere in the log. A bounded wait fails normally,
+    /// says which command hung, and gets retried.
+    ///
+    /// This is not hypothetical for `Process`. `LLMRunner.executeProcess`
+    /// documents a macOS 26 reaping race where `waitUntilExit` never returns
+    /// even after `SIGKILL`, and `readDataToEndOfFile` never returns while any
+    /// process — including a helper `git` spawned that outlived it — still
+    /// holds the write end of the pipe. `ProcessGitCommandRunner.runSync`
+    /// bounds both for exactly these reasons; this helper did not, and it is
+    /// the last unbounded subprocess wait in the bundle.
+    private static let gitCommandTimeout: TimeInterval = 60
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let git = ProcessGitCommandRunner.gitExecutable() else {
@@ -95,7 +120,7 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         let note = vault.appendingPathComponent("2026-01-02 Meeting.md")
         try write("# Meeting\n\nSummary body.\n", to: note)
 
-        let syncer = ObsidianGitSyncer()   // real ProcessGitCommandRunner
+        let syncer = ObsidianGitSyncer(runner: Self.boundedRunner())
         let error = await syncer.sync(vault: vault,
                                       changedPaths: [note],
                                       branch: "main",
@@ -126,7 +151,7 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         // the remote's commit, then push both.
         let note = vault.appendingPathComponent("a.md")
         try write("local-added\n", to: note)
-        let syncer = ObsidianGitSyncer()
+        let syncer = ObsidianGitSyncer(runner: Self.boundedRunner())
         let error = await syncer.sync(vault: vault,
                                       changedPaths: [note],
                                       branch: "main",
@@ -139,6 +164,21 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// The REAL production runner — still `ProcessGitCommandRunner`, so these
+    /// stay integration tests — with its per-command bound brought inside the
+    /// per-test allowance (issue #208).
+    ///
+    /// Its shipped 120s is right for a background sync over the network and
+    /// wrong here: `sync` issues up to six commands, so 6 × (120s + kill
+    /// grace) is ~780s against a 240s allowance. One wedged command would take
+    /// the test host with it instead of failing the test. 20s is still ~4
+    /// orders of magnitude above what a local-path git command costs.
+    private static func boundedRunner() -> ProcessGitCommandRunner {
+        var runner = ProcessGitCommandRunner()
+        runner.timeout = 20
+        return runner
+    }
 
     @discardableResult
     private func runGit(_ arguments: [String], in directory: URL) throws -> String {
@@ -180,10 +220,45 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
                 drain.leave()
             }
         }
-        process.waitUntilExit()
-        drain.wait()
+        // Both waits are BOUNDED (issue #208), mirroring
+        // `ProcessGitCommandRunner.runSync`. They used to be
+        // `process.waitUntilExit()` / `drain.wait()` with no deadline, which
+        // meant a single wedged `git` in `setUp` hung this test until XCTest
+        // killed the test host — a red run naming a test with no reason
+        // attached, and one the retry policy cannot recover. See
+        // `gitCommandTimeout` for why that distinction is the whole point.
+        let running = DispatchGroup()
+        running.enter()
+        DispatchQueue.global().async {
+            process.waitUntilExit()
+            running.leave()
+        }
+        var timedOut = false
+        if running.wait(timeout: .now() + .seconds(Int(Self.gitCommandTimeout))) == .timedOut {
+            timedOut = true
+            process.terminate()
+            if running.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = running.wait(timeout: .now() + 3)
+            }
+        }
+        // Bounded too: EOF is not guaranteed even after exit, because a helper
+        // `git` spawned can inherit the pipes and outlive it. The readers are
+        // abandoned rather than waited out; they exit when the pipes close.
+        _ = drain.wait(timeout: .now() + 5)
+        // Take the lock: unlike the old unbounded `drain.wait()`, the readers
+        // are not guaranteed to be finished here.
+        lock.lock()
         let stdout = String(data: outData, encoding: .utf8) ?? ""
         let stderr = String(data: errData, encoding: .utf8) ?? ""
+        lock.unlock()
+        if timedOut {
+            throw NSError(domain: "git", code: -1, userInfo: [
+                NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) "
+                    + "did not exit within \(Int(Self.gitCommandTimeout))s and was killed"
+                    + " (stderr so far: \(stderr))"
+            ])
+        }
         if process.terminationStatus != 0 {
             throw NSError(domain: "git", code: Int(process.terminationStatus), userInfo: [
                 NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(stderr)\(stdout)"

--- a/MilaTests/PostRecordingCoordinatorSendTests.swift
+++ b/MilaTests/PostRecordingCoordinatorSendTests.swift
@@ -22,6 +22,48 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
 
     private let diarSuite = "PostRecordingCoordinatorSendTests.diarization"
 
+    // MARK: - Bounds (issue #208)
+    //
+    // Both constants exist for one reason: **a test must never adopt a
+    // production timeout that is longer than the budget CI gives the test.**
+    // This bundle runs with `-default-test-execution-time-allowance 240`
+    // (`.github/workflows/ios-tests.yml`), and the two waits a send makes
+    // ship at 600s and 300s respectively. When the test's bound is the longer
+    // one, it decides which watchdog fires first — and the two outcomes are
+    // not equivalent:
+    //
+    //   * bound < allowance — the wait expires on its own, the assertion
+    //     fails with a message, and `-retry-tests-on-failure` re-runs it.
+    //   * bound > allowance — XCTest kills the whole test HOST. There is no
+    //     assertion message and nothing for the retry policy to recover, so
+    //     the job reports a bare `Failing tests: …` line with no cause
+    //     attached anywhere in the log.
+    //
+    // The second shape is what took main red on aec65fc (via `LLMRunnerTests`)
+    // and it is the "red tick that tells you nothing" #208 is about.
+
+    /// Bound for `awaitFinalTranscript`. `transcriptWaitTimeout` ships at
+    /// **600s** — right for a user who hit Send while a long meeting is still
+    /// transcribing, wrong here.
+    ///
+    /// This suite is not hypothetically exposed to that wait; several cases
+    /// enter it on purpose. `test_send_waits_for_transcript_when_fired_early`
+    /// fires before the transcript exists, and the #211 cases park in
+    /// `awaitSpeakerFinalization` until the test releases the marker. If
+    /// whatever is supposed to release the wait ever doesn't, 60s vs 600s is
+    /// the difference between a legible, retryable failure and a dead runner.
+    ///
+    /// 60s is still far longer than the longest wait any case here actually
+    /// needs (hundreds of milliseconds), so it cannot make a slow runner
+    /// fail; it only caps the pathological case. Cases that assert the wait
+    /// is NOT taken set their own, shorter value on top of this.
+    private static let testTranscriptWait: TimeInterval = 60
+
+    /// Bound for the CLI half: `sendToLLM`'s `cliTimeout` defaults to
+    /// `LLMRunner.defaultTimeout` (300s), also longer than the allowance. The
+    /// longest script in this file sleeps 20s.
+    private static let testCLITimeout: TimeInterval = 30
+
     override func setUp() async throws {
         try await super.setUp()
         tempRoot = TestSupport.makeTempRoot(label: "PostRecordingCoordinatorSendTests")
@@ -39,6 +81,7 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         )
         coordinator = PostRecordingCoordinator(store: store, transcription: service,
                                                llm: LLMSettings(defaults: UserDefaults(suiteName: "PostRecordingCoordinatorSendTests.llm")!))
+        coordinator.transcriptWaitTimeout = Self.testTranscriptWait
     }
 
     override func tearDown() async throws {
@@ -69,7 +112,8 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
                               prompt: "Summarize",
                               transcript: "the transcript text",
                               summary: "",
-                              executableOverride: script.path)
+                              executableOverride: script.path,
+                              cliTimeout: Self.testCLITimeout)
         // Yield so the task body starts and registers itself.
         try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(coordinator.isSending(rec.id),
@@ -104,11 +148,13 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
 
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
                               transcript: "transcript", summary: "",
-                              executableOverride: slow.path)
+                              executableOverride: slow.path,
+                              cliTimeout: Self.testCLITimeout)
         try await Task.sleep(nanoseconds: 100_000_000)
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
                               transcript: "transcript", summary: "",
-                              executableOverride: fast.path)
+                              executableOverride: fast.path,
+                              cliTimeout: Self.testCLITimeout)
 
         // The fast replacement wins; the slow one was cancelled (its
         // .cancelled error is swallowed silently).
@@ -145,13 +191,15 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
 
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
                               transcript: "transcript", summary: "",
-                              executableOverride: first.path)
+                              executableOverride: first.path,
+                              cliTimeout: Self.testCLITimeout)
         try await Task.sleep(nanoseconds: 150_000_000)
         // Replace: cancels the first task (its CLI gets SIGTERM'd and it
         // unwinds through its defer while the second is still running).
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
                               transcript: "transcript", summary: "",
-                              executableOverride: second.path)
+                              executableOverride: second.path,
+                              cliTimeout: Self.testCLITimeout)
         // Give the replaced task ample time to unwind and run its cleanup.
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
@@ -192,7 +240,8 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
 
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "p",
                               transcript: "transcript", summary: "",
-                              executableOverride: slow.path)
+                              executableOverride: slow.path,
+                              cliTimeout: Self.testCLITimeout)
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertTrue(coordinator.isSending(rec.id))
 
@@ -233,7 +282,8 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         coordinator.sendToLLM(recordingID: rec.id, tool: .claude, prompt: "Do it",
                               transcript: "",  // empty: fired early
                               summary: "",
-                              executableOverride: script.path)
+                              executableOverride: script.path,
+                              cliTimeout: Self.testCLITimeout)
         // It should still be in flight (waiting on the transcript), not
         // bailed out.
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -761,8 +811,15 @@ final class PostRecordingCoordinatorSendTests: XCTestCase {
         let llm = LLMSettings(defaults: UserDefaults(suiteName: suiteName)!,
                               apiKeyKeychainKey: suiteName)
         llm.tool = .claude
-        return PostRecordingCoordinator(store: store, transcription: service,
-                                        llm: llm, runLLM: runLLM)
+        let made = PostRecordingCoordinator(store: store, transcription: service,
+                                            llm: llm, runLLM: runLLM)
+        // Same bound as the setUp coordinator — see `testTranscriptWait`.
+        // These coordinators are the ones that deliberately park in
+        // `awaitSpeakerFinalization`, so they are the ones most exposed to the
+        // 600s production default outliving CI's 240s per-test allowance.
+        // Cases that want a shorter wait still override it after this.
+        made.transcriptWaitTimeout = Self.testTranscriptWait
+        return made
     }
 
     private func waitForBanner(containing needle: String,


### PR DESCRIPTION
Closes #208

> **On `Closes` vs a partial reference.** Two of the five suites in #208 are *not* diagnosed here, so auto-closing it loses the thread on exactly the suites that have cost the most time. I checked whether a non-closing `Refs #208` would satisfy CI: it would not — `.github/workflows/require-linked-issue.yml` accepts only GitHub's own `closingIssuesReferences` linkage or a closing keyword in the body, and the `no-issue-needed` bypass explicitly does not apply to something a user could file a bug about. So `Closes` stays, and the remainder is carried by **#246**, filed for the two undiagnosed suites with the full state of the investigation. The handoff is explicit rather than silent.

## What & why

Three of the five suites on #208 get a diagnosed fix, one gets a diagnostics guard, and the CI change removes the reason any of it was hard to see. **Nothing here was compiled or run locally — there is no Swift toolchain in this environment.** Everything below was found by reading; CI is the only compiler.

### The race: a test bound longer than the test's own allowance

CI runs this bundle with `-default-test-execution-time-allowance 240`. Several tests drive production code paths and adopt the *production* timeout, which is longer than that — and one test helper had no bound at all. Whichever bound is shorter decides which watchdog fires first, and the two outcomes are not equivalent:

| | what happens | recoverable? |
|---|---|---|
| bound **&lt;** allowance | the wait expires, the code under test kills its child, the test fails with a message | yes — `-retry-tests-on-failure` re-runs it |
| bound **&gt;** allowance | XCTest kills the whole test **host** at 240 s | no — there is no assertion failure to retry |

This is not what *causes* a stall; it is what turns an intermittent stall — the thing the retry policy exists to absorb — into an unretryable red build carrying no explanation.

**First-hand evidence, main at `aec65fc`** (run `33497644272`, job `99823404608`):

```
Test Suite 'MilaTests.xctest' passed …
	 Executed 1057 tests, with 7 tests skipped and 0 failures (0 unexpected) in 97.752 seconds
IDETestOperationsObserverDebug: 378.079 elapsed -- Testing started completed.
Failing tests:
	LLMRunnerTests.test_runner_surfaces_nonzero_exit_code()
** TEST FAILED **
```

A suite reporting **0 failures** next to a named failing test is what a host kill looks like: the first attempt was killed at the allowance, XCTest restarted, and the surviving session passed everything. 378 s elapsed against a 97.7 s surviving session leaves ~280 s — ~40 s of tests before `LLMRunnerTests` plus the 240 s allowance. Attempt 2 passed on the same commit, so the trigger is intermittent and the bound is what made it fatal and silent.

### `LLMRunnerTests` — fixed (`d1969b2`)

`test_runner_surfaces_nonzero_exit_code` was the only test in the bundle spawning a real child through `LLMRunner.run` without `timeout:`, so it adopted `LLMRunner.defaultTimeout` = **300 s** under a 240 s allowance. (Audited every `LLMRunner.run`/`diagnose` call in `MilaTests/`; three lacked a stated timeout, and only this one was over the line — `diagnose` defaults to 120 s.)

The child is `/usr/bin/false`, which exits instantly, so the stall is in the spawn/reap/drain path — and `executeProcess` already documents a macOS 26 reaping race where `waitUntilExit` never returns *even after `SIGKILL`*. The runner survives that because its wait is bounded; a 300 s bound under a 240 s allowance removes the safety net.

### `PostRecordingCoordinatorSendTests` — fixed (`2ffc164`)

Bounded **neither** wait a send makes: `transcriptWaitTimeout` = **600 s** and `cliTimeout` = **300 s**. The suite enters the long wait on purpose — `test_send_waits_for_transcript_when_fired_early` sends before a transcript exists, and the #211 cases park in `awaitSpeakerFinalization` until the test releases the marker — so anything that stops the release landing parks the send for 600 s, 2.5× the allowance. `test_second_send_for_same_id_replaces_the_first`, which #208 records failing on `6b64e8b`, ran under both.

Bounded at 60 s / 30 s, orders of magnitude above the sub-second waits these cases take.

### `ObsidianGitSyncerIntegrationTests` — fixed (`45c8037`), then I broke it, then fixed properly (`f0b663f`)

`runGit` — the helper every `setUp` command and every post-condition assertion goes through — had **no deadline at all** on `waitUntilExit`/`drain.wait`. These were the last unbounded subprocess waits in the bundle, and under a 240 s allowance an unbounded wait cannot fail *as a test*.

**Then I introduced a worse bug than the one I fixed, and CI caught it.** Bounding `drain.wait` at 5 s while leaving the readers on `readDataToEndOfFile()` — which assigns only after reading everything — meant an expiry left `outData` as the empty `Data()` it was initialised with. A **successful** git then reported empty stdout, exit code 0, no error. `unit-and-ui-tests` on `929e35c` failed `test_sync_rebases_nonconflicting_remote_change_and_pushes` **4 of 4 iterations** — deterministic, where the pre-existing flake was intermittent. Verified the mechanism reaches this test rather than assuming: its closing assertions consume helper stdout (`ls-tree --name-only main` → `files.contains("a.md")`), so empty stdout fails both every time.

5 s was also too tight on evidence I had already cited: `executeProcess` documents 10-15 s of dispatch latency on this image, and my change added a *third* blocking work item per git command to the same non-overcommit global queue. `f0b663f`:

1. readers append chunk-by-chunk via `availableData`, mirroring `ProcessGitCommandRunner.runSync` — production never had this bug, and the contrast was the fix;
2. drain bound 5 s → 30 s;
3. a drain that still expires now **throws** rather than returning possibly-truncated stdout.

Found by Cursor Bugbot. Worth recording that the bot was right and I was wrong: I had made exactly this argument against `executeProcess` returning `""` from a successful run, three files away, and failed to apply it to my own helper.

### `LLMSandboxDirectoryTests` — diagnostics only, no fix claimed (`9838ec6`)

`test_session_runs_share_the_same_directory_as_oneshot_runs` failed once on #242 and passed on a rerun. I could not establish why.

`executeProcess` can return an **empty string from a successful run** (30 s drain grace, then log-and-return whatever buffered, exit code 0). Every assertion here is an equality between two script outputs, so that mode is either inscrutable (`"" != "/path/…"`) or **invisible** — four empty strings compare equal and the test passes proving nothing. Added the non-empty guard its sibling `test_two_oneshot_runs_share_one_working_directory` already has.

Also, as arithmetic rather than speculation: six children, and the caller's `timeout:` does not cover the drain grace, so worst case is 6 × (30 + 30) = 360 s — over the allowance. Not restructured; that is a rewrite I cannot compile. Carried to #246.

### CI — why none of this was visible (`e45d7d7`, extended in `f0b663f`)

`xcodebuild … | tail -200`. A ~1000-test run emits thousands of lines, so the log kept the closing summary and never the `file:line: error:` message of a suite in the alphabetical middle. #208 records this directly.

* `tee build/unit-tests.log` before the tail, shipped with the xcresult artifact.
* A `Summarise test failures` step (`if: always()`) reporting the failed **execution** count — with `-retry-tests-on-failure` a green job can sit on top of several failed executions, and counting executions rather than tests keeps a retried-green flake visible.
* It prints the failure lines to **stdout** as well as `$GITHUB_STEP_SUMMARY`. The summary has no API: one CI round on this PR was spent unable to read an assertion message that had in fact been captured, because the artifact download is proxy-blocked from here and the summary is browser-only. The job log is retrievable.

## What I could NOT diagnose — carried to #246

* **`MicrophoneConfigurationChangeTests`** — untouched. Not a timeout-vs-allowance case: `bringUpOverride` means no real `AVAudioEngine`, so `stop()` cannot block on CoreAudio teardown, and every wait is already bounded. The remaining hypothesis is wall-clock-shaped assertions (`posts > 10` after a 0.6 s burst at 15 ms cadence; `restartCount <= 2` against a 1 s floor). Tuning those blind just relocates the threshold.
* **`LLMSandboxDirectoryTests`** — the guard above is legibility, not a fix.

## Verdict on the `sandboxTenants` lead (PR #233)

Asked to check whether the reference-counted lease leaks tenants or races on the shared directory. I read `acquireSandbox` / `releaseSandbox` / `emptySandbox` and every caller and **found no defect**: `executeProcess` releases in a `defer` covering the launch-failure throw, the timeout path and the cancel path; the only direct test caller pairs each acquire with an explicit release plus a guarded `defer`; `sandboxLock` is non-recursive and never re-entered.

The lease does introduce a machine-global resource plus a mutex held across file I/O, but XCTest runs one test at a time and the job owns its runner, so two holders can only overlap if a test leaves an invocation in flight past its end — and the only overlapping runs (`async let` pairs in `LLMSandboxDirectoryTests`) are awaited or cancelled-and-awaited first. Verified, negative, unchanged.

The contention hypothesis I could not prove and did not act on: `executeProcess` parks three blocking work items on `DispatchQueue.global()` per invocation, and on the kill path readers can be abandoned while an orphaned grandchild holds the pipes. That root queue is non-overcommit and hard-capped, which would produce this signature — a different victim each run, never reproducing. My own drain regression above is a small, confirmed instance of that class. Confirming the larger one needs a sample of a wedged run, which the CI change now makes possible.

## How it was tested

**Not locally — there is no Swift toolchain or Xcode here.** CI is the first and only compiler.

What CI has established so far: `build-and-test` passes, and because it runs `-only-testing:MilaTests/WhisperEngineCoreMLTests` with the `test` action (`-only-testing` filters at *run* time, not compile time) it compiles the entire `MilaTests` bundle. So the syntactic risk is gone. The behavioural risk is not, and `929e35c` is the proof — it compiled clean and still broke a test.

A single green run is weak evidence for a flakiness fix: the job's failure rate is ~20% and the retry policy hides most of it. Judge this on the argument, plus the `Failed test-case executions` count in the new job summary trending to zero over several runs. I have not used a re-run to get past anything here — a re-run cannot fix a deterministic failure, and using one would be the exact move this PR exists to prevent.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible here; no Swift toolchain. CI is the only compiler.**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, test and CI only