### PR TITLE
fix(speakers): give back the profile weight a re-diarized name takes with it

### DIFF
--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -1262,37 +1262,24 @@ final class QuickActionsController: ObservableObject {
                 // the decision a waiting send is gated on and the work
                 // actually done here can never disagree.
                 if willRediarize {
-                    // Re-fetch before writing: the user may have renamed the
-                    // recording (rename sheet) while this tail was running, so
-                    // we update only the segments rather than clobbering the row.
+                    // The write itself re-fetches the row and touches only the
+                    // segments and the speaker names, rather than clobbering a
+                    // rename the user made while this tail ran — see
+                    // `applyRediarizedSpeakers`.
                     if let rediarized = await self.transcription.rediarizeSegments(
                         wavURL: self.store.audioURL(for: updated),
                         segments: updated.segments,
                         recordingID: id) {
                         let preRediarize = updated.segments
                         updated.segments = rediarized
-                        if var current = self.store.recordings.first(where: { $0.id == id }) {
-                            current.segments = rediarized
-                            // The offline pass re-keyed every SPEAKER_NN, so
-                            // names assigned mid-recording (or in the detail
-                            // view while this pass ran — hence the re-fetched
-                            // row's map, not the snapshot's) must follow the
-                            // utterances they labeled onto the new IDs.
-                            current.speakerNames = SpeakerNameRemapper.remap(
-                                names: current.speakerNames,
-                                from: preRediarize,
-                                to: rediarized)
-                            self.store.update(current)
+                        // Names, retired names and observations all move
+                        // together — see `applyRediarizedSpeakers`. `nil`
+                        // means the row left the store mid-pass; the local
+                        // copy still carries the new segments so the `.srt`
+                        // below is written from them.
+                        if let current = self.applyRediarizedSpeakers(
+                            rediarized, replacing: preRediarize, recordingID: id) {
                             updated = current
-                            // The observed embeddings follow the utterances
-                            // onto the new ids, on the same dominance mapping
-                            // the names just used. Anything else leaves the
-                            // profile contributions those names justified
-                            // impossible to reverse.
-                            self.onSpeakerIDsRekeyed?(
-                                id,
-                                SpeakerNameRemapper.dominantOldIDs(from: preRediarize,
-                                                                   to: rediarized))
                         }
                     }
                 }
@@ -1341,6 +1328,63 @@ final class QuickActionsController: ObservableObject {
                 self.transcription.enqueue(updated)
             }
         }
+    }
+
+    /// Land the offline re-diarize pass's re-keyed labels on the STORED row,
+    /// keeping the voice-profile bookkeeping straight. Returns the row as
+    /// written, or nil if the recording left the store mid-pass.
+    ///
+    /// The row is re-fetched rather than taken from `finalizeTail`'s local
+    /// copy: the user may have renamed the recording (rename sheet), or named
+    /// a speaker in the detail view, while the pass was running, so only the
+    /// segments and the speaker names are written.
+    ///
+    /// **Three things happen, and the order is the whole point.**
+    ///
+    /// 1. The names follow the utterances onto the new ids
+    ///    (`SpeakerNameRemapper.remap`) — the offline pass re-keys every
+    ///    `SPEAKER_NN`, so a name left on its old key would label whoever
+    ///    that number now denotes.
+    /// 2. Every name the re-key does NOT carry over is retired through
+    ///    `RecordingStore.update(_:retiringSpeakerNames:)`, which fires
+    ///    `onSpeakerUnnamed` for it. That subtracts exactly what naming that
+    ///    old id added: the observation backing it is still keyed to that id
+    ///    at this moment. Before island-io/mila#254 nothing fired here at
+    ///    all — the map was replaced wholesale, and the hooks fire only from
+    ///    `setSpeakerName` and friends — so a dropped name left its
+    ///    contribution in the profile with no label left to un-name.
+    /// 3. Only THEN are the surviving observations re-keyed
+    ///    (`onSpeakerIDsRekeyed` → `ObservedVoiceSnapshots.remapSpeakerIDs`).
+    ///
+    /// Step 2 strictly before step 3, because step 2 resolves through the
+    /// snapshot: after the re-key `SPEAKER_00` holds a different voice, so a
+    /// retire would subtract the wrong embedding — the cross-recording
+    /// confusion `ObservedVoiceSnapshots` exists to prevent, reintroduced
+    /// across a re-clustering boundary.
+    ///
+    /// All three read ONE `dominantOldIDs` mapping. That is a correctness
+    /// requirement, not a saving: the name, the retire decision and the
+    /// observation must agree about which old fragment each new id came from,
+    /// or a contribution gets subtracted from a profile it was never added to.
+    ///
+    /// `internal`, and split out of `finalizeTail`, so a test can drive this
+    /// sequence: `rediarizeSegments` needs a pyannote subprocess, so the
+    /// ordering is otherwise unreachable from CI.
+    @discardableResult
+    func applyRediarizedSpeakers(_ rediarized: [TranscriptSegment],
+                                 replacing preRediarize: [TranscriptSegment],
+                                 recordingID id: UUID) -> Recording? {
+        guard var current = store.recordings.first(where: { $0.id == id }) else { return nil }
+        let namesBeforeRekey = current.speakerNames
+        let newToOld = SpeakerNameRemapper.dominantOldIDs(from: preRediarize, to: rediarized)
+        current.segments = rediarized
+        current.speakerNames = SpeakerNameRemapper.remap(names: namesBeforeRekey,
+                                                         dominantOldIDs: newToOld)
+        store.update(current,
+                     retiringSpeakerNames: SpeakerNameRemapper.retiredNames(
+                        names: namesBeforeRekey, dominantOldIDs: newToOld))
+        onSpeakerIDsRekeyed?(id, newToOld)
+        return current
     }
 
     /// Await every in-flight background finalize tail. Test seam so a test

