### PR TITLE
fix(tests): await the tick, not a clock, in the Live AI recovery suite

### DIFF
--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -32,6 +32,26 @@ final class LiveAISession: ObservableObject {
     private let liveAISettings: LiveAISettings
 
     private var inFlight: Task<Void, Never>?
+
+    /// Test seam: the task currently occupying the serialization slot above.
+    /// Read-only, and it exposes the one piece of state the suites pinning
+    /// this class otherwise have no way to see.
+    ///
+    /// The failure they exist to catch is a *stranded* slot — a tick task that
+    /// has finished while `inFlight` still points at it, after which
+    /// `scheduleKick` coalesces every later tick behind a task that will never
+    /// clear and Live AI is silently dead for the rest of the meeting. From
+    /// outside, a strand and a slow machine look identical: both are just "the
+    /// next call hasn't happened yet". So the tests had to bet a wall-clock
+    /// number on the difference, and the bet was wrong twice — 5s in #242, and
+    /// 30s in #251, which is the one a loaded CI runner tripped as issue #256.
+    ///
+    /// With the handle visible a test can `await` the exact tick it is
+    /// reasoning about and then read the slot: still the same handle means
+    /// stranded, and it means it *now*, with no waiting and no guess. Nothing
+    /// in the app reads this.
+    var inFlightTickForTesting: Task<Void, Never>? { inFlight }
+
     /// Set when a tick fires while a call is in flight — the next idle
     /// moment will fire one more pass against the latest transcript so
     /// late chunks are never dropped.

--- a/MilaTests/LiveAIDeletedLineSessionTests.swift
+++ b/MilaTests/LiveAIDeletedLineSessionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import Mila
 
@@ -158,8 +159,16 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     /// behind a task that will never clear -- Live AI silently stops for the
     /// rest of the meeting.
     ///
-    /// Revert the `defer` and this hangs at the second wait. (CodeRabbit
-    /// raised the mechanism on #242; verified against the code before fixing.)
+    /// Revert the `defer` and this fails at the strand check below.
+    /// (CodeRabbit raised the mechanism on #242; verified against the code
+    /// before fixing.)
+    ///
+    /// There is deliberately no wall-clock bound left in here. The chain this
+    /// used to wait on -- gate release -> the in-flight task finishes -> its
+    /// `defer` runs -> `coalesced` is observed -> `scheduleKick` fires -> the
+    /// new tick records its call -- is awaited one link at a time instead, so
+    /// a wedge is read off the state rather than inferred from elapsed time.
+    /// See `waitUntil` for why the bound had to go rather than be re-tuned.
     func test_deleting_during_an_in_flight_tick_recovers_on_a_new_session() async {
         let gate = Gate()
         defer { gate.releaseAll() }
@@ -167,8 +176,20 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
                                            hold: gate)
 
         session.feed(transcript: "[00:00] One.\n[00:05] Two.", immediate: true)
-        let started = await waitUntil { calls.value.count == 1 }
-        XCTAssertTrue(started, "precondition: the first tick must actually be in flight")
+        // `kick()` fills the slot synchronously, so "a tick launched at all"
+        // is a fact the instant `feed` returns -- assert it here, where a
+        // failure is immediate, rather than folding it into a wait.
+        guard let dropped = session.inFlightTickForTesting else {
+            XCTFail("precondition: the first tick must occupy the in-flight slot")
+            return
+        }
+        // Then let the gate say when that tick is inside the runner; its only
+        // suspension point is the park, so it must arrive. Inferring this from
+        // `calls.value.count` instead left a window in which `release(1)`
+        // below ran before the park had recorded its continuation -- a lost
+        // wakeup, which strands the tick and is indistinguishable from the
+        // product wedge this test is about. See `Gate`.
+        await gate.awaitPark(1)
 
         // The user deletes "Two." while that call is still running, and the
         // feed loop follows with the shortened transcript -- which coalesces,
@@ -177,19 +198,37 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         session.feed(transcript: "[00:00] One.", immediate: true)
 
         gate.release(1)
+        // Await the dropped tick itself. It has to end -- the gate just
+        // released its only suspension point -- and everything under test
+        // happens in its `defer`, which runs before the task completes.
+        _ = await dropped.value
 
-        // `mustHappen`, not a hand-picked 5s: this waits on a chain of six
-        // hops (gate release -> the in-flight task finishes -> its `defer`
-        // runs -> `coalesced` is observed -> `scheduleKick` fires -> the new
-        // tick records its call), and a wedge never completes it however long
-        // we wait. See `mustHappen`.
-        let recovered = await waitUntil { calls.value.count == 2 }
-        XCTAssertTrue(recovered,
-                      "the replacement tick never ran within \(Int(Self.mustHappen))s. "
-                      + "The behaviour under test is that a dropped tick must not "
-                      + "strand `inFlight` — if it did, every later tick coalesces "
-                      + "behind a task that never clears and Live AI is silently "
-                      + "dead for the rest of the meeting")
+        // The wedge is now a fact rather than a deadline: the tick has
+        // finished, so if the slot still holds it, it is stranded, and it is
+        // stranded *now*. No amount of extra waiting would change the answer,
+        // which is exactly what made a bound the wrong instrument here.
+        //
+        // The replacement is created inside that same `defer`, so if one was
+        // scheduled it is in the slot by now -- but nothing parks it (only
+        // call 1 parks), so it may equally have run to completion already, in
+        // which case the slot is empty and the call count below is what
+        // reports success.
+        if let replacement = session.inFlightTickForTesting {
+            if replacement == dropped {
+                XCTFail("Live AI wedged: the dropped tick left `inFlight` set, so every "
+                        + "later tick coalesces behind a task that never clears and Live "
+                        + "AI is silently dead for the rest of the meeting")
+                return
+            }
+            _ = await replacement.value
+        }
+
+        guard calls.value.count == 2 else {
+            XCTFail("the slot was released but the coalesced re-kick the deletion "
+                    + "queued never ran, so the post-deletion transcript never "
+                    + "reaches the model (recorded \(calls.value.count) call(s))")
+            return
+        }
         XCTAssertEqual(kind(calls.value[1].session), "new",
                        "the replacement tick must open a new session, not resume the abandoned one")
         XCTAssertTrue(calls.value[1].transcript.contains("One."))
@@ -215,37 +254,47 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     /// deliberately, matching `PostRecordingCoordinator.sendToLLM`.
     /// (Bugbot on #242, a86b392.)
     func test_a_cancelled_tick_does_not_clobber_the_next_recordings_tick() async {
-        let gate = Gate()
-        gate.parkThrough = 2
+        let gate = Gate(parkThrough: 2)
         defer { gate.releaseAll() }
         let (session, calls) = makeSession(suite: "LiveAIDeletedLineSessionTests.clobber",
                                            hold: gate)
 
         session.feed(transcript: "[00:00] First meeting.", immediate: true)
-        let firstStarted = await waitUntil { calls.value.count == 1 }
-        XCTAssertTrue(firstStarted,
-                      "precondition: recording one's tick must be in flight")
+        guard let abandoned = session.inFlightTickForTesting else {
+            XCTFail("precondition: recording one's tick must be in flight")
+            return
+        }
+        await gate.awaitPark(1)
 
         // The recording stops and a new one starts before the LLM answers.
         session.cancel()
         session.start()
         session.feed(transcript: "[00:00] Second meeting.", immediate: true)
-        let secondStarted = await waitUntil { calls.value.count == 2 }
-        XCTAssertTrue(secondStarted,
-                      "precondition: the new recording's tick must have started")
+        guard let live = session.inFlightTickForTesting, live != abandoned else {
+            XCTFail("precondition: the new recording's tick must have started and "
+                    + "must own the in-flight slot")
+            return
+        }
+        await gate.awaitPark(2)
 
-        // Let the ABANDONED tick finish, underneath the live one.
+        // Let the ABANDONED tick finish, underneath the live one, and wait for
+        // it to actually be finished before opening the quiet windows below.
+        // Polling for its side effects instead meant the windows also had to
+        // cover it finishing at all, which weakens exactly the assertions that
+        // depend on the window being quiet for a reason.
         gate.release(1)
+        _ = await abandoned.value
 
         // Asserted as a negative, because the harm is state being cleared that
         // belongs to the tick still running.
         //
-        // `quietWindow`, deliberately NOT `mustHappen`: these two are watching
-        // for something that must never happen, so the timeout is a window of
-        // required quiet rather than a deadline. `waitUntil` returns the moment
-        // its condition holds, so the full budget is spent only when the
-        // assertion PASSES — widening it would slow every green run and would
-        // make a spurious pass more likely, not less. See `quietWindow`.
+        // `quietWindow`, and these two are the only waits in the suite that
+        // still take a clock at all: they are watching for something that must
+        // never happen, so the timeout is a window of required quiet rather
+        // than a deadline. `waitUntil` returns the moment its condition holds,
+        // so the full budget is spent only when the assertion PASSES —
+        // widening it would slow every green run and would make a spurious
+        // pass more likely, not less. See `quietWindow`.
         let wentIdle = await waitUntil(timeout: Self.quietWindow) { !session.isThinking }
         XCTAssertFalse(wentIdle,
                        "the cancelled tick cleared `isThinking` while the new recording's tick was still running")
@@ -256,9 +305,12 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
         // And the surviving tick still completes normally once released.
         gate.release(2)
-        let drained = await waitUntil { !session.isThinking }
-        XCTAssertTrue(drained,
-                      "the new recording's tick must still finish and clear state on its own")
+        _ = await live.value
+        XCTAssertFalse(session.isThinking,
+                       "the new recording's tick must still finish and clear state on its own")
+        XCTAssertEqual(calls.value.count, 2,
+                       "no further call may have started: nothing fed the session after "
+                       + "recording two's first tick")
     }
 
     // MARK: - Helpers
@@ -277,27 +329,110 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     /// their own index, so a test can let an EARLIER tick finish while a later
     /// one is still parked -- the only way to reproduce an abandoned tick
     /// completing underneath its replacement.
+    ///
+    /// **Order-independent by construction, which is the whole point.** The
+    /// two halves of the handshake do not necessarily run in the same place:
+    /// `park` records its continuation inside `withCheckedContinuation`, whose
+    /// body only stays on the caller's executor on a toolchain carrying
+    /// SE-0420's `isolation:` parameter, while `release` is called straight
+    /// from the @MainActor test body. If the store lands after the release,
+    /// the wakeup is lost, the parked call never resumes, and `inFlight` is
+    /// never cleared -- a symptom identical to the product wedge these tests
+    /// exist to catch, permanent in the same way ("a wedge never completes it
+    /// however long we wait"), and machine-sensitive in exactly the way a
+    /// loaded CI runner is. That is issue #256's failure, and the version of
+    /// this gate that had `release(_:)` drop an unmatched wakeup on the floor
+    /// was the only one of the four gates in these suites that could lose it
+    /// (`ConcurrencyProbe.released` and `TestGate.isOpen` both guard the same
+    /// ordering; `OpenAICompatibleTests`' stub takes a lock).
+    ///
+    /// So: a `release(i)` that arrives before call `i` parks is remembered and
+    /// the park returns immediately, `awaitPark(_:)` lets a test wait for a
+    /// call to be genuinely parked instead of inferring it from the recorded
+    /// call count, and a lock makes both hold wherever the continuation body
+    /// runs. Deliberately a lock rather than an actor annotation: assuming
+    /// isolation would serialise the handshake is the assumption that broke,
+    /// and it is not one a reader should have to re-derive from the nesting.
     private final class Gate {
-        var parkThrough = 1
+        /// Calls with an index at or below this park; later ones run straight
+        /// through. `let`, so it cannot be mutated once a call might read it.
+        let parkThrough: Int
+
+        /// Guards every field below. See the type comment: the
+        /// `withCheckedContinuation` body and `release(_:)` are not reliably
+        /// on the same executor, so the ordering is enforced here rather than
+        /// assumed.
+        private let lock = NSLock()
         private var parked: [Int: CheckedContinuation<Void, Never>] = [:]
+        /// `release(i)` calls that arrived before call `i` parked.
+        private var releasedEarly: Set<Int> = []
+        /// Indices that have reached `park`, plus anyone waiting to hear it.
+        private var arrived: Set<Int> = []
+        private var arrivalWaiters: [(index: Int, cont: CheckedContinuation<Void, Never>)] = []
+        /// Set by `releaseAll()`: after the drain nothing may park again.
+        private var draining = false
+
+        init(parkThrough: Int = 1) { self.parkThrough = parkThrough }
 
         func park(_ index: Int) async {
             await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-                parked[index] = c
+                lock.lock()
+                arrived.insert(index)
+                let waking = arrivalWaiters.filter { $0.index == index }
+                arrivalWaiters.removeAll { $0.index == index }
+                // A release that beat this park still counts.
+                let straightThrough = draining || releasedEarly.remove(index) != nil
+                if !straightThrough { parked[index] = c }
+                lock.unlock()
+                for w in waking { w.cont.resume() }
+                if straightThrough { c.resume() }
             }
         }
 
-        /// Let one parked call proceed. Deliberately a continuation rather
-        /// than a polled flag: a cancelled task's `Task.sleep` returns
-        /// immediately, so a polling loop would spin the main actor hot for
-        /// exactly the tick this suite needs to keep suspended.
-        func release(_ index: Int) { parked.removeValue(forKey: index)?.resume() }
+        /// Let one call proceed, whether or not it has parked yet.
+        /// Deliberately a continuation rather than a polled flag: a cancelled
+        /// task's `Task.sleep` returns immediately, so a polling loop would
+        /// spin the main actor hot for exactly the tick this suite needs to
+        /// keep suspended.
+        func release(_ index: Int) {
+            lock.lock()
+            let parkedCall = parked.removeValue(forKey: index)
+            if parkedCall == nil { releasedEarly.insert(index) }
+            lock.unlock()
+            parkedCall?.resume()
+        }
 
-        /// Drain anything still parked, so a failed assertion leaves no
-        /// suspended task behind.
+        /// Suspend until call `index` is parked inside the stub, so a test can
+        /// act while a tick is demonstrably inside the runner without polling
+        /// a clock for it. Returns immediately if it already parked. Same
+        /// shape as `ConcurrencyProbe.waitUntilCurrent` in
+        /// `RecordingSummarizerBackfillTests`.
+        func awaitPark(_ index: Int) async {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                lock.lock()
+                if arrived.contains(index) || draining {
+                    lock.unlock()
+                    c.resume()
+                } else {
+                    arrivalWaiters.append((index: index, cont: c))
+                    lock.unlock()
+                }
+            }
+        }
+
+        /// Drain anything still parked or still waiting, so a failed assertion
+        /// leaves no suspended task behind.
         func releaseAll() {
-            for (_, c) in parked { c.resume() }
+            lock.lock()
+            draining = true
+            let stillParked = parked
+            let stillWaiting = arrivalWaiters
             parked.removeAll()
+            arrivalWaiters.removeAll()
+            releasedEarly.removeAll()
+            lock.unlock()
+            for (_, c) in stillParked { c.resume() }
+            for w in stillWaiting { w.cont.resume() }
         }
     }
 
