### PR TITLE
test(speakers): an offline sweep that can answer the seed-anchor question

### DIFF
--- a/Mila/Transcription/LiveSpeakerDiarizer.swift
+++ b/Mila/Transcription/LiveSpeakerDiarizer.swift
@@ -97,13 +97,66 @@ final class LiveSpeakerDiarizer: ObservableObject {
     /// always a proper convex combination — so there is no degenerate value
     /// in that range and no discontinuity at the cap boundary. Picking among
     /// them is empirical, and needs multi-recording audio of the same
-    /// speakers across different capture setups. #206 records the replay
-    /// protocol (embed once, cache, sweep n₀ × `similarityThreshold`) and the
-    /// decision rule; until someone runs it, changing 3 to another unmeasured
-    /// number would only move the guess.
+    /// speakers across different capture setups. The replay that would settle
+    /// it now exists — `SeedAnchorSweepHarness` in the test target replays a
+    /// cached corpus through this very code across n₀ × `similarityThreshold`,
+    /// driven by `seedAnchorWeightOverride` below, and
+    /// `docs/seed-anchor-sweep.md` is the procedure. Nobody has the corpus
+    /// yet, so until someone runs it, changing 3 to another unmeasured number
+    /// would only move the guess.
     ///
     /// `SeedAnchorWeightTests` pins this value and the behaviour it buys.
     static let seedAnchorWeight = 3
+
+    /// Sweep hook: replaces `seedAnchorWeight` **for this instance only**.
+    /// `nil` — the only value anything in the app ever leaves here — means
+    /// "use the constant", so the shipped behaviour is exactly what it was.
+    ///
+    /// It exists because the replay protocol in #206 sweeps n₀ over
+    /// {1, 2, 3, 4, 6, 8, 12, uncapped}, and the upper half of that grid is
+    /// otherwise unreachable. `seedPool` applies the weight as a **ceiling**
+    /// (`min(stored, n₀)`), so a harness can simulate a *lighter* anchor just
+    /// by seeding a smaller `sampleCount` — but no input it can pass raises
+    /// the anchor above the constant. Without this the sweep could measure
+    /// only the light end, and the heavy end is the one whose failure mode is
+    /// documented above and has never been observed on real audio.
+    ///
+    /// Pass `Int.max` for the uncapped configuration: `min(stored, .max)` is
+    /// the profile's true stored count, which is precisely what deleting the
+    /// `min` in `seedPool` would do.
+    ///
+    /// See `SeedAnchorSweepHarness` for the replay that drives this, and
+    /// `docs/seed-anchor-sweep.md` for the procedure.
+    var seedAnchorWeightOverride: Int?
+
+    /// The weight `seedPool` actually applies — and the only reader of
+    /// `seedAnchorWeightOverride`, so a new code path cannot pick up the raw
+    /// constant and silently ignore a sweep configuration.
+    ///
+    /// Clamped to `>= 1`. That floor is arithmetic safety, not tidiness:
+    /// `assign`'s fold divides by `Float(n + 1)`, so
+    ///
+    ///   * `n₀ == 0` reproduces the provably-wrong end documented above —
+    ///     `(0·c₀ + e)/1 == e`, the stored voice discarded by its own first
+    ///     match;
+    ///   * `n₀ == -1` divides by zero, and any other negative divides by a
+    ///     negative, so the fold stops being a convex combination and writes
+    ///     an infinity, a NaN, or a centroid reflected through the origin.
+    ///
+    /// A NaN centroid is the worst of those and the reason this is a clamp
+    /// rather than a comment: `cosineSimilarity` returns NaN for it, and
+    /// `sim > best.sim` is false for NaN, so the entry can never be a
+    /// confident match again. It stops folding, stops accruing
+    /// `observedCount`, and therefore stops being auto-nameable, while
+    /// remaining able to absorb short utterances through the attach branch —
+    /// a silent, permanent break with no error anywhere. `VoiceProfile.unusableReason`
+    /// exists to keep exactly this off disk; this keeps it out of the pool.
+    ///
+    /// The sweep grid therefore starts at 1, not 0. `SeedAnchorWeightTests`
+    /// already pins why 0 would be wrong.
+    var effectiveSeedAnchorWeight: Int {
+        max(1, seedAnchorWeightOverride ?? Self.seedAnchorWeight)
+    }
 
     private var pool: [SpeakerProfile] = []
     private var process: Process?
@@ -299,7 +352,8 @@ final class LiveSpeakerDiarizer: ObservableObject {
     /// Pre-populate the pool with known speaker voice profiles so
     /// returning speakers are auto-recognised. Call after `reset()` at
     /// recording start. Each entry gets a fresh `SPEAKER_NN` ID and a
-    /// `sampleCount` capped at `seedAnchorWeight` so the centroid can adapt
+    /// `sampleCount` capped at `effectiveSeedAnchorWeight` — the constant
+    /// `seedAnchorWeight` unless a sweep overrode it — so the centroid can adapt
     /// to current-session acoustics on the first few matches — see that
     /// constant for what the cap buys and why it is 3.
     ///
@@ -319,7 +373,7 @@ final class LiveSpeakerDiarizer: ObservableObject {
             pool.append(SpeakerProfile(
                 id: id,
                 centroid: entry.centroid,
-                sampleCount: min(entry.sampleCount, Self.seedAnchorWeight),
+                sampleCount: min(entry.sampleCount, effectiveSeedAnchorWeight),
                 observedCentroid: [],
                 observedCount: 0,
                 profileName: entry.name

--- a/MilaTests/SeedAnchorAutoNameAgreementTests.swift
+++ b/MilaTests/SeedAnchorAutoNameAgreementTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import Mila
+
+/// **Invariant: the sweep harness's auto-name metric counts exactly the names
+/// `RecognisedSpeakerAssigner.finish` would actually apply.**
+///
+/// ## Why this file exists
+///
+/// `SeedAnchorTally` scores recording-level auto-naming from a predicate over
+/// the pool — `profileName != nil && observedCount > 0` — rather than by
+/// running the real `finish` per grid cell. That is a deliberate trade: a
+/// 40-cell sweep would otherwise need a `RecordingStore`, a
+/// `SpeakerProfileStore` and a disk write per cell, turning a
+/// milliseconds-per-configuration replay into something nobody will run.
+///
+/// The cost of that trade is the classic one: a predicate copied out of
+/// `finish` drifts from `finish`, and a drifted metric does not fail — it
+/// quietly reports a different number. #248 found the same hazard one layer
+/// down, where a *simulation* of `assign` agreed with itself for every anchor
+/// weight from 1 to uncapped while the real fold did not.
+///
+/// So the predicate is not trusted; it is pinned. Each test below drives the
+/// real pipeline — real `RecordingStore`, real `SpeakerProfileStore`, real
+/// `LiveSpeakerDiarizer`, real `RecognisedSpeakerAssigner` — and the harness's
+/// replay over an identical corpus, and asserts the two agree on how many
+/// names get applied. If someone adds a fifth guard to `finish`, or changes
+/// what `observedCount` means, this fails instead of the sweep silently
+/// measuring the old behaviour.
+///
+/// ## The two guards that are not modelled, and why that is sound
+///
+/// `finish` has four guards. Two depend on acoustics and are modelled here.
+/// The other two cannot vary during a replay:
+///
+///   * *the user did not already name this speaker* — a replay has no live
+///     transcript and so no user-typed names;
+///   * *the profile is still stored* — a corpus's profiles exist for the
+///     whole run; nobody deletes one mid-sweep.
+///
+/// Both would only ever *suppress* a name, so modelling them as "true" is also
+/// the direction that cannot overstate recognition.
+@MainActor
+final class SeedAnchorAutoNameAgreementTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteNames: [String] = []
+
+    /// Alice's stored profile, and a vector close enough to it to be a
+    /// confident match at the 0.7 threshold used throughout.
+    private let aliceStored: [Float] = [1, 0, 0, 0]
+    private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
+    /// Cosine exactly 0.6 to `aliceStored`: above the 0.55 create floor, below
+    /// the 0.7 match threshold — so `assign` attaches it to Alice's entry
+    /// without folding it in, leaving `observedCount` at zero. This is the
+    /// case that separates "produced an interval" from "confidently matched",
+    /// and the reason `finish` gates on `observedCount` rather than intervals.
+    private let borderline: [Float] = [0.6, 0.8, 0, 0]
+    /// Orthogonal to everything seeded: mints a speaker of its own.
+    private let stranger: [Float] = [0, 0, 1, 0]
+
+    private let threshold = 0.7
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: "SeedAnchorAutoNameAgreementTests")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in suiteNames { UserDefaults().removePersistentDomain(forName: name) }
+        suiteNames.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - The real pipeline
+
+    private struct World {
+        let store: RecordingStore
+        let profiles: SpeakerProfileStore
+        let diarizer: LiveSpeakerDiarizer
+        let assigner: RecognisedSpeakerAssigner
+    }
+
+    /// Alice on disk and a seeded pool — the same wiring `MilaApp.init`
+    /// installs, and the same shape `RecognisedSpeakerAssignerTests` uses.
+    private func makeWorld() -> World {
+        let suite = "SeedAnchorAutoNameAgreementTests.\(UUID())"
+        suiteNames.append(suite)
+        let settings = VoiceRecognitionSettings(defaults: UserDefaults(suiteName: suite)!)
+        settings.diarizationReady = { true }
+        settings.isEnabled = true
+
+        let profiles = SpeakerProfileStore(directory: tempRoot, settings: settings)
+        profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 40)
+
+        let store = RecordingStore(rootDirectory: tempRoot)
+        let snapshots = ObservedVoiceSnapshots()
+        store.onSpeakerNamed = { recordingID, rawID, name in
+            guard settings.isConfigured else { return }
+            guard let observed = snapshots.observation(forSpeaker: rawID,
+                                                       in: recordingID) else { return }
+            profiles.updateProfile(name: name,
+                                   embedding: observed.observedCentroid,
+                                   sampleCount: observed.observedCount)
+        }
+
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = threshold
+        diarizer.reset()
+        diarizer.seedPool(with: profiles.seedEntries())
+
+        let assigner = RecognisedSpeakerAssigner(
+            store: store,
+            diarizer: diarizer,
+            snapshots: snapshots,
+            settings: settings,
+            profileStillStored: { profiles.profileExists(name: $0) })
+        return World(store: store, profiles: profiles, diarizer: diarizer, assigner: assigner)
+    }
+
+    /// The same utterances, replayed through the harness against a corpus that
+    /// mirrors the world: one enrolment for Alice at the same stored count,
+    /// the shipping anchor weight, the same threshold.
+    private func harnessNamesIssued(for embeddings: [[Float]]) throws -> Int {
+        let utterances = embeddings.enumerated().map { index, embedding in
+            SeedAnchorCorpus.Utterance(speaker: "Alice",
+                                       start: Double(index) * 3,
+                                       end: Double(index) * 3 + 2,
+                                       embedding: embedding)
+        }
+        let corpus = try SeedAnchorCorpus(
+            enrolments: [.init(speaker: "Alice", centroid: aliceStored, sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: "agreement", utterances: utterances)]
+        ).validated()
+
+        let results = try SeedAnchorSweepHarness.sweep(
+            corpus: corpus,
+            anchorWeights: [LiveSpeakerDiarizer.seedAnchorWeight],
+            thresholds: [threshold])
+        return try XCTUnwrap(results.first).tally.autoNamesIssued
+    }
+
+    /// Drive the world's diarizer with the same embeddings, finish the
+    /// recording, and report how many raw ids ended up carrying a name.
+    private func pipelineNamesApplied(for embeddings: [[Float]]) -> (applied: Int, names: [String: String]) {
+        let world = makeWorld()
+        for embedding in embeddings {
+            _ = world.diarizer.assign(embedding: embedding)
+        }
+        let meeting = Recording(title: "Meeting", createdAt: Date(),
+                                source: .microphone, audioFileName: "Meeting.wav")
+        world.store.add(meeting)
+        world.assigner.finish(recording: meeting.id)
+        let names = world.store.recordings.first { $0.id == meeting.id }?.speakerNames ?? [:]
+        return (names.count, names)
+    }
+
+    // MARK: - Agreement
+
+    /// A speaker who confidently matched is named by the pipeline, and counted
+    /// by the harness.
+    func test_a_confident_match_is_named_by_both() throws {
+        let embeddings = [aliceSpeaking]
+        let pipeline = pipelineNamesApplied(for: embeddings)
+
+        XCTAssertEqual(pipeline.names["SPEAKER_00"], "Alice",
+                       "precondition: the real pipeline auto-names the recognised speaker")
+        XCTAssertEqual(try harnessNamesIssued(for: embeddings), pipeline.applied,
+                       "the harness's auto-name metric must count exactly the names `finish` "
+                       + "applies — if these diverge the sweep is scoring a predicate that no "
+                       + "longer matches the code it claims to model")
+    }
+
+    /// The case that makes the predicate non-obvious: an utterance that
+    /// *attaches* to Alice's entry without folding into it. The entry produces
+    /// an interval and carries her name from the seed, but `observedCount`
+    /// stays 0 — so `finish` refuses to auto-name, and the harness must refuse
+    /// to count it.
+    ///
+    /// A predicate written as "was seeded and got at least one utterance"
+    /// would pass every other test in this file and fail only here.
+    func test_a_borderline_attach_is_named_by_neither() throws {
+        let embeddings = [borderline, stranger]
+        let pipeline = pipelineNamesApplied(for: embeddings)
+
+        XCTAssertTrue(pipeline.names.isEmpty,
+                      "precondition: a borderline attach is not a recognition, and a minted "
+                      + "speaker has no profile to be named from")
+        XCTAssertEqual(try harnessNamesIssued(for: embeddings), 0)
+        XCTAssertEqual(try harnessNamesIssued(for: embeddings), pipeline.applied)
+    }
+
+    /// And the mixed case: one confident match plus a stranger. Exactly one
+    /// name, from both sides — the minted speaker must not be counted just
+    /// because it has observations.
+    func test_a_minted_speaker_is_counted_by_neither() throws {
+        let embeddings = [aliceSpeaking, stranger]
+        let pipeline = pipelineNamesApplied(for: embeddings)
+
+        XCTAssertEqual(pipeline.applied, 1)
+        XCTAssertNil(pipeline.names["SPEAKER_01"],
+                     "precondition: a speaker minted in-recording has no stored profile "
+                     + "behind it, so there is no name to apply")
+        XCTAssertEqual(try harnessNamesIssued(for: embeddings), 1)
+    }
+}

--- a/MilaTests/SeedAnchorSweepHarness.swift
+++ b/MilaTests/SeedAnchorSweepHarness.swift
@@ -86,7 +86,13 @@ struct SeedAnchorCorpus: Decodable {
 
 /// Why a corpus was refused. Every case is something that would otherwise
 /// produce a grid of plausible-looking numbers that measure nothing.
-enum SeedAnchorCorpusError: Error, CustomStringConvertible {
+///
+/// `LocalizedError` as well as `CustomStringConvertible` so the explanation
+/// survives whichever of the two XCTest reaches for: a bare `Error` enum's
+/// `localizedDescription` is the useless generic "operation couldn't be
+/// completed", and someone whose corpus was rejected mid-run needs the reason,
+/// not the case name.
+enum SeedAnchorCorpusError: Error, LocalizedError, CustomStringConvertible {
     case noEnrolments
     case noRecordings
     case duplicateEnrolment(speaker: String)
@@ -119,6 +125,8 @@ enum SeedAnchorCorpusError: Error, CustomStringConvertible {
             return "utterance by \(speaker) in \(recording) ends before it starts"
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 extension SeedAnchorCorpus {

--- a/MilaTests/SeedAnchorSweepHarness.swift
+++ b/MilaTests/SeedAnchorSweepHarness.swift
@@ -1,0 +1,623 @@
+import Foundation
+@testable import Mila
+
+// MARK: - Corpus
+
+/// A cached corpus of speaker embeddings, and the ground truth for who said
+/// what — the input to the seed-anchor sweep (#206).
+///
+/// ## Why this shape
+///
+/// The question #206 asks is whether `LiveSpeakerDiarizer.seedAnchorWeight`
+/// (n₀ = 3) recognises returning speakers better than 2 or 4 would. Answering
+/// it needs real audio, but it does **not** need the app or the Python daemon
+/// in the replay loop: `seedPool`, `assign` and `cosineSimilarity` are
+/// synchronous and pure over their inputs, and the only thing that needs
+/// pyannote is turning audio into embeddings.
+///
+/// So the expensive step happens exactly once. `scripts/extract-voice-embeddings.py`
+/// runs the same embedding model the app uses over a labelled corpus and
+/// writes this JSON; every configuration in the sweep then replays the cached
+/// vectors through the real matching code in milliseconds. That is what makes
+/// a 40-cell grid (8 anchor weights × 5 thresholds) cheap enough to run at
+/// all, and it is why the numbers are reproducible: the same corpus file
+/// gives the same grid on any machine, with no model or GPU in the loop.
+///
+/// `docs/seed-anchor-sweep.md` documents the file format for humans, how to
+/// produce one, and what to do with the result.
+struct SeedAnchorCorpus: Decodable {
+
+    /// One VAD utterance: the embedding the daemon produced for it, its
+    /// ground-truth speaker, and its position in the recording.
+    ///
+    /// `start`/`end` are not decoration. `assign` treats an utterance shorter
+    /// than a second as untrustworthy for *minting* a speaker, and it folds
+    /// matches into the centroid in arrival order, so both the duration and
+    /// the chronology change the outcome. A corpus that loses them measures
+    /// something other than what the app does.
+    struct Utterance: Decodable {
+        let speaker: String
+        let start: Double
+        let end: Double
+        let embedding: [Float]
+
+        var duration: Double { max(0, end - start) }
+    }
+
+    /// One recording, replayed as a unit: a fresh pool, seeded once, then
+    /// every utterance in chronological order.
+    struct Recording: Decodable {
+        let id: String
+        /// Free-text capture setup ("headset-office", "laptop-mic-kitchen").
+        /// Reported but not used in any metric — its purpose is to let
+        /// whoever runs the sweep confirm the corpus actually spans more than
+        /// one setup, which is the case the whole question is about.
+        let setup: String?
+        let utterances: [Utterance]
+    }
+
+    /// A speaker's stored profile as it would sit in `speaker-profiles.json`
+    /// at the moment the recording starts.
+    ///
+    /// Build these from a **held-out** enrolment recording, never from the
+    /// recordings being replayed: `centroid` is that recording's observed
+    /// centroid and `sampleCount` its observation count, which is exactly
+    /// what `SpeakerProfileStore.updateProfile` would have written. Reusing a
+    /// replayed recording here leaks the answer into the profile and every
+    /// anchor weight scores implausibly well.
+    struct Enrolment: Decodable {
+        let speaker: String
+        let centroid: [Float]
+        let sampleCount: Int
+    }
+
+    let enrolments: [Enrolment]
+    let recordings: [Recording]
+
+    /// Every speaker with a stored profile. The recall metric is defined only
+    /// over these; utterances from anyone else can still *harm* a metric (see
+    /// `SeedAnchorTally.falseAttachRate`) but they cannot be recognised.
+    var enrolledSpeakers: Set<String> { Set(enrolments.map(\.speaker)) }
+
+    /// The dimension every vector in the corpus must share, from the first
+    /// enrolment. `validated()` enforces it.
+    var embeddingDimension: Int { enrolments.first?.centroid.count ?? 0 }
+}
+
+/// Why a corpus was refused. Every case is something that would otherwise
+/// produce a grid of plausible-looking numbers that measure nothing.
+enum SeedAnchorCorpusError: Error, CustomStringConvertible {
+    case noEnrolments
+    case noRecordings
+    case duplicateEnrolment(speaker: String)
+    case emptyRecording(recording: String)
+    case emptyVector(context: String)
+    case nonFiniteVector(context: String)
+    case dimensionMismatch(context: String, expected: Int, found: Int)
+    case badSampleCount(speaker: String, count: Int)
+    case negativeDuration(recording: String, speaker: String)
+
+    var description: String {
+        switch self {
+        case .noEnrolments:
+            return "corpus has no enrolments — with no stored profile there is nothing for the seed anchor to weight"
+        case .noRecordings:
+            return "corpus has no recordings to replay"
+        case .duplicateEnrolment(let speaker):
+            return "two enrolments for speaker \(speaker) — seeded ids are resolved by profile name, so the mapping would be ambiguous"
+        case .emptyRecording(let recording):
+            return "recording \(recording) has no utterances"
+        case .emptyVector(let context):
+            return "empty embedding at \(context) — `assign` skips empty centroids and refuses empty embeddings, so this row would silently vanish"
+        case .nonFiniteVector(let context):
+            return "non-finite value in embedding at \(context) — a NaN makes every later comparison NaN, which reads as 'never matched' rather than as an error"
+        case .dimensionMismatch(let context, let expected, let found):
+            return "embedding dimension \(found) at \(context), expected \(expected) — `assign` refuses a confident match across dimensions, so a mixed-dimension corpus scores zero recall for reasons that have nothing to do with the anchor weight"
+        case .badSampleCount(let speaker, let count):
+            return "enrolment for \(speaker) has sampleCount \(count), which must be in 1...VoiceProfile.maxSampleCount — the same bound `updateProfile` enforces, and what keeps `assign`'s `n + 1` from overflowing under an uncapped anchor"
+        case .negativeDuration(let recording, let speaker):
+            return "utterance by \(speaker) in \(recording) ends before it starts"
+        }
+    }
+}
+
+extension SeedAnchorCorpus {
+
+    /// Refuse a corpus that cannot answer the question, rather than reporting
+    /// a grid computed from it.
+    ///
+    /// The bounds on `sampleCount` mirror `SpeakerProfileStore.updateProfile`
+    /// deliberately: the harness must only accept profiles the app itself
+    /// would have accepted, or the sweep is measuring a state that cannot
+    /// occur. It is also load-bearing for the *uncapped* configuration —
+    /// there `seedPool` passes the stored count through untouched, and
+    /// `assign` computes `Float(n + 1)`, which would trap on `Int.max`.
+    @discardableResult
+    func validated() throws -> SeedAnchorCorpus {
+        guard !enrolments.isEmpty else { throw SeedAnchorCorpusError.noEnrolments }
+        guard !recordings.isEmpty else { throw SeedAnchorCorpusError.noRecordings }
+
+        let dimension = enrolments[0].centroid.count
+
+        var seen = Set<String>()
+        for enrolment in enrolments {
+            guard seen.insert(enrolment.speaker).inserted else {
+                throw SeedAnchorCorpusError.duplicateEnrolment(speaker: enrolment.speaker)
+            }
+            let context = "enrolment \(enrolment.speaker)"
+            guard !enrolment.centroid.isEmpty else {
+                throw SeedAnchorCorpusError.emptyVector(context: context)
+            }
+            guard enrolment.centroid.allSatisfy({ $0.isFinite }) else {
+                throw SeedAnchorCorpusError.nonFiniteVector(context: context)
+            }
+            guard enrolment.centroid.count == dimension else {
+                throw SeedAnchorCorpusError.dimensionMismatch(context: context,
+                                                              expected: dimension,
+                                                              found: enrolment.centroid.count)
+            }
+            guard enrolment.sampleCount > 0,
+                  enrolment.sampleCount <= VoiceProfile.maxSampleCount else {
+                throw SeedAnchorCorpusError.badSampleCount(speaker: enrolment.speaker,
+                                                           count: enrolment.sampleCount)
+            }
+        }
+
+        for recording in recordings {
+            guard !recording.utterances.isEmpty else {
+                throw SeedAnchorCorpusError.emptyRecording(recording: recording.id)
+            }
+            for (index, utterance) in recording.utterances.enumerated() {
+                let context = "\(recording.id)[\(index)] (\(utterance.speaker))"
+                guard !utterance.embedding.isEmpty else {
+                    throw SeedAnchorCorpusError.emptyVector(context: context)
+                }
+                guard utterance.embedding.allSatisfy({ $0.isFinite }) else {
+                    throw SeedAnchorCorpusError.nonFiniteVector(context: context)
+                }
+                guard utterance.embedding.count == dimension else {
+                    throw SeedAnchorCorpusError.dimensionMismatch(context: context,
+                                                                  expected: dimension,
+                                                                  found: utterance.embedding.count)
+                }
+                guard utterance.end >= utterance.start else {
+                    throw SeedAnchorCorpusError.negativeDuration(recording: recording.id,
+                                                                 speaker: utterance.speaker)
+                }
+            }
+        }
+        return self
+    }
+
+    static func load(from url: URL) throws -> SeedAnchorCorpus {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(SeedAnchorCorpus.self, from: data).validated()
+    }
+}
+
+// MARK: - Configuration
+
+/// One cell of the sweep grid.
+struct SeedAnchorConfiguration: Hashable {
+    /// The seed anchor weight under test, n₀ — what `seedPool` caps a
+    /// returning speaker's `sampleCount` at. `uncappedAnchorWeight` means
+    /// "no cap": the profile anchors at its true stored count, which is
+    /// exactly what deleting the `min` in `seedPool` would do.
+    let anchorWeight: Int
+    /// `LiveSpeakerDiarizer.similarityThreshold` for this cell. Swept
+    /// alongside n₀ rather than held at the default because the two
+    /// interact: n₀ sets how fast the compared centroid moves and the
+    /// threshold sets how far it may move before a match is refused, so the
+    /// best n₀ at 0.55 need not be the best at 0.70 — and Settings lets users
+    /// pick anything in 0.5...0.95.
+    let similarityThreshold: Double
+
+    static let uncappedAnchorWeight = Int.max
+
+    /// The grid from #206's protocol. It includes both ends deliberately —
+    /// 1 is the lightest well-formed anchor and `uncapped` is the failure
+    /// `seedAnchorWeight`'s doc comment describes — so the sweep *reports*
+    /// them instead of assuming them.
+    static let defaultAnchorWeights: [Int] = [1, 2, 3, 4, 6, 8, 12,
+                                              SeedAnchorConfiguration.uncappedAnchorWeight]
+
+    /// Spans the useful part of the Settings slider around the 0.55 default.
+    /// Swept alongside n₀ because the two knobs interact — see
+    /// `similarityThreshold` above.
+    static let defaultThresholds: [Double] = [0.50, 0.55, 0.60, 0.65, 0.70]
+
+    var anchorLabel: String {
+        anchorWeight == Self.uncappedAnchorWeight ? "uncapped" : "\(anchorWeight)"
+    }
+
+    var label: String {
+        String(format: "n0=%@ thr=%.2f", anchorLabel, similarityThreshold)
+    }
+}
+
+// MARK: - Replay output
+
+/// What one replayed recording produced. Deliberately just the observations —
+/// every metric is computed from this by `SeedAnchorTally`, so the metric
+/// definitions are testable without a diarizer and the replay is testable
+/// without the metrics.
+struct SeedAnchorRecordingOutcome {
+
+    struct Assignment: Equatable {
+        let trueSpeaker: String
+        let assignedID: String
+    }
+
+    /// The end-of-recording pool as `currentProfiles()` reports it — the
+    /// exact rows `RecognisedSpeakerAssigner.finish` reads.
+    struct PoolEntry: Equatable {
+        let id: String
+        let observedCount: Int
+        let profileName: String?
+    }
+
+    let recordingID: String
+    /// One per utterance, in replay (chronological) order.
+    let assignments: [Assignment]
+    let pool: [PoolEntry]
+    /// speaker label → the `SPEAKER_NN` id `seedPool` gave that speaker's
+    /// profile. Read back out of the pool rather than recomputed, so it
+    /// cannot drift from how `seedPool` actually mints ids.
+    let seededID: [String: String]
+    /// The inverse: `SPEAKER_NN` → the speaker whose profile seeded it.
+    let speakerBehindSeededID: [String: String]
+    /// Every speaker with a stored profile, whether or not they spoke here.
+    let enrolledSpeakers: Set<String>
+}
+
+// MARK: - Metrics
+
+/// The four metrics #206 asks for, as raw counts so recordings aggregate by
+/// addition and the rates are computed once over the whole corpus.
+///
+/// Counts rather than per-recording rates on purpose: a rate whose
+/// denominator is zero for some recordings (a recording where nobody
+/// enrolled spoke, say) has no well-defined average, and averaging rates
+/// across recordings of very different lengths silently weights a 20-utterance
+/// recording the same as a 300-utterance one.
+struct SeedAnchorTally: Equatable {
+
+    /// Utterances whose true speaker has a stored profile.
+    var returningTotal = 0
+    /// …of those, the ones `assign` sent to the entry seeded from *that
+    /// speaker's* profile. "It recognised me."
+    var returningHits = 0
+
+    /// Every utterance replayed, the denominator for `falseAttachRate`.
+    var utterancesTotal = 0
+    /// Utterances that landed on a seeded entry belonging to a **different**
+    /// true speaker. This is the harm the whole knob risks: the wrong name
+    /// against someone's words, and — once `finish` auto-names it — the wrong
+    /// voice folded into a stored profile.
+    ///
+    /// Counted for utterances from *any* speaker, enrolled or not: a
+    /// stranger's utterance landing on Alice's entry is exactly as harmful as
+    /// Bob's, so restricting this to enrolled speakers would hide the case a
+    /// heavy anchor makes most likely.
+    var falseAttachments = 0
+
+    /// Pool entries that would be auto-named — `profileName != nil &&
+    /// observedCount > 0`, which is `RecognisedSpeakerAssigner.finish`'s guard
+    /// set restricted to the two guards that depend on acoustics. (Its other
+    /// two cannot vary in a replay: there are no live user-typed names, and
+    /// every profile in a corpus is still stored.)
+    ///
+    /// `SeedAnchorAutoNameAgreementTests` pins this predicate against the real
+    /// `finish`, so it cannot drift into a private reimplementation.
+    var autoNamesIssued = 0
+    /// …of those, the ones naming the right person: the utterances assigned to
+    /// that id have a *unique* plurality true speaker and it is the named one.
+    /// A tie counts as wrong, matching how the rest of this subsystem fails
+    /// closed.
+    var autoNamesCorrect = 0
+    /// Enrolled speakers who actually spoke, summed over recordings — the
+    /// recall denominator. A profile whose owner never opened their mouth
+    /// cannot be recognised and must not count against recall.
+    var autoNamesExpected = 0
+
+    /// Σ |distinct ids used − distinct true speakers| over recordings.
+    var speakerCountAbsError = 0
+    /// The same sum, signed. Positive means over-segmentation — the same
+    /// person split across several `SPEAKER_NN`s, which is the
+    /// counter-intuitive interaction a *heavier* anchor is expected to make
+    /// worse.
+    var speakerCountSignedError = 0
+
+    var recordings = 0
+
+    /// Recognisable and recognised utterance counts for one speaker.
+    ///
+    /// A named struct rather than a tuple because `SeedAnchorTally` is
+    /// `Equatable` and a `Dictionary` whose value is a tuple is not — tuples
+    /// have `==` overloads, not a conformance, so the synthesized
+    /// `Equatable` would fail to compile.
+    struct SpeakerCounts: Equatable {
+        var total = 0
+        var hits = 0
+    }
+
+    /// speaker → how many of their utterances were recognisable, and how many
+    /// were recognised. Kept per speaker because the significance test has to
+    /// be paired **across speakers**: utterances inside one recording are
+    /// heavily correlated, so an utterance-level test finds significance that
+    /// is not there.
+    var perSpeaker: [String: SpeakerCounts] = [:]
+
+    var returningRecall: Double? {
+        returningTotal == 0 ? nil : Double(returningHits) / Double(returningTotal)
+    }
+    var falseAttachRate: Double? {
+        utterancesTotal == 0 ? nil : Double(falseAttachments) / Double(utterancesTotal)
+    }
+    var autoNamePrecision: Double? {
+        autoNamesIssued == 0 ? nil : Double(autoNamesCorrect) / Double(autoNamesIssued)
+    }
+    var autoNameRecall: Double? {
+        autoNamesExpected == 0 ? nil : Double(autoNamesCorrect) / Double(autoNamesExpected)
+    }
+    var meanSpeakerCountAbsError: Double? {
+        recordings == 0 ? nil : Double(speakerCountAbsError) / Double(recordings)
+    }
+    var meanSpeakerCountSignedError: Double? {
+        recordings == 0 ? nil : Double(speakerCountSignedError) / Double(recordings)
+    }
+
+    /// Per-speaker recall, the vector the Wilcoxon test is paired over.
+    var perSpeakerRecall: [String: Double] {
+        perSpeaker.compactMapValues { counts -> Double? in
+            counts.total == 0 ? nil : Double(counts.hits) / Double(counts.total)
+        }
+    }
+
+    static func + (lhs: SeedAnchorTally, rhs: SeedAnchorTally) -> SeedAnchorTally {
+        var out = lhs
+        out.returningTotal += rhs.returningTotal
+        out.returningHits += rhs.returningHits
+        out.utterancesTotal += rhs.utterancesTotal
+        out.falseAttachments += rhs.falseAttachments
+        out.autoNamesIssued += rhs.autoNamesIssued
+        out.autoNamesCorrect += rhs.autoNamesCorrect
+        out.autoNamesExpected += rhs.autoNamesExpected
+        out.speakerCountAbsError += rhs.speakerCountAbsError
+        out.speakerCountSignedError += rhs.speakerCountSignedError
+        out.recordings += rhs.recordings
+        for (speaker, counts) in rhs.perSpeaker {
+            var existing = out.perSpeaker[speaker] ?? SpeakerCounts()
+            existing.total += counts.total
+            existing.hits += counts.hits
+            out.perSpeaker[speaker] = existing
+        }
+        return out
+    }
+
+    /// Score one replayed recording. Pure — no diarizer, no I/O — so every
+    /// metric definition above is pinned by tests over hand-built outcomes.
+    static func scoring(_ outcome: SeedAnchorRecordingOutcome) -> SeedAnchorTally {
+        var tally = SeedAnchorTally()
+        tally.recordings = 1
+        tally.utterancesTotal = outcome.assignments.count
+
+        for assignment in outcome.assignments {
+            if outcome.enrolledSpeakers.contains(assignment.trueSpeaker) {
+                tally.returningTotal += 1
+                var counts = tally.perSpeaker[assignment.trueSpeaker] ?? SpeakerCounts()
+                counts.total += 1
+                if outcome.seededID[assignment.trueSpeaker] == assignment.assignedID {
+                    tally.returningHits += 1
+                    counts.hits += 1
+                }
+                tally.perSpeaker[assignment.trueSpeaker] = counts
+            }
+            if let seededOwner = outcome.speakerBehindSeededID[assignment.assignedID],
+               seededOwner != assignment.trueSpeaker {
+                tally.falseAttachments += 1
+            }
+        }
+
+        // Auto-naming, evaluated over the same pool rows `finish` reads.
+        for entry in outcome.pool {
+            guard let profileName = entry.profileName, entry.observedCount > 0 else { continue }
+            tally.autoNamesIssued += 1
+            var byTrueSpeaker: [String: Int] = [:]
+            for assignment in outcome.assignments where assignment.assignedID == entry.id {
+                byTrueSpeaker[assignment.trueSpeaker, default: 0] += 1
+            }
+            guard let top = byTrueSpeaker.values.max() else { continue }
+            let leaders = byTrueSpeaker.filter { $0.value == top }.map { $0.key }
+            if leaders.count == 1, leaders[0] == profileName {
+                tally.autoNamesCorrect += 1
+            }
+        }
+        let spoke = Set(outcome.assignments.map(\.trueSpeaker))
+        tally.autoNamesExpected = outcome.enrolledSpeakers.intersection(spoke).count
+
+        let idsUsed = Set(outcome.assignments.map(\.assignedID)).count
+        let signed = idsUsed - spoke.count
+        tally.speakerCountSignedError = signed
+        tally.speakerCountAbsError = abs(signed)
+
+        return tally
+    }
+}
+
+/// One cell of the grid, scored.
+struct SeedAnchorResult {
+    let configuration: SeedAnchorConfiguration
+    let tally: SeedAnchorTally
+    /// Per-recording tallies, kept so a run can be inspected recording by
+    /// recording when a cell looks surprising.
+    let perRecording: [String: SeedAnchorTally]
+}
+
+// MARK: - Harness
+
+/// Replays a cached corpus through the **real** `LiveSpeakerDiarizer` matching
+/// path once per grid cell, and scores it.
+///
+/// The replay drives `reset()`, `seedPool(with:)` and `assign(embedding:
+/// utteranceDuration:)` — the shipping code, not a model of it. That is the
+/// point: #248 established that a simulation of `assign` was green for every
+/// anchor weight from 1 to uncapped, so anything short of the real fold can
+/// agree with itself while disagreeing with the app.
+///
+/// Nothing here has a default that changes app behaviour: the only knob it
+/// touches is `seedAnchorWeightOverride`, which is `nil` everywhere else.
+@MainActor
+enum SeedAnchorSweepHarness {
+
+    /// Replay one recording under one configuration.
+    static func replay(recording: SeedAnchorCorpus.Recording,
+                       enrolments: [SeedAnchorCorpus.Enrolment],
+                       configuration: SeedAnchorConfiguration) -> SeedAnchorRecordingOutcome {
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = configuration.similarityThreshold
+        diarizer.seedAnchorWeightOverride = configuration.anchorWeight
+        diarizer.reset()
+
+        // Sorted by speaker so the seeded id a speaker gets is a function of
+        // the corpus, not of dictionary or file ordering. Ids are minted
+        // positionally by `seedPool`, so an unstable order would reshuffle
+        // them between runs and make two grids incomparable.
+        let ordered = enrolments.sorted { $0.speaker < $1.speaker }
+        diarizer.seedPool(with: ordered.map {
+            (id: $0.speaker, name: $0.speaker, centroid: $0.centroid, sampleCount: $0.sampleCount)
+        })
+
+        // Read the mapping back off the pool instead of recomputing
+        // `SPEAKER_%02d` from the index: if `seedPool` ever mints ids
+        // differently, this follows it rather than silently mislabelling
+        // every hit as a miss.
+        var seededID: [String: String] = [:]
+        var speakerBehindSeededID: [String: String] = [:]
+        for entry in diarizer.currentProfiles() {
+            guard let name = entry.profileName else { continue }
+            seededID[name] = entry.id
+            speakerBehindSeededID[entry.id] = name
+        }
+
+        // Chronological, with a total order so equal timestamps cannot
+        // reorder between runs — `sorted(by:)` is not documented as stable.
+        let chronological = recording.utterances.enumerated().sorted { lhs, rhs in
+            if lhs.element.start != rhs.element.start { return lhs.element.start < rhs.element.start }
+            if lhs.element.end != rhs.element.end { return lhs.element.end < rhs.element.end }
+            return lhs.offset < rhs.offset
+        }.map { $0.element }
+
+        var assignments: [SeedAnchorRecordingOutcome.Assignment] = []
+        assignments.reserveCapacity(chronological.count)
+        for utterance in chronological {
+            let assigned = diarizer.assign(embedding: utterance.embedding,
+                                           utteranceDuration: utterance.duration)
+            assignments.append(.init(trueSpeaker: utterance.speaker, assignedID: assigned))
+        }
+
+        let pool = diarizer.currentProfiles().map {
+            SeedAnchorRecordingOutcome.PoolEntry(id: $0.id,
+                                                 observedCount: $0.observedCount,
+                                                 profileName: $0.profileName)
+        }
+
+        return SeedAnchorRecordingOutcome(recordingID: recording.id,
+                                          assignments: assignments,
+                                          pool: pool,
+                                          seededID: seededID,
+                                          speakerBehindSeededID: speakerBehindSeededID,
+                                          enrolledSpeakers: Set(enrolments.map(\.speaker)))
+    }
+
+    /// Score every recording in the corpus under one configuration.
+    static func evaluate(corpus: SeedAnchorCorpus,
+                         configuration: SeedAnchorConfiguration) -> SeedAnchorResult {
+        var total = SeedAnchorTally()
+        var perRecording: [String: SeedAnchorTally] = [:]
+        for recording in corpus.recordings {
+            let outcome = replay(recording: recording,
+                                 enrolments: corpus.enrolments,
+                                 configuration: configuration)
+            let tally = SeedAnchorTally.scoring(outcome)
+            perRecording[recording.id] = tally
+            total = total + tally
+        }
+        return SeedAnchorResult(configuration: configuration,
+                                tally: total,
+                                perRecording: perRecording)
+    }
+
+    /// The whole grid, in row-major order (anchor weight outer, threshold
+    /// inner) so `report` can slice it without re-sorting.
+    static func sweep(corpus: SeedAnchorCorpus,
+                      anchorWeights: [Int] = SeedAnchorConfiguration.defaultAnchorWeights,
+                      thresholds: [Double] = SeedAnchorConfiguration.defaultThresholds)
+                      throws -> [SeedAnchorResult] {
+        try corpus.validated()
+        var results: [SeedAnchorResult] = []
+        for weight in anchorWeights {
+            for threshold in thresholds {
+                let configuration = SeedAnchorConfiguration(anchorWeight: weight,
+                                                            similarityThreshold: threshold)
+                results.append(evaluate(corpus: corpus, configuration: configuration))
+            }
+        }
+        return results
+    }
+}
+
+// MARK: - Recommendation
+
+/// The decision rule from #206, applied to a finished grid — as a **starting
+/// point for a human**, not a verdict.
+///
+/// The rule: prefer the *smallest* anchor weight whose worst false-attach rate
+/// across the threshold row is within `tolerance` of the best any weight
+/// achieves. Smallest-wins comes from the asymmetry that keeps the anchor
+/// small in the first place — a too-light anchor's damage is confined to one
+/// recording, because n₀ never reaches persistence, while a too-heavy anchor's
+/// damage persists across every future recording of that speaker.
+///
+/// `tolerance` is a judgement call with no measurement behind it, which is why
+/// it is a parameter and why this type reports what it rejected. The gate that
+/// actually matters is the paired significance test on per-speaker recall
+/// (`WilcoxonSignedRank`), reported per cell alongside this.
+struct SeedAnchorRecommendation {
+    let anchorWeight: Int
+    let anchorLabel: String
+    /// Worst (highest) false-attach rate this weight produced across the
+    /// swept thresholds — the row is judged by its worst cell, not its best,
+    /// because users can set any threshold in 0.5...0.95.
+    let worstCaseFalseAttach: Double
+    let gridBestWorstCase: Double
+    let tolerance: Double
+    /// Weights ruled out, with the worst-case that ruled them out.
+    let rejected: [(anchorLabel: String, worstCaseFalseAttach: Double)]
+
+    static func from(_ results: [SeedAnchorResult],
+                     tolerance: Double = 0.01) -> SeedAnchorRecommendation? {
+        var worstCase: [Int: Double] = [:]
+        for result in results {
+            guard let rate = result.tally.falseAttachRate else { continue }
+            worstCase[result.configuration.anchorWeight] =
+                max(worstCase[result.configuration.anchorWeight] ?? 0, rate)
+        }
+        guard let best = worstCase.values.min() else { return nil }
+        let candidates = worstCase.filter { $0.value <= best + tolerance }.keys.sorted()
+        guard let winner = candidates.first else { return nil }
+        let rejected = worstCase.filter { !candidates.contains($0.key) }
+            .sorted { $0.key < $1.key }
+            .map { (anchorLabel: SeedAnchorConfiguration(anchorWeight: $0.key,
+                                                         similarityThreshold: 0).anchorLabel,
+                    worstCaseFalseAttach: $0.value) }
+        return SeedAnchorRecommendation(
+            anchorWeight: winner,
+            anchorLabel: SeedAnchorConfiguration(anchorWeight: winner,
+                                                 similarityThreshold: 0).anchorLabel,
+            worstCaseFalseAttach: worstCase[winner] ?? best,
+            gridBestWorstCase: best,
+            tolerance: tolerance,
+            rejected: rejected)
+    }
+}

--- a/MilaTests/SeedAnchorSweepHarnessTests.swift
+++ b/MilaTests/SeedAnchorSweepHarnessTests.swift
@@ -333,7 +333,8 @@ final class SeedAnchorSweepHarnessTests: XCTestCase {
         XCTAssertEqual(pooled.utterancesTotal, 100)
         XCTAssertEqual(try XCTUnwrap(pooled.falseAttachRate), 0.45, accuracy: 1e-12,
                        "0.45, not the 0.30 that averaging the two rates would give")
-        XCTAssertEqual(pooled.perSpeaker["alice"], .init(total: 100, hits: 54))
+        XCTAssertEqual(pooled.perSpeaker["alice"],
+                       SeedAnchorTally.SpeakerCounts(total: 100, hits: 54))
         XCTAssertEqual(pooled.recordings, 2)
     }
 

--- a/MilaTests/SeedAnchorSweepHarnessTests.swift
+++ b/MilaTests/SeedAnchorSweepHarnessTests.swift
@@ -1,0 +1,416 @@
+import XCTest
+@testable import Mila
+
+/// Exercises `SeedAnchorSweepHarness` — the offline replay that makes #206's
+/// question answerable — on synthetic embeddings, so the harness itself is
+/// verified on every CI run rather than the first time someone points it at a
+/// corpus.
+///
+/// ## What these tests are for
+///
+/// The sweep's output will be used to decide whether to move
+/// `LiveSpeakerDiarizer.seedAnchorWeight`, a constant that changes how every
+/// existing user's stored profiles behave. A harness that quietly measured
+/// nothing would be worse than no harness: it would produce a grid of
+/// plausible numbers and licence a change on the strength of them. So the
+/// tests below pin, on hand-checkable geometry:
+///
+///   * that varying the anchor weight actually **changes the outcome** — the
+///     one property that cannot be assumed, since #248 established that every
+///     seeded fixture in the existing suite scores identically for every
+///     weight from 1 to uncapped;
+///   * each metric's definition, on a fixture built so the four metrics
+///     disagree;
+///   * that replay is chronological rather than file-ordered.
+///
+/// ## Fixture geometry
+///
+/// A 2-D geometry embedded in 4-D vectors, the same one `SeedAnchorWeightTests`
+/// uses, so the two files describe one arithmetic:
+///
+///   * `stored` = `[1, 0, 0, 0]` — the profile on disk, at 0°.
+///   * `sessionVoice` = `[0.8, 0.6, 0, 0]` — today's acoustics, 36.87° away
+///     (cosine 0.8), above every threshold used here, so it always folds.
+///   * `farProbe` — 70° from `stored`. Whether it still matches after ten
+///     folds is exactly the question the anchor weight decides.
+///   * `backProbe` — 33° the *other* side of `stored`.
+///
+/// Every expected number below was cross-computed by replaying the same fold
+/// arithmetic in float32 outside Swift, and the values agree with the weight
+/// table in `seedAnchorWeight`'s doc comment (0.750 at n₀=3, 0.685 at n₀=6,
+/// 0.456 uncapped) — which was derived independently, in #248.
+@MainActor
+final class SeedAnchorSweepHarnessTests: XCTestCase {
+
+    private let stored: [Float] = [1, 0, 0, 0]
+    /// 36.87° off `stored` — cosine exactly 0.8.
+    private let sessionVoice: [Float] = [0.8, 0.6, 0, 0]
+    /// 70° off `stored`, same side as `sessionVoice`.
+    private let farProbe: [Float] = [0.34202, 0.93969, 0, 0]
+    /// 33° off `stored`, the opposite side.
+    private let backProbe: [Float] = [0.83867, -0.54464, 0, 0]
+
+    private let uncapped = SeedAnchorConfiguration.uncappedAnchorWeight
+
+    // MARK: - Fixtures
+
+    private func utterance(_ speaker: String,
+                           _ embedding: [Float],
+                           at start: Double,
+                           duration: Double = 2.0) -> SeedAnchorCorpus.Utterance {
+        .init(speaker: speaker, start: start, end: start + duration, embedding: embedding)
+    }
+
+    /// One returning speaker, ten of today's utterances, then a probe far
+    /// enough out that whether it still matches depends on how hard the
+    /// stored voice is still anchoring.
+    ///
+    /// The shape is not arbitrary. The anchor weight can only change an
+    /// outcome *after* a confident match has folded something into the
+    /// centroid — before that, every weight compares against the same stored
+    /// vector. So any fixture that discriminates between weights must have a
+    /// confident match first and the interesting probe second, which is why
+    /// this one runs ten folds before asking the question.
+    private func adaptationCorpus(reversed: Bool = false) -> SeedAnchorCorpus {
+        var utterances = (0..<10).map { utterance("alice", sessionVoice, at: Double($0) * 3) }
+        utterances.append(utterance("alice", farProbe, at: 30))
+        if reversed { utterances.reverse() }
+        return SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: stored, sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: "headset", utterances: utterances)])
+    }
+
+    /// Two enrolled speakers and one stranger who sounds like Alice — built so
+    /// the four metrics give four different answers about the same recording.
+    private func mixedCorpus() -> SeedAnchorCorpus {
+        SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40),
+                         .init(speaker: "bob", centroid: [0, 1, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: "office", utterances: [
+                utterance("alice", [1, 0, 0, 0], at: 0),
+                // 18° off Alice's stored centroid: comfortably a confident
+                // match, and not Alice.
+                utterance("carol", [0.95, 0.31, 0, 0], at: 3),
+                utterance("bob", [0, 1, 0, 0], at: 6)
+            ])])
+    }
+
+    private func tally(_ results: [SeedAnchorResult], weight: Int) throws -> SeedAnchorTally {
+        try XCTUnwrap(results.first { $0.configuration.anchorWeight == weight }?.tally,
+                      "no result for anchor weight \(weight)")
+    }
+
+    // MARK: - The harness measures the knob
+
+    /// **The load-bearing test.** If the anchor weight did not reach
+    /// `seedPool`, every cell of the grid would be identical and the sweep
+    /// would report a confident, meaningless answer.
+    ///
+    /// With ten of this session's utterances folded in, the eleventh probe at
+    /// 70° is a confident match at every capped weight — the entry has moved
+    /// far enough towards today's acoustics — but *uncapped*, the entry is
+    /// still pinned at the stored voice (7.13° away, probe similarity 0.456,
+    /// below the 0.55 create floor), so the same speaker mints a second
+    /// `SPEAKER_NN`. That is the over-segmentation interaction
+    /// `seedAnchorWeight` describes, reproduced end to end through the real
+    /// `seedPool`/`assign`.
+    func test_the_grid_separates_anchor_weights_instead_of_reporting_one_number() throws {
+        let corpus = try adaptationCorpus().validated()
+        let results = try SeedAnchorSweepHarness.sweep(
+            corpus: corpus,
+            anchorWeights: [1, 2, 3, 4, 6, 12, uncapped],
+            thresholds: [0.70])
+
+        for weight in [1, 2, 3, 4, 6, 12] {
+            let capped = try tally(results, weight: weight)
+            XCTAssertEqual(try XCTUnwrap(capped.returningRecall), 1.0, accuracy: 1e-9,
+                           "at n0=\(weight) every utterance should reach the seeded entry")
+            XCTAssertEqual(try XCTUnwrap(capped.meanSpeakerCountAbsError), 0, accuracy: 1e-9,
+                           "and no duplicate speaker should be minted for the same person")
+            XCTAssertEqual(try XCTUnwrap(capped.falseAttachRate), 0, accuracy: 1e-9)
+        }
+
+        let uncappedTally = try tally(results, weight: uncapped)
+        XCTAssertEqual(try XCTUnwrap(uncappedTally.returningRecall), 10.0 / 11.0, accuracy: 1e-9,
+                       "uncapped, the anchor holds the entry on the stored voice and the "
+                       + "eleventh utterance falls out of the speaker entirely")
+        XCTAssertEqual(try XCTUnwrap(uncappedTally.meanSpeakerCountAbsError), 1, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(uncappedTally.meanSpeakerCountSignedError), 1, accuracy: 1e-9,
+                       "positive means over-segmentation — a heavier anchor splitting one "
+                       + "person across two ids, which runs opposite to the intuition that a "
+                       + "stronger anchor means more stable speakers")
+
+        let three = try tally(results, weight: LiveSpeakerDiarizer.seedAnchorWeight)
+        XCTAssertNotEqual(three.returningRecall, uncappedTally.returningRecall,
+                          "if these are equal the anchor weight is not reaching seedPool and "
+                          + "every cell of the sweep is measuring the same configuration")
+    }
+
+    /// The override must not leak into the app: an untouched diarizer anchors
+    /// at the shipping constant.
+    func test_a_diarizer_nobody_configured_uses_the_shipping_weight() {
+        let diarizer = LiveSpeakerDiarizer()
+        XCTAssertNil(diarizer.seedAnchorWeightOverride,
+                     "the sweep hook must be off unless a sweep turned it on")
+        XCTAssertEqual(diarizer.effectiveSeedAnchorWeight, LiveSpeakerDiarizer.seedAnchorWeight)
+    }
+
+    /// A weight below 1 is clamped, not honoured.
+    ///
+    /// `assign` folds with `(c·n + e) / (n + 1)`, so n₀ = 0 discards the stored
+    /// voice on its own first match and n₀ = -1 divides by zero. The clamp is
+    /// what keeps a mistyped sweep configuration from putting an infinity or a
+    /// NaN into a centroid, which reads as "never matched" rather than as an
+    /// error.
+    ///
+    /// The behavioural half is discriminating by construction: after one fold
+    /// of `sessionVoice` at n₀ = 1 the centroid sits at 18.43°, leaving
+    /// `backProbe` at cosine 0.623 — borderline, so it attaches and the pool
+    /// stays at one speaker. Had 0 been honoured the centroid would *be*
+    /// `sessionVoice`, putting `backProbe` at 0.344 — below the 0.55 create
+    /// floor, minting a second speaker for the same person.
+    func test_an_anchor_weight_below_one_is_clamped() {
+        XCTAssertEqual(clampedDiarizer(override: 0).effectiveSeedAnchorWeight, 1)
+        XCTAssertEqual(clampedDiarizer(override: -5).effectiveSeedAnchorWeight, 1)
+
+        let diarizer = clampedDiarizer(override: 0)
+        diarizer.reset()
+        diarizer.seedPool(with: [(id: "alice", name: "alice", centroid: stored, sampleCount: 40)])
+        XCTAssertEqual(diarizer.assign(embedding: sessionVoice), "SPEAKER_00")
+        XCTAssertEqual(diarizer.assign(embedding: backProbe), "SPEAKER_00",
+                       "clamped to 1 the stored voice still carries half the centroid, so the "
+                       + "probe attaches. SPEAKER_01 here means 0 was honoured and the stored "
+                       + "voice was discarded by its own first match")
+        XCTAssertEqual(diarizer.currentProfiles().count, 1)
+    }
+
+    private func clampedDiarizer(override: Int) -> LiveSpeakerDiarizer {
+        let diarizer = LiveSpeakerDiarizer()
+        diarizer.similarityThreshold = 0.7
+        diarizer.seedAnchorWeightOverride = override
+        return diarizer
+    }
+
+    /// Replay order is the corpus's chronology, not the order the file happens
+    /// to list utterances in. Discriminating: reversed, the 70° probe would be
+    /// the *first* utterance, and at 0.342 against the stored centroid it is
+    /// below the create floor — so a file-ordered replay mints a speaker for
+    /// it and scores differently.
+    func test_replay_follows_the_clock_not_the_file() throws {
+        let inOrder = try SeedAnchorSweepHarness.sweep(
+            corpus: try adaptationCorpus().validated(),
+            anchorWeights: [3, uncapped], thresholds: [0.70])
+        let shuffled = try SeedAnchorSweepHarness.sweep(
+            corpus: try adaptationCorpus(reversed: true).validated(),
+            anchorWeights: [3, uncapped], thresholds: [0.70])
+
+        for weight in [3, uncapped] {
+            XCTAssertEqual(try tally(inOrder, weight: weight),
+                           try tally(shuffled, weight: weight),
+                           "listing the utterances in a different order must not change the "
+                           + "result — `assign` folds in arrival order, so a file-ordered "
+                           + "replay measures a recording that never happened")
+        }
+    }
+
+    // MARK: - The metric definitions
+
+    /// One fixture, four metrics, four different answers — which is the point
+    /// #206 makes about reporting all of them.
+    ///
+    /// Alice speaks once and is recognised. A stranger who sounds like her
+    /// lands on her seeded entry. Bob speaks once and is recognised. So:
+    /// recall is perfect (both enrolled speakers reached their own entry),
+    /// while a third of all utterances were false-attached; auto-naming is
+    /// half right (Alice's entry is a tie between her and the stranger, so it
+    /// is not counted correct); and the recording under-segments, three true
+    /// speakers collapsing onto two ids.
+    func test_the_four_metrics_score_the_same_recording_differently() throws {
+        let results = try SeedAnchorSweepHarness.sweep(corpus: try mixedCorpus().validated(),
+                                                       anchorWeights: [3],
+                                                       thresholds: [0.70])
+        let scored = try tally(results, weight: 3)
+
+        XCTAssertEqual(scored.utterancesTotal, 3)
+        XCTAssertEqual(scored.recordings, 1)
+
+        XCTAssertEqual(scored.returningTotal, 2, "carol has no profile, so she is not recallable")
+        XCTAssertEqual(scored.returningHits, 2)
+        XCTAssertEqual(try XCTUnwrap(scored.returningRecall), 1.0, accuracy: 1e-9)
+
+        XCTAssertEqual(scored.falseAttachments, 1, "carol landed on alice's seeded entry")
+        XCTAssertEqual(try XCTUnwrap(scored.falseAttachRate), 1.0 / 3.0, accuracy: 1e-9,
+                       "the denominator is every utterance, not just the recallable ones — a "
+                       + "stranger's utterance on someone's entry is exactly the harm this "
+                       + "metric exists to count")
+
+        XCTAssertEqual(scored.autoNamesIssued, 2)
+        XCTAssertEqual(scored.autoNamesCorrect, 1, "only bob's entry names the right person")
+        XCTAssertEqual(scored.autoNamesExpected, 2)
+        XCTAssertEqual(try XCTUnwrap(scored.autoNamePrecision), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(scored.autoNameRecall), 0.5, accuracy: 1e-9)
+
+        XCTAssertEqual(scored.speakerCountSignedError, -1,
+                       "two ids for three speakers — negative is under-segmentation")
+        XCTAssertEqual(scored.speakerCountAbsError, 1)
+
+        XCTAssertEqual(scored.perSpeakerRecall["alice"], 1.0)
+        XCTAssertEqual(scored.perSpeakerRecall["bob"], 1.0)
+        XCTAssertNil(scored.perSpeakerRecall["carol"],
+                     "a speaker with no profile has no recall to pair on")
+    }
+
+    /// An auto-name whose entry heard two people equally is not counted
+    /// correct. Failing closed on a tie matches the rest of this subsystem,
+    /// and the alternative — picking one arbitrarily — would make the metric
+    /// depend on dictionary ordering.
+    func test_an_auto_name_split_between_two_speakers_is_not_correct() {
+        let outcome = SeedAnchorRecordingOutcome(
+            recordingID: "r1",
+            assignments: [.init(trueSpeaker: "alice", assignedID: "SPEAKER_00"),
+                          .init(trueSpeaker: "carol", assignedID: "SPEAKER_00")],
+            pool: [.init(id: "SPEAKER_00", observedCount: 2, profileName: "alice")],
+            seededID: ["alice": "SPEAKER_00"],
+            speakerBehindSeededID: ["SPEAKER_00": "alice"],
+            enrolledSpeakers: ["alice"])
+
+        let scored = SeedAnchorTally.scoring(outcome)
+        XCTAssertEqual(scored.autoNamesIssued, 1)
+        XCTAssertEqual(scored.autoNamesCorrect, 0, "a tie is not a plurality")
+
+        // One more utterance from Alice breaks the tie in her favour.
+        let clear = SeedAnchorRecordingOutcome(
+            recordingID: "r1",
+            assignments: outcome.assignments + [.init(trueSpeaker: "alice",
+                                                      assignedID: "SPEAKER_00")],
+            pool: outcome.pool,
+            seededID: outcome.seededID,
+            speakerBehindSeededID: outcome.speakerBehindSeededID,
+            enrolledSpeakers: outcome.enrolledSpeakers)
+        XCTAssertEqual(SeedAnchorTally.scoring(clear).autoNamesCorrect, 1)
+    }
+
+    /// A seeded speaker who never confidently matched is not auto-named — the
+    /// `observedCount > 0` half of `finish`'s guard set — and does not count
+    /// against recall unless they actually spoke.
+    func test_a_seeded_speaker_who_never_matched_issues_no_name() {
+        let silent = SeedAnchorRecordingOutcome(
+            recordingID: "r1",
+            assignments: [.init(trueSpeaker: "carol", assignedID: "SPEAKER_01")],
+            pool: [.init(id: "SPEAKER_00", observedCount: 0, profileName: "alice"),
+                   .init(id: "SPEAKER_01", observedCount: 1, profileName: nil)],
+            seededID: ["alice": "SPEAKER_00"],
+            speakerBehindSeededID: ["SPEAKER_00": "alice"],
+            enrolledSpeakers: ["alice"])
+
+        let scored = SeedAnchorTally.scoring(silent)
+        XCTAssertEqual(scored.autoNamesIssued, 0)
+        XCTAssertEqual(scored.autoNamesExpected, 0,
+                       "alice never spoke, so failing to name her is not a miss")
+        XCTAssertNil(scored.autoNameRecall, "and the rate is undefined rather than zero")
+        XCTAssertEqual(scored.falseAttachments, 0,
+                       "SPEAKER_01 was minted in-recording, so nobody was attached to a "
+                       + "stored voice that is not theirs")
+    }
+
+    /// Tallies add, so recordings of different lengths pool by count rather
+    /// than by averaging rates — a 20-utterance recording must not weigh the
+    /// same as a 300-utterance one.
+    func test_tallies_pool_by_count() throws {
+        var first = SeedAnchorTally()
+        first.utterancesTotal = 10
+        first.falseAttachments = 1
+        first.recordings = 1
+        first.perSpeaker["alice"] = .init(total: 10, hits: 9)
+
+        var second = SeedAnchorTally()
+        second.utterancesTotal = 90
+        second.falseAttachments = 44
+        second.recordings = 1
+        second.perSpeaker["alice"] = .init(total: 90, hits: 45)
+
+        let pooled = first + second
+        XCTAssertEqual(pooled.utterancesTotal, 100)
+        XCTAssertEqual(try XCTUnwrap(pooled.falseAttachRate), 0.45, accuracy: 1e-12,
+                       "0.45, not the 0.30 that averaging the two rates would give")
+        XCTAssertEqual(pooled.perSpeaker["alice"], .init(total: 100, hits: 54))
+        XCTAssertEqual(pooled.recordings, 2)
+    }
+
+    // MARK: - The corpus is refused rather than mis-measured
+
+    func test_a_corpus_with_mixed_dimensions_is_refused() {
+        let corpus = SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: nil,
+                               utterances: [utterance("alice", [1, 0], at: 0)])])
+        XCTAssertThrowsError(try corpus.validated(),
+                             "a dimension mismatch can never be a confident match, so this "
+                             + "would score zero recall for a reason unrelated to the anchor")
+    }
+
+    func test_a_corpus_with_a_non_finite_embedding_is_refused() {
+        let corpus = SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: nil,
+                               utterances: [utterance("alice", [.nan, 0, 0, 0], at: 0)])])
+        XCTAssertThrowsError(try corpus.validated(),
+                             "a NaN reads as 'never matched' rather than as an error")
+    }
+
+    func test_a_corpus_with_an_out_of_range_sample_count_is_refused() {
+        for count in [0, -1, VoiceProfile.maxSampleCount + 1] {
+            let corpus = SeedAnchorCorpus(
+                enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: count)],
+                recordings: [.init(id: "r1", setup: nil,
+                                   utterances: [utterance("alice", [1, 0, 0, 0], at: 0)])])
+            XCTAssertThrowsError(try corpus.validated(),
+                                 "sampleCount \(count) is outside what updateProfile would "
+                                 + "have written, and an uncapped anchor would carry it into "
+                                 + "`Float(n + 1)`")
+        }
+    }
+
+    func test_two_enrolments_for_one_speaker_are_refused() {
+        let corpus = SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40),
+                         .init(speaker: "alice", centroid: [0, 1, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: nil,
+                               utterances: [utterance("alice", [1, 0, 0, 0], at: 0)])])
+        XCTAssertThrowsError(try corpus.validated(),
+                             "seeded ids are resolved by profile name, so two profiles under "
+                             + "one name make the mapping ambiguous")
+    }
+
+    // MARK: - The file format
+
+    func test_a_corpus_decodes_from_json() throws {
+        let json = """
+        {
+          "enrolments": [
+            {"speaker": "alice", "centroid": [1, 0], "sampleCount": 12}
+          ],
+          "recordings": [
+            {"id": "r1", "setup": "headset-office", "utterances": [
+              {"speaker": "alice", "start": 0.0, "end": 1.5, "embedding": [0.9, 0.1]}
+            ]},
+            {"id": "r2", "utterances": [
+              {"speaker": "alice", "start": 2.0, "end": 2.4, "embedding": [0.8, 0.2]}
+            ]}
+          ]
+        }
+        """
+        let corpus = try JSONDecoder()
+            .decode(SeedAnchorCorpus.self, from: Data(json.utf8))
+            .validated()
+
+        XCTAssertEqual(corpus.enrolledSpeakers, ["alice"])
+        XCTAssertEqual(corpus.embeddingDimension, 2)
+        XCTAssertEqual(corpus.recordings.count, 2)
+        XCTAssertEqual(corpus.recordings[0].setup, "headset-office")
+        XCTAssertNil(corpus.recordings[1].setup, "setup is optional")
+        XCTAssertEqual(corpus.recordings[1].utterances[0].duration, 0.4, accuracy: 1e-9,
+                       "durations survive decoding — `assign` refuses to mint a speaker from "
+                       + "anything under a second, so they change the outcome")
+    }
+}

