### PR TITLE
fix(subprocess): take every blocking subprocess wait off the shared thread pool

### DIFF
--- a/.claude/rules/python-subprocess.md
+++ b/.claude/rules/python-subprocess.md
@@ -39,6 +39,50 @@ let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()  // too late
 let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
 ```
 
+## Never Park a Blocking Subprocess Wait on `DispatchQueue.global()`
+
+The global concurrent queues are **non-overcommit**: libdispatch will not spin
+up a thread for a queued work item just because the existing ones are blocked in
+the kernel. It notices the stall on a delay and grows the pool slowly, up to a
+hard cap. So every blocking item you park there makes the *next* one slower to
+be **scheduled at all** — and that delay is unbounded in the bad case.
+
+A subprocess wait is three blocking items if you write it the obvious way: two
+pipe readers parked in `availableData` until EOF, and one thread parked in
+`waitUntilExit()`. The caller then blocks a fourth waiting on the group. Under
+load this produced ordinary-looking timeouts on commands that had already
+succeeded (issue #246):
+
+```text
+git checkout -b main did not exit within 60s and was killed
+  (stderr so far: Switched to a new branch 'main'
+```
+
+`Switched to a new branch 'main'` is git's own success message. git ran,
+succeeded, and wrote to a pipe we were reading — and 65s later the work item
+meant to notice its exit still had not run. Not a slow command; a wait that
+never started.
+
+**Rules:**
+
+1. Observe the exit with `process.terminationHandler` plus a
+   `DispatchSemaphore`, installed **before** `process.run()`. That costs no
+   thread of ours at all.
+2. Anything that must genuinely block — a pipe reader, a `waitUntilExit()`
+   backstop, a synchronous `runSync` body — goes on a thread of its own via
+   `BlockingWork.onDedicatedThread(named:)` (`Mila/Actions/BlockingWork.swift`).
+   A dedicated thread cannot be starved, cannot starve anyone else, and if it
+   leaks (a grandchild holding a pipe open forever) it costs one thread rather
+   than a slot in a pool the whole process shares.
+3. Keep the `waitUntilExit()` backstop even with a `terminationHandler`: macOS
+   26 has a reaping race where `waitUntilExit` never returns even after
+   `SIGKILL`. The two paths fail independently; whichever notices first signals.
+   Only wait on the semaphore once, so a double signal is harmless.
+
+This applies to tests as much as to production code — the test host is one
+process, and a suite that parks blocking work on the shared pool degrades every
+other suite in the bundle.
+
 ## Known Compatibility Patches
 These monkey-patches are required as of pyannote.audio 3.x + PyTorch >= 2.6 + speechbrain:
 

--- a/.claude/rules/python-subprocess.md
+++ b/.claude/rules/python-subprocess.md
@@ -77,7 +77,21 @@ never started.
 3. Keep the `waitUntilExit()` backstop even with a `terminationHandler`: macOS
    26 has a reaping race where `waitUntilExit` never returns even after
    `SIGKILL`. The two paths fail independently; whichever notices first signals.
-   Only wait on the semaphore once, so a double signal is harmless.
+   Both may signal, and that is harmless: a `DispatchSemaphore` is only unsafe
+   to destroy while its value is *below* where it started, and every wait on it
+   is bounded (`wait(timeout:)`), including the further waits the
+   SIGTERM-then-SIGKILL escalation performs. Never add an unbounded
+   `semaphore.wait()` — that is the hang this whole section exists to remove.
+
+**Bounding the threads.** A dedicated thread per blocking wait means the thread
+count follows the number of concurrent CHILD PROCESSES, so that is what has to
+be bounded — and it already is, upstream, where it also bounds the thing users
+actually care about (`RecordingSummarizer.maxConcurrent = 2` exists so a
+20-recording catch-up sweep does not fork 20 `claude -p` processes). Do not
+"fix" this by capping thread creation inside `BlockingWork`: a cap there just
+re-queues blocked work behind a limit, which is the original bug. If you add a
+new caller that can spawn subprocesses in a batch, give the CALLER a concurrency
+limit.
 
 This applies to tests as much as to production code — the test host is one
 process, and a suite that parks blocking work on the shared pool degrades every

--- a/Mila/Actions/BlockingWork.swift
+++ b/Mila/Actions/BlockingWork.swift
@@ -45,6 +45,42 @@ import Foundation
 /// work — private serial queues target an *overcommit* root queue, so they
 /// always get a thread — but that is a subtle property to rely on, and it is
 /// invisible at the call site. `Thread` says what it means.
+///
+/// ## What bounds the thread count
+///
+/// The obvious objection to "a thread per blocking wait" is that it trades a
+/// bounded pool that starves for unbounded native threads that do not. It is
+/// worth being precise about why that is not what happens here.
+///
+/// A subprocess invocation costs **four** threads for its lifetime: two pipe
+/// readers, one `waitUntilExit()` backstop, and the caller blocked inside
+/// `executeProcess` / `runSync`. So the ceiling is four times the number of
+/// concurrent CHILD PROCESSES — and every path that spawns one is already
+/// bounded, upstream, by something that exists to bound *processes*, which is
+/// the scarcer resource:
+///
+/// | caller | what bounds it | concurrent children |
+/// |---|---|---|
+/// | `RecordingSummarizer` backfill / regeneration | `maxConcurrent = 2`, with `backfillQueue` holding the rest — added so a 20-recording catch-up sweep does not fork 20 `claude -p` processes | 2 |
+/// | `LiveAISession` ticks | one `inFlight` Task, with coalescing | 1 |
+/// | `PostRecordingCoordinator` | one in-flight handle | 1 |
+/// | `RenameRecordingSheet` "Suggest" | one modal sheet, guarded by `isFetchingName` | 1 |
+/// | `LLMSettings.diagnose` (Settings → Test) | one Settings panel, user-driven | 1 |
+/// | `ProcessGitCommandRunner` via `ObsidianGitSyncer` | an `actor`, and `sync` issues its commands sequentially | 1 |
+///
+/// Even with every one of those in flight at once — a batch summary sweep
+/// during a live meeting while an Obsidian sync runs — that is ~7 children and
+/// ~28 threads, transient, against a per-process limit in the hundreds.
+///
+/// Note this is the SAME bound as before. The old code created exactly the same
+/// number of work items; the only difference is that they used to contend for a
+/// capped shared pool, which is what starved. The change does not raise
+/// concurrency, it moves where the concurrency lands.
+///
+/// **Do not add a cap here.** A limit on thread creation inside this type would
+/// re-queue blocked work behind a bound — which is precisely the failure this
+/// exists to remove. A new caller that can spawn subprocesses in a batch needs
+/// a concurrency limit of its own, like `RecordingSummarizer.maxConcurrent`.
 enum BlockingWork {
 
     /// Start `body` on a thread of its own, right now.

--- a/Mila/Actions/BlockingWork.swift
+++ b/Mila/Actions/BlockingWork.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Somewhere to park a **blocking** wait that is not
+/// `DispatchQueue.global()`.
+///
+/// ## Why this exists (issue #246)
+///
+/// Every subprocess we run — `LLMRunner.executeProcess`,
+/// `ProcessGitCommandRunner.runSync`, and the `runGit` helper in
+/// `ObsidianGitSyncerIntegrationTests` — used to hand three *blocking* work
+/// items to `DispatchQueue.global()` per invocation: two pipe readers parked
+/// in `FileHandle.availableData` until EOF, and one thread parked in
+/// `Process.waitUntilExit()`. The caller then blocked a fourth pooled thread
+/// waiting on the resulting `DispatchGroup`.
+///
+/// The global concurrent queues are **non-overcommit**: libdispatch will not
+/// spin up a thread for a queued item just because the existing ones are
+/// blocked in the kernel. It notices the stall on a delay and grows the pool
+/// slowly, up to a hard cap on constrained threads. So the more of these waits
+/// are in flight, the longer an item sits before it is *scheduled at all* —
+/// which is exactly the "10-15s of dispatch latency on this CI image" that
+/// several comments in this codebase already record as ordinary.
+///
+/// That latency is not a slow wait, it is a wait that has not started, and it
+/// is unbounded in the bad case. It produced this signature on CI:
+///
+/// ```text
+/// git checkout -b main did not exit within 60s and was killed
+///   (stderr so far: Switched to a new branch 'main'
+/// ```
+///
+/// `Switched to a new branch 'main'` is git's own success message. git ran,
+/// succeeded, and wrote to a pipe we were reading — and 65s later the item
+/// that was supposed to observe its exit still had not run. The two
+/// `LLMSandboxDirectoryTests` timeouts in the same run have the same shape:
+/// each overshot its bound by ~6s, which is precisely the SIGTERM + SIGKILL
+/// grace, i.e. the exit observer never reported in even after the child was
+/// killed.
+///
+/// A thread of our own cannot be starved and cannot starve anybody else, and
+/// if it does leak (a grandchild holding a pipe open forever) it costs one
+/// thread rather than one slot in a pool the whole process shares.
+///
+/// This is deliberately not a queue. A `DispatchQueue(label:)` would also
+/// work — private serial queues target an *overcommit* root queue, so they
+/// always get a thread — but that is a subtle property to rely on, and it is
+/// invisible at the call site. `Thread` says what it means.
+enum BlockingWork {
+
+    /// Start `body` on a thread of its own, right now.
+    ///
+    /// `name` shows up in a sample / crash report, which is the whole reason
+    /// to prefer this over `Thread.detachNewThread`: the point of the change
+    /// is to make "who is blocked on what" legible, and an unnamed thread is
+    /// not.
+    static func onDedicatedThread(named name: String,
+                                  _ body: @escaping @Sendable () -> Void) {
+        let thread = Thread(block: body)
+        thread.name = name
+        thread.start()
+    }
+}

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -563,7 +563,10 @@ enum LLMRunner {
         let handle = ProcessHandle()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
+                // A thread of its own: `executeProcess` blocks for the whole
+                // life of the child, and a pooled thread parked there starves
+                // everything else queued behind it (issue #246).
+                BlockingWork.onDedicatedThread(named: "io.island.mila.llm.run") {
                     do {
                         let outcome = try executeProcess(executable: executable,
                                                          arguments: arguments,
@@ -840,7 +843,9 @@ enum LLMRunner {
         let handle = ProcessHandle()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
+                // See `run` above — `executeProcess` blocks, so it must not
+                // hold a shared pool thread (issue #246).
+                BlockingWork.onDedicatedThread(named: "io.island.mila.llm.diagnose") {
                     let elapsed: () -> TimeInterval = { Date().timeIntervalSince(start) }
                     do {
                         let outcome = try executeProcess(executable: executable,
@@ -1425,6 +1430,21 @@ enum LLMRunner {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // Observe the exit WITHOUT parking a blocking wait on the shared
+        // `DispatchQueue.global()` pool (issue #246 — the reasoning is in
+        // `BlockingWork`). `terminationHandler` is driven by Foundation's own
+        // child-reaping source, so nothing of ours is blocked to notice the
+        // exit; it has to be installed BEFORE `run()`.
+        //
+        // The `waitUntilExit()` backstop further down is not redundant with
+        // it: this method already documents a macOS 26 reaping race where
+        // that call never returns even after `SIGKILL`, so the two paths can
+        // fail independently. Whichever notices first signals. Only one wait
+        // below ever succeeds, so a second signal is harmless (a semaphore is
+        // only unsafe to destroy while its value is BELOW where it started).
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+
         do {
             try process.run()
         } catch {
@@ -1439,8 +1459,8 @@ enum LLMRunner {
         // result the user no longer cares about.
         handle.attach(process)
 
-        // Read stdout/stderr eagerly on background queues so a chatty CLI
-        // can't deadlock by filling the OS pipe buffer while we waitUntilExit.
+        // Read stdout/stderr eagerly on background threads so a chatty CLI
+        // can't deadlock by filling the OS pipe buffer while we wait for exit.
         // Chunked reads into lock-guarded boxes (not one readDataToEndOfFile
         // into a captured var) so the bounded drain below can snapshot what
         // arrived so far without racing a still-blocked reader.
@@ -1449,7 +1469,13 @@ enum LLMRunner {
         let group = DispatchGroup()
         for (pipe, box) in [(stdoutPipe, outBox), (stderrPipe, errBox)] {
             group.enter()
-            DispatchQueue.global().async {
+            // A thread of its own, NOT the global pool: `availableData` blocks
+            // until EOF, and a pooled thread parked there is one the whole
+            // process cannot use (issue #246, see `BlockingWork`). It also
+            // means the documented "an orphaned grandchild still holds the
+            // pipe" leak below costs a thread instead of a pool slot.
+            let stream = pipe === stdoutPipe ? "stdout" : "stderr"
+            BlockingWork.onDedicatedThread(named: "io.island.mila.llm.drain.\(stream)") {
                 let handle = pipe.fileHandleForReading
                 while true {
                     let chunk = handle.availableData   // blocks until data or EOF
@@ -1460,21 +1486,23 @@ enum LLMRunner {
             }
         }
 
-        // Bounded wait — kill the process if it's still running at deadline.
-        let runningGroup = DispatchGroup()
-        runningGroup.enter()
-        DispatchQueue.global().async {
+        // Backstop for `terminationHandler`, on a thread of its own for the
+        // same reason as the readers — and so that a `waitUntilExit()` which
+        // never returns (see below) leaks one thread rather than a pool slot.
+        BlockingWork.onDedicatedThread(named: "io.island.mila.llm.reap") {
             process.waitUntilExit()
-            runningGroup.leave()
+            exited.signal()
         }
+
+        // Bounded wait — kill the process if it's still running at deadline.
         let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
-        let timedOut = runningGroup.wait(timeout: deadline) == .timedOut
+        let timedOut = exited.wait(timeout: deadline) == .timedOut
         if timedOut {
             // SIGTERM first; if the CLI ignores it, hard-kill after a short
             // grace period so we don't read half-drained pipes or remove the
             // sandbox out from under a still-running child.
             process.terminate()
-            if runningGroup.wait(timeout: .now() + 1) == .timedOut {
+            if exited.wait(timeout: .now() + 1) == .timedOut {
                 kill(process.processIdentifier, SIGKILL)
                 // BOUNDED: `waitUntilExit` has been observed never returning
                 // even after a SIGKILL (macOS 26, sampled live — likely a
@@ -1482,7 +1510,7 @@ enum LLMRunner {
                 // either way, and this is the timedOut path so its exit
                 // status is already being discarded — don't hang the caller
                 // (and its awaiting continuation) on the obituary.
-                if runningGroup.wait(timeout: .now() + 5) == .timedOut {
+                if exited.wait(timeout: .now() + 5) == .timedOut {
                     // `error`: a child that outlives SIGKILL is a genuine
                     // anomaly (see the comment above), and it explains a
                     // truncated result — it must not need `--debug` to see.

--- a/Mila/Actions/ObsidianGitSyncer.swift
+++ b/Mila/Actions/ObsidianGitSyncer.swift
@@ -133,11 +133,30 @@ actor ObsidianGitSyncer {
 struct ProcessGitCommandRunner: GitCommandRunning {
     var timeout: TimeInterval = 120
 
+    /// Extra environment applied to the child `git` only, after the defaults
+    /// below and before `run()`. Empty in production.
+    ///
+    /// It exists so a test can isolate git's config discovery
+    /// (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, `HOME`) **per invocation**
+    /// instead of via `setenv` on the test host (issue #246). The host is a
+    /// live SwiftUI app: `setenv` can `realloc` `environ` underneath a
+    /// concurrent `getenv`/`posix_spawn` on another thread, which is a real
+    /// data race and not one the suite doing it can contain.
+    var environment: [String: String] = [:]
+
     func run(_ arguments: [String], in directory: URL) async -> GitCommandResult {
         let timeout = self.timeout
+        let environment = self.environment
         return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .utility).async {
-                continuation.resume(returning: Self.runSync(arguments, in: directory, timeout: timeout))
+            // A thread of its own, not `DispatchQueue.global()`: `runSync`
+            // blocks for the whole life of the child, and a pooled thread
+            // parked there starves whatever is queued behind it (issue #246,
+            // see `BlockingWork`).
+            BlockingWork.onDedicatedThread(named: "io.island.mila.git.run") {
+                continuation.resume(returning: Self.runSync(arguments,
+                                                            in: directory,
+                                                            timeout: timeout,
+                                                            environment: environment))
             }
         }
     }
@@ -181,7 +200,8 @@ struct ProcessGitCommandRunner: GitCommandRunning {
 
     private static func runSync(_ arguments: [String],
                                 in directory: URL,
-                                timeout: TimeInterval) -> GitCommandResult {
+                                timeout: TimeInterval,
+                                environment: [String: String]) -> GitCommandResult {
         guard let git = gitExecutable() else {
             return GitCommandResult(exitCode: -1, stdout: "",
                                     stderr: "git executable not found on PATH", timedOut: false)
@@ -214,6 +234,9 @@ struct ProcessGitCommandRunner: GitCommandRunning {
         env["LC_ALL"] = "C"
         env["LANG"] = "C"
         env.removeValue(forKey: "LANGUAGE")
+        // Caller overrides last, so a test can pin git's config discovery for
+        // this child without touching the host process's `environ`.
+        for (key, value) in environment { env[key] = value }
         process.environment = env
 
         let stdinPipe = Pipe()
@@ -222,6 +245,13 @@ struct ProcessGitCommandRunner: GitCommandRunning {
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
+
+        // Exit notification with no blocking wait on the shared pool — same
+        // change, same reason, as `LLMRunner.executeProcess` (issue #246).
+        // Must be installed before `run()`. The `waitUntilExit()` backstop
+        // below covers the macOS 26 reaping race the runner documents.
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
 
         do {
             try process.run()
@@ -239,7 +269,10 @@ struct ProcessGitCommandRunner: GitCommandRunning {
         let drain = DispatchGroup()
         for (pipe, box) in [(stdoutPipe, outBox), (stderrPipe, errBox)] {
             drain.enter()
-            DispatchQueue.global().async {
+            // Dedicated threads, not the global pool: `availableData` blocks
+            // until EOF (issue #246, see `BlockingWork`).
+            let stream = pipe === stdoutPipe ? "stdout" : "stderr"
+            BlockingWork.onDedicatedThread(named: "io.island.mila.git.drain.\(stream)") {
                 let handle = pipe.fileHandleForReading
                 while true {
                     let chunk = handle.availableData
@@ -250,22 +283,28 @@ struct ProcessGitCommandRunner: GitCommandRunning {
             }
         }
 
-        let running = DispatchGroup()
-        running.enter()
-        DispatchQueue.global().async {
+        BlockingWork.onDedicatedThread(named: "io.island.mila.git.reap") {
             process.waitUntilExit()
-            running.leave()
+            exited.signal()
         }
         let deadline = DispatchTime.now() + .seconds(Int(timeout.rounded(.up)))
-        let timedOut = running.wait(timeout: deadline) == .timedOut
+        let timedOut = exited.wait(timeout: deadline) == .timedOut
         if timedOut {
             process.terminate()
-            if running.wait(timeout: .now() + 2) == .timedOut {
+            if exited.wait(timeout: .now() + 2) == .timedOut {
                 kill(process.processIdentifier, SIGKILL)
-                _ = running.wait(timeout: .now() + 3)
+                _ = exited.wait(timeout: .now() + 3)
             }
         }
-        _ = drain.wait(timeout: .now() + 5)
+        // 5s used to be a coin toss: the readers were queued on the
+        // non-overcommit global pool, where simply BEING SCHEDULED could take
+        // 10-15s on a loaded runner, and an expired drain here silently
+        // returns short output. They now run on threads of their own and hit
+        // EOF as soon as git's write ends close, so this bounds a genuinely
+        // stuck reader (a helper git spawned still holding the pipes) rather
+        // than dispatch latency — but keep the headroom anyway, because the
+        // cost of expiring early is a wrong answer, not a slow one.
+        _ = drain.wait(timeout: .now() + 15)
 
         let stdout = String(data: outBox.withLock { $0 }, encoding: .utf8) ?? ""
         let stderr = String(data: errBox.withLock { $0 }, encoding: .utf8) ?? ""

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -22,6 +22,25 @@ import XCTest
 /// `cursor-agent` / `gemini` binaries.
 final class LLMSandboxDirectoryTests: XCTestCase {
 
+    /// Per-spawn bound for the echo scripts. Nothing here does more than
+    /// `printf`, so this is a hang detector, not a budget.
+    ///
+    /// It has to stay well under CI's 240s `-default-test-execution-time-`
+    /// `allowance` MULTIPLIED BY the number of children a test spawns, plus
+    /// each child's kill grace (~6s) — over the allowance XCTest kills the
+    /// test host, which records no message and cannot be retried, which is the
+    /// whole subject of #245. Four spawns at 30s + grace is ~156s worst case.
+    private static let spawnTimeout: TimeInterval = 30
+
+    /// `test_a_oneshot_run_does_not_sweep_a_concurrent_tick` holds a child
+    /// inside the sandbox for as long as the rest of the test takes, so its
+    /// bound must EXCEED every wait that has to finish before the barrier
+    /// releasing it can be written. `test_tick_budget_exceeds_the_waits_it_`
+    /// `spans` pins that; the numbers below are what makes it true.
+    private static let tickTimeout: TimeInterval = 120
+    /// Time allowed for the tick to spawn and write its handshake file.
+    private static let tickReadyTimeout: TimeInterval = 20
+
     /// A stand-in for `claude -p` that just prints its working directory.
     /// Prints the cwd and then its whole argv, on separate marked lines, so a
     /// test can assert both "where did it run" and "what was it told" from one
@@ -172,11 +191,11 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         let first = try await LLMRunner.run(tool: .claude,
                                             prompt: "x", transcript: "y",
                                             executablePathOverride: script.path,
-                                            timeout: 30)
+                                            timeout: Self.spawnTimeout)
         let second = try await LLMRunner.run(tool: .claude,
                                              prompt: "x", transcript: "y",
                                              executablePathOverride: script.path,
-                                             timeout: 30)
+                                             timeout: Self.spawnTimeout)
         XCTAssertFalse(first.isEmpty)
         XCTAssertEqual(first, second,
                        "each invocation got its own CWD — that is one leaked "
@@ -188,84 +207,96 @@ final class LLMSandboxDirectoryTests: XCTestCase {
     /// in argv, never from the cwd, so `--resume` continuity survives — while
     /// a per-session cwd would mint a project directory per recording.
     func test_session_runs_share_the_same_directory_as_oneshot_runs() async throws {
-        let script = makeCWDEchoScript()
+        // ONE script that echoes both the cwd and argv, used for all four
+        // runs (issue #246). This test used to spawn six children: four
+        // cwd-only runs, then two more that re-ran the session/resume pair
+        // just to look at argv. Six children at `spawnTimeout` each, plus
+        // their kill grace, put the worst case within sight of CI's 240s
+        // per-test allowance — and over that line XCTest kills the test host
+        // instead of failing the test, which is unretryable and reports no
+        // reason (#245). Four children asserting BOTH properties on every run
+        // is strictly more coverage for two-thirds of the spawns.
+        let script = makeCWDAndArgvEchoScript()
         defer { try? FileManager.default.removeItem(at: script) }
-        let oneShot = try await LLMRunner.run(tool: .claude,
-                                              prompt: "x", transcript: "y",
-                                              executablePathOverride: script.path,
-                                              timeout: 30)
         let id = UUID()
-        let newSession = try await LLMRunner.run(tool: .claude,
-                                                 prompt: "x", transcript: "y",
-                                                 executablePathOverride: script.path,
-                                                 session: .new(id),
-                                                 timeout: 30)
-        let resumed = try await LLMRunner.run(tool: .claude,
-                                               prompt: "x", transcript: "y",
-                                               executablePathOverride: script.path,
-                                               session: .resume(id),
-                                               timeout: 30)
-        let other = try await LLMRunner.run(tool: .claude,
-                                             prompt: "x", transcript: "y",
-                                             executablePathOverride: script.path,
-                                             session: .new(UUID()),
-                                             timeout: 30)
-        // Diagnostics, not a new contract (issue #208). This test failed once
-        // on PR #242 and passed on a rerun of the same code, and the reason is
-        // not recoverable from the CI log — so the next occurrence should at
-        // least name itself.
-        //
-        // Every assertion below is an equality between two script outputs,
-        // and `executeProcess` has a documented path that returns an EMPTY
-        // string from a successful run: on normal exit it waits up to 30s for
-        // the pipe readers to reach EOF and, when that expires, logs and
-        // returns whatever it buffered — exit code 0, `timedOut` false. On a
-        // loaded macos-26 VM that dispatch latency is real; the sibling
-        // `LLMRunnerTests` case notes 10-15s of it, and the 30s grace exists
-        // precisely because a tighter one "truncated perfectly good output
-        // mid-stream".
-        //
-        // Without this guard that failure mode is indistinguishable from a
-        // real regression when it hits one run ("" != "/path/…"), and is
-        // INVISIBLE when it hits all of them — four empty strings compare
-        // equal and the test passes having proven nothing. `oneShot` is the
-        // value every other assertion is measured against, so guarding it
-        // covers both. Mirrors the guard
-        // `test_two_oneshot_runs_share_one_working_directory` already has.
-        XCTAssertFalse(oneShot.isEmpty,
+        let oneShot = try await runEcho(script)
+        let newSession = try await runEcho(script, session: .new(id))
+        let resumed = try await runEcho(script, session: .resume(id))
+        let other = try await runEcho(script, session: .new(UUID()))
+        // Diagnostics, not a new contract (issue #208): this test failed once
+        // on PR #242 and passed on a rerun of the same code, so the next
+        // occurrence should at least name itself. `runEcho` carries the bulk
+        // of that guard now — a run that produced no output fails there, by
+        // name, instead of arriving here as `"" == ""`. This is the last
+        // remaining hole: a child that printed the markers and nothing after
+        // them.
+        XCTAssertFalse(oneShot.cwd.isEmpty,
                        "the child printed no cwd at all — the run produced no "
                        + "output rather than the wrong output, so the "
                        + "comparisons below prove nothing")
-        XCTAssertEqual(newSession, oneShot)
-        XCTAssertEqual(resumed, oneShot)
-        XCTAssertEqual(other, oneShot,
+        XCTAssertEqual(newSession.cwd, oneShot.cwd)
+        XCTAssertEqual(resumed.cwd, oneShot.cwd)
+        XCTAssertEqual(other.cwd, oneShot.cwd,
                        "a second session got its own CWD — one project "
                        + "directory per Live AI session, which is the leak")
         // The cwd must not carry the UUID...
-        XCTAssertFalse(newSession.contains(id.uuidString),
-                       "session UUID leaked into the CWD: \(newSession)")
+        XCTAssertFalse(newSession.cwd.contains(id.uuidString),
+                       "session UUID leaked into the CWD: \(newSession.cwd)")
 
         // ...but the UUID does have to reach the CLI, because that is what
-        // keeps the conversations apart inside the one shared project. The
-        // assertion above cannot show it: this script echoes only the cwd, so
-        // "UUID absent" is equally consistent with "never passed at all".
-        // Check argv directly.
-        let argvScript = makeCWDAndArgvEchoScript()
-        defer { try? FileManager.default.removeItem(at: argvScript) }
-        let newOut = try await LLMRunner.run(tool: .claude,
+        // keeps the conversations apart inside the one shared project. The cwd
+        // assertions cannot show it: "UUID absent from the cwd" is equally
+        // consistent with "never passed at all". Now checked on the SAME runs
+        // rather than on two extra spawns.
+        XCTAssertTrue(newSession.argv.contains(id.uuidString),
+                      "a new session must pass its UUID to the CLI; argv was: \(newSession.argv)")
+        XCTAssertTrue(resumed.argv.contains(id.uuidString),
+                      "a resumed session must pass its UUID to the CLI; argv was: \(resumed.argv)")
+        // The negative half, which the old shape never checked: a run with no
+        // session must not carry one, and a different session must not carry
+        // this one's id.
+        XCTAssertFalse(oneShot.argv.contains(id.uuidString),
+                       "a one-shot run must not carry a session id; argv was: \(oneShot.argv)")
+        XCTAssertFalse(other.argv.contains(id.uuidString),
+                       "a different session reused this session's id; argv was: \(other.argv)")
+    }
+
+    /// One run of `makeCWDAndArgvEchoScript`, split back into its two lines.
+    private struct EchoedRun {
+        let cwd: String
+        let argv: String
+    }
+
+    /// Run the cwd+argv echo script and parse its two marked lines.
+    ///
+    /// Parsing rather than asserting on the raw string because
+    /// `executeProcess` has a documented path that returns an EMPTY string
+    /// from a SUCCESSFUL run: on normal exit it waits a bounded time for the
+    /// pipe readers to reach EOF and, on expiry, logs and returns whatever it
+    /// buffered — exit code 0, `timedOut` false. Left as a raw comparison that
+    /// is either inscrutable (`"" != "/path/…"`) or, when it hits every run,
+    /// invisible: four empty strings compare equal and the test passes having
+    /// proven nothing. Missing markers fail here, by name.
+    private func runEcho(_ script: URL,
+                         session: LLMSession = .none,
+                         file: StaticString = #filePath,
+                         line: UInt = #line) async throws -> EchoedRun {
+        let output = try await LLMRunner.run(tool: .claude,
                                              prompt: "x", transcript: "y",
-                                             executablePathOverride: argvScript.path,
-                                             session: .new(id),
-                                             timeout: 30)
-        let resumedOut = try await LLMRunner.run(tool: .claude,
-                                                 prompt: "x", transcript: "y",
-                                                 executablePathOverride: argvScript.path,
-                                                 session: .resume(id),
-                                                 timeout: 30)
-        XCTAssertTrue(newOut.contains(id.uuidString),
-                      "a new session must pass its UUID to the CLI; argv was: \(newOut)")
-        XCTAssertTrue(resumedOut.contains(id.uuidString),
-                      "a resumed session must pass its UUID to the CLI; argv was: \(resumedOut)")
+                                             executablePathOverride: script.path,
+                                             session: session,
+                                             timeout: Self.spawnTimeout)
+        let lines = output.components(separatedBy: "\n")
+        func value(_ marker: String) -> String? {
+            lines.first { $0.hasPrefix(marker) }.map { String($0.dropFirst(marker.count)) }
+        }
+        guard let cwd = value("CWD:"), let argv = value("ARGV:") else {
+            XCTFail("the child produced no CWD:/ARGV: lines — a successful run "
+                    + "with no output proves nothing. Got: \(output.debugDescription)",
+                    file: file, line: line)
+            return EchoedRun(cwd: "", argv: "")
+        }
+        return EchoedRun(cwd: cwd, argv: argv)
     }
 
     /// The PR claims concurrent invocations can share one cwd. Sequential runs
@@ -306,7 +337,7 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         _ = try await LLMRunner.run(tool: .claude,
                                     prompt: "x", transcript: "y",
                                     executablePathOverride: script.path,
-                                    timeout: 30)
+                                    timeout: Self.spawnTimeout)
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: LLMRunner.sandboxDirectory().path),
             "shared sandbox was torn down after the run")
@@ -361,6 +392,37 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                        + "invocation left: \(marker.path)")
     }
 
+    /// The budget invariant behind `test_a_oneshot_run_does_not_sweep_a_`
+    /// `concurrent_tick`, asserted separately so it is checked in
+    /// milliseconds instead of only being discovered by a two-minute timeout.
+    ///
+    /// The tick's clock starts when it is spawned, but it cannot RETURN until
+    /// the barrier is written — and the barrier is written only after the two
+    /// waits above it have finished. So its budget has to exceed their sum, or
+    /// the test times out its own child by construction.
+    ///
+    /// It did: the bounds were 120 for the tick and 60 + 60 for the waits it
+    /// spans, i.e. exactly zero margin, and it survived only because both
+    /// waits normally take milliseconds. It was observed failing with
+    /// `timedOut(seconds: 120)` at 126.8s (issue #246).
+    ///
+    /// The fix is NOT a bigger tick budget — 120s is already half of CI's 240s
+    /// per-test allowance, and crossing that swaps an ordinary retryable
+    /// failure for a test-host kill (#245). It is a smaller sum, checked here
+    /// so the next person to touch a number finds out immediately.
+    func test_tick_budget_exceeds_the_waits_it_spans() {
+        XCTAssertGreaterThan(Self.tickTimeout,
+                             2 * (Self.tickReadyTimeout + Self.spawnTimeout),
+                             "the concurrent-tick test cannot release its tick "
+                             + "until \(Self.tickReadyTimeout)s + "
+                             + "\(Self.spawnTimeout)s of waits have elapsed, so a "
+                             + "\(Self.tickTimeout)s tick budget leaves no margin")
+        XCTAssertLessThan(Self.tickTimeout, 240,
+                          "a bound at or above CI's -default-test-execution-time-"
+                          + "allowance makes XCTest kill the test HOST rather "
+                          + "than fail the test — no message, and no retry")
+    }
+
     /// The same property with real children, because the lease test cannot show
     /// that `executeProcess` actually holds its lease for the whole life of the
     /// child rather than just across the launch.
@@ -386,16 +448,17 @@ final class LLMSandboxDirectoryTests: XCTestCase {
 
         async let live = LLMRunner.run(tool: .claude, prompt: "x", transcript: "y",
                                        executablePathOverride: tick.path,
-                                       session: .new(UUID()), timeout: 120)
+                                       session: .new(UUID()),
+                                       timeout: Self.tickTimeout)
         // Don't start the one-shot until the tick is genuinely inside with its
         // file written — otherwise the two might not overlap at all and the
         // test would pass without exercising anything.
-        try await waitForFile(ready, timeout: 60)
+        try await waitForFile(ready, timeout: Self.tickReadyTimeout)
 
         let oneShotCWD = try await LLMRunner.run(tool: .claude,
                                                  prompt: "x", transcript: "y",
                                                  executablePathOverride: oneShot.path,
-                                                 timeout: 60)
+                                                 timeout: Self.spawnTimeout)
         XCTAssertEqual(oneShotCWD, LLMRunner.sandboxDirectory().path,
                        "the one-shot didn't run in the shared sandbox, so it "
                        + "never had the chance to sweep the tick's file")
@@ -416,7 +479,7 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         let result = await LLMRunner.diagnose(tool: .claude,
                                               prompt: "x", transcript: "y",
                                               executablePathOverride: script.path,
-                                              timeout: 30)
+                                              timeout: Self.spawnTimeout)
         XCTAssertTrue(result.succeeded, "diagnose failed: \(result)")
         XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
                        LLMRunner.sandboxDirectory().path)

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -41,15 +41,31 @@ final class LLMSandboxDirectoryTests: XCTestCase {
     /// Time allowed for the tick to spawn and write its handshake file.
     private static let tickReadyTimeout: TimeInterval = 20
 
-    /// A stand-in for `claude -p` that just prints its working directory.
-    /// Prints the cwd and then its whole argv, on separate marked lines, so a
-    /// test can assert both "where did it run" and "what was it told" from one
-    /// invocation. The cwd assertions can't speak to argv, which is what let
-    /// the session-UUID claim go unchecked.
+    /// A stand-in for `claude -p` that reports where it ran and what it was
+    /// told, so one invocation can answer both questions. The cwd assertions
+    /// can't speak to argv, which is what let the session-UUID claim go
+    /// unchecked.
+    ///
+    /// Three markers, and the middle one is the important one:
+    ///
+    ///     CWD:<pwd>          one line
+    ///     ARGC:<count>       one line — `$#`, taken before any joining
+    ///     ARGV:<joined>      NOT one line: `$*` carries the prompt's newlines
+    ///
+    /// `ARGC` exists because `ARGV` alone cannot tell "the CLI was never given
+    /// `--session-id`" apart from "our parse of `$*` dropped it". `$*` also
+    /// collapses argument boundaries, so a count taken before the join is the
+    /// only value here that can see an argument disappear. The first version
+    /// of this fixture had no count and a line-wise parse, and CI reported
+    /// `argv was: -p x` — on its face indistinguishable from a production
+    /// regression that had stopped passing the session flag.
     private func makeCWDAndArgvEchoScript() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("island-mila-sandbox-test-\(UUID().uuidString).sh")
-        try? "#!/bin/sh\nprintf 'CWD:%s\\n' \"$PWD\"\nprintf 'ARGV:%s\\n' \"$*\"\n".write(
+        try? ("#!/bin/sh\n"
+              + "printf 'CWD:%s\\n' \"$PWD\"\n"
+              + "printf 'ARGC:%s\\n' \"$#\"\n"
+              + "printf 'ARGV:%s\\n' \"$*\"\n").write(
             to: url, atomically: true, encoding: .utf8)
         try? FileManager.default.setAttributes([.posixPermissions: 0o755],
                                               ofItemAtPath: url.path)
@@ -248,6 +264,22 @@ final class LLMSandboxDirectoryTests: XCTestCase {
         // assertions cannot show it: "UUID absent from the cwd" is equally
         // consistent with "never passed at all". Now checked on the SAME runs
         // rather than on two extra spawns.
+        //
+        // Assert the COUNT before the contents. `LLMTool.arguments` adds
+        // exactly two arguments for a session (`--session-id <uuid>` for
+        // `.new`, `--resume <uuid>` for `.resume`) and nothing else differs
+        // between these four runs, so the delta is exactly 2. That check
+        // depends on no string matching at all, which matters twice: it
+        // catches a production path that stopped emitting the flag — every
+        // Live AI tick would then silently start a fresh conversation instead
+        // of continuing the meeting — and it cannot be satisfied by a uuid
+        // that merely appears somewhere in the output.
+        XCTAssertEqual(newSession.argc, oneShot.argc + 2,
+                       "a new session must add `--session-id <uuid>`: "
+                       + "\(newSession.argc) arguments vs \(oneShot.argc) for the one-shot")
+        XCTAssertEqual(resumed.argc, oneShot.argc + 2,
+                       "a resumed session must add `--resume <uuid>`: "
+                       + "\(resumed.argc) arguments vs \(oneShot.argc) for the one-shot")
         XCTAssertTrue(newSession.argv.contains(id.uuidString),
                       "a new session must pass its UUID to the CLI; argv was: \(newSession.argv)")
         XCTAssertTrue(resumed.argv.contains(id.uuidString),
@@ -261,13 +293,16 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                        "a different session reused this session's id; argv was: \(other.argv)")
     }
 
-    /// One run of `makeCWDAndArgvEchoScript`, split back into its two parts.
+    /// One run of `makeCWDAndArgvEchoScript`, split back into its three parts.
     private struct EchoedRun {
         let cwd: String
+        /// `$#` — the count BEFORE `$*` joined everything with spaces. The
+        /// only value here that can detect an argument going missing.
+        let argc: Int
         let argv: String
     }
 
-    /// Run the cwd+argv echo script and split its output at the two markers.
+    /// Run the echo script and split its output at the three markers.
     ///
     /// Parsing rather than asserting on the raw string because
     /// `executeProcess` has a documented path that returns an EMPTY string
@@ -286,21 +321,26 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                                              executablePathOverride: script.path,
                                              session: session,
                                              timeout: Self.spawnTimeout)
-        // Split on the ARGV marker, NOT on newlines. `CWD:` is one line, but
-        // `ARGV:` is not: the composed prompt is a single argv element
-        // containing newlines, so argv runs from its marker to the end of the
-        // output. A line-wise parse silently truncates it to `-p x` and then
-        // fails the UUID assertions on a run that passed the UUID correctly —
+        // Split on the MARKERS, never on newlines. `CWD:` and `ARGC:` are one
+        // line each, but `ARGV:` is not — the composed prompt is a single argv
+        // element containing newlines, so argv runs from its marker to the end
+        // of the output. A line-wise parse truncates it to `-p x` and then
+        // fails the UUID assertions on a run that passed the UUID correctly;
         // CI caught exactly that on the first version of this helper.
-        guard output.hasPrefix("CWD:"), let marker = output.range(of: "\nARGV:") else {
-            XCTFail("the child produced no CWD:/ARGV: markers — a successful "
-                    + "run with no output proves nothing. Got: "
+        guard output.hasPrefix("CWD:"),
+              let argcMarker = output.range(of: "\nARGC:"),
+              let argvMarker = output.range(of: "\nARGV:"),
+              argcMarker.upperBound <= argvMarker.lowerBound,
+              let argc = Int(output[argcMarker.upperBound..<argvMarker.lowerBound]) else {
+            XCTFail("the child produced no CWD:/ARGC:/ARGV: markers — a "
+                    + "successful run with no output proves nothing. Got: "
                     + "\(output.debugDescription)",
                     file: file, line: line)
-            return EchoedRun(cwd: "", argv: "")
+            return EchoedRun(cwd: "", argc: 0, argv: "")
         }
-        return EchoedRun(cwd: String(output[..<marker.lowerBound].dropFirst("CWD:".count)),
-                         argv: String(output[marker.upperBound...]))
+        return EchoedRun(cwd: String(output[..<argcMarker.lowerBound].dropFirst("CWD:".count)),
+                         argc: argc,
+                         argv: String(output[argvMarker.upperBound...]))
     }
 
     /// The PR claims concurrent invocations can share one cwd. Sequential runs

--- a/MilaTests/LLMSandboxDirectoryTests.swift
+++ b/MilaTests/LLMSandboxDirectoryTests.swift
@@ -261,13 +261,13 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                        "a different session reused this session's id; argv was: \(other.argv)")
     }
 
-    /// One run of `makeCWDAndArgvEchoScript`, split back into its two lines.
+    /// One run of `makeCWDAndArgvEchoScript`, split back into its two parts.
     private struct EchoedRun {
         let cwd: String
         let argv: String
     }
 
-    /// Run the cwd+argv echo script and parse its two marked lines.
+    /// Run the cwd+argv echo script and split its output at the two markers.
     ///
     /// Parsing rather than asserting on the raw string because
     /// `executeProcess` has a documented path that returns an EMPTY string
@@ -286,17 +286,21 @@ final class LLMSandboxDirectoryTests: XCTestCase {
                                              executablePathOverride: script.path,
                                              session: session,
                                              timeout: Self.spawnTimeout)
-        let lines = output.components(separatedBy: "\n")
-        func value(_ marker: String) -> String? {
-            lines.first { $0.hasPrefix(marker) }.map { String($0.dropFirst(marker.count)) }
-        }
-        guard let cwd = value("CWD:"), let argv = value("ARGV:") else {
-            XCTFail("the child produced no CWD:/ARGV: lines — a successful run "
-                    + "with no output proves nothing. Got: \(output.debugDescription)",
+        // Split on the ARGV marker, NOT on newlines. `CWD:` is one line, but
+        // `ARGV:` is not: the composed prompt is a single argv element
+        // containing newlines, so argv runs from its marker to the end of the
+        // output. A line-wise parse silently truncates it to `-p x` and then
+        // fails the UUID assertions on a run that passed the UUID correctly —
+        // CI caught exactly that on the first version of this helper.
+        guard output.hasPrefix("CWD:"), let marker = output.range(of: "\nARGV:") else {
+            XCTFail("the child produced no CWD:/ARGV: markers — a successful "
+                    + "run with no output proves nothing. Got: "
+                    + "\(output.debugDescription)",
                     file: file, line: line)
             return EchoedRun(cwd: "", argv: "")
         }
-        return EchoedRun(cwd: cwd, argv: argv)
+        return EchoedRun(cwd: String(output[..<marker.lowerBound].dropFirst("CWD:".count)),
+                         argv: String(output[marker.upperBound...]))
     }
 
     /// The PR claims concurrent invocations can share one cwd. Sequential runs

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -178,9 +178,18 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
         gate.release(1)
 
-        let recovered = await waitUntil(timeout: 5) { calls.value.count == 2 }
+        // `mustHappen`, not a hand-picked 5s: this waits on a chain of six
+        // hops (gate release -> the in-flight task finishes -> its `defer`
+        // runs -> `coalesced` is observed -> `scheduleKick` fires -> the new
+        // tick records its call), and a wedge never completes it however long
+        // we wait. See `mustHappen`.
+        let recovered = await waitUntil { calls.value.count == 2 }
         XCTAssertTrue(recovered,
-                      "Live AI wedged: the dropped tick left `inFlight` set, so every later tick coalesced behind a task that never clears")
+                      "the replacement tick never ran within \(Int(Self.mustHappen))s. "
+                      + "The behaviour under test is that a dropped tick must not "
+                      + "strand `inFlight` — if it did, every later tick coalesces "
+                      + "behind a task that never clears and Live AI is silently "
+                      + "dead for the rest of the meeting")
         XCTAssertEqual(kind(calls.value[1].session), "new",
                        "the replacement tick must open a new session, not resume the abandoned one")
         XCTAssertTrue(calls.value[1].transcript.contains("One."))
@@ -230,17 +239,24 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
         // Asserted as a negative, because the harm is state being cleared that
         // belongs to the tick still running.
-        let wentIdle = await waitUntil(timeout: 1) { !session.isThinking }
+        //
+        // `quietWindow`, deliberately NOT `mustHappen`: these two are watching
+        // for something that must never happen, so the timeout is a window of
+        // required quiet rather than a deadline. `waitUntil` returns the moment
+        // its condition holds, so the full budget is spent only when the
+        // assertion PASSES — widening it would slow every green run and would
+        // make a spurious pass more likely, not less. See `quietWindow`.
+        let wentIdle = await waitUntil(timeout: Self.quietWindow) { !session.isThinking }
         XCTAssertFalse(wentIdle,
                        "the cancelled tick cleared `isThinking` while the new recording's tick was still running")
 
-        let startedAThird = await waitUntil(timeout: 1) { calls.value.count == 3 }
+        let startedAThird = await waitUntil(timeout: Self.quietWindow) { calls.value.count == 3 }
         XCTAssertFalse(startedAThird,
                        "`inFlight` was clobbered: a third call started while the second was still in flight")
 
         // And the surviving tick still completes normally once released.
         gate.release(2)
-        let drained = await waitUntil(timeout: 3) { !session.isThinking }
+        let drained = await waitUntil { !session.isThinking }
         XCTAssertTrue(drained,
                       "the new recording's tick must still finish and clear state on its own")
     }
@@ -327,9 +343,43 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         return (session, calls)
     }
 
+    /// Bound for a wait on something that MUST happen (the caller asserts the
+    /// result is `true`).
+    ///
+    /// Chosen on the principle that **the only way to exceed it is the failure
+    /// mode under test**. Every such wait here is for state that a genuine bug
+    /// leaves wrong *forever* — a wedged `inFlight` is never cleared, however
+    /// long you wait — so a generous bound removes contention-induced failures
+    /// without costing one bit of discriminating power. It is also free on a
+    /// passing run: the condition holds in milliseconds, so this budget is
+    /// spent only when the test is failing anyway.
+    ///
+    /// These were 2-5s, and the 5s one is what failed on a loaded CI runner
+    /// while reporting "Live AI wedged" — a diagnosis that was simply false;
+    /// the machine was slow (issue #250). Same mistake as the 5s pipe-drain
+    /// bound #245 had to widen. **Do not re-tighten them.** 30s still fails
+    /// fast against CI's 240s per-test allowance, and no test here makes more
+    /// than three of these waits, so the worst case stays well inside it.
+    private static let mustHappen: TimeInterval = 30
+
+    /// Window for watching that something must NOT happen (the caller asserts
+    /// the result is `false`).
+    ///
+    /// This is the OPPOSITE case and it must stay short. `waitUntil` returns
+    /// the instant its condition holds, so a negative assertion only ever
+    /// spends its whole budget when it is **passing** — raising it would add
+    /// that budget to every green run for no gain at all. And a longer window
+    /// gives unrelated scheduling more chance to satisfy the condition, so it
+    /// makes a spurious *pass* more likely, not less. 1s is already ~1000x the
+    /// scale these transitions happen on.
+    private static let quietWindow: TimeInterval = 1
+
     /// Spin until `condition` holds, or the timeout expires. Returns whether
     /// it held -- callers assert on that rather than hanging the suite.
-    private func waitUntil(timeout: TimeInterval = 2,
+    ///
+    /// Defaults to `mustHappen` because that is the common case; a caller
+    /// asserting the result is `false` must pass `quietWindow` explicitly.
+    private func waitUntil(timeout: TimeInterval = LiveAIDeletedLineSessionTests.mustHappen,
                            _ condition: () -> Bool) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -340,8 +390,11 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         return condition()
     }
 
+    /// Settle an in-flight tick. Same `mustHappen` reasoning: a session that
+    /// never goes idle is broken, and the assertions after the call are what
+    /// report it — this wait only has to avoid expiring on a slow runner.
     private func waitUntilIdle(_ session: LiveAISession,
-                               timeout: TimeInterval = 2) async {
+                               timeout: TimeInterval = LiveAIDeletedLineSessionTests.mustHappen) async {
         let deadline = Date().addingTimeInterval(timeout)
         while session.isThinking && Date() < deadline {
             await Task.yield()

--- a/MilaTests/MicrophoneRecorderTests.swift
+++ b/MilaTests/MicrophoneRecorderTests.swift
@@ -393,6 +393,18 @@ final class MicrophoneWatchdogTests: XCTestCase {
 @MainActor
 final class MicrophoneConfigurationChangeTests: XCTestCase {
 
+    /// Rebuilds `test_a_storm_of_configuration_changes_is_bounded` tolerates.
+    /// One is the expected answer — the burst window sits inside the 1s
+    /// `minimumRebuildInterval` — and 2 allows for clock jitter at the edge.
+    /// This is the assertion the test exists for; it passes and must not move.
+    private static let maximumExpectedRebuilds = 2
+
+    /// The burst's wall-clock window. Must stay BELOW `minimumRebuildInterval`
+    /// (1s, set in `makeRecorder`) or "at most one rebuild" stops being the
+    /// right expectation and the test would be judging the policy over a
+    /// window it was never given.
+    private static let burstWindow: TimeInterval = 0.6
+
     /// `grace` is per-test on purpose. The handler timestamps a notification
     /// when it RUNS, not when it was posted, so a test that wants a change
     /// treated as self-inflicted needs a window comfortably longer than any
@@ -487,11 +499,22 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
 
         // Post continuously for a fixed WALL-CLOCK window at roughly the
         // cadence observed in the bug (~150ms, compressed to 15ms here).
-        // Wall-clock rather than a fixed iteration count so a slow CI runner
-        // stretches the number of posts, not the window the policy is judged
-        // over.
+        //
+        // The WINDOW is what must stay fixed, and it is load-bearing for the
+        // assertion below: 0.6s sits inside the 1s `minimumRebuildInterval`,
+        // which is what makes "one rebuild" the expected answer. A fixed
+        // iteration count would let a slow runner stretch the window past that
+        // floor and legitimately produce more rebuilds, so the policy would be
+        // judged over a window it was never given.
+        //
+        // The COUNT is the part that moves, and it moves DOWNWARDS under load.
+        // (A previous version of this comment claimed a slow runner "stretches
+        // the number of posts". It does the opposite: `Task.sleep(15ms)` is a
+        // floor, so a loaded machine makes each iteration cost more and fewer
+        // of them fit in the fixed window. Nominal yield is 40; CI has been
+        // observed at 6-10, i.e. ~4-6x scheduling overhead.)
         var posts = 0
-        let deadline = Date().addingTimeInterval(0.6)
+        let deadline = Date().addingTimeInterval(Self.burstWindow)
         while Date() < deadline {
             postConfigurationChange(to: mic)
             posts += 1
@@ -499,12 +522,30 @@ final class MicrophoneConfigurationChangeTests: XCTestCase {
         }
         try await Task.sleep(nanoseconds: 200_000_000)
 
-        XCTAssertGreaterThan(posts, 10, "the burst should have delivered plenty of notifications")
+        // PRECONDITION, not the property under test — the property is the
+        // rebuild bound on the next line. All this has to establish is that
+        // enough notifications arrived for "paced" and "one rebuild per
+        // notification" to be visibly different outcomes, and at twice the
+        // rebuild bound they already are: the bug would have produced
+        // `posts` rebuilds, and `posts` is at least double what is allowed.
+        //
+        // It used to demand `> 10`, which was not derived from that argument —
+        // it sat exactly on the yield the loop happens to produce, so it was a
+        // load sensor rather than a sanity check, and it failed at its own trip
+        // point on loaded runners with 10, 9, 10 and 8, 6, 6 (#246, #250). The
+        // 0.6s window is untouched; only the bar that never had timing meaning
+        // moves. Do not raise this back towards the nominal yield: a bigger
+        // number adds no discriminating power and re-arms the same failure.
+        XCTAssertGreaterThan(posts, 2 * Self.maximumExpectedRebuilds,
+                             "the burst delivered only \(posts) notifications, which is too "
+                             + "few to tell a paced rebuild policy apart from one rebuild "
+                             + "per notification — the storm never happened, so the bound "
+                             + "below proves nothing")
         // Floor is 1s and the burst is 0.6s, so one rebuild is the expected
         // answer; the bound is 2 purely for CI clock jitter. The point is that
         // the count tracks the POLICY, not the number of notifications.
-        XCTAssertLessThanOrEqual(mic.restartCount, 2,
-                                 "\(posts) configuration changes in 0.6s produced \(mic.restartCount) rebuilds — the notification path is not paced")
+        XCTAssertLessThanOrEqual(mic.restartCount, Self.maximumExpectedRebuilds,
+                                 "\(posts) configuration changes in \(Self.burstWindow)s produced \(mic.restartCount) rebuilds — the notification path is not paced")
         XCTAssertLessThanOrEqual(bringUps(), 3)
         await mic.stop()
     }

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -123,7 +123,22 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        // Report a removal that FAILED, rather than swallowing it with `try?`.
+        // The ledger in `setUp` is the cross-test net, but it is only read by
+        // the NEXT test — so without this the last test in the class could leak
+        // and nothing would ever say so. `tearDown` still runs in the failing
+        // test's own context, so the attribution is right either way.
+        if let tempRoot, FileManager.default.fileExists(atPath: tempRoot.path) {
+            do {
+                try FileManager.default.removeItem(at: tempRoot)
+                Self.previousRoots.removeAll { $0 == tempRoot }
+            } catch {
+                XCTFail("could not remove this test's temp root "
+                        + "\(tempRoot.lastPathComponent): \(error.localizedDescription)")
+            }
+        } else if let tempRoot {
+            Self.previousRoots.removeAll { $0 == tempRoot }
+        }
         try super.tearDownWithError()
     }
 

--- a/MilaTests/ObsidianGitSyncerIntegrationTests.swift
+++ b/MilaTests/ObsidianGitSyncerIntegrationTests.swift
@@ -13,9 +13,19 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     private var home: URL!
     private var remote: URL!
     private var vault: URL!
-    /// Original values of the git-config env vars we override on THIS process,
-    /// so `tearDown` can put them back. `nil` value == the var was unset.
-    private var savedEnvironment: [String: String?] = [:]
+
+    /// Temp roots this class has created so far in this process.
+    ///
+    /// `setUp` asserts every EARLIER one is gone (issue #246). Checking in
+    /// `setUp` rather than `tearDown` is the point: a root is named after the
+    /// test that created it, so the failure says which test leaked rather than
+    /// landing on whichever test happened to run next. The ledger is drained
+    /// as it is checked, so one leak reports once instead of reddening every
+    /// remaining test in the class.
+    ///
+    /// Not concurrency-guarded because XCTest runs a class's tests serially on
+    /// one thread; `setUp` is the only reader and writer.
+    private static var previousRoots: [URL] = []
 
     /// Per-`git`-invocation bound, for BOTH the setup helper below and the
     /// production runner the tests drive (issue #208).
@@ -44,11 +54,15 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
 
     /// How long to wait for the output pipes to reach EOF once `git` has
     /// exited. Separate from `gitCommandTimeout` because it bounds a different
-    /// hazard: not a wedged `git`, but a reader work item that has not been
-    /// scheduled yet. `executeProcess` documents 10-15s of dispatch latency on
-    /// the macos-26 CI image and each `runGit` parks three blocking items on
-    /// the global queue, so this has to clear that comfortably — 5s did not,
-    /// and cost this suite a deterministic failure.
+    /// hazard: not a wedged `git`, but a reader that has not finished.
+    ///
+    /// It used to bound a reader that had not been SCHEDULED — the readers sat
+    /// on the non-overcommit global queue, where 10-15s of dispatch latency is
+    /// documented for this CI image, and a 5s bound cost this suite a
+    /// deterministic failure. They now run on threads of their own (issue
+    /// #246), so scheduling is immediate and this bounds only a reader still
+    /// blocked on a pipe some helper `git` spawned is holding open. Kept
+    /// generous anyway: expiring early returns a WRONG answer, not a slow one.
     private static let pipeDrainTimeout: TimeInterval = 30
 
     override func setUpWithError() throws {
@@ -57,28 +71,36 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
             throw XCTSkip("git is not installed on this machine")
         }
         gitURL = git
+
+        // Cleanliness is asserted HERE, before this test creates anything, so
+        // a leaked root is reported against the test named in its own path
+        // (issue #246). Drain the ledger while checking it: the leak is a fact
+        // about the run that caused it, not about every test after it.
+        let stale = Self.previousRoots.filter {
+            FileManager.default.fileExists(atPath: $0.path)
+        }
+        Self.previousRoots.removeAll()
+        for root in stale {
+            XCTFail("a previous test in this class left its temp root behind — "
+                    + "the directory name says which one: \(root.lastPathComponent)")
+            try? FileManager.default.removeItem(at: root)
+        }
+
         tempRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("MilaGitIntegration-\(UUID())", isDirectory: true)
+            .appendingPathComponent("MilaGitIntegration-\(testLabel)-\(UUID())",
+                                    isDirectory: true)
+        Self.previousRoots.append(tempRoot)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         // Isolated HOME so setup commands don't read the developer's global
         // git config (default branch name, gpg signing, hooks).
         home = tempRoot.appendingPathComponent("home", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
 
-        // `runGit` can isolate its own child env, but the code under test runs
-        // through `ProcessGitCommandRunner`, which inherits this process's
-        // environment verbatim. Without overriding these here, the sync steps
-        // would read the developer's / CI machine's real global + system git
-        // config (default branch, gpg signing, hooks, insteadOf rewrites).
-        // `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` need git >= 2.32; the older
-        // `GIT_CONFIG_NOSYSTEM` is set too so isolation still holds below that.
-        let globalConfig = home.appendingPathComponent(".gitconfig")
-        FileManager.default.createFile(atPath: globalConfig.path, contents: nil)
-        setEnvironment([
-            "GIT_CONFIG_GLOBAL": globalConfig.path,
-            "GIT_CONFIG_SYSTEM": "/dev/null",
-            "GIT_CONFIG_NOSYSTEM": "1"
-        ])
+        // The empty global config `gitIsolation` points at. Both `runGit` and
+        // the production runner receive that pointer as CHILD environment (see
+        // `gitIsolation`) — this process's own `environ` is never touched.
+        FileManager.default.createFile(atPath: home.appendingPathComponent(".gitconfig").path,
+                                       contents: nil)
 
         remote = tempRoot.appendingPathComponent("remote.git", isDirectory: true)
         vault = tempRoot.appendingPathComponent("vault", isDirectory: true)
@@ -101,26 +123,42 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        restoreEnvironment()
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
         try super.tearDownWithError()
     }
 
-    /// Override env vars on this process, remembering the previous values.
-    private func setEnvironment(_ values: [String: String]) {
-        for (key, value) in values {
-            if !savedEnvironment.keys.contains(key) {
-                savedEnvironment[key] = ProcessInfo.processInfo.environment[key]
-            }
-            setenv(key, value, 1)
-        }
+    /// `name` is `-[ObsidianGitSyncerIntegrationTests test_foo]`; keep the
+    /// `test_foo` so a leaked temp root names the test that leaked it.
+    private var testLabel: String {
+        let raw = name.split(separator: " ").last.map(String.init) ?? name
+        return String(raw.filter { $0.isLetter || $0.isNumber || $0 == "_" })
     }
 
-    private func restoreEnvironment() {
-        for (key, value) in savedEnvironment {
-            if let value { setenv(key, value, 1) } else { unsetenv(key) }
-        }
-        savedEnvironment.removeAll()
+    /// Git-config isolation, as CHILD environment rather than as a mutation of
+    /// this process (issue #246).
+    ///
+    /// This used to be `setenv`/`unsetenv` in `setUp`/`tearDown`, because the
+    /// code under test runs through `ProcessGitCommandRunner`, which inherits
+    /// the host's environment verbatim and had no other way in. The test host
+    /// is a live SwiftUI app: `setenv` can `realloc` `environ` underneath a
+    /// concurrent `getenv` or `posix_spawn` on another thread, so a suite
+    /// reaching for it is a process-wide data race that no amount of care
+    /// inside this class can contain. `ProcessGitCommandRunner` now takes
+    /// per-invocation `environment`, so nothing here escapes the child.
+    ///
+    /// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` need git >= 2.32; the older
+    /// `GIT_CONFIG_NOSYSTEM` is set too so isolation still holds below that.
+    /// Without them the sync steps would read the developer's / CI machine's
+    /// real global + system git config (default branch, gpg signing, hooks,
+    /// insteadOf rewrites).
+    private var gitIsolation: [String: String] {
+        [
+            "HOME": home.path,
+            "GIT_CONFIG_GLOBAL": home.appendingPathComponent(".gitconfig").path,
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0"
+        ]
     }
 
     // MARK: - Tests
@@ -129,7 +167,7 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         let note = vault.appendingPathComponent("2026-01-02 Meeting.md")
         try write("# Meeting\n\nSummary body.\n", to: note)
 
-        let syncer = ObsidianGitSyncer(runner: Self.boundedRunner())
+        let syncer = ObsidianGitSyncer(runner: boundedRunner())
         let error = await syncer.sync(vault: vault,
                                       changedPaths: [note],
                                       branch: "main",
@@ -160,7 +198,7 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         // the remote's commit, then push both.
         let note = vault.appendingPathComponent("a.md")
         try write("local-added\n", to: note)
-        let syncer = ObsidianGitSyncer(runner: Self.boundedRunner())
+        let syncer = ObsidianGitSyncer(runner: boundedRunner())
         let error = await syncer.sync(vault: vault,
                                       changedPaths: [note],
                                       branch: "main",
@@ -183,9 +221,10 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
     /// grace) is ~780s against a 240s allowance. One wedged command would take
     /// the test host with it instead of failing the test. 20s is still ~4
     /// orders of magnitude above what a local-path git command costs.
-    private static func boundedRunner() -> ProcessGitCommandRunner {
+    private func boundedRunner() -> ProcessGitCommandRunner {
         var runner = ProcessGitCommandRunner()
         runner.timeout = 20
+        runner.environment = gitIsolation
         return runner
     }
 
@@ -196,10 +235,13 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         process.arguments = arguments
         process.currentDirectoryURL = directory
         var env = ProcessInfo.processInfo.environment
-        env["HOME"] = home.path
-        env["GIT_TERMINAL_PROMPT"] = "0"
-        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        for (key, value) in gitIsolation { env[key] = value }
         process.environment = env
+
+        // Exit notification that costs no thread at all, installed before
+        // `run()` — mirrors `ProcessGitCommandRunner.runSync` (issue #246).
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
 
         let out = Pipe(), err = Pipe()
         process.standardOutput = out
@@ -216,12 +258,19 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         // is synchronous: the rule prefers `Task.detached` specifically to
         // avoid blocking a cooperative thread from an *async* context, which
         // this is not.
+        //
+        // The readers run on threads of their OWN rather than on
+        // `DispatchQueue.global()` (issue #246). `availableData` blocks until
+        // EOF, and the global queues are non-overcommit: a pooled thread
+        // parked in a blocking read is one the whole process loses, and the
+        // items queued behind it then wait to be *scheduled* — which is what
+        // the dispatch latency `pipeDrainTimeout` describes actually was.
         let lock = NSLock()
         var outData = Data(), errData = Data()
         let drain = DispatchGroup()
         for (pipe, isStdout) in [(out, true), (err, false)] {
             drain.enter()
-            DispatchQueue.global().async {
+            BlockingWork.onDedicatedThread(named: "mila.test.git.drain") {
                 // Append chunk-by-chunk rather than one `readDataToEndOfFile()`
                 // — the same shape as `ProcessGitCommandRunner.runSync`, and
                 // load-bearing now that the drain below is bounded.
@@ -252,29 +301,35 @@ final class ObsidianGitSyncerIntegrationTests: XCTestCase {
         // killed the test host — a red run naming a test with no reason
         // attached, and one the retry policy cannot recover. See
         // `gitCommandTimeout` for why that distinction is the whole point.
-        let running = DispatchGroup()
-        running.enter()
-        DispatchQueue.global().async {
+        //
+        // The exit is now observed by `terminationHandler` (installed above)
+        // with `waitUntilExit()` on a dedicated thread as a backstop, rather
+        // than by a `waitUntilExit()` parked on the global queue. That is what
+        // produced this suite's most legible failure to date (issue #246):
+        //
+        //     git checkout -b main did not exit within 60s and was killed
+        //       (stderr so far: Switched to a new branch 'main'
+        //
+        // `Switched to a new branch 'main'` is git's own success message, so
+        // git had run, succeeded, and written to a pipe we were reading — and
+        // 65s later the work item meant to notice its exit still had not been
+        // scheduled.
+        BlockingWork.onDedicatedThread(named: "mila.test.git.reap") {
             process.waitUntilExit()
-            running.leave()
+            exited.signal()
         }
         var timedOut = false
-        if running.wait(timeout: .now() + .seconds(Int(Self.gitCommandTimeout))) == .timedOut {
+        if exited.wait(timeout: .now() + .seconds(Int(Self.gitCommandTimeout))) == .timedOut {
             timedOut = true
             process.terminate()
-            if running.wait(timeout: .now() + 2) == .timedOut {
+            if exited.wait(timeout: .now() + 2) == .timedOut {
                 kill(process.processIdentifier, SIGKILL)
-                _ = running.wait(timeout: .now() + 3)
+                _ = exited.wait(timeout: .now() + 3)
             }
         }
         // Bounded too: EOF is not guaranteed even after exit, because a helper
-        // `git` spawned can inherit the pipes and outlive it.
-        //
-        // The bound is generous on purpose. 5s was too tight and it regressed
-        // this suite: `executeProcess` documents 10-15s of dispatch latency on
-        // this CI image, and each `runGit` now parks three blocking work items
-        // on the global queue, so a reader simply not being SCHEDULED inside 5s
-        // is ordinary here, not pathological.
+        // `git` spawned can inherit the pipes and outlive it. See
+        // `pipeDrainTimeout` for why the bound is generous.
         let drained = drain.wait(timeout: .now() + .seconds(Int(Self.pipeDrainTimeout))) != .timedOut
         // Take the lock: unlike an unbounded `drain.wait()`, the readers are
         // not guaranteed to be finished here.

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -847,10 +847,18 @@ final class TranscriptionServiceTests: XCTestCase {
 
         // Force the post-completion compression to FULLY complete: this renames
         // the WAV to .m4a and deletes the WAV — exactly the on-disk state the CI
-        // flake hit when compression won the race against re-transcribe. (The
-        // first pass also auto-kicks a compression; awaiting here is idempotent
-        // and guarantees the on-disk file is the .m4a regardless of which won.)
-        await store.compressRecordingAudio(id: fixture.recording.id)
+        // flake hit when compression won the race against re-transcribe.
+        //
+        // Via `drainPostCompletionCompression`, NOT a bare
+        // `await store.compressRecordingAudio(id:)`. That call is not a join:
+        // its `compressingIDs` guard is taken before the first suspension, so
+        // when the first pass's auto-kicked transcode is already mid-encode our
+        // call returns straight back having done nothing, and the assertions
+        // below then run against the still-`.wav` state. That is a scheduling
+        // race, not a code fault, and it is what this test failed on in CI —
+        // three wrong values in 0.124s, i.e. it never paid for an encode
+        // (issue #255). The helper waits for the observable end state instead.
+        await drainPostCompletionCompression(fixture.recording.id)
         let compressed = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
         XCTAssertTrue(compressed.audioFileName.lowercased().hasSuffix(".m4a"),
                       "Compression should have swapped the audio to .m4a")
@@ -886,10 +894,14 @@ final class TranscriptionServiceTests: XCTestCase {
         await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 1, text: "done")])
         service.enqueue(fixture.recording)
         await service.waitForIdle()
-        await store.compressRecordingAudio(id: fixture.recording.id)
+        // Same reason as the test above: `compressRecordingAudio` no-ops rather
+        // than joins when the auto-kicked transcode is already in flight, so
+        // wait for the end state (issue #255).
+        await drainPostCompletionCompression(fixture.recording.id)
 
         let beforeName = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id }).audioFileName
-        XCTAssertTrue(beforeName.lowercased().hasSuffix(".m4a"))
+        XCTAssertTrue(beforeName.lowercased().hasSuffix(".m4a"),
+                      "compression must have run before this asserts on its result")
 
         let prepared = try XCTUnwrap(store.prepareForRetranscription(id: fixture.recording.id, language: "en"))
         XCTAssertEqual(prepared.audioFileName, beforeName, "audioFileName must be preserved")


### PR DESCRIPTION
Closes #250
Closes #255

Part of #246 — threads 1, 3 and 4. **Deliberately does not close #246**: its `MicrophoneConfigurationChangeTests` thread is untouched and stays open there (see "What I left alone" below). #250 is the narrower issue this actually fixes; #255 is a second scheduling-shaped test flake this PR surfaced and fixes.

## What & why

### The diagnosis

`LLMRunner.executeProcess`, `ProcessGitCommandRunner.runSync` and the `runGit` helper in `ObsidianGitSyncerIntegrationTests` each parked **three blocking work items on `DispatchQueue.global()` per invocation** — two pipe readers in `FileHandle.availableData` until EOF, one thread in `Process.waitUntilExit()` — and the caller then blocked a fourth pooled thread on the resulting `DispatchGroup`. `LLMRunner.run`/`.diagnose` and `ProcessGitCommandRunner.run` supplied that fourth one explicitly.

The global concurrent queues are **non-overcommit**: libdispatch will not spin up a thread for a queued item just because the existing ones are blocked in the kernel. It notices the stall on a delay and grows the pool slowly, up to a hard cap. So every blocking item parked there makes the next one slower to be **scheduled at all**, and that delay is unbounded in the bad case.

That is not a new observation here — it is the "10-15s of dispatch latency on this CI image" several comments in this repo already treat as ordinary, and it is why `pipeDrainTimeout` had to be widened from 5s to 30s in #245. The latency *was* the bug; it was being budgeted for rather than removed.

### The evidence it was the wait, not the command

The #245 instrumentation earned its keep. From `unit-and-ui-tests` on `f0b663f`:

```
git checkout -b main did not exit within 60s and was killed
  (stderr so far: Switched to a new branch 'main'
```

`Switched to a new branch 'main'` is **git's own success message**. git ran, completed its work, and wrote to a pipe we were reading — and 65s later the item meant to observe its exit still had not run.

The overshoot arithmetic seals it. Each of the three failures in that run exceeded its own bound by almost exactly the SIGTERM + SIGKILL grace of the code reporting it — `executeProcess` 1 + 5 = 6s (observed 6.8s, 6.3s), `runGit` 2 + 3 = 5s (observed 5.9s). In every case the exit observer never reported in **even after the child was killed**. That is a work item that was never scheduled, not a command that was slow.

### The fix

- New `Mila/Actions/BlockingWork.swift`: `onDedicatedThread(named:)`, a named `Thread` per blocking wait. Not starvable, and not a starver; a reader that leaks (a grandchild holding a pipe open forever) costs one thread instead of a slot the whole process shares. **No `DispatchQueue.global()` call sites remain in the repo** — `grep` finds only comments.
- The exit is observed by `Process.terminationHandler` + a `DispatchSemaphore`, installed before `run()`, which costs no thread at all. `waitUntilExit()` stays on a dedicated thread as a **backstop**, because `executeProcess` documents a macOS 26 reaping race where it never returns even after `SIGKILL` — the two paths fail independently, whichever notices first signals, and every wait is bounded so a double signal is harmless.
- `ProcessGitCommandRunner` gains a per-invocation child `environment`, which is what lets the Obsidian suite stop calling `setenv` on the test **host**. The host is a live SwiftUI app; `setenv` can `realloc` `environ` underneath a concurrent `getenv`/`posix_spawn`, and no amount of care inside one test class contains that.
- `.claude/rules/python-subprocess.md` gains the rule, next to the existing pipe-drain rule that BUGBOT already reads.

### What bounds the thread count

An invocation costs **four** threads for the child's lifetime (2 pipe readers, 1 `waitUntilExit()` backstop, 1 blocked caller), so the ceiling is 4 × concurrent **child processes** — and every spawning path is already bounded upstream, by limits that exist to bound *processes*, which is the scarcer resource:

| caller | bound | children |
|---|---|---|
| `RecordingSummarizer` backfill / regeneration | `maxConcurrent = 2` + `backfillQueue`; exists "so a 20-recording catch-up sweep doesn't fork 20 `claude -p` subprocesses" | 2 |
| `LiveAISession` ticks | one `inFlight` Task + coalescing | 1 |
| `PostRecordingCoordinator` | one in-flight handle | 1 |
| `RenameRecordingSheet` "Suggest" | one modal sheet, guarded by `isFetchingName` | 1 |
| `LLMSettings.diagnose` | one Settings panel, user-driven | 1 |
| `ProcessGitCommandRunner` via `ObsidianGitSyncer` | an `actor`; `sync` issues commands sequentially | 1 |

Worst case — batch re-summarise during a live meeting with an Obsidian sync — is ~7 children, ~28 transient threads, against a per-process limit in the hundreds. The only path that could fan out is the one that is *explicitly* capped, at 2.

This is the **same** concurrency as before: the old code created the same work items, they just contended for a capped pool, which is what starved. The change moves where concurrency lands; it does not raise it. A cap inside `BlockingWork` would be a regression rather than a safeguard — limiting thread creation there re-queues blocked work behind a bound, which is the original bug in a smaller box. That is now an explicit "do not add a cap here" in the type's docs and in the rules file, pointing new batch callers at `RecordingSummarizer.maxConcurrent` as the pattern. The whole accounting lives in `BlockingWork`'s doc comment so it is reviewable in-tree.

### The two `LLMSandboxDirectoryTests` budgets

Local arithmetic, independent of load, and worth fixing on their own merits:

- **`test_a_oneshot_run_does_not_sweep_a_concurrent_tick`** gave its tick `timeout: 120`, but the barrier that lets the tick return is written only after `waitForFile(ready, timeout: 60)` and a `timeout: 60` one-shot — **60 + 60 = exactly the tick's own budget**, i.e. zero margin by construction. Observed failing with `timedOut(seconds: 120)` at 126.8s. The sub-waits shrink to 20 + 30; the tick's bound is **not** raised, because 120s is already half the 240s `-default-test-execution-time-allowance` and crossing that swaps a retryable failure for the unretryable host kill #245 existed to remove. A new `test_tick_budget_exceeds_the_waits_it_spans` asserts `tickTimeout > 2 × (tickReadyTimeout + spawnTimeout)` and `tickTimeout < 240`, so the next person to touch a number finds out in milliseconds rather than in two minutes.
- **`test_session_runs_share_the_same_directory_as_oneshot_runs`** spawned six children; the last two only re-ran the session/resume pair to look at argv. One echo script for all four runs cuts it to four spawns (~156s worst case rather than ~234s against a 240s allowance) while asserting **strictly more**. The fixture now emits `ARGC:$#` alongside the joined `$*`, and the test asserts `argc == oneShot.argc + 2` for both session modes *before* it looks at the uuid — a check that depends on no string matching and would catch a production path that stopped emitting `--session-id`/`--resume` (every Live AI tick would then silently start a fresh conversation instead of continuing the meeting). Plus two negative cases the old shape never had.

### Obsidian isolation

- Temp roots are named after the test that created them, and `setUp` — not `tearDown` — asserts every earlier root is gone, so a leak is attributed to the test that caused it. `tearDown` reports a *failed* removal rather than swallowing it with `try?`, which is the only way the last test in the class can report its own leak.
- `setenv`/`unsetenv` are gone; git-config isolation is per-invocation child environment for both `runGit` and the production runner.

### #255 — a second scheduling-shaped flake this PR surfaced

`RecordingStore.compressRecordingAudio(id:)` takes its `compressingIDs` guard before the first suspension: it is "start one unless one is running", not "wait for one". The completion path kicks an unawaited `Task { await store.compressRecordingAudio(id:) }` that `waitForIdle()` does not cover, so two tests using it as a barrier got one only when the auto-kicked transcode had already finished — or had not started. In the middle state they awaited nothing and asserted against still-`.wav` state (three wrong values in 0.124s: never paid for an encode).

`TranscriptionServiceTests` already had the right helper, `drainPostCompletionCompression`, whose doc comment spells the mechanism out; these two older tests were never migrated to it. They are now, so the only bare `compressRecordingAudio` call left in the bundle is inside the helper. No assertion is weakened. Not a production regression — the whole compression path is byte-for-byte identical to `main` on this branch and `AudioCompressor` is AVFoundation-only; this PR's scheduling change is what moved a latent race into the reachable window.

## What I left alone, and why

**`MicrophoneConfigurationChangeTests`.** It has still never produced a failure message, including in the green runs on this branch. #246 is explicit that its wall-clock-shaped assertions (`posts > 10` after a 0.6s burst at 15ms cadence; `restartCount <= 2` against a 1s `minimumRebuildInterval`) must not be tuned blind, and I agree: the burst window is genuinely load-bearing for the `restartCount` assertion, so "just use a fixed iteration count" would trade one wall-clock dependency for a worse one. It also spawns no subprocesses, so nothing here should move it either way — which makes its next occurrence a clean signal rather than a confounded one. It stays on #246.

**The 30s drain grace that can return an empty string from a successful run.** Still there in `executeProcess`. This PR removes the thing that made it *fire* (readers are now scheduled immediately) and hardens the caller that was blind to it, but the underlying return-success-with-no-output behaviour is a separate design question I did not want to change unvalidated.

## How it was tested

**Not tested locally — there is no Swift toolchain in this environment, so CI is the only compiler.** No claim is made beyond what CI reports.

On `b2df3cb`: `build-and-test` ✅, `unit-and-ui-tests` ✅, Cursor Bugbot ✅ (zero findings), both e2e jobs ✅, UI layout ✅. The `Summarise test failures` step reported **one** failed execution in the whole bundle — the compression test, now fixed in `35991bc` — and **none** of the #246 family: no `LLMSandboxDirectoryTests`, no `ObsidianGitSyncerIntegrationTests.test_sync_rebases…`, no `LLMRunnerTests`, no `LiveAIDeletedLineSessionTests`, and no timeout anywhere in the run.

One clean run is consistent with the fix working, not proof of it, against a ~20% historical rate. What raises it above luck is that the four tests failed as a group under load and the run is clean of all four at once, and the diagnosis predicted exactly which would stop and why. The **`Failed test-case executions`** count remains the metric. No test is skipped, quarantined or retried to get there.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — cannot be run here; CI is the compiler, and `build-and-test` is green
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, no user-facing change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core subprocess lifecycle (LLM CLI, git sync) and thread usage; behavior is intended to be equivalent but mis-tuned timeouts or semaphore handling could affect cancellation or output capture under edge cases.
> 
> **Overview**
> Fixes **issue #246**-style CI hangs where fast commands (e.g. `git checkout`) hit timeouts even though stderr already showed success — caused by parking pipe drains and `waitUntilExit()` on **non-overcommit** `DispatchQueue.global()`, so exit observers could sit unscheduled for tens of seconds.
> 
> **Production:** Adds `BlockingWork.onDedicatedThread(named:)` and moves all blocking subprocess work in `LLMRunner` and `ProcessGitCommandRunner` onto named dedicated threads. Child exit is signaled via **`terminationHandler` + bounded `DispatchSemaphore` wait** (installed before `run()`), with `waitUntilExit()` kept on a dedicated thread as a macOS 26 backstop. `ProcessGitCommandRunner` gains **per-invocation child `environment`** so tests can isolate git config without `setenv` on the SwiftUI test host. Documents the rule in `.claude/rules/python-subprocess.md`.
> 
> **Tests:** Hardens flakes exposed under load — Obsidian integration uses child env + same threading model; sandbox tests tighten timeout budgets and merge argv/cwd checks into four spawns; Live AI waits use `mustHappen` vs `quietWindow`; microphone storm test lowers the notification-count precondition; transcription tests **`drainPostCompletionCompression`** instead of a no-op `compressRecordingAudio` when auto-compression is in flight (**#255**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8d2e3ee9300445351405b1e3fb8d1dd2de2de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability and responsiveness when running AI and Git operations, especially under heavy or constrained system load.
  - Added safer timeout and process-cleanup handling to prevent operations from hanging indefinitely.
  - Improved Git synchronization cleanup and output handling, including more reliable completion detection.

- **Tests**
  - Expanded coverage for session isolation, timing behavior, temporary-directory cleanup, audio compression completion, and configuration-change bursts.

- **Documentation**
  - Clarified guidance for safely running blocking subprocess work and controlling concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->