@@ -329,38 +464,24 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
 
         let calls = Calls()
         let session = LiveAISession(llmSettings: llm, liveAISettings: live)
+        // Snapshot the gate's threshold here, on the main actor, rather than
+        // reading it back off `hold` from inside the stub -- the stub's own
+        // isolation is whatever the closure inherits, and this keeps a plain
+        // `Int` in the capture list either way.
+        let parkThrough = hold?.parkThrough ?? 0
         session.performCall = { call in
             calls.value.append(call)
             // Park early calls so the test can act while a tick is
             // demonstrably inside the runner.
             if let hold {
                 let index = calls.value.count   // 1-based: appended just above
-                if index <= hold.parkThrough { await hold.park(index) }
+                if index <= parkThrough { await hold.park(index) }
             }
             return #"{"summary":"ok","items":[]}"#
         }
         session.start()
         return (session, calls)
     }
-
-    /// Bound for a wait on something that MUST happen (the caller asserts the
-    /// result is `true`).
-    ///
-    /// Chosen on the principle that **the only way to exceed it is the failure
-    /// mode under test**. Every such wait here is for state that a genuine bug
-    /// leaves wrong *forever* — a wedged `inFlight` is never cleared, however
-    /// long you wait — so a generous bound removes contention-induced failures
-    /// without costing one bit of discriminating power. It is also free on a
-    /// passing run: the condition holds in milliseconds, so this budget is
-    /// spent only when the test is failing anyway.
-    ///
-    /// These were 2-5s, and the 5s one is what failed on a loaded CI runner
-    /// while reporting "Live AI wedged" — a diagnosis that was simply false;
-    /// the machine was slow (issue #250). Same mistake as the 5s pipe-drain
-    /// bound #245 had to widen. **Do not re-tighten them.** 30s still fails
-    /// fast against CI's 240s per-test allowance, and no test here makes more
-    /// than three of these waits, so the worst case stays well inside it.
-    private static let mustHappen: TimeInterval = 30
 
     /// Window for watching that something must NOT happen (the caller asserts
     /// the result is `false`).
