### PR TITLE
fix(models): sticky model deletion, plus reselect and test-crash fallout

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2044,7 +2044,9 @@ struct MilaApp: App {
         guard !remoteTranscriptionSettings.isActive else { return }
         modelManager.setSelected(WhisperModel.ivritLarge)
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
-            if !modelManager.isInstalled(model) && modelManager.downloads[model.name] == nil {
+            if !modelManager.isInstalled(model)
+                && !modelManager.isDeclined(model)
+                && modelManager.downloads[model.name] == nil {
                 modelManager.download(model)
             }
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2050,6 +2050,15 @@ struct MilaApp: App {
     /// same `URLSession` so they don't actually saturate the network, and
     /// the in-app banner shows whichever is currently selected.
     private func ensureDefaultModelsInstalled() {
+        // Skip entirely under XCTest hosting (unit or UI) — same rationale
+        // as `prewarmDefaultModel()`: `MilaTests` is app-hosted, so this
+        // `.task` runs for real during ordinary unit test runs too. Without
+        // this guard it calls `setSelected`/`download` on the production
+        // `ModelManager`, which is backed by `UserDefaults.standard` (see
+        // `MilaApp.body`'s `ModelManager(modelsDirectory:)` call) — every
+        // `xcodebuild test` invocation would mutate the real app's declined
+        // models / selected model and could kick off real network downloads.
+        guard !isRunningUnderXCTest else { return }
         // Skip the multi-GB local model downloads + CoreML prep entirely for
         // users who've opted into the remote backend — they don't need any
         // local weights. (The Models tab still offers manual downloads, and

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2011,23 +2011,36 @@ struct MilaApp: App {
     /// button, and any too-eager Record press during the window finds
     /// the model already loaded.
     private func prewarmDefaultModel() {
-        // Skip prewarm under UI tests. No UI test relies on a launch-time
-        // warm — the transcription E2E tests pass `--ui-test-tiny-model-path=`
-        // and load on demand — so warming the (potentially multi-GB) default
-        // model here just burns CPU/IO on every UI-test launch and creates a
-        // whisper/Metal context that XCTest never frees (it exits via
-        // `exit()`, bypassing `gracefulShutdown()`), which is what prints the
-        // ggml-metal teardown backtrace at process exit.
-        guard !isRunningUITests else { return }
+        // Skip prewarm under any XCTest hosting (UI or unit tests). No test
+        // relies on a launch-time warm — the transcription E2E tests pass
+        // `--ui-test-tiny-model-path=` and load on demand — so warming the
+        // (potentially multi-GB) default model here just burns CPU/IO on
+        // every test launch and creates a whisper/Metal context that XCTest
+        // never frees (it exits via `exit()`, bypassing `gracefulShutdown()`),
+        // which is what prints the ggml-metal teardown backtrace at process
+        // exit. This used to be guarded by `--uitests` alone, which covers
+        // XCUITest, but `MilaTests` is an app-hosted unit test bundle
+        // (`TEST_HOST` = Mila.app in project.yml) — SwiftUI's `.task`
+        // modifiers, prewarm included, run there too, just without that flag.
+        guard !isRunningUnderXCTest else { return }
         // No local weights to warm when the remote backend is selected.
         guard !remoteTranscriptionSettings.isActive else { return }
         transcription.prewarm(language: languageSettings.current.rawValue)
     }
 
-    /// True when the process was launched by an XCUITest run. Keyed off the
-    /// `--uitests` / `--ui-test-*` launch arguments the UI test targets pass.
-    private var isRunningUITests: Bool {
+    /// True when the process is hosting an XCTest run — either an XCUITest
+    /// (keyed off the `--uitests` / `--ui-test-*` launch arguments the UI
+    /// test targets pass) or an app-hosted unit test bundle (`MilaTests`),
+    /// which loads `XCTestCase` directly into this process via
+    /// `BUNDLE_LOADER`/`TEST_HOST` — no launch argument marks that case, so
+    /// `XCTestCase`'s presence is the only reliable signal.
+    /// `XCTestConfigurationFilePath`, the usual env-var check for "is this
+    /// process under XCTest," is present but empty for app-hosted unit
+    /// tests on this toolchain — verified empirically, not a documented
+    /// contract — so it can't be used here.
+    private var isRunningUnderXCTest: Bool {
         CommandLine.arguments.contains { $0 == "--uitests" || $0.hasPrefix("--ui-test") }
+            || NSClassFromString("XCTestCase") != nil
     }
 
     /// Pre-download the two default models on first launch:
@@ -2042,7 +2055,12 @@ struct MilaApp: App {
         // local weights. (The Models tab still offers manual downloads, and
         // switching back to local re-triggers this on next launch.)
         guard !remoteTranscriptionSettings.isActive else { return }
-        modelManager.setSelected(WhisperModel.ivritLarge)
+        // Don't re-select a model the user explicitly deleted — that would
+        // silently revert their delete every launch, same as skipping its
+        // auto-download below.
+        if !modelManager.isDeclined(WhisperModel.ivritLarge) {
+            modelManager.setSelected(WhisperModel.ivritLarge)
+        }
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
             if !modelManager.isInstalled(model)
                 && !modelManager.isDeclined(model)

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -99,6 +99,7 @@ final class ModelManager: NSObject, ObservableObject {
     @Published var lastDownloadErrors: [String: String] = [:]
 
     private let modelsDirectory: URL
+    private let defaults: UserDefaults
     private static let declinedModelsKey = "model.declinedNames"
 
     /// Names of models the user explicitly deleted via Settings. Consulted
@@ -109,19 +110,29 @@ final class ModelManager: NSObject, ObservableObject {
     /// model, since that's an explicit request for it.
     @Published private(set) var declinedModelNames: Set<String>
 
+    /// Test-only hook: stub `URLProtocol` classes to install on the download
+    /// session's configuration, so tests can exercise `download(_:)` without
+    /// making a real network request. `nil` in production.
+    private let sessionProtocolClasses: [AnyClass]?
+
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForResource = 60 * 60
+        if let sessionProtocolClasses {
+            config.protocolClasses = sessionProtocolClasses
+        }
         return URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }()
     private var observers: [Int: WhisperModel] = [:]
     private var didShutDownSession = false
 
-    init(modelsDirectory: URL) {
+    init(modelsDirectory: URL, defaults: UserDefaults = .standard, sessionProtocolClasses: [AnyClass]? = nil) {
         self.modelsDirectory = modelsDirectory
-        let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
+        self.defaults = defaults
+        self.sessionProtocolClasses = sessionProtocolClasses
+        let lastUsed = defaults.string(forKey: "selectedModelName")
         self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
-        let declined = UserDefaults.standard.array(forKey: Self.declinedModelsKey) as? [String] ?? []
+        let declined = defaults.array(forKey: Self.declinedModelsKey) as? [String] ?? []
         self.declinedModelNames = Set(declined)
         super.init()
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
@@ -134,7 +145,7 @@ final class ModelManager: NSObject, ObservableObject {
 
     func setSelected(_ model: WhisperModel) {
         selectedModelName = model.name
-        UserDefaults.standard.set(model.name, forKey: "selectedModelName")
+        defaults.set(model.name, forKey: "selectedModelName")
     }
 
     /// The model the app should use when transcribing audio in `languageCode`.
@@ -211,7 +222,7 @@ final class ModelManager: NSObject, ObservableObject {
         } else {
             declinedModelNames.remove(model.name)
         }
-        UserDefaults.standard.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
+        defaults.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
     }
 
     func delete(_ model: WhisperModel) throws {

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -99,6 +99,16 @@ final class ModelManager: NSObject, ObservableObject {
     @Published var lastDownloadErrors: [String: String] = [:]
 
     private let modelsDirectory: URL
+    private static let declinedModelsKey = "model.declinedNames"
+
+    /// Names of models the user explicitly deleted via Settings. Consulted
+    /// by `MilaApp.ensureDefaultModelsInstalled()` so a deliberate delete
+    /// doesn't come back on the next launch — `isInstalled` alone can't
+    /// distinguish "never downloaded" from "downloaded, then removed on
+    /// purpose." Cleared the moment `download(_:)` is called again for that
+    /// model, since that's an explicit request for it.
+    @Published private(set) var declinedModelNames: Set<String>
+
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForResource = 60 * 60
@@ -111,6 +121,8 @@ final class ModelManager: NSObject, ObservableObject {
         self.modelsDirectory = modelsDirectory
         let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
         self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
+        let declined = UserDefaults.standard.array(forKey: Self.declinedModelsKey) as? [String] ?? []
+        self.declinedModelNames = Set(declined)
         super.init()
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         refreshInstalled()
@@ -179,6 +191,10 @@ final class ModelManager: NSObject, ObservableObject {
         return installed.contains(model.name)
     }
 
+    func isDeclined(_ model: WhisperModel) -> Bool {
+        declinedModelNames.contains(model.name)
+    }
+
     func refreshInstalled() {
         let fm = FileManager.default
         var found: Set<String> = []
@@ -189,14 +205,25 @@ final class ModelManager: NSObject, ObservableObject {
         modelLogger.log("refreshInstalled: dir=\(self.modelsDirectory.path, privacy: .public) found=\(found, privacy: .public)")
     }
 
+    private func setDeclined(_ declined: Bool, for model: WhisperModel) {
+        if declined {
+            declinedModelNames.insert(model.name)
+        } else {
+            declinedModelNames.remove(model.name)
+        }
+        UserDefaults.standard.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
+    }
+
     func delete(_ model: WhisperModel) throws {
         try FileManager.default.removeItem(at: url(for: model))
         refreshInstalled()
+        setDeclined(true, for: model)
     }
 
     func download(_ model: WhisperModel) {
         guard downloads[model.name] == nil else { return }
         guard !didShutDownSession else { return }
+        setDeclined(false, for: model)
         // A fresh attempt supersedes the previous failure report for THIS
         // model only — a concurrent sibling download's error must survive.
         lastDownloadErrors[model.name] = nil

--- a/MilaTests/DictationControllerTests.swift
+++ b/MilaTests/DictationControllerTests.swift
@@ -12,32 +12,24 @@ final class DictationControllerTests: XCTestCase {
     private var service: TranscriptionService!
     private var hotkeys: HotkeySettings!
     private var defaultsSuite: UserDefaults!
-    private var savedSelection: String?
 
     override func setUp() async throws {
         try await super.setUp()
         tempRoot = TestSupport.makeTempRoot(label: "DictationControllerTests")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        UserDefaults().removePersistentDomain(forName: "DictationControllerTests")
+        defaultsSuite = UserDefaults(suiteName: "DictationControllerTests")
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"), defaults: defaultsSuite)
         try TestSupport.installFakeModel(into: manager, model: .ivritLarge)
         try TestSupport.installFakeModel(into: manager, model: .openaiTurbo)
         stub = StubWhisperEngine()
         service = TranscriptionService(store: store, modelManager: manager, diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "DictationControllerTests.diarization")!), remoteSettings: TestSupport.isolatedRemoteSettings(label: "DictationControllerTests"), engine: stub)
-
-        UserDefaults().removePersistentDomain(forName: "DictationControllerTests")
-        defaultsSuite = UserDefaults(suiteName: "DictationControllerTests")
         hotkeys = HotkeySettings(defaults: defaultsSuite)
     }
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         defaultsSuite.removePersistentDomain(forName: "DictationControllerTests")
         try await super.tearDown()
     }

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -6,36 +6,31 @@ import CryptoKit
 final class ModelManagerTests: XCTestCase {
 
     private var tempRoot: URL!
-
-    private var savedSelection: String?
-    private var savedDeclined: [String]?
+    private var defaults: UserDefaults!
+    private let suite = "ModelManagerTests"
 
     override func setUp() {
         super.setUp()
         tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelManagerTests-\(UUID())", isDirectory: true)
         try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
-        savedDeclined = UserDefaults.standard.array(forKey: "model.declinedNames") as? [String]
+        UserDefaults().removePersistentDomain(forName: suite)
+        defaults = UserDefaults(suiteName: suite)
     }
 
     override func tearDown() {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
-        if let savedDeclined {
-            UserDefaults.standard.set(savedDeclined, forKey: "model.declinedNames")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "model.declinedNames")
-        }
+        defaults.removePersistentDomain(forName: suite)
         super.tearDown()
     }
 
+    private func makeManager(sessionProtocolClasses: [AnyClass]? = nil) -> ModelManager {
+        ModelManager(modelsDirectory: tempRoot, defaults: defaults,
+                     sessionProtocolClasses: sessionProtocolClasses)
+    }
+
     func test_catalog_contains_ivrit_large_as_default_selected_model() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         XCTAssertNotNil(mgr.selectedModel())
         XCTAssertEqual(mgr.selectedModelName, WhisperModel.ivritLarge.name,
                        "Default selection should be the ivrit.ai large-v3 Hebrew model")
@@ -96,14 +91,14 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_url_for_model_lives_under_models_directory() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let url = mgr.url(for: WhisperModel.ivritLarge)
         XCTAssertEqual(url.deletingLastPathComponent().path, tempRoot.path)
         XCTAssertEqual(url.lastPathComponent, "ivrit-ai-whisper-large-v3.bin")
     }
 
     func test_install_state_reflects_files_in_directory() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         XCTAssertFalse(mgr.isInstalled(.ivritLarge))
 
         let path = mgr.url(for: .ivritLarge)
@@ -116,11 +111,11 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_set_selected_persists_choice() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         mgr.setSelected(.openaiTurbo)
         XCTAssertEqual(mgr.selectedModelName, WhisperModel.openaiTurbo.name)
 
-        let reloaded = ModelManager(modelsDirectory: tempRoot)
+        let reloaded = makeManager()
         XCTAssertEqual(reloaded.selectedModelName, WhisperModel.openaiTurbo.name)
     }
 
@@ -132,7 +127,7 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_model_for_language_falls_back_to_selected_when_best_not_installed() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         // Install only the OpenAI turbo, then ask for the Hebrew best model.
         let openaiPath = mgr.url(for: .openaiTurbo)
         try Data("not-a-real-model".utf8).write(to: openaiPath)
@@ -145,7 +140,7 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_delete_marks_model_declined() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -158,20 +153,20 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_declined_status_persists_across_reload() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
         try mgr.delete(.ivritLarge)
 
-        let reloaded = ModelManager(modelsDirectory: tempRoot)
+        let reloaded = makeManager()
 
         XCTAssertTrue(reloaded.isDeclined(.ivritLarge),
                       "Declined status must survive process relaunch, same as selectedModelName")
     }
 
     func test_download_clears_declined_status() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager(sessionProtocolClasses: [StubModelDownloadURLProtocol.self])
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -179,14 +174,14 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
 
         mgr.download(.ivritLarge)
-        mgr.shutdown() // cancel the in-flight network task; we only care about the declined-set side effect
+        mgr.shutdown() // stop the stubbed task; we only care about the declined-set side effect
 
         XCTAssertFalse(mgr.isDeclined(.ivritLarge),
                        "An explicit download request means the user wants the model again")
     }
 
     func test_declining_one_model_does_not_affect_another() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -196,4 +191,19 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
         XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
     }
+}
+
+/// Returns a tiny 200 response for any request — lets `ModelManager.download(_:)`
+/// exercise its declined-status side effect without a real network fetch.
+private final class StubModelDownloadURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("stub-model-bytes".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
 }

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -8,6 +8,7 @@ final class ModelManagerTests: XCTestCase {
     private var tempRoot: URL!
 
     private var savedSelection: String?
+    private var savedDeclined: [String]?
 
     override func setUp() {
         super.setUp()
@@ -15,6 +16,7 @@ final class ModelManagerTests: XCTestCase {
             .appendingPathComponent("ModelManagerTests-\(UUID())", isDirectory: true)
         try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        savedDeclined = UserDefaults.standard.array(forKey: "model.declinedNames") as? [String]
     }
 
     override func tearDown() {
@@ -23,6 +25,11 @@ final class ModelManagerTests: XCTestCase {
             UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
         } else {
             UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        if let savedDeclined {
+            UserDefaults.standard.set(savedDeclined, forKey: "model.declinedNames")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "model.declinedNames")
         }
         super.tearDown()
     }
@@ -135,5 +142,58 @@ final class ModelManagerTests: XCTestCase {
         // Hebrew best is ivritLarge (not installed) so we should fall back.
         let resolved = mgr.model(for: "he")
         XCTAssertEqual(resolved, .openaiTurbo)
+    }
+
+    func test_delete_marks_model_declined() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge))
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge),
+                      "Deleting a model must mark it declined so launch-time auto-download skips it")
+    }
+
+    func test_declined_status_persists_across_reload() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+
+        let reloaded = ModelManager(modelsDirectory: tempRoot)
+
+        XCTAssertTrue(reloaded.isDeclined(.ivritLarge),
+                      "Declined status must survive process relaunch, same as selectedModelName")
+    }
+
+    func test_download_clears_declined_status() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+
+        mgr.download(.ivritLarge)
+        mgr.shutdown() // cancel the in-flight network task; we only care about the declined-set side effect
+
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge),
+                       "An explicit download request means the user wants the model again")
+    }
+
+    func test_declining_one_model_does_not_affect_another() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+        XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
     }
 }

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -10,8 +10,7 @@ final class TranscriptionServiceTests: XCTestCase {
     private var manager: ModelManager!
     private var stub: StubWhisperEngine!
     private var service: TranscriptionService!
-
-    private var savedSelection: String?
+    private var modelDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -19,8 +18,9 @@ final class TranscriptionServiceTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
 
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        UserDefaults().removePersistentDomain(forName: "TranscriptionServiceTests.models")
+        modelDefaults = UserDefaults(suiteName: "TranscriptionServiceTests.models")
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"), defaults: modelDefaults)
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -37,11 +37,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
+        modelDefaults.removePersistentDomain(forName: "TranscriptionServiceTests.models")
         try await super.tearDown()
     }
 