--- a/MilaTests/SeedAnchorSweepReport.swift
+++ b/MilaTests/SeedAnchorSweepReport.swift
@@ -1,0 +1,380 @@
+import Foundation
+@testable import Mila
+
+// MARK: - Significance
+
+/// Exact two-sided Wilcoxon signed-rank test, for pairing the sweep's
+/// per-speaker recall between two configurations.
+///
+/// ## Why this test, and why paired across speakers
+///
+/// #206's protocol is explicit about the pairing: utterances inside one
+/// recording are heavily correlated (same mic, same room, same cold), so an
+/// utterance-level test treats hundreds of near-duplicate observations as
+/// independent and reports significance that is not there. The unit of
+/// evidence is a **speaker**, and the comparison is within-speaker (their
+/// recall at n₀=2 versus their recall at n₀=3), which is what makes it paired.
+/// Signed-rank rather than a paired *t*-test because recall over a few dozen
+/// utterances is bounded, discrete and skewed, so normality is not on offer.
+///
+/// ## Why exact rather than the normal approximation
+///
+/// The corpus the protocol asks for has ≥ 8 speakers, which is exactly where
+/// the normal approximation is least trustworthy — and where it matters most,
+/// since a marginal *p* is the whole reason to run the test. The null here is
+/// a sign-flip permutation over the observed signed ranks, so the exact
+/// distribution is computable: `p[sum]` is accumulated by a dynamic program
+/// over doubled ranks (average ranks for ties are integers or half-integers,
+/// so doubling makes every subset sum an integer). Cost is O(n² ) in the
+/// number of speakers — nothing, at this scale — and the answer is the same on
+/// every machine.
+///
+/// Because the null is a permutation over the *observed* ranks, ties are
+/// handled without a correction factor: they enter the distribution the same
+/// way they enter the statistic.
+///
+/// `WilcoxonSignedRankTests` pins the output against values cross-checked by
+/// exhaustive enumeration (2ⁿ sign assignments) and against the textbook
+/// all-positive case, where p must be exactly 2/2ⁿ.
+enum WilcoxonSignedRank {
+
+    struct Outcome: Equatable {
+        /// Pairs with a non-zero difference. Zero differences carry no sign
+        /// and are dropped, which is the standard treatment — and worth
+        /// noticing when reading a result, since it is also the sample size
+        /// the *p* refers to.
+        let sampleSize: Int
+        /// W⁺ — the sum of the ranks of the positive differences.
+        let statistic: Double
+        /// Exact two-sided *p*. 1.0 when there is nothing to test.
+        let pValue: Double
+        /// Median of the non-zero differences: the direction and rough size
+        /// of the effect, which the *p* alone does not give.
+        let medianDifference: Double
+    }
+
+    /// `pairs` are (candidate, baseline) per speaker. A positive difference
+    /// means the candidate recognised that speaker better.
+    static func test(pairs: [(candidate: Double, baseline: Double)]) -> Outcome {
+        let differences = pairs
+            .map { $0.candidate - $0.baseline }
+            .filter { $0 != 0 && $0.isFinite }
+        guard !differences.isEmpty else {
+            return Outcome(sampleSize: 0, statistic: 0, pValue: 1, medianDifference: 0)
+        }
+
+        // Average ranks of |d|.
+        let order = differences.indices.sorted { abs(differences[$0]) < abs(differences[$1]) }
+        var ranks = [Double](repeating: 0, count: differences.count)
+        var i = 0
+        while i < order.count {
+            var j = i
+            while j + 1 < order.count,
+                  abs(differences[order[j + 1]]) == abs(differences[order[i]]) {
+                j += 1
+            }
+            let averageRank = Double((i + 1) + (j + 1)) / 2.0
+            for k in i...j { ranks[order[k]] = averageRank }
+            i = j + 1
+        }
+
+        var statistic = 0.0
+        for (difference, rank) in zip(differences, ranks) where difference > 0 {
+            statistic += rank
+        }
+        let totalRank = ranks.reduce(0, +)
+        let mean = totalRank / 2.0
+
+        // Exact null by DP over doubled ranks. `probability[s]` is the chance
+        // that a uniformly random sign assignment puts W⁺ at s/2.
+        let scaled = ranks.map { Int(($0 * 2).rounded()) }
+        let totalScaled = scaled.reduce(0, +)
+        var probability = [Double](repeating: 0, count: totalScaled + 1)
+        probability[0] = 1
+        for rank in scaled {
+            var next = [Double](repeating: 0, count: totalScaled + 1)
+            for sum in 0...totalScaled where probability[sum] != 0 {
+                next[sum] += probability[sum] * 0.5
+                if sum + rank <= totalScaled {
+                    next[sum + rank] += probability[sum] * 0.5
+                }
+            }
+            probability = next
+        }
+
+        let observedDeviation = abs(statistic - mean)
+        var pValue = 0.0
+        for sum in 0...totalScaled where probability[sum] != 0 {
+            if abs(Double(sum) / 2.0 - mean) >= observedDeviation - 1e-9 {
+                pValue += probability[sum]
+            }
+        }
+
+        let sorted = differences.sorted()
+        let middle = sorted.count / 2
+        let median = sorted.count % 2 == 1
+            ? sorted[middle]
+            : (sorted[middle - 1] + sorted[middle]) / 2.0
+
+        return Outcome(sampleSize: differences.count,
+                       statistic: statistic,
+                       pValue: min(1, max(0, pValue)),
+                       medianDifference: median)
+    }
+
+    /// Pair two configurations' per-speaker recall on the speakers both
+    /// scored. A speaker missing from either side is dropped rather than
+    /// treated as zero recall — absent means "not measurable here", and
+    /// scoring it 0 would invent evidence.
+    static func compare(candidate: [String: Double],
+                        baseline: [String: Double]) -> Outcome {
+        var pairs: [(candidate: Double, baseline: Double)] = []
+        for speaker in Set(candidate.keys).intersection(baseline.keys).sorted() {
+            guard let mine = candidate[speaker], let theirs = baseline[speaker] else { continue }
+            pairs.append((candidate: mine, baseline: theirs))
+        }
+        return test(pairs: pairs)
+    }
+}
+
+// MARK: - Report
+
+/// Renders a finished grid as text for a human, and as JSON to attach to the
+/// issue.
+///
+/// The text report is the deliverable of an actual sweep run: paste it into
+/// #206 and the next person can see the whole grid, which metrics disagreed,
+/// and how strong the evidence was — rather than a single number with no
+/// context, which is how the current 3 got here.
+@MainActor
+enum SeedAnchorSweepReport {
+
+    static func text(for results: [SeedAnchorResult],
+                     corpus: SeedAnchorCorpus,
+                     tolerance: Double = 0.01) -> String {
+        guard !results.isEmpty else { return "no results" }
+
+        let thresholds = orderedThresholds(results)
+        let weights = orderedWeights(results)
+        var out = ""
+
+        out += "Seed anchor sweep (#206)\n"
+        out += "========================\n\n"
+        out += corpusSummary(corpus)
+        out += "\nShipping value: seedAnchorWeight = \(LiveSpeakerDiarizer.seedAnchorWeight)"
+        out += " (threshold default 0.55)\n\n"
+
+        out += table("1. Returning-speaker recall (higher is better)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.returningRecall
+        }
+        out += table("2. Cross-speaker false-attach rate (lower is better)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.falseAttachRate
+        }
+        out += table("3a. Auto-name precision (higher is better)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.autoNamePrecision
+        }
+        out += table("3b. Auto-name recall (higher is better)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.autoNameRecall
+        }
+        out += table("4a. Mean |speaker-count error| per recording (lower is better)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.meanSpeakerCountAbsError
+        }
+        out += table("4b. Mean signed speaker-count error (positive = over-segmentation)",
+                     weights: weights, thresholds: thresholds, results: results) {
+            $0.tally.meanSpeakerCountSignedError
+        }
+
+        out += significanceTable(results: results, weights: weights, thresholds: thresholds)
+
+        if let recommendation = SeedAnchorRecommendation.from(results, tolerance: tolerance) {
+            out += "\nStarting point from the decision rule\n"
+            out += "-------------------------------------\n"
+            out += "  smallest anchor weight within \(fmt(tolerance)) of the best worst-case"
+            out += " false-attach rate: n0 = \(recommendation.anchorLabel)\n"
+            out += "  its worst case \(fmt(recommendation.worstCaseFalseAttach))"
+            out += " vs grid best \(fmt(recommendation.gridBestWorstCase))\n"
+            if !recommendation.rejected.isEmpty {
+                let rejected = recommendation.rejected
+                    .map { "n0=\($0.anchorLabel) (\(fmt($0.worstCaseFalseAttach)))" }
+                    .joined(separator: ", ")
+                out += "  ruled out: \(rejected)\n"
+            }
+        }
+
+        out += """
+
+        Reading this
+        ------------
+          * The four metrics are expected to disagree. That disagreement is the
+            signal — a weight that lifts recall while lifting false-attach has
+            not improved anything, it has moved the operating point.
+          * Judge an anchor weight by its *worst* cell across the threshold row,
+            not its best: users can set any threshold in 0.5...0.95.
+          * The tolerance above is a judgement call with no measurement behind
+            it. The real gate is the paired test on per-speaker recall, and
+            #206's bar is a Wilcoxon over >= 8 speakers.
+          * Prefer the smallest weight that is within noise of the best. A
+            too-light anchor's damage is confined to one recording (n0 never
+            reaches persistence, since #204); a too-heavy anchor's persists
+            across every future recording of that speaker.
+          * If the winner is not \(LiveSpeakerDiarizer.seedAnchorWeight), update the constant, the weight
+            table in its doc comment, and SeedAnchorWeightTests together, and
+            paste this report into #206.
+
+        """
+        return out
+    }
+
+    /// The same grid as JSON, for attaching to the issue or diffing two runs.
+    static func json(for results: [SeedAnchorResult], corpus: SeedAnchorCorpus) throws -> Data {
+        var cells: [[String: Any]] = []
+        for result in results {
+            var cell: [String: Any] = [
+                "anchorWeight": result.configuration.anchorLabel,
+                "similarityThreshold": result.configuration.similarityThreshold,
+                "utterances": result.tally.utterancesTotal,
+                "recordings": result.tally.recordings,
+                "returningTotal": result.tally.returningTotal,
+                "returningHits": result.tally.returningHits,
+                "falseAttachments": result.tally.falseAttachments,
+                "autoNamesIssued": result.tally.autoNamesIssued,
+                "autoNamesCorrect": result.tally.autoNamesCorrect,
+                "autoNamesExpected": result.tally.autoNamesExpected,
+                "speakerCountAbsError": result.tally.speakerCountAbsError,
+                "speakerCountSignedError": result.tally.speakerCountSignedError,
+                "perSpeakerRecall": result.tally.perSpeakerRecall
+            ]
+            if let recall = result.tally.returningRecall { cell["returningRecall"] = recall }
+            if let rate = result.tally.falseAttachRate { cell["falseAttachRate"] = rate }
+            if let p = result.tally.autoNamePrecision { cell["autoNamePrecision"] = p }
+            if let r = result.tally.autoNameRecall { cell["autoNameRecall"] = r }
+            cells.append(cell)
+        }
+        let payload: [String: Any] = [
+            "shippingSeedAnchorWeight": LiveSpeakerDiarizer.seedAnchorWeight,
+            "speakers": corpus.enrolments.map(\.speaker).sorted(),
+            "recordings": corpus.recordings.map(\.id),
+            "setups": Array(Set(corpus.recordings.compactMap(\.setup))).sorted(),
+            "embeddingDimension": corpus.embeddingDimension,
+            "cells": cells
+        ]
+        return try JSONSerialization.data(withJSONObject: payload,
+                                          options: [.prettyPrinted, .sortedKeys])
+    }
+
+    // MARK: - Pieces
+
+    static func corpusSummary(_ corpus: SeedAnchorCorpus) -> String {
+        let utterances = corpus.recordings.reduce(0) { $0 + $1.utterances.count }
+        let setups = Set(corpus.recordings.compactMap(\.setup)).sorted()
+        var out = "Corpus: \(corpus.enrolments.count) enrolled speakers,"
+        out += " \(corpus.recordings.count) recordings,"
+        out += " \(utterances) utterances, dim \(corpus.embeddingDimension)\n"
+        out += "Setups: \(setups.isEmpty ? "(unlabelled)" : setups.joined(separator: ", "))\n"
+        if setups.count < 2 {
+            out += "WARNING: fewer than two labelled capture setups. The cross-setup case is\n"
+            out += "         the one this knob exists for; a single-setup corpus cannot show it.\n"
+        }
+        if corpus.enrolments.count < 8 {
+            out += "WARNING: fewer than 8 enrolled speakers. #206's bar for acting on a\n"
+            out += "         result is a paired test over >= 8 speakers.\n"
+        }
+        return out
+    }
+
+    private static func orderedThresholds(_ results: [SeedAnchorResult]) -> [Double] {
+        var seen: [Double] = []
+        for result in results where !seen.contains(result.configuration.similarityThreshold) {
+            seen.append(result.configuration.similarityThreshold)
+        }
+        return seen.sorted()
+    }
+
+    private static func orderedWeights(_ results: [SeedAnchorResult]) -> [Int] {
+        var seen: [Int] = []
+        for result in results where !seen.contains(result.configuration.anchorWeight) {
+            seen.append(result.configuration.anchorWeight)
+        }
+        return seen.sorted()
+    }
+
+    private static func fmt(_ value: Double?) -> String {
+        guard let value else { return "   —  " }
+        return String(format: "%6.3f", value)
+    }
+
+    private static func table(_ title: String,
+                              weights: [Int],
+                              thresholds: [Double],
+                              results: [SeedAnchorResult],
+                              metric: (SeedAnchorResult) -> Double?) -> String {
+        var out = "\(title)\n"
+        out += "  n0       " + thresholds.map { String(format: "  %.2f ", $0) }.joined() + "\n"
+        for weight in weights {
+            let label = SeedAnchorConfiguration(anchorWeight: weight,
+                                                similarityThreshold: 0).anchorLabel
+            out += "  " + label.padding(toLength: 9, withPad: " ", startingAt: 0)
+            for threshold in thresholds {
+                let cell = results.first {
+                    $0.configuration.anchorWeight == weight
+                        && $0.configuration.similarityThreshold == threshold
+                }
+                out += fmt(cell.flatMap(metric)) + " "
+            }
+            out += "\n"
+        }
+        return out + "\n"
+    }
+
+    /// Per-cell exact *p* for per-speaker recall against the shipping weight
+    /// at the same threshold. The baseline is held at the same threshold on
+    /// purpose: comparing across thresholds would confound the two knobs.
+    private static func significanceTable(results: [SeedAnchorResult],
+                                          weights: [Int],
+                                          thresholds: [Double]) -> String {
+        let baselineWeight = LiveSpeakerDiarizer.seedAnchorWeight
+        guard weights.contains(baselineWeight) else {
+            return "Significance vs n0=\(baselineWeight): not computed — the grid does not"
+                + " include the shipping weight.\n\n"
+        }
+        var out = "5. Exact Wilcoxon p for per-speaker recall vs n0=\(baselineWeight)"
+        out += " (paired across speakers)\n"
+        out += "  n0       " + thresholds.map { String(format: "  %.2f ", $0) }.joined() + "\n"
+        for weight in weights {
+            let label = SeedAnchorConfiguration(anchorWeight: weight,
+                                                similarityThreshold: 0).anchorLabel
+            out += "  " + label.padding(toLength: 9, withPad: " ", startingAt: 0)
+            for threshold in thresholds {
+                if weight == baselineWeight {
+                    out += "  base  "
+                    continue
+                }
+                let candidate = results.first {
+                    $0.configuration.anchorWeight == weight
+                        && $0.configuration.similarityThreshold == threshold
+                }
+                let baseline = results.first {
+                    $0.configuration.anchorWeight == baselineWeight
+                        && $0.configuration.similarityThreshold == threshold
+                }
+                guard let candidate, let baseline else {
+                    out += "   —   "
+                    continue
+                }
+                let outcome = WilcoxonSignedRank.compare(
+                    candidate: candidate.tally.perSpeakerRecall,
+                    baseline: baseline.tally.perSpeakerRecall)
+                out += fmt(outcome.pValue) + " "
+            }
+            out += "\n"
+        }
+        out += "  (n = speakers with a non-zero difference; a p over a handful of speakers"
+        out += " is not evidence)\n\n"
+        return out
+    }
+}

--- a/MilaTests/SeedAnchorSweepTests.swift
+++ b/MilaTests/SeedAnchorSweepTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import Mila
+
+/// The entry point for actually running the seed-anchor sweep (#206), plus
+/// tests for the two layers that turn a grid into a decision: the report and
+/// the decision rule.
+///
+/// ## How to run the sweep
+///
+/// ```
+/// MILA_SEED_ANCHOR_CORPUS=/path/to/corpus.json \
+///   xcodebuild test -scheme Mila \
+///   -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus
+/// ```
+///
+/// Optional:
+///   * `MILA_SEED_ANCHOR_REPORT=/path/out.json` — also write the grid as JSON.
+///   * `MILA_SEED_ANCHOR_WEIGHTS=1,2,3,uncapped` — narrow the anchor weights.
+///   * `MILA_SEED_ANCHOR_THRESHOLDS=0.55` — narrow the thresholds.
+///
+/// Without a corpus the sweep test skips, which is the state CI runs in and
+/// the state this repository ships in: nobody has produced the audio yet.
+/// `docs/seed-anchor-sweep.md` covers producing a corpus, and
+/// `scripts/extract-voice-embeddings.py` does the embedding pass.
+///
+/// **This test cannot tell you the anchor weight is right.** It replays real
+/// recordings through the real matching code and reports what happened; the
+/// decision is still a human reading four metrics that disagree. What it
+/// removes is the need to re-derive the protocol from a GitHub comment.
+@MainActor
+final class SeedAnchorSweepTests: XCTestCase {
+
+    // MARK: - The sweep
+
+    func test_sweep_a_provided_corpus() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["MILA_SEED_ANCHOR_CORPUS"], !path.isEmpty else {
+            throw XCTSkip("""
+                No corpus. Set MILA_SEED_ANCHOR_CORPUS to a JSON corpus of cached \
+                speaker embeddings to run the #206 sweep — see docs/seed-anchor-sweep.md. \
+                The seed anchor weight stays at \(LiveSpeakerDiarizer.seedAnchorWeight) \
+                until someone runs it; this skip is the honest state of the question, \
+                not a failure.
+                """)
+        }
+
+        let corpus = try SeedAnchorCorpus.load(from: URL(fileURLWithPath: path))
+        let weights = Self.weights(from: environment["MILA_SEED_ANCHOR_WEIGHTS"])
+            ?? SeedAnchorConfiguration.defaultAnchorWeights
+        let thresholds = Self.thresholds(from: environment["MILA_SEED_ANCHOR_THRESHOLDS"])
+            ?? SeedAnchorConfiguration.defaultThresholds
+
+        let results = try SeedAnchorSweepHarness.sweep(corpus: corpus,
+                                                        anchorWeights: weights,
+                                                        thresholds: thresholds)
+        XCTAssertEqual(results.count, weights.count * thresholds.count,
+                       "every cell of the grid must be scored")
+
+        // The deliverable of a run: paste this into #206.
+        print(SeedAnchorSweepReport.text(for: results, corpus: corpus))
+
+        if let out = environment["MILA_SEED_ANCHOR_REPORT"], !out.isEmpty {
+            let data = try SeedAnchorSweepReport.json(for: results, corpus: corpus)
+            try data.write(to: URL(fileURLWithPath: out))
+            print("seed-anchor sweep: grid written to \(out)")
+        }
+
+        // Deliberately not asserted: which anchor weight wins. A test that
+        // failed when the grid disagreed with the shipping constant would be
+        // asserting the answer nobody has measured — the exact thing #206
+        // exists to avoid.
+    }
+
+    /// `uncapped` is spelled out rather than given as a number, because the
+    /// number that means "no cap" (`VoiceProfile.maxSampleCount`) is not
+    /// something anyone should have to type.
+    static func weights(from raw: String?) -> [Int]? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let parsed = raw.split(separator: ",").compactMap { token -> Int? in
+            let trimmed = token.trimmingCharacters(in: .whitespaces).lowercased()
+            if trimmed == "uncapped" || trimmed == "none" {
+                return SeedAnchorConfiguration.uncappedAnchorWeight
+            }
+            return Int(trimmed)
+        }
+        return parsed.isEmpty ? nil : parsed
+    }
+
+    static func thresholds(from raw: String?) -> [Double]? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let parsed = raw.split(separator: ",").compactMap {
+            Double($0.trimmingCharacters(in: .whitespaces))
+        }
+        return parsed.isEmpty ? nil : parsed
+    }
+
+    func test_the_grid_can_be_narrowed_from_the_environment() {
+        XCTAssertEqual(Self.weights(from: "1, 2,3"), [1, 2, 3])
+        XCTAssertEqual(Self.weights(from: "3,uncapped"),
+                       [3, SeedAnchorConfiguration.uncappedAnchorWeight])
+        XCTAssertNil(Self.weights(from: ""), "an empty value falls back to the full grid")
+        XCTAssertNil(Self.weights(from: "nonsense"),
+                     "and so does an unparseable one, rather than sweeping nothing")
+        XCTAssertEqual(Self.thresholds(from: "0.55, 0.7"), [0.55, 0.7])
+        XCTAssertNil(Self.thresholds(from: nil))
+    }
+
+    // MARK: - The decision rule
+
+    private func result(weight: Int,
+                        threshold: Double,
+                        falseAttachments: Int,
+                        utterances: Int) -> SeedAnchorResult {
+        var tally = SeedAnchorTally()
+        tally.utterancesTotal = utterances
+        tally.falseAttachments = falseAttachments
+        tally.recordings = 1
+        return SeedAnchorResult(
+            configuration: .init(anchorWeight: weight, similarityThreshold: threshold),
+            tally: tally,
+            perRecording: [:])
+    }
+
+    /// Ties go to the **smaller** anchor weight. That is not a stylistic
+    /// preference: since #204 the seeded weight never reaches persistence, so
+    /// a too-light anchor's damage is confined to the one recording, while a
+    /// too-heavy anchor keeps a returning speaker below the match threshold
+    /// forever and the profile that most needs updating becomes the one that
+    /// cannot be updated.
+    func test_the_smallest_weight_within_tolerance_wins() throws {
+        let results = [
+            result(weight: 2, threshold: 0.55, falseAttachments: 55, utterances: 1000),
+            result(weight: 3, threshold: 0.55, falseAttachments: 50, utterances: 1000),
+            result(weight: 4, threshold: 0.55, falseAttachments: 51, utterances: 1000)
+        ]
+        let recommendation = try XCTUnwrap(SeedAnchorRecommendation.from(results,
+                                                                        tolerance: 0.01))
+        XCTAssertEqual(recommendation.anchorWeight, 2,
+                       "0.055 is within 0.01 of the grid's best 0.050, so the lighter anchor "
+                       + "wins the tie")
+        XCTAssertEqual(recommendation.gridBestWorstCase, 0.05, accuracy: 1e-9)
+    }
+
+    /// A weight is judged by its **worst** cell across the threshold row, not
+    /// its best. Users can set any threshold in 0.5...0.95, so a weight that
+    /// is excellent at 0.55 and dreadful at 0.70 has not earned the default.
+    func test_a_weight_is_judged_by_its_worst_threshold() throws {
+        let results = [
+            // Best single cell in the grid — and the worst row.
+            result(weight: 2, threshold: 0.55, falseAttachments: 5, utterances: 1000),
+            result(weight: 2, threshold: 0.70, falseAttachments: 200, utterances: 1000),
+            // Unremarkable everywhere, and therefore safe everywhere.
+            result(weight: 3, threshold: 0.55, falseAttachments: 60, utterances: 1000),
+            result(weight: 3, threshold: 0.70, falseAttachments: 62, utterances: 1000)
+        ]
+        let recommendation = try XCTUnwrap(SeedAnchorRecommendation.from(results,
+                                                                        tolerance: 0.01))
+        XCTAssertEqual(recommendation.anchorWeight, 3,
+                       "n0=2 has the single best cell (0.005) and the worst row (0.200)")
+        XCTAssertEqual(recommendation.rejected.map { $0.anchorLabel }, ["2"])
+    }
+
+    func test_no_results_recommends_nothing() {
+        XCTAssertNil(SeedAnchorRecommendation.from([]))
+    }
+
+    // MARK: - The report
+
+    /// The report is the artefact a sweep run produces, so it has to carry
+    /// enough for someone reading it in the issue months later: every metric,
+    /// the corpus it came from, and — loudly — whether that corpus was big
+    /// enough to act on.
+    func test_the_report_names_every_metric_and_warns_about_a_thin_corpus() throws {
+        let corpus = try SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: "headset", utterances: [
+                .init(speaker: "alice", start: 0, end: 2, embedding: [0.99, 0.01, 0, 0])
+            ])]).validated()
+
+        let results = try SeedAnchorSweepHarness.sweep(
+            corpus: corpus,
+            anchorWeights: [LiveSpeakerDiarizer.seedAnchorWeight,
+                            SeedAnchorConfiguration.uncappedAnchorWeight],
+            thresholds: [0.55])
+        let text = SeedAnchorSweepReport.text(for: results, corpus: corpus)
+
+        for heading in ["Returning-speaker recall",
+                        "Cross-speaker false-attach rate",
+                        "Auto-name precision",
+                        "Auto-name recall",
+                        "speaker-count error",
+                        "Exact Wilcoxon p"] {
+            XCTAssertTrue(text.contains(heading), "the report must include \(heading)")
+        }
+        XCTAssertTrue(text.contains("uncapped"), "the uncapped row must be labelled, not 9e18")
+        XCTAssertTrue(text.contains("fewer than 8 enrolled speakers"),
+                      "a corpus below #206's bar must say so in the report itself — the grid "
+                      + "will otherwise be quoted without that caveat")
+        XCTAssertTrue(text.contains("fewer than two labelled capture setups"),
+                      "the cross-setup case is the one this knob exists for")
+    }
+
+    func test_the_grid_serialises_to_json() throws {
+        let corpus = try SeedAnchorCorpus(
+            enrolments: [.init(speaker: "alice", centroid: [1, 0, 0, 0], sampleCount: 40)],
+            recordings: [.init(id: "r1", setup: "headset", utterances: [
+                .init(speaker: "alice", start: 0, end: 2, embedding: [0.99, 0.01, 0, 0])
+            ])]).validated()
+        let results = try SeedAnchorSweepHarness.sweep(corpus: corpus,
+                                                        anchorWeights: [3],
+                                                        thresholds: [0.55])
+
+        let data = try SeedAnchorSweepReport.json(for: results, corpus: corpus)
+        let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: data)
+                                    as? [String: Any])
+        XCTAssertEqual(parsed["shippingSeedAnchorWeight"] as? Int,
+                       LiveSpeakerDiarizer.seedAnchorWeight)
+        XCTAssertEqual(parsed["speakers"] as? [String], ["alice"])
+        let cells = try XCTUnwrap(parsed["cells"] as? [[String: Any]])
+        XCTAssertEqual(cells.count, 1)
+        XCTAssertEqual(cells[0]["anchorWeight"] as? String, "3")
+        XCTAssertEqual(cells[0]["returningHits"] as? Int, 1)
+    }
+}

--- a/MilaTests/SeedAnchorSweepTests.swift
+++ b/MilaTests/SeedAnchorSweepTests.swift
@@ -8,9 +8,12 @@ import XCTest
 /// ## How to run the sweep
 ///
 /// ```
+/// make project
 /// MILA_SEED_ANCHOR_CORPUS=/path/to/corpus.json \
-///   xcodebuild test -scheme Mila \
-///   -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus
+///   xcodebuild -project Mila.xcodeproj -scheme Mila -configuration Debug \
+///     -derivedDataPath build -destination 'platform=macOS' \
+///     -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus \
+///     test
 /// ```
 ///
 /// Optional:

--- a/MilaTests/SeedAnchorWeightTests.swift
+++ b/MilaTests/SeedAnchorWeightTests.swift
@@ -24,10 +24,12 @@ import XCTest
 /// These tests do not show 3 is optimal. The arithmetic pins the ends, not
 /// the interior — n₀ ∈ {2, 3, 4} are all well-formed and none of these
 /// assertions distinguishes them. That question needs multi-recording audio
-/// of the same speakers across different capture setups; #206 holds the
-/// replay protocol. What is pinned here is that the anchor exists, that it is
-/// a ceiling and not a floor, and that it stays inside the band where neither
-/// end-failure occurs.
+/// of the same speakers across different capture setups. The harness that
+/// would answer it lives in `SeedAnchorSweepHarness` /
+/// `SeedAnchorSweepTests`, with the procedure in `docs/seed-anchor-sweep.md`;
+/// it skips until someone points it at a corpus. What is pinned *here* is
+/// that the anchor exists, that it is a ceiling and not a floor, and that it
+/// stays inside the band where neither end-failure occurs.
 ///
 /// ## Fixture
 ///