@@ -374,12 +495,22 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
     /// scale these transitions happen on.
     private static let quietWindow: TimeInterval = 1
 
-    /// Spin until `condition` holds, or the timeout expires. Returns whether
+    /// Spin until `condition` holds, or the window expires. Returns whether
     /// it held -- callers assert on that rather than hanging the suite.
     ///
-    /// Defaults to `mustHappen` because that is the common case; a caller
-    /// asserting the result is `false` must pass `quietWindow` explicitly.
-    private func waitUntil(timeout: TimeInterval = LiveAIDeletedLineSessionTests.mustHappen,
+    /// **For negative assertions only**, which is why `timeout` is now
+    /// required rather than defaulted. It used to default to a `mustHappen`
+    /// bound of 30s for the positive waits; that constant is deliberately
+    /// deleted rather than re-tuned. A bound on a positive wait cannot tell a
+    /// wedge from a loaded runner -- both look like "it hasn't happened yet"
+    /// -- so no value is correct, and picking one was wrong at 5s (#242) and
+    /// wrong again at 30s (#251, tripped by #256). Every positive wait in this
+    /// suite now awaits the task it is actually reasoning about
+    /// (`LiveAISession.inFlightTickForTesting`, `Gate.awaitPark`,
+    /// `waitUntilIdle`), so a wedge is read off the state at the moment it
+    /// becomes true and a slow machine simply takes longer. Requiring the
+    /// argument keeps a future positive wait from quietly inheriting a number.
+    private func waitUntil(timeout: TimeInterval,
                            _ condition: () -> Bool) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -390,15 +521,27 @@ final class LiveAIDeletedLineSessionTests: XCTestCase {
         return condition()
     }
 
-    /// Settle an in-flight tick. Same `mustHappen` reasoning: a session that
-    /// never goes idle is broken, and the assertions after the call are what
-    /// report it — this wait only has to avoid expiring on a slow runner.
-    private func waitUntilIdle(_ session: LiveAISession,
-                               timeout: TimeInterval = LiveAIDeletedLineSessionTests.mustHappen) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while session.isThinking && Date() < deadline {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 1_000_000)
+    /// Settle whatever tick the preceding `feed` started, by awaiting the task
+    /// itself rather than polling `isThinking` against a clock.
+    ///
+    /// `makeSession` sets `llmMinIntervalSeconds = 0`, so every `feed` here
+    /// either launches a tick synchronously or declines to (an empty delta) --
+    /// there is never a `pendingKickTask` sleeping out a throttle floor with
+    /// the slot empty, which is the one case where "no task" would not mean
+    /// "settled". `nil` therefore means already settled.
+    ///
+    /// The loop drains a coalesced follow-up too, and stops as soon as the
+    /// slot stops changing. That last part matters: a STRANDED slot -- the
+    /// wedge this suite pins, a finished task still occupying `inFlight` --
+    /// returns immediately and lets the assertions report it, rather than
+    /// spinning hot the way `LiveAISession.awaitFinalTick`'s
+    /// `while let handle = inFlight` would.
+    private func waitUntilIdle(_ session: LiveAISession) async {
+        var previous: Task<Void, Never>?
+        while let tick = session.inFlightTickForTesting {
+            if let previous, previous == tick { break }
+            _ = await tick.value
+            previous = tick
         }
     }
 }

--- a/MilaTests/LiveAIMeetingContextTests.swift
+++ b/MilaTests/LiveAIMeetingContextTests.swift
@@ -211,14 +211,30 @@ final class LiveAIMeetingContextTests: XCTestCase {
         return (session, live, calls)
     }
 
-    /// Spin until the in-flight tick clears. The stub returns instantly, so
-    /// this resolves in a few hops; the timeout only guards a hang.
-    private func waitUntilIdle(_ session: LiveAISession,
-                               timeout: TimeInterval = 2) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while session.isThinking && Date() < deadline {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 1_000_000)
+    /// Settle whatever tick the preceding `feed` started, by awaiting the
+    /// task itself rather than polling `isThinking` against a clock.
+    ///
+    /// This was a 2s deadline that "only guards a hang" — the same wall-clock
+    /// bet that failed at 5s and then at 30s in the sibling suite
+    /// (`LiveAIDeletedLineSessionTests`, issues #242 / #251 / #256). A bound
+    /// on a positive wait cannot tell a hang from a loaded runner, so there is
+    /// no value to pick; awaiting the task removes the question. A hang now
+    /// belongs to the tick, where XCTest's own per-test limit reports it,
+    /// rather than being silently swallowed by a `while` that just stops.
+    ///
+    /// `makeSession` sets `llmMinIntervalSeconds = 0`, so every `feed` here
+    /// either launches a tick synchronously or declines to (an empty delta) —
+    /// there is never a `pendingKickTask` sleeping out a throttle floor with
+    /// the slot empty, which is the one case where "no task" would not mean
+    /// "settled". The loop drains a coalesced follow-up too, and stops as soon
+    /// as the slot stops changing, so a stranded slot returns immediately and
+    /// lets the assertions report it instead of spinning hot.
+    private func waitUntilIdle(_ session: LiveAISession) async {
+        var previous: Task<Void, Never>?
+        while let tick = session.inFlightTickForTesting {
+            if let previous, previous == tick { break }
+            _ = await tick.value
+            previous = tick
         }
     }
 }


### PR DESCRIPTION
Closes #256

## What & why

The issue offered two candidates for the 30s timeout on `main`: (1) a genuine intermittent stranded `inFlight` in `LiveAISession`, or (2) 30s not being generous enough on a loaded runner. **I could not confirm either, and I think both are wrong.** There is a third mechanism, it is in the test's own harness, and it produces exactly the observed signature.

### Why it is not (2)

The chain the test waits on contains **no sleep, no timer and no subprocess**. `makeSession` sets `llmMinIntervalSeconds = 0`, so the coalesced re-kick fired from the tick's `defer` goes through `scheduleKick` → `Self.kickDelay(...)`, which returns `0` immediately on its `guard minInterval > 0` — no `pendingKickTask`, no `Task.sleep`. Everything from `gate.release(1)` to the replacement call is main-actor hops over a stubbed `performCall` that returns a literal.

Thirty seconds of that is not "slow". It is *stopped*. A third number would not have helped, and neither would a bigger one.

### Why it is not (1)

I read the `defer` / `coalesced` / `scheduleKick` chain looking for an ordering that strands the slot. `LiveAISession` is `@MainActor` throughout, so every mutation of `inFlight` / `coalesced` / `sessionID` is serialised. The `defer` clears `inFlight` before calling `scheduleKick`, and `scheduleKick`'s `guard inFlight == nil` therefore passes; the only way the cleanup is skipped is `Task.isCancelled`, and the sole canceller (`cancel()`) clears the slot itself before cancelling. I could not construct an interleaving that leaves a non-cancelled tick's slot occupied. That is a reading, not a proof — but it is the same reading that says the chain has no wall-clock cost, and the two agree.

### What it actually is

`Gate`, in the test file.

```swift
func release(_ index: Int) { parked.removeValue(forKey: index)?.resume() }
```

A `release(i)` that arrives before call `i` has parked matched nothing and was dropped on the floor. And the two halves of that handshake are not reliably in the same place: `park` records its continuation inside `withCheckedContinuation`, whose body only stays on the caller's executor on a toolchain carrying SE-0420's `isolation:` parameter, while `release` is called straight from the `@MainActor` test body.

Now look at the ordering the failing test used:

```swift
let started = await waitUntil { calls.value.count == 1 }   // count appended in the stub…
session.noteTranscriptEdited()
session.feed(transcript: "[00:00] One.", immediate: true)
gate.release(1)                                            // …one statement BEFORE the park stores its continuation
```

If the store landed after the release, the wakeup was lost, the tick parked forever, `inFlight` was never cleared — and the symptom is **indistinguishable from the product wedge the test is about**, permanent in the same way ("a wedge never completes it however long we wait"). That is precisely why widening 5s → 30s bought nothing.

It fits the evidence in the issue better than either candidate:

- **Only this test failed.** It is the only one in the suite that calls `release` with no intervening await after observing the call count. The sibling clobber test waits for a *second* call before releasing, which closes the window.
- **Both retry iterations went red on one runner, three other runs were clean.** Contention widens the gap between a main-actor append and a pool-side continuation store; it does not add 30s to a chain that has no work in it.
- **It is the only one of the four gates in these suites that could lose a wakeup.** `ConcurrencyProbe.released` (`RecordingSummarizerBackfillTests`) and `TestGate.isOpen` (`RecordingSummarizerTests`) both check a released-flag before parking; `OpenAICompatibleTests`' stub takes a lock and re-checks inside the continuation body. This one did neither.