--- a/docs/plans/2026-09-04-sticky-model-deletion.md
+++ b/docs/plans/2026-09-04-sticky-model-deletion.md
@@ -1,0 +1,298 @@
+# Sticky Model Deletion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deleting a downloaded Whisper model in Settings must stay deleted — `ensureDefaultModelsInstalled()` currently re-downloads any missing default model on every app launch (including after every update, since a launch is a launch), because `ModelManager` has no concept of "the user doesn't want this," only "is the file on disk."
+
+**Architecture:** Add a persisted `Set<String>` of declined model names to `ModelManager`, backed by `UserDefaults.standard` (matching the existing `selectedModelName` persistence pattern in the same class — no new settings object, no new `UserDefaults` suite). `delete(_:)` adds the model to the set; `download(_:)` removes it (an explicit download request, whether from the Settings "Download" button or a future caller, means the user wants it again). The launch-time auto-download loop in `MilaApp.swift` gains one extra condition: skip any model that is declined.
+
+**Tech Stack:** Swift, XCTest, `UserDefaults`.
+
+## Global Constraints
+
+- Persistence key: `"model.declinedNames"` (namespaced like the existing `"selectedModelName"` key already in this file — not `diarization.*`-style namespacing, since `ModelManager` doesn't use that convention).
+- No new `UserDefaults` suite / no new `ObservableObject` — this lives inside the existing `ModelManager` class, consistent with how `selectedModelName` already works there.
+- `WhisperModel` is `Hashable`/`Codable`; the declined set stores `WhisperModel.name` (`String`), matching how `installed: Set<String>` and `downloads: [String: Double]` already key by name.
+- Existing tests in `MilaTests/ModelManagerTests.swift` save/restore `UserDefaults.standard.string(forKey: "selectedModelName")` around each test to avoid cross-test pollution — the new tests must do the same for `"model.declinedNames"`.
+
+---
+
+### Task 1: Persist declined models in `ModelManager`
+
+**Files:**
+- Modify: `Mila/Transcription/ModelManager.swift`
+- Test: `MilaTests/ModelManagerTests.swift`
+
+**Interfaces:**
+- Produces: `ModelManager.isDeclined(_ model: WhisperModel) -> Bool` — later tasks (Task 2) call this from `MilaApp.swift`.
+- Produces: `ModelManager.delete(_ model: WhisperModel) throws` (existing signature, unchanged) — now also marks the model declined.
+- Produces: `ModelManager.download(_ model: WhisperModel)` (existing signature, unchanged) — now also clears declined status for that model.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `MilaTests/ModelManagerTests.swift`. First extend `setUp`/`tearDown` to also save/restore the new key:
+
+```swift
+    private var savedSelection: String?
+    private var savedDeclined: [String]?
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelManagerTests-\(UUID())", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        savedDeclined = UserDefaults.standard.array(forKey: "model.declinedNames") as? [String]
+    }
+
+    override func tearDown() {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        if let savedSelection {
+            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        if let savedDeclined {
+            UserDefaults.standard.set(savedDeclined, forKey: "model.declinedNames")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "model.declinedNames")
+        }
+        super.tearDown()
+    }
+```
+
+Then add the new test cases:
+
+```swift
+    func test_delete_marks_model_declined() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge))
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge),
+                      "Deleting a model must mark it declined so launch-time auto-download skips it")
+    }
+
+    func test_declined_status_persists_across_reload() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+
+        let reloaded = ModelManager(modelsDirectory: tempRoot)
+
+        XCTAssertTrue(reloaded.isDeclined(.ivritLarge),
+                      "Declined status must survive process relaunch, same as selectedModelName")
+    }
+
+    func test_download_clears_declined_status() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+
+        mgr.download(.ivritLarge)
+        mgr.shutdown() // cancel the in-flight network task; we only care about the declined-set side effect
+
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge),
+                       "An explicit download request means the user wants the model again")
+    }
+
+    func test_declining_one_model_does_not_affect_another() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+        XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test` (or, for just this file, open Xcode and run `MilaTests/ModelManagerTests.swift`).
+Expected: build FAILS — `isDeclined` doesn't exist yet on `ModelManager`. (If it somehow compiles, something's wrong — there is no such member yet.)
+
+- [ ] **Step 3: Implement the declined-set persistence**
+
+In `Mila/Transcription/ModelManager.swift`, add the storage key near the top of the class (after `private let modelsDirectory: URL`):
+
+```swift
+    private static let declinedModelsKey = "model.declinedNames"
+
+    /// Names of models the user explicitly deleted via Settings. Consulted
+    /// by `MilaApp.ensureDefaultModelsInstalled()` so a deliberate delete
+    /// doesn't come back on the next launch — `isInstalled` alone can't
+    /// distinguish "never downloaded" from "downloaded, then removed on
+    /// purpose." Cleared the moment `download(_:)` is called again for that
+    /// model, since that's an explicit request for it.
+    @Published private(set) var declinedModelNames: Set<String>
+```
+
+In `init(modelsDirectory:)`, initialize it alongside the existing `selectedModelName` load (replace the current init body):
+
+```swift
+    init(modelsDirectory: URL) {
+        self.modelsDirectory = modelsDirectory
+        let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
+        self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
+        let declined = UserDefaults.standard.array(forKey: Self.declinedModelsKey) as? [String] ?? []
+        self.declinedModelNames = Set(declined)
+        super.init()
+        try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        refreshInstalled()
+    }
+```
+
+Add the query method next to `isInstalled(_:)`:
+
+```swift
+    func isDeclined(_ model: WhisperModel) -> Bool {
+        declinedModelNames.contains(model.name)
+    }
+```
+
+Add a private persistence helper, and wire it into `delete(_:)` and `download(_:)`:
+
+```swift
+    private func setDeclined(_ declined: Bool, for model: WhisperModel) {
+        if declined {
+            declinedModelNames.insert(model.name)
+        } else {
+            declinedModelNames.remove(model.name)
+        }
+        UserDefaults.standard.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
+    }
+
+    func delete(_ model: WhisperModel) throws {
+        try FileManager.default.removeItem(at: url(for: model))
+        refreshInstalled()
+        setDeclined(true, for: model)
+    }
+
+    func download(_ model: WhisperModel) {
+        guard downloads[model.name] == nil else { return }
+        guard !didShutDownSession else { return }
+        setDeclined(false, for: model)
+        // A fresh attempt supersedes the previous failure report for THIS
+        // model only — a concurrent sibling download's error must survive.
+        lastDownloadErrors[model.name] = nil
+        downloads[model.name] = 0
+        let task = session.downloadTask(with: model.url)
+        observers[task.taskIdentifier] = model
+        task.resume()
+    }
+```
+
+(Only the two new lines — `setDeclined(true, for: model)` in `delete`, `setDeclined(false, for: model)` in `download` — are additions; everything else in those two methods is unchanged from the current file.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test`
+Expected: PASS — all four new tests green, and every pre-existing `ModelManagerTests` test still green (in particular `test_install_state_reflects_files_in_directory`, which also calls `delete(_:)`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Mila/Transcription/ModelManager.swift MilaTests/ModelManagerTests.swift
+git commit -m "$(cat <<'EOF'
+fix(models): make Settings model deletion stick across relaunch
+
+ModelManager only ever asked "is the file on disk" to decide whether to
+auto-download a default model at launch, so a deliberate delete via
+Settings was indistinguishable from "never downloaded" and silently
+came back on the very next launch (including after every app update).
+Persist which models the user explicitly declined and skip them.
+
+Claude-Session: https://claude.ai/code/session_018PknxN13oghDt2XTHu7fPL
+EOF
+)"
+```
+
+---
+
+### Task 2: Skip declined models in the launch-time auto-download
+
+**Files:**
+- Modify: `Mila/App/MilaApp.swift:1440-1458` (`ensureDefaultModelsInstalled()`)
+
+**Interfaces:**
+- Consumes: `ModelManager.isDeclined(_ model: WhisperModel) -> Bool` from Task 1.
+
+There is no existing unit-test harness for `MilaApp`'s private launch-time methods (`MilaTests/` has no test that constructs `MilaApp` — it's a SwiftUI `App` with heavy environment wiring). Task 1's `ModelManager` tests are what actually exercise this behavior; this task is a one-line consumer change plus a manual smoke check.
+
+- [ ] **Step 1: Modify `ensureDefaultModelsInstalled()`**
+
+In `Mila/App/MilaApp.swift`, change the download loop (currently at lines 1447-1451):
+
+```swift
+        modelManager.setSelected(WhisperModel.ivritLarge)
+        for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
+            if !modelManager.isInstalled(model) && modelManager.downloads[model.name] == nil {
+                modelManager.download(model)
+            }
+        }
+```
+
+to:
+
+```swift
+        modelManager.setSelected(WhisperModel.ivritLarge)
+        for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
+            if !modelManager.isInstalled(model)
+                && !modelManager.isDeclined(model)
+                && modelManager.downloads[model.name] == nil {
+                modelManager.download(model)
+            }
+        }
+```
+
+(This plan intentionally leaves `modelManager.setSelected(WhisperModel.ivritLarge)` and the "always fetch both models" behavior untouched — those are separate, out-of-scope issues from the same investigation. This task only stops a *declined* model from silently reappearing.)
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Mila.xcodeproj -scheme Mila -configuration Debug build` (or open in Xcode and build) to confirm it compiles against the `isDeclined` API added in Task 1.
+
+- [ ] **Step 3: Manual smoke test**
+
+Using the `build-mila-locally` skill, build a local debug DMG and confirm end to end:
+1. Launch the freshly built app; let a default model finish downloading (or drop a placeholder file at the path `ModelManager.url(for:)` would use, matching the test pattern, if you don't want to wait on a real multi-GB download).
+2. Settings → Models → Delete the model. Confirm the deletion dialog and the "Installed" badge disappearing.
+3. Quit and relaunch the app.
+4. Confirm in Settings → Models the deleted model shows "Download" (not auto-re-downloading) and no download progress bar appears for it on launch.
+5. Click "Download" on that model manually; confirm it starts downloading again (proves `download(_:)` clearing the declined flag didn't break the manual path).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Mila/App/MilaApp.swift
+git commit -m "$(cat <<'EOF'
+fix(models): stop launch-time bootstrap from re-fetching declined models
+
+Consumes ModelManager.isDeclined(_:) so ensureDefaultModelsInstalled()
+no longer treats "user deleted this on purpose" the same as "never
+downloaded yet."
+
+Claude-Session: https://claude.ai/code/session_018PknxN13oghDt2XTHu7fPL
+EOF
+)"
+```
+
+---
+
+## Explicitly out of scope (from the same investigation, not this plan)
+
+- `ensureDefaultModelsInstalled()` still eagerly downloads **both** catalog models (Hebrew `large-v3` *and* the OpenAI turbo) for every user regardless of `RecordingLanguageSettings.current` — an English-only user still gets the 3 GB Hebrew model on first run. Scoping to the user's selected language was discussed but deferred.
+- The same function unconditionally calls `modelManager.setSelected(WhisperModel.ivritLarge)` on every launch, overwriting whatever model the user picked in Settings → Models. `ModelManager.init` already restores the persisted selection correctly on its own; this call is a leftover from the initial release. Left untouched here since it's a separate bug from the deletion-doesn't-stick complaint this plan addresses.
+
+Per `.claude/rules/pull-requests.md`, since this is a bug fix, a GitHub issue describing the repro (delete model → still comes back on relaunch/update) should be opened and linked with `Closes #<n>` before/when the PR is opened — not covered by this plan's tasks, but required before merging.


### PR DESCRIPTION
## Summary

- Persist a `declinedModelNames` set in `ModelManager` so deleting a model via Settings sticks across relaunch instead of silently re-downloading (Closes #263).
- Guard `ensureDefaultModelsInstalled()`'s `setSelected(ivritLarge)` call against the declined state too, so a deleted model's selection doesn't come back on every launch either (Closes #266).
- Fix a `GGML_ASSERT` crash at process exit on every unit test run: `prewarmDefaultModel()`'s test-hosting guard only checked the `--uitests` XCUITest flag, missing that `MilaTests` is an app-hosted unit test bundle that also runs launch-time `.task`s for real (Closes #267).
- Give `ModelManager` an injectable `UserDefaults`, matching the `DiarizationSettings`/`HotkeySettings` DI pattern, so tests stop writing into the real app's on-disk preferences domain (Closes #268).

## Test plan

- [x] `MilaTests/ModelManagerTests` (14/14 pass)
- [x] `MilaTests/DictationControllerTests` (3/3 pass)
- [x] `MilaTests/TranscriptionServiceTests` (39/39 pass)
- [x] Confirmed no `GGML_ASSERT`/crash report and no `prewarm: kicking off` log line after the fix
- [x] Confirmed `defaults read io.island.whisper.IslandWhisper model.declinedNames` no longer gets written by test runs

https://claude.ai/code/session_01FNNpYS4agJ1gmgHjMRSFWt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-launch model bootstrap and persisted selection/download behavior for users who delete models; risk is mitigated by unit tests and XCTest guards, but regressions could affect onboarding or model settings.
> 
> **Overview**
> **Deleted models stay deleted.** `ModelManager` now persists a `declinedModelNames` set (`model.declinedNames` in `UserDefaults`): `delete(_:)` marks a model declined, `download(_:)` clears that flag, and launch-time `ensureDefaultModelsInstalled()` skips auto-download and the unconditional `setSelected(ivritLarge)` when a default model was declined.
> 
> **App-hosted unit tests no longer run production launch work.** `isRunningUITests` becomes `isRunningUnderXCTest`, also true when `XCTestCase` is loaded (`MilaTests` as `TEST_HOST`). That guard skips `prewarmDefaultModel()` and `ensureDefaultModelsInstalled()`, avoiding Metal/whisper teardown noise and mutations to real preferences or network during `xcodebuild test`.
> 
> **Tests isolate `ModelManager` prefs and downloads.** `ModelManager` accepts injectable `UserDefaults` and optional `URLSession` protocol classes; several test suites use dedicated suites instead of `UserDefaults.standard`, with new coverage for declined-state persistence and download clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f580b1495e74fc7da1c5cb2fa507a440329f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deleted transcription models are no longer automatically selected or downloaded again.
  - Model deletion preferences now persist between app launches.
  - Downloading a previously deleted model explicitly restores it and clears its declined status.
  - Declining one model does not affect the availability or download behavior of other models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->