--- a/MilaTests/WilcoxonSignedRankTests.swift
+++ b/MilaTests/WilcoxonSignedRankTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Mila
+
+/// Pins `WilcoxonSignedRank` — the paired significance test the seed-anchor
+/// sweep (#206) uses to decide whether a difference in per-speaker recall is
+/// worth acting on.
+///
+/// ## Why this needs its own tests
+///
+/// The sweep's *p*-values are the gate on changing
+/// `LiveSpeakerDiarizer.seedAnchorWeight`, a constant that affects every user
+/// with stored voice profiles. A subtly wrong test statistic would not look
+/// wrong — it would produce plausible *p*-values and licence a change on
+/// invented evidence, which is a worse outcome than having no test at all.
+///
+/// Every expected value below was cross-checked against exhaustive
+/// enumeration of all 2ⁿ sign assignments, computed outside Swift. The
+/// implementation reaches the same numbers by a dynamic program over doubled
+/// ranks, so the two disagree if either is wrong.
+final class WilcoxonSignedRankTests: XCTestCase {
+
+    private func outcome(_ differences: [Double]) -> WilcoxonSignedRank.Outcome {
+        // Expressed as (candidate, baseline) pairs against a zero baseline,
+        // which is what the harness does with per-speaker recall.
+        WilcoxonSignedRank.test(pairs: differences.map { (candidate: $0, baseline: 0.0) })
+    }
+
+    /// The textbook case: eight speakers, every one improved, no ties. The
+    /// exact two-sided *p* has a closed form — only the all-positive and
+    /// all-negative sign assignments are at least as extreme, so p = 2/2⁸.
+    func test_all_eight_speakers_improving_gives_the_closed_form_p() {
+        let result = outcome([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+        XCTAssertEqual(result.sampleSize, 8)
+        XCTAssertEqual(result.statistic, 36, accuracy: 1e-9, "W+ = 1+2+…+8")
+        XCTAssertEqual(result.pValue, 2.0 / 256.0, accuracy: 1e-12)
+        XCTAssertEqual(result.medianDifference, 0.45, accuracy: 1e-12)
+    }
+
+    /// Six speakers up, two barely down — the shape a real marginal result
+    /// takes. p = 0.0390625 exactly (10/256).
+    func test_a_marginal_result_gets_a_marginal_p() {
+        let result = outcome([0.05, 0.10, 0.15, 0.20, 0.25, 0.30, -0.02, -0.03])
+        XCTAssertEqual(result.sampleSize, 8)
+        XCTAssertEqual(result.statistic, 33, accuracy: 1e-9)
+        XCTAssertEqual(result.pValue, 10.0 / 256.0, accuracy: 1e-12)
+        XCTAssertGreaterThan(result.medianDifference, 0)
+    }
+
+    /// Ties in |d| take average ranks, and a zero difference is dropped —
+    /// so the sample size the *p* refers to is seven, not eight. Both matter
+    /// when reading a sweep: a cell whose *p* rests on three non-zero
+    /// speakers is not evidence, and only `sampleSize` says so.
+    func test_ties_are_average_ranked_and_zero_differences_are_dropped() {
+        let result = outcome([0.1, 0.1, -0.1, 0.2, 0.0, 0.4, 0.5, -0.6])
+        XCTAssertEqual(result.sampleSize, 7, "the zero difference carries no sign")
+        XCTAssertEqual(result.statistic, 19, accuracy: 1e-9,
+                       "three |d| = 0.1 share ranks 1, 2, 3 as 2 each; two of them positive")
+        XCTAssertEqual(result.pValue, 31.0 / 64.0, accuracy: 1e-12)
+    }
+
+    /// Nothing to test is not the same as no effect, but it must not report a
+    /// significant one either.
+    func test_no_differences_at_all_reports_no_evidence() {
+        let result = outcome([0, 0, 0])
+        XCTAssertEqual(result.sampleSize, 0)
+        XCTAssertEqual(result.pValue, 1.0)
+        XCTAssertEqual(result.medianDifference, 0)
+    }
+
+    /// A single speaker cannot produce a two-sided *p* below 1, and one that
+    /// cancels exactly cannot either. Both are guards against a sweep run on
+    /// a corpus far below #206's bar of eight speakers reporting significance.
+    func test_a_tiny_sample_cannot_be_significant() {
+        XCTAssertEqual(outcome([0.4]).pValue, 1.0, accuracy: 1e-12)
+        XCTAssertEqual(outcome([0.4, -0.4]).pValue, 1.0, accuracy: 1e-12)
+    }
+
+    /// Direction is carried by the statistic and the median, not by the *p*:
+    /// the test is two-sided, so a uniformly *worse* candidate is exactly as
+    /// significant as a uniformly better one, and only `medianDifference`
+    /// says which way.
+    func test_the_p_is_two_sided_and_the_direction_is_in_the_median() {
+        let better = outcome([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+        let worse = outcome([-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8])
+        XCTAssertEqual(better.pValue, worse.pValue, accuracy: 1e-12)
+        XCTAssertEqual(worse.statistic, 0, accuracy: 1e-9)
+        XCTAssertLessThan(worse.medianDifference, 0)
+        XCTAssertGreaterThan(better.medianDifference, 0)
+    }
+
+    /// `compare` pairs on speaker identity, and drops a speaker who is missing
+    /// from either side rather than scoring them zero. Inventing a zero would
+    /// invent evidence — a speaker absent from one configuration was not
+    /// measured there, which is not the same as having been recognised none of
+    /// the time.
+    func test_comparing_per_speaker_recall_pairs_by_name() {
+        let candidate = ["alice": 0.9, "bob": 0.8, "carol": 0.5]
+        let baseline = ["bob": 0.4, "alice": 0.5, "dave": 0.9]
+        let result = WilcoxonSignedRank.compare(candidate: candidate, baseline: baseline)
+        XCTAssertEqual(result.sampleSize, 2, "only alice and bob appear on both sides")
+        XCTAssertEqual(result.medianDifference, 0.4, accuracy: 1e-9,
+                       "alice +0.4 and bob +0.4")
+    }
+}

--- a/docs/seed-anchor-sweep.md
+++ b/docs/seed-anchor-sweep.md
@@ -1,0 +1,257 @@
+# Running the seed-anchor sweep (#206)
+
+This is the procedure for answering a question the repository has been unable
+to answer since the code was written: **is `3` the right seed anchor weight?**
+
+Everything here exists so that whoever first has the audio does not have to
+re-derive the protocol from a GitHub comment. Nothing here has been run —
+nobody has the corpus yet, which is exactly why the question is still open.
+
+## The question
+
+When a recording starts, `LiveSpeakerDiarizer.seedPool` turns every stored
+voice profile into a pool entry whose `sampleCount` is capped at
+`seedAnchorWeight` — **n₀**, currently 3. `assign` folds each confident match
+into that entry's centroid as a running mean, which telescopes over *k*
+matches to
+
+```
+centroid_k = (n₀·c₀ + Σ eⱼ) / (n₀ + k)
+```
+
+so n₀ is literally *how many of this session's utterances the stored voice is
+worth*. It is the only knob controlling how strongly a returning speaker's
+stored centroid anchors matching, versus adapting to today's mic, room and
+throat.
+
+Since #204 it is a **matching-only** parameter — the persisted delta is
+`observedCentroid`/`observedCount`, which n₀ never touches — so it can be
+tuned with no risk to anyone's stored profiles. #248 pinned the value and
+wrote down the derivation. What neither did, and what no amount of arithmetic
+can do, is say whether 2, 3 or 4 recognises returning speakers *better*. Both
+ends are provably wrong (0 discards the stored voice on its first match;
+uncapped makes within-recording adaptation arithmetically impossible), and
+everything in between is well-formed. That is an empirical question.
+
+## What you need
+
+From #206's protocol. The corpus is the expensive part; the sweep is free.
+
+* **≥ 8 speakers.** The decision rule below is a paired test across speakers,
+  and 8 is about the weakest thing worth acting on.
+* **≥ 3 recordings per speaker, spanning ≥ 2 capture setups** — different
+  mic, room, or headset. The cross-setup case is the *whole point*: a corpus
+  recorded in one room on one microphone cannot show the thing the anchor
+  weight trades off.
+* **Real multi-party conversation, not read speech.** `assign` is fed VAD
+  utterances, so realistic lengths (many under two seconds) and channel
+  conditions matter. It refuses to mint a new speaker from anything under a
+  second, so a corpus of tidy long turns exercises a path users rarely hit.
+* **≥ 20 utterances per speaker per recording**, with per-utterance
+  ground-truth labels (RTTM).
+* **One held-out enrolment recording per speaker**, used only to build the
+  stored profile. If enrolment audio is also replayed, the profile already
+  contains the acoustics being matched against and every anchor weight scores
+  implausibly well. `extract-voice-embeddings.py` refuses that overlap.
+
+## Step 1 — extract embeddings once
+
+This is the only slow step, and the only one needing pyannote or a GPU.
+
+Write a manifest naming the audio and its ground truth:
+
+```json
+{
+  "enrolments": [
+    {"speaker": "alice", "wav": "alice-enrol.wav", "rttm": "alice-enrol.rttm"},
+    {"speaker": "bob",   "wav": "bob-enrol.wav",   "rttm": "bob-enrol.rttm"}
+  ],
+  "recordings": [
+    {"id": "standup-01", "setup": "headset-office",
+     "wav": "standup-01.wav", "rttm": "standup-01.rttm"},
+    {"id": "standup-02", "setup": "laptop-mic-kitchen",
+     "wav": "standup-02.wav", "rttm": "standup-02.rttm"}
+  ]
+}
+```
+
+Audio must be 16 kHz mono WAV — what Mila records. Convert with
+`ffmpeg -i in.m4a -ar 16000 -ac 1 out.wav`.
+
+```
+python3 scripts/extract-voice-embeddings.py \
+  /Applications/Mila.app/Contents/Resources/DiarizationModels \
+  manifest.json --out corpus.json
+```
+
+The script embeds every labelled turn with the same model the app uses, builds
+each stored profile as the mean of that speaker's held-out embeddings (which is
+what `SpeakerProfileStore.updateProfile` would have written, because a running
+mean is the mean), and prints a summary — speakers enrolled, speakers heard but
+not enrolled, capture setups, and warnings if the corpus is below the bar
+above.
+
+Keep `corpus.json`. Every later run replays it, so results stay comparable and
+nobody needs the audio again.
+
+## Step 2 — run the sweep
+
+```
+MILA_SEED_ANCHOR_CORPUS=$PWD/corpus.json \
+MILA_SEED_ANCHOR_REPORT=$PWD/grid.json \
+  xcodebuild test -scheme Mila -destination 'platform=macOS' \
+  -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus
+```
+
+It replays the corpus through the **real** `seedPool` / `assign` — not a model
+of them — once per cell of
+
+* n₀ ∈ {1, 2, 3, 4, 6, 8, 12, uncapped}
+* `similarityThreshold` ∈ {0.50, 0.55, 0.60, 0.65, 0.70}
+
+and prints the grid. Narrow it with `MILA_SEED_ANCHOR_WEIGHTS=1,2,3,uncapped`
+and `MILA_SEED_ANCHOR_THRESHOLDS=0.55` while you are getting set up.
+
+The threshold is swept alongside n₀ rather than held at its default because
+the two interact: n₀ sets how fast the compared centroid moves, and the
+threshold sets how far it may move before a match is refused. The best n₀ at
+0.55 need not be the best at 0.70 — and Settings lets users pick anything in
+0.5–0.95.
+
+Without `MILA_SEED_ANCHOR_CORPUS` the test skips. That skip is the honest
+state of the question, not a failure.
+
+## Step 3 — read the grid
+
+Five tables come out. **Expect them to disagree; that disagreement is the
+signal.**
+
+1. **Returning-speaker recall** — utterances whose true speaker reached the
+   entry seeded from *their* profile. "It recognised me." Note this counts the
+   raw-id assignment, including a *borderline attach* that produces an interval
+   without folding into the centroid. Whether the speaker's **name** actually
+   appeared is table 3.
+2. **Cross-speaker false-attach rate** — utterances that landed on someone
+   else's seeded entry, over all utterances. This is the harm: the wrong name
+   against someone's words, and the wrong voice folded into a stored profile.
+   Counted for non-enrolled speakers too — a stranger landing on Alice's entry
+   is exactly as harmful as Bob doing it.
+3. **Auto-name precision / recall** — did the recording end up applying the
+   right names? This includes `RecognisedSpeakerAssigner.finish`'s
+   `observedCount > 0` guard, which per-utterance metrics cannot see: a speaker
+   who only ever attached borderline is *not* auto-named, however many
+   utterances they got.
+4. **Speaker-count error** — `|ids used − true speakers|`, plus the signed
+   version. Positive is over-segmentation. Watch this one when reading a heavy
+   anchor: keeping the entry further from today's acoustics makes a returning
+   speaker's *later* utterances more likely to fall below the create floor and
+   mint a duplicate `SPEAKER_NN`, so a **stronger** anchor can *increase*
+   fragmentation. That runs opposite to intuition and is a reason to distrust
+   reasoning here.
+5. **Exact Wilcoxon p** for per-speaker recall against the shipping weight, at
+   the same threshold.
+
+Two rules for reading it:
+
+* **Judge a weight by its worst cell across the threshold row, not its best.**
+  Users can set any threshold in 0.5–0.95, so a weight that is excellent at
+  0.55 and dreadful at 0.70 has not earned the default.
+* **The paired test is across speakers, never across utterances.** Utterances
+  within a recording are heavily correlated — same mic, same room, same
+  cold — so an utterance-level test will report significance that is not there.
+  The harness pairs per-speaker recall for exactly this reason.
+
+## Step 4 — decide, and prefer the smaller number
+
+The report prints a starting point: the smallest weight whose worst-case
+false-attach rate is within a tolerance of the grid's best. Treat it as a
+starting point — the tolerance is a judgement call with no measurement behind
+it, and the gate that matters is the paired test over ≥ 8 speakers.
+
+Ties go to the **smaller** weight, on an asymmetry that is an argument rather
+than a guess:
+
+* A too-light anchor lets one noisy or false-positive match half-steal the
+  entry — but the damage is confined to that recording, because n₀ never
+  reaches persistence.
+* A too-heavy anchor keeps a returning speaker below the match threshold
+  forever. They never confidently match, so `observedCount` stays 0, so
+  `finish` correctly refuses to auto-name them, so **nothing is learned and
+  the profile can never adapt in a future recording either.** The profile that
+  most needs updating becomes the one that cannot be updated.
+
+If the answer is not 3, change these together:
+
+1. `LiveSpeakerDiarizer.seedAnchorWeight`;
+2. the weight table and rationale in its doc comment;
+3. `SeedAnchorWeightTests` — it hardcodes 3 deliberately, as a tripwire;
+4. post the report into #206 so the next person sees the evidence, not just
+   the number.
+
+If the answer *is* 3, that is a result worth posting too. It is the difference
+between a measured 3 and the current one.
+
+## What this does not measure
+
+#206 carries a second question the sweep does not touch: the stored centroid is
+a plain running mean over every observation ever recorded, so it never forgets
+old acoustics. A decayed or windowed mean might recognise a returning speaker
+better.
+
+That is deliberately out of scope here, and the order of experiments matters:
+
+* **Cheapest first, and it changes no persisted state.** Have `assign` compare
+  against both the stored centroid *and* the most recent recording's observed
+  centroid, taking the higher similarity. Pure matching change, no schema
+  change, measurable on this same corpus with this same harness, and it
+  degrades safely — it can only make a returning speaker easier to match.
+* **A windowed mean beats a decay constant** if it comes to that: keeping the
+  last K per-recording observations gives forgetting *and* repair (a bad
+  observation can be dropped, which a decayed scalar can never be). The cost
+  is a `speaker-profiles.json` schema change, which needs lenient decoding for
+  older builds and `VoiceProfile.unusableReason` extended to validate every
+  element of the window — that file is user-editable, and a NaN reaching a
+  centroid poisons it permanently.
+* Note that the stored mean **already** forgets slowly and by accident:
+  `updateProfile` clamps the stored count at `VoiceProfile.maxSampleCount`
+  while dividing by the true total, so a mature profile's effective learning
+  rate settles at a floor instead of going to zero. An explicit decay would
+  compound with that. Decide the interaction deliberately.
+
+## Corpus file format
+
+Written by `extract-voice-embeddings.py`, read by `SeedAnchorCorpus` in
+`MilaTests/SeedAnchorSweepHarness.swift`.
+
+```json
+{
+  "enrolments": [
+    {"speaker": "alice", "centroid": [0.01, -0.02, "…"], "sampleCount": 24}
+  ],
+  "recordings": [
+    {"id": "standup-01", "setup": "headset-office",
+     "utterances": [
+       {"speaker": "alice", "start": 12.4, "end": 14.9,
+        "embedding": [0.01, -0.03, "…"]}
+     ]}
+  ]
+}
+```
+
+* `centroid` / `embedding` — every vector in the corpus must have the same
+  dimension (256 for the bundled wespeaker model). A mismatch is refused
+  rather than measured: `assign` cannot make a confident match across
+  dimensions, so a mixed corpus would score zero recall for a reason that has
+  nothing to do with the anchor.
+* `sampleCount` — must be in `1...VoiceProfile.maxSampleCount`, the same bound
+  `updateProfile` enforces, so the sweep only ever sees profiles the app could
+  have written.
+* `start` / `end` — seconds. Both matter: replay is chronological, and
+  `assign` treats a sub-second utterance as untrustworthy for minting a
+  speaker.
+* `setup` — optional free text, reported so you can confirm the corpus really
+  spans more than one capture setup.
+
+Non-finite values, empty vectors, duplicate enrolments for one speaker and
+empty recordings are all refused up front, because each of them produces a
+grid of plausible numbers that measures nothing.

--- a/docs/seed-anchor-sweep.md
+++ b/docs/seed-anchor-sweep.md
@@ -97,11 +97,25 @@ nobody needs the audio again.
 ## Step 2 — run the sweep
 
 ```
+make project        # project.yml is the source of truth; regenerate first
+
 MILA_SEED_ANCHOR_CORPUS=$PWD/corpus.json \
 MILA_SEED_ANCHOR_REPORT=$PWD/grid.json \
-  xcodebuild test -scheme Mila -destination 'platform=macOS' \
-  -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus
+  xcodebuild -project Mila.xcodeproj -scheme Mila -configuration Debug \
+    -derivedDataPath build -destination 'platform=macOS' \
+    -only-testing:MilaTests/SeedAnchorSweepTests/test_sweep_a_provided_corpus \
+    test
 ```
+
+The grid is printed to stdout, so it lands in xcodebuild's output; pipe through
+`tee` if you want it in a file. `MILA_SEED_ANCHOR_REPORT` is the dependable
+route — a machine-readable grid you can attach to the issue or diff against a
+later run.
+
+If the environment variables do not reach the test process on your setup, set
+them in the scheme's **Test** action instead (Product → Scheme → Edit Scheme →
+Test → Arguments → Environment Variables). The test reads them through
+`ProcessInfo`, so either route works.
 
 It replays the corpus through the **real** `seedPool` / `assign` — not a model
 of them — once per cell of

--- a/scripts/extract-voice-embeddings.py
+++ b/scripts/extract-voice-embeddings.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Turn labelled audio into a cached embedding corpus for the seed-anchor
+sweep (island-io/mila#206).
+
+The sweep replays Mila's real speaker-matching code (`seedPool` / `assign`)
+over cached embeddings, once per configuration. Only this step needs pyannote,
+a GPU, or minutes of your life: run it once, and the 40-cell grid then takes
+milliseconds and is reproducible on any machine.
+
+    extract-voice-embeddings.py <models-dir> <manifest.json> --out corpus.json
+
+`models-dir` is the bundled `DiarizationModels/` directory (the same one
+`diarize-e2e.py` takes): `config.yaml` plus the segmentation-3.0 and
+pyannote-wespeaker-voxceleb-resnet34-LM subdirectories. In an installed app
+that is
+`/Applications/Mila.app/Contents/Resources/DiarizationModels`.
+
+The manifest names the audio and its ground truth:
+
+    {
+      "enrolments": [
+        {"speaker": "alice", "wav": "alice-enrol.wav", "rttm": "alice-enrol.rttm"}
+      ],
+      "recordings": [
+        {"id": "standup-01", "setup": "headset-office",
+         "wav": "standup-01.wav", "rttm": "standup-01.rttm"}
+      ]
+    }
+
+Enrolment recordings build the stored profiles and **must be held out** — an
+enrolment file that also appears under `recordings` leaks the answer into the
+profile and every anchor weight scores implausibly well. The script refuses
+that.
+
+Audio must be 16 kHz mono WAV, which is what Mila records. Convert with:
+
+    ffmpeg -i in.m4a -ar 16000 -ac 1 out.wav
+
+RTTM is the standard diarization ground-truth format, one line per turn:
+
+    SPEAKER <file> 1 <start> <duration> <NA> <NA> <speaker> <NA> <NA>
+
+See `docs/seed-anchor-sweep.md` for the whole procedure, and
+`MilaTests/SeedAnchorSweepHarness.swift` for the corpus schema this writes.
+
+NOTE: this script has never been run — nobody has the audio yet. It is
+modelled line by line on the embedding path that ships in
+`LiveSpeakerDiarizer.daemonScript` (same patches, same
+`pipeline._embedding` call, same tensor shape). Expect to debug it the first
+time; the sweep it feeds is exercised by CI on synthetic embeddings.
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import types
+
+
+def _apply_patches():
+    """Same two monkey-patches the app applies. See
+    `.claude/rules/python-subprocess.md` — keep them in sync with
+    `SpeakerDiarizer.swift` and `LiveSpeakerDiarizer.swift` if either
+    dependency is bumped."""
+    try:
+        import speechbrain.utils.importutils as _sbiu
+        _orig_ensure = _sbiu.LazyModule.ensure_module
+
+        def _safe_ensure(self, *a, **kw):
+            try:
+                return _orig_ensure(self, *a, **kw)
+            except ImportError:
+                self.lazy_module = types.ModuleType(self.target)
+                return self.lazy_module
+
+        _sbiu.LazyModule.ensure_module = _safe_ensure
+    except Exception:
+        pass
+
+    import torch
+    _orig_torch_load = torch.load
+
+    def _patched_torch_load(*args, **kwargs):
+        kwargs["weights_only"] = False
+        return _orig_torch_load(*args, **kwargs)
+
+    torch.load = _patched_torch_load
+
+
+def read_rttm(path):
+    """[(start, duration, speaker)] sorted by start."""
+    turns = []
+    with open(path) as f:
+        for line_number, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith(";;"):
+                continue
+            fields = line.split()
+            if len(fields) < 8 or fields[0].upper() != "SPEAKER":
+                continue
+            try:
+                start, duration = float(fields[3]), float(fields[4])
+            except ValueError:
+                sys.exit(f"{path}:{line_number}: unparseable start/duration")
+            turns.append((start, duration, fields[7]))
+    if not turns:
+        sys.exit(f"{path}: no SPEAKER lines")
+    turns.sort(key=lambda t: (t[0], t[1], t[2]))
+    return turns
+
+
+def load_wav(path):
+    import soundfile as sf
+    samples, sample_rate = sf.read(path, dtype="float32")
+    if samples.ndim > 1:
+        samples = samples.mean(axis=1)
+    if sample_rate != 16000:
+        sys.exit(
+            f"{path}: sample rate {sample_rate}, expected 16000. "
+            f"Convert with:  ffmpeg -i {path} -ar 16000 -ac 1 out.wav"
+        )
+    return samples, sample_rate
+
+
+def embed_turns(embedder, samples, sample_rate, turns, min_duration, label):
+    """One embedding per turn long enough to be worth embedding."""
+    import numpy as np
+    import torch
+
+    out, skipped = [], 0
+    for start, duration, speaker in turns:
+        if duration < min_duration:
+            skipped += 1
+            continue
+        first = int(round(start * sample_rate))
+        last = int(round((start + duration) * sample_rate))
+        clip = samples[max(0, first):min(len(samples), last)]
+        if len(clip) < int(min_duration * sample_rate):
+            skipped += 1
+            continue
+        # Shape (batch, channels, samples) — pyannote 3.x's
+        # `pipeline._embedding` is a PretrainedSpeakerEmbedding and takes the
+        # tensor directly, NOT the {"waveform":…, "sample_rate":…} dict that
+        # `Inference` takes. Passing the dict makes it call `.to(device)` on a
+        # dict and fail; the app hit exactly that.
+        wave = torch.from_numpy(np.ascontiguousarray(clip)).unsqueeze(0).unsqueeze(0)
+        vector = embedder(wave)
+        if hasattr(vector, "detach"):
+            vector = vector.detach().cpu().numpy()
+        array = np.asarray(vector).flatten()
+        if not np.all(np.isfinite(array)):
+            sys.exit(f"{label}: non-finite embedding at {start:.2f}s ({speaker})")
+        out.append({
+            "speaker": speaker,
+            "start": round(float(start), 3),
+            "end": round(float(start + duration), 3),
+            "embedding": [float(x) for x in array],
+        })
+    if skipped:
+        print(f"{label}: skipped {skipped} turns under {min_duration}s",
+              file=sys.stderr)
+    return out
+
+
+def mean_vector(vectors):
+    return [sum(column) / float(len(vectors)) for column in zip(*vectors)]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("models_dir")
+    parser.add_argument("manifest")
+    parser.add_argument("--out", required=True, help="corpus JSON to write")
+    parser.add_argument("--min-duration", type=float, default=0.5,
+                        help="skip turns shorter than this (seconds). Embeddings of "
+                             "very short clips are noise; the default keeps the "
+                             "sub-second turns `assign` deliberately refuses to mint "
+                             "a speaker from, while dropping the unusable ones")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.models_dir):
+        sys.exit(f"models dir not found: {args.models_dir}")
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    base = os.path.dirname(os.path.abspath(args.manifest))
+
+    def resolve(path):
+        return path if os.path.isabs(path) else os.path.join(base, path)
+
+    enrolments_in = manifest.get("enrolments") or []
+    recordings_in = manifest.get("recordings") or []
+    if not enrolments_in:
+        sys.exit("manifest has no enrolments — with no stored profile there is "
+                 "nothing for the seed anchor to weight")
+    if not recordings_in:
+        sys.exit("manifest has no recordings to replay")
+
+    # The held-out check. An enrolment recording that is also replayed makes
+    # every anchor weight look good, because the profile already contains the
+    # exact acoustics being matched against.
+    enrolment_wavs = {os.path.realpath(resolve(e["wav"])) for e in enrolments_in}
+    for recording in recordings_in:
+        if os.path.realpath(resolve(recording["wav"])) in enrolment_wavs:
+            sys.exit(f"{recording['wav']} is used both as an enrolment and as a "
+                     f"replayed recording. Enrolment audio must be held out — see "
+                     f"docs/seed-anchor-sweep.md")
+
+    _apply_patches()
+
+    import torch
+    from pyannote.audio import Pipeline
+
+    config_path = os.path.join(args.models_dir, "config.yaml")
+    with open(config_path) as f:
+        config_text = f.read().replace("__MODELS_DIR__", args.models_dir)
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    tmp.write(config_text)
+    tmp.close()
+    try:
+        pipeline = Pipeline.from_pretrained(tmp.name)
+        if torch.backends.mps.is_available():
+            pipeline.to(torch.device("mps"))
+            print("device: mps", file=sys.stderr)
+        else:
+            print("device: cpu", file=sys.stderr)
+        embedder = getattr(pipeline, "_embedding", None)
+        if embedder is None:
+            sys.exit("pipeline._embedding not available — pyannote version changed?")
+    finally:
+        os.unlink(tmp.name)
+
+    # Enrolments: the stored profile is the mean of that speaker's embeddings
+    # in the held-out recording, with sampleCount the number of them. That is
+    # exactly what `SpeakerProfileStore.updateProfile` would have written from
+    # a recording where they were recognised, because the pool's
+    # `observedCentroid` is a running mean and a running mean is the mean.
+    enrolments = []
+    for entry in enrolments_in:
+        speaker = entry["speaker"]
+        wav = resolve(entry["wav"])
+        samples, sample_rate = load_wav(wav)
+        turns = [t for t in read_rttm(resolve(entry["rttm"])) if t[2] == speaker]
+        if not turns:
+            sys.exit(f"{entry['rttm']}: no turns for enrolled speaker {speaker}")
+        vectors = [u["embedding"] for u in
+                   embed_turns(embedder, samples, sample_rate, turns,
+                               args.min_duration, f"enrol/{speaker}")]
+        if not vectors:
+            sys.exit(f"enrol/{speaker}: every turn was too short to embed")
+        enrolments.append({
+            "speaker": speaker,
+            "centroid": mean_vector(vectors),
+            "sampleCount": len(vectors),
+        })
+        print(f"enrol/{speaker}: {len(vectors)} utterances", file=sys.stderr)
+
+    recordings = []
+    for entry in recordings_in:
+        wav = resolve(entry["wav"])
+        samples, sample_rate = load_wav(wav)
+        turns = read_rttm(resolve(entry["rttm"]))
+        utterances = embed_turns(embedder, samples, sample_rate, turns,
+                                 args.min_duration, entry["id"])
+        if not utterances:
+            sys.exit(f"{entry['id']}: no usable turns")
+        recordings.append({
+            "id": entry["id"],
+            "setup": entry.get("setup"),
+            "utterances": utterances,
+        })
+        speakers = sorted({u["speaker"] for u in utterances})
+        print(f"{entry['id']}: {len(utterances)} utterances, speakers {speakers}",
+              file=sys.stderr)
+
+    corpus = {"enrolments": enrolments, "recordings": recordings}
+    with open(args.out, "w") as f:
+        json.dump(corpus, f)
+
+    enrolled = {e["speaker"] for e in enrolments}
+    heard = {u["speaker"] for r in recordings for u in r["utterances"]}
+    setups = sorted({r["setup"] for r in recordings if r.get("setup")})
+    print(f"\nwrote {args.out}", file=sys.stderr)
+    print(f"  enrolled speakers: {len(enrolled)}", file=sys.stderr)
+    print(f"  speakers heard but not enrolled: {sorted(heard - enrolled)}",
+          file=sys.stderr)
+    print(f"  enrolled but never heard: {sorted(enrolled - heard)}", file=sys.stderr)
+    print(f"  capture setups: {setups}", file=sys.stderr)
+    if len(enrolled) < 8:
+        print("  WARNING: #206's bar for acting on a result is >= 8 speakers",
+              file=sys.stderr)
+    if len(setups) < 2:
+        print("  WARNING: fewer than two capture setups — the cross-setup case is "
+              "the one the seed anchor exists for", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #261

## What & why

**No recognition measurement was performed, and the default anchor weight does not move.** There is no Mac, no Swift toolchain and no multi-speaker corpus in the environment this was written in; nothing here was compiled or run locally, and CI is the first compiler to see it. Both facts are the reason the change has the shape it does.

#206 asks whether `LiveSpeakerDiarizer.seedAnchorWeight` should be 2, 3 or 4, and whether the stored centroid should forget. Its own body rules out answering either from code — *"unit tests can pin the arithmetic but cannot tell us whether recognition actually improves"* — and #248 already landed the half that does belong in the repo: the constant is named, derived, and pinned by a test that drives the real fold.

What was left is not another argument about the number. It is that **running the experiment required re-deriving it from a GitHub comment** — replay order, four metrics and their exact denominators, the grid, the pairing, the decision rule — with two obstacles in the code itself. #261 has the full statement; the short version is that the protocol sweeps n₀ ∈ {1, 2, 3, 4, 6, 8, 12, uncapped} while `seedPool` applies the weight as a *ceiling*, so the heavy end of the grid was unreachable without a rebuild, and the expensive pyannote pass had no cached artifact to make two runs comparable.

So this builds the experiment rather than guessing at its answer.

### The harness

`SeedAnchorSweepHarness` (test target) replays a cached corpus of speaker embeddings through the **real** `seedPool` / `assign` — not a model of them — once per cell of n₀ × `similarityThreshold`, and scores the four metrics #206 names: returning-speaker recall, cross-speaker false-attach rate, recording-level auto-name precision/recall, and speaker-count error. Not a model of them matters: #248 established that a *simulation* of `assign` scored identically for every weight from 1 to uncapped while the real fold did not.

Embeddings are cached because that is the only step needing pyannote. The 40-cell grid then runs in milliseconds and is reproducible on any machine from the same file, with no model in the loop.

`SeedAnchorSweepReport` renders the grid, an exact Wilcoxon signed-rank test paired across speakers, and the decision rule as a *starting point* rather than a verdict.

### The one production change

`seedAnchorWeightOverride` on `LiveSpeakerDiarizer` — `nil` everywhere in the app, so shipped behaviour is byte-for-byte what it was. It is a precondition, not a convenience: without it the sweep can only measure the light end of the specified grid, and the heavy end is the one whose failure mode the doc comment describes and nobody has observed on real audio.

It is clamped to `>= 1`, which is arithmetic safety rather than tidiness. `assign`'s fold divides by `Float(n + 1)`: `0` reproduces the provably-wrong end (the stored voice discarded by its own first match) and `-1` divides by zero, putting a NaN into a centroid — after which `cosineSimilarity` returns NaN, `sim > best.sim` is false for NaN, and the entry silently never confidently matches again. That is the permanent poisoning `VoiceProfile.unusableReason` exists to keep off disk.

### What is deliberately not here

The anchor weight itself, and the decayed/windowed mean. Both need the measurement this makes possible; the latter is also a `speaker-profiles.json` schema change, and #206's own analysis says to measure the cheap matching-only option first. **#206 remains open**, which is why this PR is linked to #261 instead — the empirical question is untouched by it.

## How it was tested

Not compiled, not run — no toolchain here. CI is the only build. What CI will exercise, on synthetic embeddings, every run:

* **`test_the_grid_separates_anchor_weights_instead_of_reporting_one_number`** — the load-bearing one. Ten folds in, a 70° probe is a confident match at every capped weight but falls below the create floor uncapped, minting a second speaker for the same person. If the override stopped reaching `seedPool`, every cell would agree and the sweep would report a confident, meaningless answer.
* **Each metric's definition**, on a fixture built so all four disagree — perfect recall alongside a 1/3 false-attach rate, half-right auto-naming, and under-segmentation, in one three-utterance recording.
* **`SeedAnchorAutoNameAgreementTests`** — the auto-name metric against the real `RecognisedSpeakerAssigner.finish`, with a real store, profile store and assigner. The harness scores auto-naming from a predicate over the pool rather than running `finish` per cell (that would need a disk write per cell); these tests are what stop the predicate drifting into a private reimplementation. The discriminating case is a *borderline attach*: an interval is produced but `observedCount` stays 0, so `finish` refuses to name and the harness must refuse to count.
* **`WilcoxonSignedRankTests`** — cross-checked against exhaustive enumeration of all 2ⁿ sign assignments and the closed-form all-positive case. Its p-values are the gate on changing a constant that affects every user with stored profiles, so a subtly wrong statistic would not look wrong; it would licence a change on invented evidence.
* **Corpus validation** — mixed dimensions, NaNs, duplicate enrolments and out-of-range sample counts are all refused up front, because each produces a grid of plausible numbers that measures nothing.

Every expected value in those tests was cross-computed by replaying the same float32 fold arithmetic outside Swift, and the results agree with the weight table #248 derived independently (0.750 at n₀=3, 0.685 at n₀=6, 0.456 uncapped).

`SeedAnchorSweepTests/test_sweep_a_provided_corpus` **skips** without `MILA_SEED_ANCHOR_CORPUS`, so the suite's skip count goes up by one. That skip is the honest state of the question, not a failure.

`scripts/extract-voice-embeddings.py` has **never been executed** — nobody has the audio. It is modelled line by line on the embed path in `LiveSpeakerDiarizer.daemonScript` (same monkey-patches, same `pipeline._embedding` call, same tensor shape, since passing the `Inference` dict shape is a mistake the app already made once). Its pure-Python helpers were exercised locally; the pyannote path was not. `docs/seed-anchor-sweep.md` says so, and says what to do when it needs debugging.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible here**: no macOS, no Swift toolchain, `download.swift.org` is proxy-blocked. Every line is unverified until CI compiles it.
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, nothing user-facing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN


---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shipped diarization is unchanged when `seedAnchorWeightOverride` stays nil; risk is mostly new test/tooling surface, with a small foot-gun if production ever sets override without the clamp (mitigated by `max(1, …)`).
> 
> **Overview**
> Adds the **#206 measurement pipeline** so `seedAnchorWeight` can be evaluated empirically without re-deriving the protocol from issues. **Production change is minimal:** `LiveSpeakerDiarizer` gains `seedAnchorWeightOverride` (nil in the app) and `effectiveSeedAnchorWeight` (clamped ≥ 1); `seedPool` caps seeded `sampleCount` through that property so tests can sweep heavy anchor weights and `Int.max` “uncapped” while shipped behaviour stays at **n₀ = 3**.
> 
> The test target adds **`SeedAnchorSweepHarness`** — loads/validates a JSON embedding corpus, replays each recording through real `reset` / `seedPool` / `assign` on an n₀ × `similarityThreshold` grid, and tallies recall, false-attach, auto-name, and speaker-count metrics plus **`SeedAnchorRecommendation`** and **`SeedAnchorSweepReport`** (text + JSON, exact Wilcoxon vs shipping weight). **`SeedAnchorAutoNameAgreementTests`** locks the harness auto-name predicate to **`RecognisedSpeakerAssigner.finish`**. CI exercises synthetic fixtures; **`SeedAnchorSweepTests/test_sweep_a_provided_corpus`** skips unless `MILA_SEED_ANCHOR_CORPUS` is set.
> 
> Also adds **`docs/seed-anchor-sweep.md`** and **`scripts/extract-voice-embeddings.py`** (one-time pyannote embed → corpus JSON); the default anchor constant is **not** changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944e00b7d30a819f552809bf86e1340f1204cc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->