I could not download the xcresult (artifact `9812256914`) to settle it outright — the Actions artifact endpoint 302s to Azure blob storage and the proxy refuses the tunnel with `403`. So this remains a reading of the code plus the failure signature, not a recorded trace. **The fix does not depend on winning that argument**: it is correct under either continuation semantics, and it removes the ambiguity permanently.

## The change

**`Gate` becomes order-independent, under a lock.** A `release(i)` that beats its park is remembered and the park returns immediately; `parked` is guarded rather than assumed-serialised. Deliberately a lock rather than an actor annotation — assuming isolation would serialise the handshake is the assumption that broke.

**`Gate.awaitPark(_:)`** lets a test wait for a call to be genuinely inside the runner, instead of inferring it from the recorded count. Same shape as `ConcurrencyProbe.waitUntilCurrent`.

**`LiveAISession.inFlightTickForTesting`** — a read-only test seam returning the existing private `inFlight`. This is the load-bearing part. From outside, a stranded slot and a slow machine look identical: both are just "the next call hasn't happened yet". That ambiguity is *why* a wall-clock number had to be picked at all, and why it was wrong at 5s (#242) and again at 30s (#251). With the handle visible, the test awaits the exact tick it is reasoning about and then reads the slot: still the same handle means stranded, and it means it **now** — no waiting, no guess, and the wedge fails fast.

**`mustHappen` is deleted, not re-tuned.** The recovery test has no wall-clock bound left anywhere:

```swift
gate.release(1)
_ = await dropped.value        // the tick must end; its only suspension point was just released
if let replacement = session.inFlightTickForTesting {
    if replacement == dropped { XCTFail("Live AI wedged: …"); return }
    _ = await replacement.value
}
guard calls.value.count == 2 else { … }
```

`waitUntil` keeps a **required** (no longer defaulted) `timeout`, used only by the two negative assertions on `quietWindow = 1`. Per #251 that asymmetry is deliberate and preserved: `waitUntil` returns the instant its condition holds, so a negative assertion spends its full budget on every green run, and a longer window makes a spurious *pass* more likely. Making the argument mandatory stops a future positive wait from quietly inheriting a number.

Two incidental strengthenings fell out, both from removing polls rather than adding anything:

- The clobber test now awaits the abandoned tick's completion before opening its quiet windows. Previously the 1s window also had to cover that tick finishing at all, so on a slow run the negative assertions could pass vacuously — the thing they assert had not happened yet for an unrelated reason.
- `XCTAssertFalse(session.isThinking)` at the end of the recovery test used to be read the instant `calls.value.count` hit 2, which is inside the stub, before the tick's `defer` clears the flag. It is now read after the task has actually completed.

## Other bounds in the file, and the sweep

- Both `waitUntilIdle` helpers (this suite and `LiveAIMeetingContextTests`, the latter a 2s bet described as "the timeout only guards a hang") now await the task instead of polling a clock. No call sites changed. The drain loop stops as soon as the slot stops changing, so a stranded slot returns immediately and lets the assertions report it — rather than spinning hot the way `awaitFinalTick`'s `while let handle = inFlight` would.
- **`LiveAIThrottleTests` is deliberately left alone** despite having the same 2s `waitUntilIdle`. Its whole subject is *deferred* ticks, where `inFlight` is legitimately nil while a `pendingKickTask` sleeps out the floor — so "no task" does not mean "settled" there and this substitution would be wrong. Flagging rather than half-fixing.

## Adjacent observation, not fixed here

`LiveAISession.awaitFinalTick()`'s `while let handle = inFlight { _ = await handle.value }` would **hot-spin forever** on a stranded slot: the handle is already complete, so the await returns instantly and the loop re-reads the same handle. It is only reachable via the strand the `defer` exists to prevent, so it is a consequence rather than an independent bug, and fixing it is out of scope for this PR. Worth an issue if you want one.

## How it was tested

**Nothing was compiled or run locally.** There is no Swift toolchain and no Mac in the environment this was authored in (`download.swift.org` is proxy-blocked), so CI is the only compiler. The diff was re-read adversarially against that constraint; the specific things checked by hand were `Task`'s `Equatable` conformance, avoiding optional-promotion comparisons in favour of explicit `if let` forms, avoiding any cross-isolation read from the stub closure (the gate's threshold is snapshotted on the main actor as a plain `Int`), non-escaping `withCheckedContinuation` bodies permitting implicit `self`, and brace balance.