--- a/Mila/Models/ObservedVoiceSnapshots.swift
+++ b/Mila/Models/ObservedVoiceSnapshots.swift
@@ -250,11 +250,23 @@ final class ObservedVoiceSnapshots {
     ///
     /// **What is deliberately given up.** When the pass collapses several old
     /// ids into one — which is the main reason it runs — the non-dominant
-    /// fragments' observations are dropped rather than folded in. If such a
-    /// fragment had been named, its contribution stays in that profile and
-    /// un-naming will not remove it: residue.
+    /// fragments' observations are dropped rather than folded in, so that
+    /// audio stops contributing to any profile. That is an accuracy loss, and
+    /// it is the one taken on purpose.
     ///
-    /// **Why residue is the right side to err on, with the arithmetic.** An
+    /// **What is no longer given up.** A non-dominant fragment that had been
+    /// NAMED used to leave its contribution behind as residue: the re-key
+    /// dropped its name through a wholesale `speakerNames` write, so nothing
+    /// fired `onSpeakerUnnamed` and there was no label left to un-name. The
+    /// caller now retires such a name in the same operation and BEFORE this
+    /// runs — `SpeakerNameRemapper.retiredNames` decides which ones, and
+    /// `RecordingStore.update(_:retiringSpeakerNames:)` fires the hook while
+    /// the observation is still keyed to the old id, so the subtraction takes
+    /// back exactly what naming that id added. Same for the split case below.
+    /// What this type carries and what the profiles hold therefore stay
+    /// reconstructible from each other across a re-key (island-io/mila#254).
+    ///
+    /// **Why folding every fragment in is still wrong, with the arithmetic.** An
     /// earlier revision folded every fragment onto the survivor, reasoning
     /// that `finish` had folded them all into the profile. It has not:
     /// `finish` snapshots *every* pool entry but names only the ones seeded
@@ -268,23 +280,29 @@ final class ObservedVoiceSnapshots {
     /// through the on-demand path) and otherwise writes back a centroid
     /// dragged toward a voice the profile never received.
     ///
-    /// Residue is recoverable — the user can delete the profile and let it
-    /// re-learn. A deleted profile is not, and a quietly corrupted centroid
-    /// is worse than either, because it degrades recognition invisibly, which
-    /// is the failure this whole feature exists to remove. `main` under-
-    /// corrects on every path (it has no subtraction at all), so this is a
-    /// limitation the codebase already lives with rather than a new one.
+    /// Under-correcting is recoverable — the user can delete the profile and
+    /// let it re-learn. A deleted profile is not, and a quietly corrupted
+    /// centroid is worse than either, because it degrades recognition
+    /// invisibly, which is the failure this whole feature exists to remove.
     ///
     /// **Do not "fix" this by folding again without also knowing which
     /// fragments the profile actually received.** That information is not in
     /// this type — it holds what was *observed*, which stops being the same
-    /// thing the moment a fragment goes unnamed. See island-io/mila#254 for
-    /// the exact rule and the structural fix.
+    /// thing the moment a fragment goes unnamed. The retire pass above needs
+    /// no such knowledge: it only ever reverses a name that a hook already
+    /// applied, one fragment at a time.
     ///
     /// A split is the other direction: one old id dominating two new ids
     /// would hand its observation to both, and un-naming both would subtract
     /// it twice. Such an id is dropped rather than duplicated — again the
     /// under-correcting side.
+    ///
+    /// **The survival rule below — `timesDominant[oldID] == 1` — is mirrored
+    /// by `SpeakerNameRemapper.retiredNames`**, which retires exactly the
+    /// names whose old id does NOT survive it. Change one and change the
+    /// other: retiring a name whose observation is carried over subtracts the
+    /// same contribution twice, and not retiring one whose observation is
+    /// dropped is the residue this pair exists to remove.
     func remapSpeakerIDs(_ newToOld: [String: String], in recordingID: UUID) {
         guard let existing = byRecording[recordingID] else { return }
         var timesDominant: [String: Int] = [:]

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -468,6 +468,97 @@ final class RecordingStore: ObservableObject {
         return transcriptWritten && persisted
     }
 
+    /// `update(_:)` plus the one piece of bookkeeping a caller owes when it
+    /// replaces a recording's **whole** `speakerNames` map because a pass
+    /// re-keyed its `SPEAKER_NN` ids: `onSpeakerUnnamed` fires for every
+    /// `[oldID: previousName]` pair in `retired`, so the voice-profile
+    /// contribution each of those names justified is subtracted back out.
+    ///
+    /// Without it, a name the re-key drops takes its label away and leaves
+    /// its observation folded into that profile with nothing left to un-name
+    /// — #237's correction is unreachable for it, permanently
+    /// (island-io/mila#254).
+    ///
+    /// **One caller, deliberately.** Two paths replace the map wholesale. The
+    /// offline re-diarize remap
+    /// (`QuickActionsController.applyRediarizedSpeakers`) comes through here.
+    /// The batch pass's clear (`TranscriptionService.mergePassResult`) does
+    /// NOT, and it is not an oversight: `OfflineVoiceEmbedder.matchAfterPass`
+    /// runs immediately after that write, re-embeds every speaker and
+    /// re-matches them against the stored profiles — so a retire there would
+    /// subtract the weight the re-match is about to look the speaker up by,
+    /// and a profile whose only content came from that recording would be
+    /// deleted before the pass could restore its name. That path needs the
+    /// retire and the re-match designed together (see #254); the re-diarize
+    /// path has no re-match behind it, since it carries the names rather than
+    /// re-deriving them.
+    ///
+    /// **The one destructive case, and why it is left exact.** A retire
+    /// subtracts exactly what naming that id added, so a profile holding
+    /// nothing else reaches zero and `SpeakerProfileStore` removes it — which
+    /// is also precisely what un-naming that speaker by hand does today. It
+    /// is bounded to that: a profile carrying weight from any other recording
+    /// keeps it, so no other recording's contribution is ever touched, and
+    /// every profile seeded from a stored one survives by construction (it
+    /// had weight before this recording could add any). Clamping instead
+    /// would keep a name→voice mapping the pass has just contradicted — the
+    /// retired fragment's audio is now another speaker's — and would need a
+    /// second, quieter correction policy beside this hook.
+    /// `SpeakerCorrectionActionsTests.test_retiring_the_only_contribution_a_profile_ever_had_removes_it`
+    /// pins it so the trade is reviewable rather than incidental.
+    ///
+    /// **Call this BEFORE the observations are re-keyed.** The hook resolves
+    /// `rawID` through `ObservedVoiceSnapshots`, which is still keyed to the
+    /// ids these names were attached to; after the re-key `SPEAKER_00` is a
+    /// different voice and the subtraction would take the wrong embedding out
+    /// of the profile.
+    ///
+    /// **Why `retired` is caller-supplied instead of `update(_:)` diffing the
+    /// map.** Because a re-key changes what the KEYS mean, so no key-by-key
+    /// diff can be right. Take old `{00: Bob, 01: Alice}` becoming
+    /// `{00: Alice}` — new 00 is old 01's voice. A diff sees `00` change
+    /// `Bob → Alice` and `01` disappear, so it would fire
+    /// `onSpeakerNamed(00, "Alice")`, folding old 00's embedding (Bob's, since
+    /// the snapshot has not been re-keyed yet) into Alice's profile, and
+    /// `onSpeakerUnnamed(01, "Alice")`, taking back a contribution Alice
+    /// legitimately still holds — which then gets subtracted a second time
+    /// when the user un-names her, out of her other recordings. The pairing
+    /// of a name with the observation backing it, not the key it happens to
+    /// sit under, is the identity that matters; `SpeakerNameRemapper` is where
+    /// the mapping that establishes it lives, so that is where the retired
+    /// set is computed (`retiredNames`).
+    ///
+    /// **Only the retiring direction fires.** A re-key never *adds* a name: a
+    /// carried name is the same string its dominant old id already had, and
+    /// the observation moves onto the same new id, so the pair arrives intact
+    /// and firing `onSpeakerNamed` for it would double-count. Every genuinely
+    /// new name still comes through `setSpeakerName`, which fires the hooks
+    /// itself and does not route through `update(_:)` — so nothing here can
+    /// double-fire against it.
+    ///
+    /// The hooks run after the write, and nothing is read out of `recordings`
+    /// afterwards: a hook is caller-supplied code and may mutate the store,
+    /// which would invalidate an index held across it (the trap
+    /// `mergeSpeakers` documents). They run whether or not the write reached
+    /// disk, because `update(_:)` has already replaced the in-memory row —
+    /// skipping them would leave the profiles describing names the app no
+    /// longer shows.
+    @discardableResult
+    func update(_ recording: Recording,
+                retiringSpeakerNames retired: [String: String]) -> Bool {
+        // No row means the recording left the store mid-pass (hard-deleted,
+        // trash emptied). `update` writes nothing in that case, so this must
+        // not correct profiles for a change that did not happen.
+        guard recordings.contains(where: { $0.id == recording.id }) else { return false }
+        let persisted = update(recording)
+        // Sorted: `Dictionary` iteration order is unspecified per process and
+        // each of these can rewrite a profile on disk.
+        for (rawID, previousName) in retired.sorted(by: { $0.key < $1.key }) {
+            onSpeakerUnnamed?(recording.id, rawID, previousName)
+        }
+        return persisted
+    }
+
     /// Replace several stored records in one pass with a SINGLE persist, vs.
     /// `update(_:)`'s one full-file rewrite per call. Used by the launch
     /// crash-recovery sweep, which can flip many stale rows at once (a large
@@ -475,6 +566,14 @@ final class RecordingStore: ObservableObject {
     /// status/metadata bulk update — transcript/summary sidecars are left
     /// as-is (recovery doesn't change their content). Unknown ids are skipped;
     /// persists only if something actually changed.
+    ///
+    /// Deliberately fires no speaker hooks, unlike
+    /// `update(_:retiringSpeakerNames:)`: its callers copy live rows and
+    /// change `status`, and the launch sweep in particular runs before any
+    /// recording has been observed, so a name arriving through it has no
+    /// observation to reconcile — while `onSpeakerNamed` there would kick off
+    /// an on-demand embedding subprocess per row. A caller that ever needs to
+    /// move `speakerNames` in bulk must use the single-row method instead.
     func updateAll(_ updated: [Recording]) {
         var touched = false
         for recording in updated {

--- a/Mila/Transcription/SpeakerNameRemapper.swift
+++ b/Mila/Transcription/SpeakerNameRemapper.swift
@@ -57,11 +57,81 @@ enum SpeakerNameRemapper {
     static func remap(names: [String: String],
                       from old: [TranscriptSegment],
                       to new: [TranscriptSegment]) -> [String: String] {
+        remap(names: names, dominantOldIDs: dominantOldIDs(from: old, to: new))
+    }
+
+    /// `remap` for a caller that already holds the dominance mapping. The
+    /// re-diarize path needs it three times in a row — for the names, for the
+    /// names it RETIRES, and for the observations — and each
+    /// `dominantOldIDs` call re-tallies every segment. Same mapping for all
+    /// three is also the correctness requirement, not just a saving: see
+    /// `retiredNames`.
+    static func remap(names: [String: String],
+                      dominantOldIDs: [String: String]) -> [String: String] {
         guard !names.isEmpty else { return [:] }
         var remapped: [String: String] = [:]
-        for (newID, oldID) in dominantOldIDs(from: old, to: new) {
+        for (newID, oldID) in dominantOldIDs {
             if let name = names[oldID] { remapped[newID] = name }
         }
         return remapped
+    }
+
+    /// The `[oldID: name]` pairs the re-key **retires**: names whose observed
+    /// embedding does not travel with them onto a new id.
+    ///
+    /// **What this is for.** Naming a speaker folds that speaker's observed
+    /// embedding into the named voice profile
+    /// (`RecordingStore.onSpeakerNamed`), and un-naming subtracts it back out.
+    /// The subtraction is only an exact inverse while the profile's weight
+    /// stays reconstructible from the observations backing it — so every
+    /// operation that changes which observation backs which name has to
+    /// update both sides. A re-key is such an operation, and it used to
+    /// update neither: `remap` silently dropped names, leaving their
+    /// contributions in a profile with no label left to un-name
+    /// (island-io/mila#254).
+    ///
+    /// **The rule, and why it is exactly this.** An old id's name and its
+    /// observation travel together onto exactly one new id — `remap` takes
+    /// the name from the dominant old id, and
+    /// `ObservedVoiceSnapshots.remapSpeakerIDs` takes the observation from
+    /// the same one — **iff that old id dominates exactly one new id.** So:
+    ///
+    /// | old id, with a name          | name after | observation after | retired |
+    /// |------------------------------|------------|-------------------|---------|
+    /// | dominates one new id         | on that id | on that id        | no — the pair is intact, and subtracting would take back weight the profile still backs |
+    /// | dominates none (a collapse's non-dominant fragment) | gone | dropped | **yes** — this issue's headline case |
+    /// | dominates two or more (a split) | duplicated onto each | dropped, to avoid a double subtract | **yes** — the label survives with nothing backing it |
+    ///
+    /// The middle row is why this exists. The last row is why the rule is
+    /// "dominates exactly one" rather than "has no surviving label": the name
+    /// string is still on the row, but the thing that could reverse it is
+    /// gone, so the contribution has to come out now or never.
+    ///
+    /// **This mirrors `ObservedVoiceSnapshots.remapSpeakerIDs`' survival
+    /// rule** (`timesDominant[oldID] == 1`) and has to keep mirroring it:
+    /// retiring a name whose observation IS carried over would subtract the
+    /// same contribution twice, and the second subtraction comes out of the
+    /// profile's other recordings.
+    /// `ObservedVoiceSnapshotsTests.test_retiring_a_name_mirrors_which_observations_survive`
+    /// pins the two together.
+    ///
+    /// Names for ids that were never observed are returned too: the hook
+    /// resolves them against the snapshot and a missing observation subtracts
+    /// nothing, so an unobserved id costs one no-op rather than needing a
+    /// second source of truth here.
+    static func retiredNames(names: [String: String],
+                             dominantOldIDs: [String: String]) -> [String: String] {
+        guard !names.isEmpty else { return [:] }
+        var timesDominant: [String: Int] = [:]
+        for oldID in dominantOldIDs.values { timesDominant[oldID, default: 0] += 1 }
+        return names.filter { timesDominant[$0.key] != 1 }
+    }
+
+    /// `retiredNames` from the two segment arrays, for callers that do not
+    /// already hold the dominance mapping.
+    static func retiredNames(names: [String: String],
+                             from old: [TranscriptSegment],
+                             to new: [TranscriptSegment]) -> [String: String] {
+        retiredNames(names: names, dominantOldIDs: dominantOldIDs(from: old, to: new))
     }
 }

--- a/MilaTests/ObservedVoiceSnapshotsTests.swift
+++ b/MilaTests/ObservedVoiceSnapshotsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TranscriptionCore
 @testable import Mila
 
 /// Unit tests for the per-recording snapshot store that keeps one recording's
@@ -338,10 +339,17 @@ final class ObservedVoiceSnapshotsTests: XCTestCase {
     /// difference out of the profile's other recordings — deleting it
     /// outright once `S ≤ n_B`. Carrying only the dominant fragment — the one
     /// whose NAME the new id also inherited — keeps un-naming an exact
-    /// inverse of that fragment's naming and leaves the rest as residue.
+    /// inverse of that fragment's naming.
+    ///
+    /// What the dropped fragments leave behind is no longer residue in the
+    /// profile: a dropped fragment that HAD a name is retired by the caller
+    /// before this runs (`SpeakerNameRemapper.retiredNames` →
+    /// `RecordingStore.update(_:retiringSpeakerNames:)`), and one that had no
+    /// name contributed nothing to begin with. What is given up is their
+    /// audio, which stops informing any profile. See island-io/mila#254.
     ///
     /// The `6` this asserted before is the bug; `2` is the dominant
-    /// fragment's own count. See island-io/mila#254.
+    /// fragment's own count.
     func test_a_collapse_carries_only_the_dominant_fragment() {
         let snapshots = ObservedVoiceSnapshots()
         let rec = UUID()
@@ -382,6 +390,40 @@ final class ObservedVoiceSnapshotsTests: XCTestCase {
         XCTAssertNil(snapshots.observation(forSpeaker: "SPEAKER_02", in: rec))
         XCTAssertEqual(snapshots.observation(forSpeaker: "SPEAKER_01", in: rec)?.observedCentroid,
                        [0, 1], "the speaker that mapped one-to-one is unaffected")
+    }
+
+    /// `SpeakerNameRemapper.retiredNames` and `remapSpeakerIDs` implement the
+    /// same survival rule from opposite ends, and they have to stay mirrored:
+    /// the names whose contribution must be subtracted are exactly the ones
+    /// whose observation this type does not carry across. Disagreement is
+    /// silent either way — a contribution subtracted twice (retired AND
+    /// carried) or never (kept AND dropped), which is island-io/mila#254.
+    func test_retiring_a_name_mirrors_which_observations_survive() {
+        let snapshots = ObservedVoiceSnapshots()
+        let rec = UUID()
+        snapshots.record(entries([("SPEAKER_00", [1, 0], 1, nil),
+                                  ("SPEAKER_01", [0, 1], 1, nil),
+                                  ("SPEAKER_02", [1, 1], 1, nil)]), for: rec)
+        let names = ["SPEAKER_00": "Alice", "SPEAKER_01": "Bob", "SPEAKER_02": "Carol"]
+        // new -> old, as `SpeakerNameRemapper.dominantOldIDs` reports it: old
+        // 00 keeps one id of its own, old 01 was split across two new ids, and
+        // old 02 was absorbed into a cluster it does not dominate.
+        let newToOld = ["SPEAKER_00": "SPEAKER_00",
+                        "SPEAKER_01": "SPEAKER_01",
+                        "SPEAKER_02": "SPEAKER_01"]
+
+        let retired = SpeakerNameRemapper.retiredNames(names: names, dominantOldIDs: newToOld)
+        snapshots.remapSpeakerIDs(newToOld, in: rec)
+
+        XCTAssertEqual(Set(retired.keys), Set(["SPEAKER_01", "SPEAKER_02"]),
+                       "Bob's observation is dropped (a split) and Carol's is dropped (she "
+                       + "dominates nothing), so both names lose their backing")
+        let stillReachable = Set(["SPEAKER_00", "SPEAKER_01", "SPEAKER_02"].compactMap {
+            snapshots.observation(forSpeaker: $0, in: rec)?.observedCentroid
+        })
+        XCTAssertEqual(stillReachable, Set([[1, 0] as [Float]]),
+                       "exactly the one name that was NOT retired still has an observation "
+                       + "reachable under a new id")
     }
 
     /// A mapping that carries nothing is an invalidation, eviction slot and

--- a/MilaTests/SpeakerCorrectionActionsTests.swift
+++ b/MilaTests/SpeakerCorrectionActionsTests.swift
@@ -289,56 +289,286 @@ final class SpeakerCorrectionActionsTests: XCTestCase {
         XCTAssertEqual(speakers(w), ["SPEAKER_00"])
     }
 
-    /// The same round trip across the **offline re-diarize**, pinning the one
-    /// place this PR deliberately does NOT come out clean.
+    // MARK: - The offline re-diarize round trip (island-io/mila#254)
+
+    /// A real `QuickActionsController`, so the re-diarize tests drive the
+    /// sequence that ships (`applyRediarizedSpeakers`) instead of a
+    /// re-implementation of it here — which is how the half this fixes went
+    /// unnoticed: the test simulated the store write and the observation
+    /// re-key, and simulating them is exactly what hid the missing notify.
+    /// `rediarizeSegments` needs a pyannote subprocess, so only the pass's
+    /// OUTPUT is supplied by hand; everything after it is production code.
+    private func makeController(for w: World) -> QuickActionsController {
+        let suite = "SpeakerCorrectionActionsTests.\(UUID())"
+        for sub in ["diarization", "language", "llm"] { suiteNames.append("\(suite).\(sub)") }
+        let service = TranscriptionService(
+            store: w.store,
+            modelManager: ModelManager(
+                modelsDirectory: tempRoot.appendingPathComponent("Models-\(UUID().uuidString)")),
+            diarizationSettings: DiarizationSettings(
+                defaults: UserDefaults(suiteName: "\(suite).diarization")!),
+            remoteSettings: TestSupport.isolatedRemoteSettings(label: suite),
+            engine: StubWhisperEngine())
+        let controller = QuickActionsController(
+            session: RecordingSession(),
+            store: w.store,
+            transcription: service,
+            languageSettings: RecordingLanguageSettings(
+                defaults: UserDefaults(suiteName: "\(suite).language")!),
+            postRecording: PostRecordingCoordinator(
+                store: w.store,
+                transcription: service,
+                llm: LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)))
+        // The other half of `MilaApp.init`'s wiring, verbatim.
+        let snapshots = w.snapshots
+        controller.onSpeakerIDsRekeyed = { recordingID, newToOld in
+            snapshots.remapSpeakerIDs(newToOld, in: recordingID)
+        }
+        return controller
+    }
+
+    /// The re-key's output for a recording whose speakers all collapse into
+    /// one, or are renumbered: `rediarizeSegments` reassigns `.speaker` on
+    /// the SAME array, so this is what the pass is allowed to return.
+    private func rekeyed(_ segments: [TranscriptSegment], to speakers: [String]) -> [TranscriptSegment] {
+        var out = segments
+        for i in out.indices { out[i].speaker = speakers[i] }
+        return out
+    }
+
+    /// **The bug this closes.** The live diarizer over-segmented Alice into
+    /// `SPEAKER_00` and `SPEAKER_02`, both were named at stop, so her profile
+    /// received two contributions from this recording. The offline pass
+    /// merges them into one cluster dominated by `SPEAKER_00`, and `remap`
+    /// drops `SPEAKER_02`'s name — the label is gone from the recording, so
+    /// there is nothing left for the user to un-name and #237's correction
+    /// could never reach that contribution. The re-diarize write now retires
+    /// it.
     ///
-    /// A collapse carries only the dominant fragment's observation, so
-    /// un-naming reverses that fragment exactly and leaves the other
-    /// fragments' contributions in the profile as residue. That is chosen
-    /// over folding them all in, because `finish` names only *some* fragments
-    /// — a fold then claims more than the profile ever received, and
-    /// un-naming subtracts the difference out of the profile's OTHER
-    /// recordings, deleting it outright when its stored count is small.
-    /// Residue can be undone by deleting the profile and letting it re-learn;
-    /// a deleted profile cannot. See `ObservedVoiceSnapshots.remapSpeakerIDs`
-    /// and island-io/mila#254.
+    /// **Discriminating in both directions.** Alice arrives carrying 3
+    /// samples from earlier recordings and leaves this one at 5:
     ///
-    /// Discriminating in both directions: folding deletes Alice, carrying
-    /// nothing leaves her at 2.
-    func test_a_collapsed_speaker_leaves_residue_rather_than_over_subtracting() throws {
+    /// * retire the dropped fragment → 4, and un-naming the survivor returns
+    ///   her to exactly 3 — her weight before this recording, nothing left
+    ///   behind and nothing taken twice;
+    /// * retire nothing (`main`) → 5, and the un-name leaves 4: one
+    ///   contribution stranded under a label that no longer exists;
+    /// * fold both fragments onto the survivor instead (the shape #253
+    ///   refused) → the un-name subtracts 2 in one go from a profile that
+    ///   received them under two different labels, and at `S == 1` deletes it.
+    func test_a_name_dropped_by_the_rediarize_pass_gives_its_observation_back() throws {
         let voice: [Float] = [1, 0, 0, 0]
         let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
-                                     segment("SPEAKER_03", 2, "two")],
+                                     segment("SPEAKER_02", 2, "two"),
+                                     segment("SPEAKER_00", 4, "three")],
                           snapshotEntries: [("SPEAKER_00", voice, 1),
-                                            ("SPEAKER_03", voice, 1)])
-        // Both fragments named, so the profile received both.
-        for raw in ["SPEAKER_00", "SPEAKER_03"] {
+                                            ("SPEAKER_02", voice, 1)])
+        // Alice as she stands from earlier recordings…
+        w.profiles.updateProfile(name: "Alice", embedding: voice, sampleCount: 3)
+        // …then `RecognisedSpeakerAssigner.finish` names both fragments at stop.
+        for raw in ["SPEAKER_00", "SPEAKER_02"] {
             w.store.setSpeakerName("Alice", forSpeaker: raw, recordingID: w.recordingID)
         }
-        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 2,
-                       "precondition: two fragments, two contributions")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "precondition: two named fragments, two contributions")
 
-        // What `finalizeTail` does when the offline pass collapses them into
-        // one speaker: swap the segments, remap the names, and carry the
-        // observations on the same new-to-old mapping the names used.
-        var rediarized = row(w)
-        rediarized.segments = rediarized.segments.map {
-            var seg = $0
-            seg.speaker = "SPEAKER_00"
-            return seg
-        }
-        rediarized.speakerNames = ["SPEAKER_00": "Alice"]
-        w.store.update(rediarized)
-        w.snapshots.remapSpeakerIDs(["SPEAKER_00": "SPEAKER_00"], in: w.recordingID)
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        // The offline pass puts all three utterances under one id. Old
+        // SPEAKER_00 dominates it (4s against 2s), so its name survives.
+        let after = rekeyed(before, to: ["SPEAKER_00", "SPEAKER_00", "SPEAKER_00"])
+
+        controller.applyRediarizedSpeakers(after, replacing: before, recordingID: w.recordingID)
+
+        XCTAssertEqual(row(w).speakerNames, ["SPEAKER_00": "Alice"],
+                       "the collapsed fragment's label is gone — that part is pre-existing")
+        XCTAssertNil(w.snapshots.observation(forSpeaker: "SPEAKER_02", in: w.recordingID),
+                     "and so is its observation")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 4,
+                       "so its contribution came back out, while the survivor's stayed")
 
         w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_00", recordingID: w.recordingID)
 
-        let alice = try XCTUnwrap(
-            w.profiles.profile(named: "Alice"),
-            "Alice must survive — folding both fragments into the snapshot would "
-            + "subtract 2 from 2 and delete her, which is the failure this shape avoids")
-        XCTAssertEqual(alice.sampleCount, 1,
-                       "the dominant fragment came back out exactly; the other is residue")
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"),
+                                  "Alice's earlier recordings are untouched")
+        XCTAssertEqual(alice.sampleCount, 3,
+                       "un-naming the survivor returns her to exactly her pre-recording weight")
+        XCTAssertEqual(alice.embedding, voice)
+    }
+
+    /// The shape that rules out diffing `speakerNames` inside
+    /// `RecordingStore.update(_:)`, and the reason the retired set is computed
+    /// from the dominance mapping instead: a re-key changes what the KEYS
+    /// mean. Bob and Alice swap ids here, so a key-by-key diff sees
+    /// `SPEAKER_00` change "Bob" → "Alice" and would fire
+    /// `onSpeakerNamed(SPEAKER_00, "Alice")` — folding Bob's voice, still
+    /// keyed to `SPEAKER_00` at that moment, into Alice's profile — plus
+    /// `onSpeakerUnnamed(SPEAKER_01, "Alice")`, taking back a contribution
+    /// Alice legitimately still holds. Both names survive here with their own
+    /// observations, so nothing may fire at all.
+    func test_a_rekey_that_renumbers_two_named_speakers_moves_no_weight() throws {
+        let aliceVoice: [Float] = [1, 0, 0, 0]
+        let bobVoice: [Float] = [0, 1, 0, 0]
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "bob"),
+                                     segment("SPEAKER_01", 2, "alice")],
+                          speakerNames: ["SPEAKER_00": "Bob", "SPEAKER_01": "Alice"],
+                          snapshotEntries: [("SPEAKER_00", bobVoice, 1),
+                                            ("SPEAKER_01", aliceVoice, 1)])
+        // Both profiles as they stand having been named — each already holds
+        // this recording's observation.
+        w.profiles.updateProfile(name: "Bob", embedding: bobVoice, sampleCount: 3)
+        w.profiles.updateProfile(name: "Alice", embedding: aliceVoice, sampleCount: 3)
+
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        // Same two people, same utterances; the offline pass just numbered
+        // them the other way round.
+        let after = rekeyed(before, to: ["SPEAKER_01", "SPEAKER_00"])
+
+        controller.applyRediarizedSpeakers(after, replacing: before, recordingID: w.recordingID)
+
+        XCTAssertEqual(row(w).speakerNames, ["SPEAKER_01": "Bob", "SPEAKER_00": "Alice"],
+                       "each name followed its person onto the new id")
+        XCTAssertEqual(w.profiles.profile(named: "Bob")?.sampleCount, 3,
+                       "a pure renumber moves no weight at all")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 3)
+
+        // And the observations followed the people, not the numbers: un-naming
+        // the speaker now called Alice must take ALICE's voice out of Alice.
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(alice.sampleCount, 2)
+        XCTAssertEqual(alice.embedding, aliceVoice,
+                       "subtracting Bob's observation instead would leave [1.5, -0.5, 0, 0]")
+        XCTAssertEqual(w.profiles.profile(named: "Bob")?.sampleCount, 3,
+                       "Bob is not touched by un-naming somebody else")
+    }
+
+    /// A split hands the name to both halves while
+    /// `ObservedVoiceSnapshots.remapSpeakerIDs` refuses to hand the
+    /// observation to either (un-naming both would subtract it twice) and
+    /// drops it. The label therefore survives with nothing backing it, so the
+    /// contribution comes out now — exactly once — and un-naming the halves
+    /// afterwards must subtract nothing at all.
+    func test_a_split_speaker_gives_its_observation_back_exactly_once() throws {
+        let voice: [Float] = [1, 0, 0, 0]
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
+                                     segment("SPEAKER_00", 2, "two")],
+                          speakerNames: ["SPEAKER_00": "Alice"],
+                          snapshotEntries: [("SPEAKER_00", voice, 1)])
+        w.profiles.updateProfile(name: "Alice", embedding: voice, sampleCount: 3)
+
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        let after = rekeyed(before, to: ["SPEAKER_00", "SPEAKER_01"])
+
+        controller.applyRediarizedSpeakers(after, replacing: before, recordingID: w.recordingID)
+
+        XCTAssertEqual(row(w).speakerNames, ["SPEAKER_00": "Alice", "SPEAKER_01": "Alice"],
+                       "the label follows both halves — better than dropping it from one")
+        XCTAssertNil(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: w.recordingID),
+                     "the observation is not duplicated onto them")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 2,
+                       "so the contribution it justified is subtracted once, here")
+
+        for raw in ["SPEAKER_00", "SPEAKER_01"] {
+            w.store.setSpeakerName(nil, forSpeaker: raw, recordingID: w.recordingID)
+        }
+
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 2,
+                       "and un-naming the halves subtracts nothing more — a second subtraction "
+                       + "would come out of Alice's other recordings")
+    }
+
+    /// The one destructive case, pinned on purpose rather than left to be
+    /// discovered: a profile whose ENTIRE content is the retired contribution
+    /// is removed, because the subtraction is exact rather than clamped.
+    ///
+    /// Reachable, and this is the route — the user hand-names a speaker in
+    /// the live pane, which CREATES that profile from this recording's one
+    /// observation, and the offline pass then folds that fragment into a
+    /// cluster another speaker dominates, dropping the name. `1 − 1 = 0`, and
+    /// `SpeakerProfileStore` removes a profile at zero, exactly as it does
+    /// when the user un-names that speaker by hand.
+    ///
+    /// The argument for leaving it exact is that it is bounded: a profile
+    /// holding weight from any OTHER recording keeps that weight (`remaining
+    /// > 0`), so nothing outside this recording is ever touched — every
+    /// profile seeded from a stored one survives by construction, since it
+    /// had weight before this recording could add any. Clamping would instead
+    /// keep a name→voice mapping the pass has just contradicted (that
+    /// fragment's audio is now the dominant speaker's) and would need a
+    /// second correction policy beside the hook. See island-io/mila#254.
+    func test_retiring_the_only_contribution_a_profile_ever_had_removes_it() {
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
+                                     segment("SPEAKER_02", 2, "two"),
+                                     segment("SPEAKER_00", 4, "three")],
+                          snapshotEntries: [("SPEAKER_00", [1, 0, 0, 0], 1),
+                                            ("SPEAKER_02", [0, 1, 0, 0], 1)])
+        // Naming a brand-new speaker is how profiles get created at all.
+        w.store.setSpeakerName("Bob", forSpeaker: "SPEAKER_02", recordingID: w.recordingID)
+        XCTAssertEqual(w.profiles.profile(named: "Bob")?.sampleCount, 1,
+                       "precondition: Bob exists only because of this fragment")
+
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        controller.applyRediarizedSpeakers(
+            rekeyed(before, to: ["SPEAKER_00", "SPEAKER_00", "SPEAKER_00"]),
+            replacing: before,
+            recordingID: w.recordingID)
+
+        XCTAssertTrue(row(w).speakerNames.isEmpty,
+                      "the pass folded Bob's fragment into the dominant, unnamed speaker")
+        XCTAssertNil(w.profiles.profile(named: "Bob"),
+                     "his profile held nothing but that fragment, so it goes with it")
+    }
+
+    /// The pass runs on a recording nobody named. Nothing to retire, nothing
+    /// to subtract, and in particular no `onSpeakerNamed` for the ids the
+    /// remap creates — the naming hook is what WRITES a profile, and a
+    /// re-diarize is not a user naming anybody.
+    func test_a_rekey_with_no_names_writes_no_profiles() {
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
+                                     segment("SPEAKER_01", 2, "two")],
+                          snapshotEntries: [("SPEAKER_00", [1, 0, 0, 0], 1),
+                                            ("SPEAKER_01", [0, 1, 0, 0], 1)])
+
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        controller.applyRediarizedSpeakers(rekeyed(before, to: ["SPEAKER_00", "SPEAKER_00"]),
+                                           replacing: before,
+                                           recordingID: w.recordingID)
+
+        XCTAssertTrue(row(w).speakerNames.isEmpty)
+        XCTAssertTrue(w.profiles.profiles.isEmpty,
+                      "a re-diarize must never create a voice profile")
+    }
+
+    /// The recording was hard-deleted while the pass ran. Nothing is written
+    /// and — the part that matters — nothing is subtracted from a profile for
+    /// a change that never landed.
+    func test_a_rekey_for_a_vanished_recording_touches_nothing() {
+        let voice: [Float] = [1, 0, 0, 0]
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
+                                     segment("SPEAKER_02", 2, "two")],
+                          speakerNames: ["SPEAKER_00": "Alice", "SPEAKER_02": "Alice"],
+                          snapshotEntries: [("SPEAKER_00", voice, 1),
+                                            ("SPEAKER_02", voice, 1)])
+        w.profiles.updateProfile(name: "Alice", embedding: voice, sampleCount: 5)
+
+        let controller = makeController(for: w)
+        let before = row(w).segments
+        w.store.permanentlyDelete(row(w))
+
+        let written = controller.applyRediarizedSpeakers(
+            rekeyed(before, to: ["SPEAKER_00", "SPEAKER_00"]),
+            replacing: before,
+            recordingID: w.recordingID)
+
+        XCTAssertNil(written)
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "no row, no re-key, no correction")
     }
 
     // MARK: - Move one line