Every `waitUntilIdle` call site in both touched suites was checked to immediately follow a synchronous transcript-extending `feed(immediate: true)`, so the slot is always populated when the helper is entered.

- [ ] Builds locally (`make build`) and tests pass (`make test`) — not possible here, see above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, test-only behaviour change plus a read-only test seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a read-only production test hook; no user-facing Live AI behavior is altered.
> 
> **Overview**
> Addresses flaky CI on the Live AI **in-flight deletion recovery** tests by fixing the test harness and how waits are expressed, not by changing production scheduling logic.
> 
> **`LiveAISession`** gains a read-only **`inFlightTickForTesting`** seam so tests can `await` the exact tick task and detect a **stranded `inFlight` slot** immediately (same handle after completion) instead of guessing with 5s/30s timeouts.
> 
> **`LiveAIDeletedLineSessionTests`** reworks **`Gate`** to be **order-independent** (`NSLock`, early `release` remembered, **`awaitPark`**) so a `release` before `park` cannot lose a wakeup (issue #256). Recovery and clobber scenarios now chain **`awaitPark` → `release` → `await task.value`** and explicit strand checks; **`mustHappen`** is removed and **`waitUntil`** requires an explicit timeout (only for **negative** `quietWindow` assertions). **`waitUntilIdle`** awaits in-flight tasks (with stranded-slot detection) instead of polling **`isThinking`**.
> 
> **`LiveAIMeetingContextTests`** adopts the same **`waitUntilIdle`** pattern for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2749c5e99c46f5a668e3b78d8c4552d47a967a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for live AI session behavior when transcript lines are deleted.
  - Made asynchronous session tests more deterministic by waiting for actual processing to complete instead of relying on timing-based checks.
  - Added validation for session task coordination and follow-up processing during live meetings.
  - Strengthened synchronization checks to reduce flaky test results and improve confidence in live AI session stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->