--- a/MilaTests/SpeakerNameRemapperTests.swift
+++ b/MilaTests/SpeakerNameRemapperTests.swift
@@ -86,4 +86,93 @@ final class SpeakerNameRemapperTests: XCTestCase {
                                                  from: old, to: new)
         XCTAssertEqual(remapped, ["SPEAKER_01": "Daniel"])
     }
+
+    // MARK: - Retired names (island-io/mila#254)
+
+    /// The headline case. The live diarizer over-segmented one person into a
+    /// long fragment and a short one, the user named BOTH (or a recogniser
+    /// did), and the offline pass merges them: the short fragment's name is
+    /// dropped from the recording entirely. Its voice-profile contribution
+    /// has to come back out, because there is no longer a label to un-name.
+    func test_a_collapsed_fragment_retires_the_name_the_remap_drops() {
+        let old = [seg(0, 8, "SPEAKER_00"), seg(8, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_00"])
+        let names = ["SPEAKER_00": "Daniel", "SPEAKER_01": "Noa"]
+
+        XCTAssertEqual(SpeakerNameRemapper.remap(names: names, from: old, to: new),
+                       ["SPEAKER_00": "Daniel"],
+                       "precondition: the dominant fragment's name is the one that survives")
+        XCTAssertEqual(SpeakerNameRemapper.retiredNames(names: names, from: old, to: new),
+                       ["SPEAKER_01": "Noa"],
+                       "Noa's label is gone from the recording, so her profile must give "
+                       + "this recording's observation back — Daniel's must not")
+    }
+
+    /// A name that MOVES is not a name that is retired. This is the case a
+    /// key-by-key diff of `speakerNames` gets wrong in both directions: the
+    /// keys are renumbered, so `SPEAKER_00` losing "Daniel" looks like a drop
+    /// while the pair is in fact intact on `SPEAKER_01`.
+    func test_a_name_that_moves_to_another_id_is_not_retired() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_01", "SPEAKER_00"])
+        let names = ["SPEAKER_00": "Daniel"]
+
+        XCTAssertEqual(SpeakerNameRemapper.remap(names: names, from: old, to: new),
+                       ["SPEAKER_01": "Daniel"])
+        XCTAssertTrue(SpeakerNameRemapper.retiredNames(names: names, from: old, to: new).isEmpty,
+                      "the name and its observation both land on SPEAKER_01, so retiring it "
+                      + "would subtract a contribution the profile still backs — twice, once "
+                      + "the user un-names it for real")
+    }
+
+    /// A split duplicates the name onto both halves, but
+    /// `ObservedVoiceSnapshots.remapSpeakerIDs` refuses to duplicate the
+    /// observation (un-naming both halves would subtract it twice) and drops
+    /// it. The label survives with nothing backing it, so the contribution is
+    /// retired even though the string is still on the row.
+    func test_a_split_retires_the_name_it_duplicates() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_00")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+        let names = ["SPEAKER_00": "Daniel"]
+
+        XCTAssertEqual(SpeakerNameRemapper.remap(names: names, from: old, to: new),
+                       ["SPEAKER_00": "Daniel", "SPEAKER_01": "Daniel"])
+        XCTAssertEqual(SpeakerNameRemapper.retiredNames(names: names, from: old, to: new),
+                       ["SPEAKER_00": "Daniel"])
+    }
+
+    func test_retiring_ignores_ids_that_were_never_named() {
+        let old = [seg(0, 8, "SPEAKER_00"), seg(8, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_00"])
+
+        XCTAssertTrue(SpeakerNameRemapper.retiredNames(names: [:], from: old, to: new).isEmpty)
+        XCTAssertTrue(
+            SpeakerNameRemapper.retiredNames(names: ["SPEAKER_00": "Daniel"],
+                                             from: old, to: new).isEmpty,
+            "the collapsed fragment was never named, so it contributed nothing to subtract")
+    }
+
+    /// An old id that the pass left with no labelled utterances at all
+    /// dominates nothing, so its name — and its contribution — are retired.
+    func test_an_id_the_pass_stopped_labelling_is_retired() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", nil])
+        let names = ["SPEAKER_00": "Daniel", "SPEAKER_01": "Noa"]
+
+        XCTAssertEqual(SpeakerNameRemapper.remap(names: names, from: old, to: new),
+                       ["SPEAKER_00": "Daniel"])
+        XCTAssertEqual(SpeakerNameRemapper.retiredNames(names: names, from: old, to: new),
+                       ["SPEAKER_01": "Noa"])
+    }
+
+    func test_retiring_on_an_identity_rekey_notifies_nothing() {
+        let old = [seg(0, 5, "SPEAKER_00"), seg(5, 10, "SPEAKER_01")]
+        let new = rekeyed(old, to: ["SPEAKER_00", "SPEAKER_01"])
+
+        XCTAssertTrue(
+            SpeakerNameRemapper.retiredNames(names: ["SPEAKER_00": "Daniel",
+                                                     "SPEAKER_01": "Noa"],
+                                             from: old, to: new).isEmpty,
+            "nothing changed hands, so nothing may be subtracted")
+    }
 }


### PR DESCRIPTION
Closes #254

## What & why

The offline re-diarize pass carries the user's speaker names onto the pass's new `SPEAKER_NN` ids with a wholesale `current.speakerNames = SpeakerNameRemapper.remap(...)` followed by `store.update(current)`. `remap` emits an entry only for a new id whose *dominant* old id had a name, so a name can be dropped — most often the non-dominant fragment of an over-segmented speaker. The speaker hooks fire only from `setSpeakerName` / `mergeSpeakers` / `reassignSegmentSpeaker`, so nothing fired `onSpeakerUnnamed` for a dropped name: its observation stayed folded into that voice profile with no label left to un-name, which makes #237's correction unreachable for it permanently. Pre-existing on `main`, not a regression.

**The fix.** The re-diarize write now retires those names.

- `SpeakerNameRemapper.retiredNames(names:dominantOldIDs:)` — the `[oldID: name]` pairs whose observation does **not** travel with them: old ids dominating **zero** new ids (a collapse's non-dominant fragment — the headline case) or **two or more** (a split, where `ObservedVoiceSnapshots.remapSpeakerIDs` drops the observation rather than let un-naming both halves subtract it twice, so the label survives with nothing backing it). It mirrors `remapSpeakerIDs`' survival rule (`timesDominant == 1`) and there is a test pinning the two together.
- `RecordingStore.update(_:retiringSpeakerNames:)` — `update(_:)` plus `onSpeakerUnnamed` for each retired pair, fired after the write and **before** the observations are re-keyed, so each subtraction takes back exactly what naming that id added.
- `QuickActionsController.applyRediarizedSpeakers(_:replacing:recordingID:)` — the re-diarize branch of `finalizeTail`, split out so the ordering is drivable from a test (`rediarizeSegments` needs a pyannote subprocess). Names → retire → *then* re-key the observations, all three off one `dominantOldIDs` mapping.

`update(_:)` itself is unchanged, so **no existing caller changes behaviour**.

### Why not a diff inside `update(_:)`

That is what the issue leaned toward, and the audit it asked for is what argued against it: **a re-key changes what the keys mean, so no key-by-key diff can be right.** Old `{00: Bob, 01: Alice}` becoming `{00: Alice}`, where new `00` is old `01`'s voice, reads to a diff as "`00` changed Bob → Alice" plus "`01` disappeared". It would therefore

- fire `onSpeakerNamed(00, "Alice")`, folding old `00`'s embedding — Bob's, since the snapshot has not been re-keyed yet — into Alice's profile, and
- fire `onSpeakerUnnamed(01, "Alice")`, taking back a contribution Alice legitimately still holds, which then gets subtracted a *second* time when the user un-names her, out of her other recordings.

Reversing the order (re-key first) breaks the other direction instead. The pairing of a name with the observation backing it — not the key it happens to sit under — is the identity that matters, so the retired set is computed where that mapping lives. `test_a_rekey_that_renumbers_two_named_speakers_moves_no_weight` is the regression pin for exactly this shape.

It also means no name is ever *added* by a re-key (a carried name is the same string its dominant old id had, arriving with its own observation), so only the retiring direction fires and there is nothing to double-fire against `setSpeakerName` — which does not route through `update(_:)` at all.

### What the audit found

Exactly two paths replace a stored row's `speakerNames` wholesale. Everything else goes through `setSpeakerName` / `mergeSpeakers` / `reassignSegmentSpeaker` (which fire the hooks) or is live-only state (`LiveTranscriber`, the sidecar writer).

1. `QuickActionsController.finalizeTail`'s re-diarize remap — fixed here.
2. `TranscriptionService.mergePassResult`'s `speakerNames = [:]` on a segment-producing pass — the same bug through the re-transcribe door, **deliberately not fixed here: filed as #260 with the full reasoning.** In short: `OfflineVoiceEmbedder.matchAfterPass` runs immediately after that write, re-embeds every speaker and re-matches them against the stored profiles *by voice*. Retiring first subtracts the weight — and shifts the centroid — that the re-match looks the speaker up by, and would delete a profile whose only content came from that recording before the pass could restore its name, turning "name auto-restored, profile slightly inflated" into "profile deleted, name lost, voice forgotten". It cannot simply be reordered either: `matchAfterPass` invalidates the snapshot at the top, so after the re-match there is nothing left to subtract. I had that change written and reverted it. That path needs the retire and the re-match designed together, as one swap of a recording's contribution — see #260. The new store method's doc records the deferral where the next caller will look.

### The one destructive case, deliberately

A retire subtracts exactly what naming added, so a profile holding *nothing else* reaches zero and `SpeakerProfileStore` removes it — which is also precisely what un-naming that speaker by hand does today. Reachable route: the user hand-names a speaker in the live pane (that *creates* the profile, at this recording's one observation) and the pass then folds that fragment into a cluster another speaker dominates.

It is bounded, and that is the argument for leaving it exact rather than clamped: `remaining > 0` means a profile carrying weight from any other recording keeps it, so nothing outside this recording is ever touched, and every profile seeded from a stored one survives by construction. Clamping would keep a name→voice mapping the pass has just contradicted, and would need a second, quieter correction policy beside the hook. `test_retiring_the_only_contribution_a_profile_ever_had_removes_it` pins it so the trade is reviewable rather than incidental.

`ObservedVoiceSnapshots.remapSpeakerIDs`' docs are corrected in the same pass: its "residue" caveat no longer holds for a *named* dropped fragment (the retire handles it); what is still given up is that fragment's audio, and folding is still forbidden for the reason #253 records.

## How it was tested

**Nothing was compiled or run locally: there is no Swift toolchain and no Mac in this environment. CI is the only compiler here.** The diff was re-read adversarially, the arithmetic in every assertion worked through by hand, and every constructor/API used in the new tests copied from an existing call site.

New/changed tests:

- `MilaTests/SpeakerNameRemapperTests.swift` — `retiredNames` for a collapse, a name that *moves* to another id (not retired), a split, ids that were never named, an id the pass stopped labelling, and an identity re-key.
- `MilaTests/ObservedVoiceSnapshotsTests.swift` — `test_retiring_a_name_mirrors_which_observations_survive`: the tripwire holding `retiredNames` and `remapSpeakerIDs` to the same survival rule from opposite ends.
- `MilaTests/SpeakerCorrectionActionsTests.swift` — the re-diarize round trip now drives the **production** sequence through a real `QuickActionsController` (real store, real `SpeakerProfileStore`, real `ObservedVoiceSnapshots`, `MilaApp.init`'s wiring verbatim) instead of re-implementing it in the test, which is how this half stayed hidden: the old test simulated the store write and the observation re-key, and simulating them is what hid the missing notify. Collapse, pure renumber, split, unnamed recording, vanished row, and the bounded destructive case.

The collapse test is discriminating in both directions. Alice arrives at 3 samples from earlier recordings and leaves this recording at 5: retire the dropped fragment → 4, and un-naming the survivor returns her to exactly 3; retire nothing (`main`) → 5, and the un-name leaves 4 stranded forever; fold both fragments onto the survivor (the shape #253 refused) → the un-name subtracts 2 at once and deletes her.

`test_a_collapsed_speaker_leaves_residue_rather_than_over_subtracting` is replaced by `test_a_name_dropped_by_the_rediarize_pass_gives_its_observation_back`: it pinned the trade #253 took, and that trade is what this PR removes. The residue it asserted is now subtracted, so keeping the old expectation would pin the bug.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible in this environment; relying on CI**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, a data-integrity fix with no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN