### PR TITLE
feat(claude): set up Claude without a terminal — managed CLI install + in-app login

### DIFF
--- a/Mila/Actions/ClaudeBinaryInstaller.swift
+++ b/Mila/Actions/ClaudeBinaryInstaller.swift
@@ -224,6 +224,11 @@ struct ClaudeBinaryInstaller {
         } catch {
             throw ClaudeInstallError.installFailed(error.localizedDescription)
         }
+        // Re-assert 0o755 on the FINAL path: `replaceItemAt` preserves the
+        // *destination's* metadata by default, so a reinstall over a
+        // non-executable leftover would inherit its permissions — and a
+        // non-executable managed binary reads as "not installed" everywhere.
+        try makeExecutable(destination)
         // Best effort: the attribute is usually absent (URLSession does not
         // quarantine on behalf of a non-sandboxed app), and its absence is
         // reported as an error we deliberately ignore.
@@ -335,11 +340,11 @@ final class URLSessionClaudeDownloader: NSObject, ClaudeBinaryDownloading {
                             error.localizedDescription))
                     }
                 }
-                box.task = task
+                box.adopt(task)
                 task.resume()
             }
         } onCancel: {
-            box.task?.cancel()
+            box.cancel()
         }
 
         do {
@@ -380,7 +385,29 @@ final class URLSessionClaudeDownloader: NSObject, ClaudeBinaryDownloading {
     /// Holds the in-flight task so `onCancel` can reach it. A class because the
     /// cancellation handler runs outside the continuation's closure.
     private final class TaskBox: @unchecked Sendable {
-        var task: URLSessionTask?
+        private let lock = NSLock()
+        private var task: URLSessionTask?
+        private var isCancelled = false
+
+        /// Adopt the task, cancelling it immediately if cancellation already
+        /// won the race. The unsynchronized version dropped exactly that
+        /// cancel: `onCancel` could read `task` as nil an instant before the
+        /// assignment, leaving the download running with nobody awaiting it.
+        func adopt(_ task: URLSessionTask) {
+            lock.lock()
+            let cancelNow = isCancelled
+            self.task = task
+            lock.unlock()
+            if cancelNow { task.cancel() }
+        }
+
+        func cancel() {
+            lock.lock()
+            isCancelled = true
+            let task = self.task
+            lock.unlock()
+            task?.cancel()
+        }
     }
 
     /// Session delegate: refuses off-host redirects and reports progress.

--- a/Mila/Actions/ClaudeBinaryInstaller.swift
+++ b/Mila/Actions/ClaudeBinaryInstaller.swift
@@ -105,11 +105,18 @@ struct ClaudeBinaryInstaller {
         // outside the resolution path.
         do {
             try await downloader.downloadFile(from: binaryURL, to: staged, progress: progress)
+            // A cancel that arrives during (or right after) the download must
+            // not proceed to change what is on disk: past `moveIntoPlace`
+            // there is no undo, and the caller that cancelled has already
+            // stopped listening. Checked twice — once before the (slow) hash
+            // and signature work, once right before the irreversible move.
+            try Task.checkCancellation()
             try verifyDownload(at: staged,
                                expectedChecksum: expectedChecksum,
                                expectedSize: expectedSize)
             try makeExecutable(staged)
             try verifySignature(at: staged)
+            try Task.checkCancellation()
             let installed = try moveIntoPlace(staged)
             installLog.notice("""
                 claude install ok version=\(version, privacy: .public) \

--- a/Mila/Actions/ClaudeBinaryInstaller.swift
+++ b/Mila/Actions/ClaudeBinaryInstaller.swift
@@ -1,0 +1,428 @@
+import Foundation
+import os
+
+private let installLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                   category: "ClaudeInstall")
+
+/// The network half of the managed install, behind a protocol so the installer
+/// can be driven end-to-end in a unit test without touching the network.
+///
+/// Two methods rather than one because the two kinds of fetch have genuinely
+/// different shapes: the version string and the manifest are a few hundred
+/// bytes and want to be `Data`, while the binary is ~200 MB, needs a progress
+/// bar, and must never be held in memory.
+protocol ClaudeBinaryDownloading {
+    /// Small `GET`, whole body in memory.
+    func data(from url: URL) async throws -> Data
+    /// Large `GET` streamed to `destination`. `progress` receives 0…1, or a
+    /// negative value while the total size is unknown.
+    func downloadFile(from url: URL,
+                      to destination: URL,
+                      progress: @escaping (Double) -> Void) async throws
+}
+
+/// What a completed install knows about itself. Persisted by
+/// `ClaudeSetupSettings` so the Settings row can say *which* version is
+/// installed, and so a "Reinstall" can report that it changed something.
+struct ClaudeInstallResult: Equatable {
+    let version: String
+    let platform: String
+    let binary: URL
+}
+
+/// Downloads, verifies and installs Anthropic's native `claude` binary.
+///
+/// The ordering here is the whole point, and it is: **download → size →
+/// checksum → signature → make executable → install**. Nothing is moved to the
+/// path `LLMRunner` resolves until every check has passed, and the staging
+/// directory is deliberately not on that resolution path (see
+/// `ClaudeManagedInstall.stagingDirectory`), so there is no window in which a
+/// half-verified file is reachable by something that would run it.
+///
+/// The two verification steps are not redundant. The checksum proves the bytes
+/// are the ones the release manifest describes — it catches a truncated or
+/// corrupted transfer, and it is the check `install.sh` performs. The signature
+/// proves Anthropic produced them, and keeps proving it if the manifest and the
+/// binary are served by the same compromised host. A CDN that can substitute
+/// the binary can substitute its checksum with it; it cannot forge a Developer
+/// ID signature.
+struct ClaudeBinaryInstaller {
+
+    let downloader: ClaudeBinaryDownloading
+    let verifier: ClaudeSignatureVerifying
+    let fileManager: FileManager
+    let appSupportRoot: URL
+
+    init(downloader: ClaudeBinaryDownloading = URLSessionClaudeDownloader(),
+         verifier: ClaudeSignatureVerifying = SecurityFrameworkSignatureVerifier(),
+         fileManager: FileManager = .default,
+         appSupportRoot: URL = ClaudeManagedInstall.applicationSupportRoot()) {
+        self.downloader = downloader
+        self.verifier = verifier
+        self.fileManager = fileManager
+        self.appSupportRoot = appSupportRoot
+    }
+
+    /// Resolve the current release, fetch it, verify it, and put it at
+    /// `ClaudeManagedInstall.binaryURL`. Existing installs are replaced.
+    ///
+    /// `progress` is called on an arbitrary executor with 0…1 for the download
+    /// phase; callers that drive UI must hop to the main actor themselves.
+    func install(progress: @escaping (Double) -> Void = { _ in }) async throws -> ClaudeInstallResult {
+        let machine = ClaudeManagedInstall.currentMachine()
+        guard let platform = ClaudeManagedInstall.platformKey() else {
+            throw ClaudeInstallError.unsupportedPlatform(machine)
+        }
+
+        let version = try await resolveLatestVersion()
+        let manifest = try await fetchManifest(version: version)
+        guard let expectedChecksum = manifest.checksum(for: platform) else {
+            throw ClaudeInstallError.manifestMissingPlatform(platform)
+        }
+        let expectedSize = manifest.expectedSize(for: platform)
+
+        guard let binaryURL = ClaudeManagedInstall.binaryDownloadURL(version: version,
+                                                                    platform: platform),
+              ClaudeManagedInstall.isTrusted(binaryURL) else {
+            throw ClaudeInstallError.untrustedURL("\(ClaudeManagedInstall.downloadBase)/\(version)")
+        }
+
+        installLog.notice("""
+            claude install start version=\(version, privacy: .public) \
+            platform=\(platform, privacy: .public) \
+            size=\(expectedSize ?? -1, privacy: .public)B
+            """)
+
+        let staging = ClaudeManagedInstall.stagingDirectory(appSupportRoot: appSupportRoot)
+        try createDirectory(staging)
+        let staged = staging.appendingPathComponent("claude-\(version)-\(platform)")
+        // A leftover from an interrupted run must not be mistaken for this
+        // one's download — and `downloadFile` refuses to overwrite.
+        try? fileManager.removeItem(at: staged)
+
+        // Everything from here on either finishes the install or removes the
+        // staged file: an unverified binary is never left on disk, not even
+        // outside the resolution path.
+        do {
+            try await downloader.downloadFile(from: binaryURL, to: staged, progress: progress)
+            try verifyDownload(at: staged,
+                               expectedChecksum: expectedChecksum,
+                               expectedSize: expectedSize)
+            try makeExecutable(staged)
+            try verifySignature(at: staged)
+            let installed = try moveIntoPlace(staged)
+            installLog.notice("""
+                claude install ok version=\(version, privacy: .public) \
+                platform=\(platform, privacy: .public)
+                """)
+            return ClaudeInstallResult(version: version, platform: platform, binary: installed)
+        } catch {
+            try? fileManager.removeItem(at: staged)
+            let described = (error as? ClaudeInstallError)?.logDescription
+                ?? ((error is CancellationError) ? "cancelled" : "transport-failure")
+            installLog.error("""
+                claude install failed version=\(version, privacy: .public) \
+                reason=\(described, privacy: .public)
+                """)
+            throw error
+        }
+    }
+
+    // MARK: - Steps
+
+    /// `GET /latest`, which returns a bare version string.
+    ///
+    /// The response is validated before it is ever interpolated into another
+    /// URL. `install.sh` does the same thing, and says why: an HTML error page
+    /// (a captive portal, an unsupported region) otherwise becomes a manifest
+    /// path, and the resulting failure names the wrong problem.
+    private func resolveLatestVersion() async throws -> String {
+        let data = try await downloader.data(from: ClaudeManagedInstall.latestVersionURL)
+        let text = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard ClaudeManagedInstall.isPlausibleVersion(text) else {
+            throw ClaudeInstallError.versionLookupFailed(
+                "The server didn't return a version number. This can happen if downloads.claude.ai is unreachable or unavailable in your region.")
+        }
+        return text
+    }
+
+    private func fetchManifest(version: String) async throws -> ClaudeManagedInstall.ReleaseManifest {
+        guard let url = ClaudeManagedInstall.manifestURL(version: version) else {
+            throw ClaudeInstallError.versionLookupFailed("Version \(version) isn't a shape Mila recognises.")
+        }
+        let data = try await downloader.data(from: url)
+        do {
+            return try JSONDecoder().decode(ClaudeManagedInstall.ReleaseManifest.self, from: data)
+        } catch {
+            throw ClaudeInstallError.versionLookupFailed("Anthropic's release manifest couldn't be read.")
+        }
+    }
+
+    /// Size first, then checksum. The order is for the error message, not for
+    /// correctness: a truncated download fails both checks, and "the download
+    /// stopped early" tells the user to retry while "checksum mismatch" reads
+    /// like tampering.
+    func verifyDownload(at url: URL,
+                        expectedChecksum: String,
+                        expectedSize: Int64?) throws {
+        if let expectedSize {
+            let actual = (try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber)??.int64Value ?? 0
+            guard actual == expectedSize else {
+                throw ClaudeInstallError.sizeMismatch(expected: expectedSize, actual: actual)
+            }
+        }
+        let actualChecksum: String
+        do {
+            actualChecksum = try ClaudeBinaryVerification.sha256Hex(ofFileAt: url)
+        } catch {
+            throw ClaudeInstallError.installFailed("Couldn't read the downloaded file back to check it.")
+        }
+        guard ClaudeBinaryVerification.digestsMatch(actualChecksum, expectedChecksum) else {
+            throw ClaudeInstallError.checksumMismatch(expected: expectedChecksum,
+                                                      actual: actualChecksum)
+        }
+    }
+
+    /// Ask the verifier who signed this, and refuse anything that isn't
+    /// Anthropic's CLI. The decision itself lives in
+    /// `ClaudeBinaryVerification.accept` so it is testable without a real
+    /// signed binary.
+    func verifySignature(at url: URL) throws {
+        let identity = try verifier.identity(ofBinaryAt: url)
+        if let refusal = ClaudeBinaryVerification.accept(identity) {
+            throw refusal
+        }
+    }
+
+    private func makeExecutable(_ url: URL) throws {
+        do {
+            try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        } catch {
+            throw ClaudeInstallError.installFailed("Couldn't mark the download as executable.")
+        }
+    }
+
+    /// Move the verified binary to its final path, replacing any previous
+    /// install, and drop the quarantine flag.
+    ///
+    /// Quarantine is removed **only here** — after the signature check, never
+    /// before. Mila has by this point verified the Developer ID signature
+    /// against a pinned requirement, which is a stricter statement than the
+    /// first-run Gatekeeper prompt makes; and that prompt is not available to
+    /// us anyway, because the binary is launched as a subprocess of a GUI app
+    /// where a refusal surfaces as an unexplained non-zero exit.
+    private func moveIntoPlace(_ staged: URL) throws -> URL {
+        let destination = ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot)
+        try createDirectory(destination.deletingLastPathComponent())
+        do {
+            if fileManager.fileExists(atPath: destination.path) {
+                _ = try fileManager.replaceItemAt(destination, withItemAt: staged)
+            } else {
+                try fileManager.moveItem(at: staged, to: destination)
+            }
+        } catch {
+            throw ClaudeInstallError.installFailed(error.localizedDescription)
+        }
+        // Best effort: the attribute is usually absent (URLSession does not
+        // quarantine on behalf of a non-sandboxed app), and its absence is
+        // reported as an error we deliberately ignore.
+        destination.path.withCString { path in
+            _ = removexattr(path, "com.apple.quarantine", 0)
+        }
+        return destination
+    }
+
+    private func createDirectory(_ url: URL) throws {
+        do {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        } catch {
+            throw ClaudeInstallError.installFailed(
+                "Couldn't create \(url.path): \(error.localizedDescription)")
+        }
+    }
+
+    /// Remove the managed binary (and any staging leftovers). Used by "Remove"
+    /// in Settings. Returns false when something is still there afterwards, so
+    /// the caller never reports a removal that didn't happen.
+    @discardableResult
+    func removeManagedBinary() -> Bool {
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot)
+        try? fileManager.removeItem(at: binary)
+        try? fileManager.removeItem(at: ClaudeManagedInstall.stagingDirectory(appSupportRoot: appSupportRoot))
+        return !fileManager.fileExists(atPath: binary.path)
+    }
+}
+
+// MARK: - URLSession transport
+
+/// The production `ClaudeBinaryDownloading`.
+///
+/// Two properties are worth stating because they are easy to lose in a
+/// refactor:
+///
+///  * **Redirects off the release host are refused, not followed.** The host
+///    check is not just applied to the URL we compose — a 302 is a perfectly
+///    ordinary way to be handed a different binary, and following one would
+///    make the allowlist decorative.
+///  * **The download is streamed to a file.** `URLSessionDownloadTask` writes
+///    straight to disk, so a ~200 MB binary never sits in memory.
+final class URLSessionClaudeDownloader: NSObject, ClaudeBinaryDownloading {
+
+    /// Bounds the whole transfer. Generous — a 200 MB download on a slow
+    /// connection is legitimately slow — but present, because a stalled
+    /// download with no bound leaves the Settings UI in `installing` forever.
+    private let resourceTimeout: TimeInterval = 900
+    private let requestTimeout: TimeInterval = 60
+
+    func data(from url: URL) async throws -> Data {
+        guard ClaudeManagedInstall.isTrusted(url) else {
+            throw ClaudeInstallError.untrustedURL(url.absoluteString)
+        }
+        let delegate = RedirectGuard()
+        let session = URLSession(configuration: configuration(),
+                                 delegate: delegate,
+                                 delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let (data, response) = try await session.data(from: url)
+        try check(response)
+        return data
+    }
+
+    func downloadFile(from url: URL,
+                      to destination: URL,
+                      progress: @escaping (Double) -> Void) async throws {
+        guard ClaudeManagedInstall.isTrusted(url) else {
+            throw ClaudeInstallError.untrustedURL(url.absoluteString)
+        }
+        let delegate = RedirectGuard(onProgress: progress)
+        let session = URLSession(configuration: configuration(),
+                                 delegate: delegate,
+                                 delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        // The completion-handler form, not the async one: with a completion
+        // handler Foundation does NOT call `didFinishDownloadingTo` on the
+        // delegate, so the temporary file is ours to move for the duration of
+        // this closure and there is no race with an internal delegate proxy.
+        let box = TaskBox()
+        let temporary: URL = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.downloadTask(with: url) { location, response, error in
+                    if let error {
+                        continuation.resume(throwing: Self.mapped(error))
+                        return
+                    }
+                    guard let location else {
+                        continuation.resume(throwing: ClaudeInstallError.installFailed(
+                            "The download finished with no file."))
+                        return
+                    }
+                    if let http = response as? HTTPURLResponse,
+                       !(200...299).contains(http.statusCode) {
+                        continuation.resume(throwing: ClaudeInstallError.httpError(status: http.statusCode))
+                        return
+                    }
+                    // Move it out of the system temp directory NOW: Foundation
+                    // deletes this file as soon as the handler returns.
+                    let holding = location.deletingLastPathComponent()
+                        .appendingPathComponent("mila-claude-\(UUID().uuidString)")
+                    do {
+                        try FileManager.default.moveItem(at: location, to: holding)
+                        continuation.resume(returning: holding)
+                    } catch {
+                        continuation.resume(throwing: ClaudeInstallError.installFailed(
+                            error.localizedDescription))
+                    }
+                }
+                box.task = task
+                task.resume()
+            }
+        } onCancel: {
+            box.task?.cancel()
+        }
+
+        do {
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: temporary)
+            throw ClaudeInstallError.installFailed(error.localizedDescription)
+        }
+    }
+
+    private func configuration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = resourceTimeout
+        config.httpCookieStorage = nil
+        config.httpShouldSetCookies = false
+        // No credential is ever needed for a public release artifact, and not
+        // asking for one means a proxy that demands auth fails loudly.
+        config.httpAdditionalHeaders = ["Accept": "*/*"]
+        return config
+    }
+
+    private func check(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard (200...299).contains(http.statusCode) else {
+            throw ClaudeInstallError.httpError(status: http.statusCode)
+        }
+    }
+
+    private static func mapped(_ error: Error) -> Error {
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return CancellationError()
+        }
+        return error
+    }
+
+    /// Holds the in-flight task so `onCancel` can reach it. A class because the
+    /// cancellation handler runs outside the continuation's closure.
+    private final class TaskBox: @unchecked Sendable {
+        var task: URLSessionTask?
+    }
+
+    /// Session delegate: refuses off-host redirects and reports progress.
+    private final class RedirectGuard: NSObject, URLSessionDownloadDelegate {
+        private let onProgress: ((Double) -> Void)?
+
+        init(onProgress: ((Double) -> Void)? = nil) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(_ session: URLSession,
+                        task: URLSessionTask,
+                        willPerformHTTPRedirection response: HTTPURLResponse,
+                        newRequest request: URLRequest,
+                        completionHandler: @escaping (URLRequest?) -> Void) {
+            guard let url = request.url, ClaudeManagedInstall.isTrusted(url) else {
+                // nil = don't follow. The task completes with whatever the
+                // redirect response itself was, which surfaces as a non-2xx.
+                installLog.error("claude install refused an off-host redirect")
+                completionHandler(nil)
+                return
+            }
+            completionHandler(request)
+        }
+
+        func urlSession(_ session: URLSession,
+                        downloadTask: URLSessionDownloadTask,
+                        didWriteData bytesWritten: Int64,
+                        totalBytesWritten: Int64,
+                        totalBytesExpectedToWrite: Int64) {
+            guard let onProgress else { return }
+            guard totalBytesExpectedToWrite > 0 else {
+                onProgress(-1)   // indeterminate
+                return
+            }
+            onProgress(min(1, Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)))
+        }
+
+        /// Required by the protocol. Never called for a task created with a
+        /// completion handler — see the call site.
+        func urlSession(_ session: URLSession,
+                        downloadTask: URLSessionDownloadTask,
+                        didFinishDownloadingTo location: URL) {}
+    }
+}

--- a/Mila/Actions/ClaudeBinaryVerification.swift
+++ b/Mila/Actions/ClaudeBinaryVerification.swift
@@ -1,0 +1,252 @@
+import Foundation
+import CryptoKit
+import Security
+import os
+
+private let verifyLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                  category: "ClaudeInstall")
+
+/// What a code signature says about who produced a binary. Deliberately tiny —
+/// two strings — so the accept/refuse decision below is a pure function over
+/// values a test can construct, rather than something that can only be
+/// exercised by having a real signed Mach-O on disk.
+struct ClaudeSignatureIdentity: Equatable {
+    /// `TeamIdentifier=` — the Apple Developer Team ID.
+    let teamIdentifier: String?
+    /// `Identifier=` — the signing identifier baked into the binary.
+    let signingIdentifier: String?
+    /// Whether the signature itself checked out: intact, chained to the Apple
+    /// root, and matching the bytes on disk. False means the identity strings
+    /// above are unverified claims and must not be trusted for anything.
+    let isValid: Bool
+}
+
+/// Everything that can stop Mila from installing or running a downloaded CLI.
+///
+/// Each case says what failed **and** what a user can do about it, because the
+/// only place these surface is a Settings row with no log next to it. The two
+/// verification failures deliberately do not offer a way to continue: a
+/// "download it anyway" button is a button for defeating the check.
+enum ClaudeInstallError: LocalizedError, Equatable {
+    case unsupportedPlatform(String)
+    case versionLookupFailed(String)
+    case manifestMissingPlatform(String)
+    case untrustedURL(String)
+    case httpError(status: Int)
+    case checksumMismatch(expected: String, actual: String)
+    case sizeMismatch(expected: Int64, actual: Int64)
+    case signatureInvalid(String)
+    case wrongPublisher(team: String?, identifier: String?)
+    case installFailed(String)
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedPlatform(let machine):
+            return "Mila doesn't have a Claude build for this Mac's architecture (\(machine))."
+        case .versionLookupFailed(let detail):
+            return "Couldn't find out which Claude version to download. \(detail)"
+        case .manifestMissingPlatform(let platform):
+            return "Anthropic's release manifest has no \(platform) build listed."
+        case .untrustedURL(let url):
+            return "Refusing to download from an unexpected location (\(url)). Mila only downloads Claude from \(ClaudeManagedInstall.downloadHost)."
+        case .httpError(let status):
+            return "The download server returned HTTP \(status)."
+        case .checksumMismatch(let expected, let actual):
+            // Both digests in full: they are public values, and "which one
+            // differs" is the only way to tell a truncated download from a
+            // substituted file.
+            return "The downloaded file doesn't match Anthropic's published checksum, so Mila deleted it. Expected \(expected), got \(actual)."
+        case .sizeMismatch(let expected, let actual):
+            return "The download stopped early (\(actual) of \(expected) bytes). Check your connection and try again."
+        case .signatureInvalid(let detail):
+            return "The downloaded Claude binary isn't correctly signed, so Mila won't run it. \(detail)"
+        case .wrongPublisher(let team, let identifier):
+            let who = [identifier, team].compactMap { $0 }.joined(separator: ", ")
+            return "The downloaded binary is signed by someone other than Anthropic\(who.isEmpty ? "" : " (\(who))"), so Mila won't run it."
+        case .installFailed(let detail):
+            return "Couldn't finish installing Claude. \(detail)"
+        case .cancelled:
+            return "Setup was cancelled."
+        }
+    }
+
+    /// The log-safe twin, following the same split `LLMRunnerError.logDescription`
+    /// makes: shape yes, payload no. Nothing here carries a credential or user
+    /// content — these are checksums, HTTP statuses and publisher names — so the
+    /// messages pass through, except that the failure *kind* leads so a log line
+    /// is greppable without reading the sentence.
+    var logDescription: String {
+        switch self {
+        case .unsupportedPlatform(let m):     return "unsupported-platform machine=\(m)"
+        case .versionLookupFailed:            return "version-lookup-failed"
+        case .manifestMissingPlatform(let p): return "manifest-missing-platform platform=\(p)"
+        case .untrustedURL:                   return "untrusted-url"
+        case .httpError(let s):               return "http-error status=\(s)"
+        case .checksumMismatch:               return "checksum-mismatch"
+        case .sizeMismatch(let e, let a):     return "size-mismatch expected=\(e) actual=\(a)"
+        case .signatureInvalid:               return "signature-invalid"
+        case .wrongPublisher(let t, _):       return "wrong-publisher team=\(t ?? "(none)")"
+        case .installFailed:                  return "install-failed"
+        case .cancelled:                      return "cancelled"
+        }
+    }
+}
+
+/// Reads a binary's code signature. A protocol so the *refusal* paths can be
+/// tested — a unit test cannot produce a genuinely Anthropic-signed Mach-O, and
+/// a check that is only ever exercised by the happy path is a check nobody has
+/// seen fail.
+protocol ClaudeSignatureVerifying {
+    /// Validate the signature at `url` and report who signed it.
+    /// Throws only when the signature could not be *examined* at all
+    /// (unreadable file); an invalid or absent signature comes back as an
+    /// identity with `isValid == false`.
+    func identity(ofBinaryAt url: URL) throws -> ClaudeSignatureIdentity
+}
+
+/// Verification that does not need a network, a Keychain, or a real binary —
+/// so every rule here is pinned by a test.
+enum ClaudeBinaryVerification {
+
+    /// The code-signing requirement the downloaded binary must satisfy.
+    ///
+    /// This is the authoritative check, and it is a single expression on
+    /// purpose. `anchor apple generic` pins the chain to Apple's roots, so a
+    /// self-signed binary that simply *claims* Anthropic's team ID fails;
+    /// `certificate leaf[subject.OU]` is where a Developer ID certificate
+    /// carries the team; and the identifier pins which Anthropic product this
+    /// is. Comparing the strings we read back afterwards would not be
+    /// equivalent — unanchored, those strings are attacker-chosen.
+    static var designatedRequirement: String {
+        """
+        anchor apple generic and identifier "\(ClaudeManagedInstall.claudeSigningIdentifier)" \
+        and certificate leaf[subject.OU] = "\(ClaudeManagedInstall.anthropicTeamIdentifier)"
+        """
+    }
+
+    /// Whether an examined identity is one Mila will execute.
+    ///
+    /// Pure, and separate from the requirement check above so the refusal
+    /// reasons are distinguishable: "this file's signature is broken" and "this
+    /// file is signed by somebody else" send a user to different places, and
+    /// collapsing both into "verification failed" is the error message that
+    /// helps nobody.
+    static func accept(_ identity: ClaudeSignatureIdentity,
+                       expectedTeam: String = ClaudeManagedInstall.anthropicTeamIdentifier,
+                       expectedIdentifier: String = ClaudeManagedInstall.claudeSigningIdentifier)
+    -> ClaudeInstallError? {
+        guard identity.isValid else {
+            return .signatureInvalid("The signature is missing or doesn't match the file's contents.")
+        }
+        guard identity.teamIdentifier == expectedTeam,
+              identity.signingIdentifier == expectedIdentifier else {
+            return .wrongPublisher(team: identity.teamIdentifier,
+                                   identifier: identity.signingIdentifier)
+        }
+        return nil
+    }
+
+    /// Constant-time-ish comparison of two hex digests, case-insensitively.
+    ///
+    /// Not a secret comparison — a published checksum is public — but written
+    /// as a full-width compare anyway so a future reader doesn't "optimise" it
+    /// into an early-exit loop over something that later *is* secret. The
+    /// lowercasing is the part that actually matters: manifests publish
+    /// lowercase, `shasum` prints lowercase, and a future uppercase producer
+    /// must not read as a mismatch.
+    static func digestsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        let a = Array(lhs.lowercased().utf8)
+        let b = Array(rhs.lowercased().utf8)
+        guard a.count == b.count, !a.isEmpty else { return false }
+        var difference: UInt8 = 0
+        for i in 0..<a.count { difference |= a[i] ^ b[i] }
+        return difference == 0
+    }
+
+    /// SHA-256 of a file, hashed in chunks.
+    ///
+    /// Chunked rather than `Data(contentsOf:)` because the CLI is ~200 MB and
+    /// this runs while the user is looking at a progress bar: reading it all
+    /// into memory to hash it doubles the footprint of the install for no
+    /// benefit. 1 MiB chunks are large enough that the syscall overhead
+    /// disappears and small enough to stay invisible in memory graphs.
+    static func sha256Hex(ofFileAt url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 1 << 20) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// SHA-256 of an in-memory blob. Used by tests and by the small
+    /// version/manifest responses; the binary always goes through the streaming
+    /// form above.
+    static func sha256Hex(of data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// The real signature check, via the Security framework rather than a
+/// `codesign` subprocess.
+///
+/// Two reasons it is not a subprocess. It is the same evaluation `codesign`
+/// performs (both are thin wrappers over these APIs), so nothing is lost; and
+/// the alternative would mean spawning a child process, with the pipe-drain,
+/// dedicated-thread and bounded-wait machinery `.claude/rules/python-subprocess.md`
+/// requires — an entire failure surface, added to the one code path whose whole
+/// job is to decide whether something is safe to execute.
+struct SecurityFrameworkSignatureVerifier: ClaudeSignatureVerifying {
+
+    func identity(ofBinaryAt url: URL) throws -> ClaudeSignatureIdentity {
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode)
+        guard createStatus == errSecSuccess, let code = staticCode else {
+            throw ClaudeInstallError.signatureInvalid(Self.message(for: createStatus))
+        }
+
+        // The authoritative check: validity AND publisher in one evaluation,
+        // anchored to Apple's roots. See `designatedRequirement`.
+        var requirement: SecRequirement?
+        let requirementStatus = SecRequirementCreateWithString(
+            ClaudeBinaryVerification.designatedRequirement as CFString, [], &requirement)
+        guard requirementStatus == errSecSuccess, let requirement else {
+            throw ClaudeInstallError.signatureInvalid(Self.message(for: requirementStatus))
+        }
+        let validity = SecStaticCodeCheckValidity(
+            code, SecCSFlags(rawValue: kSecCSCheckAllArchitectures), requirement)
+
+        // Read the identity back regardless of the verdict — a *failed* check is
+        // exactly when "signed by whom, then?" is the useful thing to say.
+        var infoRef: CFDictionary?
+        SecCodeCopySigningInformation(code, SecCSFlags(rawValue: kSecCSSigningInformation), &infoRef)
+        let info = infoRef as? [String: Any]
+        let team = info?[kSecCodeInfoTeamIdentifier as String] as? String
+        let identifier = info?[kSecCodeInfoIdentifier as String] as? String
+
+        if validity != errSecSuccess {
+            verifyLog.error("""
+                claude install signature check failed \
+                status=\(validity, privacy: .public) \
+                team=\(team ?? "(none)", privacy: .public)
+                """)
+        }
+        return ClaudeSignatureIdentity(teamIdentifier: team,
+                                       signingIdentifier: identifier,
+                                       isValid: validity == errSecSuccess)
+    }
+
+    /// Turn an OSStatus into something a Settings row can show. Falls back to
+    /// the numeric status, which is still greppable in Apple's headers, rather
+    /// than to a generic sentence that erases the only clue.
+    private static func message(for status: OSStatus) -> String {
+        if let text = SecCopyErrorMessageString(status, nil) as String? {
+            return "\(text) (\(status))"
+        }
+        return "Security framework status \(status)."
+    }
+}

--- a/Mila/Actions/ClaudeManagedInstall.swift
+++ b/Mila/Actions/ClaudeManagedInstall.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// Where Mila's own copy of the `claude` CLI lives, how its download URLs are
+/// derived, and the one rule that decides when the managed OAuth token is
+/// handed to a child process.
+///
+/// Everything here is **pure** except `binaryURL` / `stagingDirectory`, which
+/// only compose paths. That is deliberate: the interesting decisions — which
+/// platform build to fetch, whether a URL is one we are willing to download
+/// from, whether this particular executable gets the token — are the ones a
+/// test needs to pin, and none of them should require a network or a Keychain.
+///
+/// ## Why Mila installs its own copy at all (issue #271)
+///
+/// The alternative is what shipped before: tell the user to run
+/// `curl … | bash` in a terminal and then hope `LLMRunner.searchDirectories()`
+/// finds the result. That search exists (#196) and is good, but it is a
+/// mitigation for a setup step nobody owned. A managed install turns three
+/// terminal steps into one button, and — because Mila knows exactly which file
+/// it installed — makes the token-injection rule below expressible at all.
+enum ClaudeManagedInstall {
+
+    // MARK: - Publisher identity
+
+    /// Apple Developer Team ID on Anthropic's Developer ID signing certificate.
+    ///
+    /// Read off the official binary with
+    /// `codesign -dv --verbose=4 $(which claude)`, which reports:
+    ///
+    ///     Authority=Developer ID Application: Anthropic PBC (Q6L2SF6YDW)
+    ///     TeamIdentifier=Q6L2SF6YDW
+    ///
+    /// This is the check that makes the download meaningful. TLS says the bytes
+    /// came from a host we trust; the signature says Anthropic produced them and
+    /// nobody has touched them since — which still holds if the CDN itself is
+    /// compromised, and which a checksum published by that same CDN cannot say.
+    ///
+    /// Hardcoded rather than configurable on purpose: a "which team do you
+    /// trust?" setting is a setting for talking a user out of the check.
+    static let anthropicTeamIdentifier = "Q6L2SF6YDW"
+
+    /// Signing identifier embedded in the official binary (`Identifier=` in the
+    /// same `codesign -dv` output). Checked alongside the team ID so a
+    /// *different* Anthropic-signed binary — a future unrelated tool from the
+    /// same team — can't be installed here and run as if it were the CLI.
+    static let claudeSigningIdentifier = "com.anthropic.claude-code"
+
+    // MARK: - Release endpoints
+
+    /// The ONLY host Mila will download the CLI from.
+    ///
+    /// Taken from `https://claude.ai/install.sh`, Anthropic's own installer,
+    /// which resolves everything under `$DOWNLOAD_BASE_URL`:
+    ///
+    ///     DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"
+    ///
+    /// Mila replicates that resolution over HTTPS rather than piping the script
+    /// to a shell — we want the version/manifest/binary steps to be code we can
+    /// test and refuse from, not an opaque program that also runs
+    /// `claude install` and edits the user's shell profile.
+    ///
+    /// `isTrusted(_:)` enforces the host, so a redirect or a manifest that tried
+    /// to send us somewhere else is refused rather than followed.
+    static let downloadHost = "downloads.claude.ai"
+
+    /// Base for every release artifact. Kept as a string constant so the three
+    /// URL builders below cannot drift apart.
+    static let downloadBase = "https://\(downloadHost)/claude-code-releases"
+
+    /// `GET` this for the current version string (e.g. `2.1.263`). Plain text,
+    /// no JSON — matching `install.sh`'s `download_file "$DOWNLOAD_BASE_URL/latest"`.
+    static var latestVersionURL: URL { URL(string: "\(downloadBase)/latest")! }
+
+    /// Per-version manifest carrying a SHA-256 and a byte size for every
+    /// platform build. See `ReleaseManifest`.
+    static func manifestURL(version: String) -> URL? {
+        guard isPlausibleVersion(version) else { return nil }
+        return URL(string: "\(downloadBase)/\(version)/manifest.json")
+    }
+
+    /// The platform binary itself.
+    static func binaryDownloadURL(version: String, platform: String) -> URL? {
+        guard isPlausibleVersion(version), isPlausiblePlatform(platform) else { return nil }
+        return URL(string: "\(downloadBase)/\(version)/\(platform)/claude")
+    }
+
+    /// Whether a URL is one we are willing to fetch: HTTPS, and on the release
+    /// host exactly (not a subdomain of it, not a userinfo trick).
+    ///
+    /// Applied to every request AND to the final URL after redirects, so a
+    /// 302 off the CDN cannot quietly become the thing we execute.
+    static func isTrusted(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https" else { return false }
+        guard url.user == nil, url.password == nil else { return false }
+        return url.host?.lowercased() == downloadHost
+    }
+
+    /// Guards the version string before it is interpolated into a URL. The
+    /// version comes off the network, and `2.1.263/../../evil` would otherwise
+    /// build a path that escapes the release prefix.
+    ///
+    /// Deliberately narrow — digits, dots, and a `-suffix` for pre-releases —
+    /// which is the same shape `install.sh` accepts
+    /// (`^[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?$`).
+    ///
+    /// Written with the `#/…/#` extended delimiters rather than a bare `/…/`
+    /// literal: this target builds in Swift 5.10 language mode, where the bare
+    /// form needs the `BareSlashRegexLiterals` upcoming-feature flag that
+    /// `project.yml` does not set. The extended form needs no flag.
+    static func isPlausibleVersion(_ version: String) -> Bool {
+        guard !version.isEmpty, version.count <= 64 else { return false }
+        return version.wholeMatch(of: #/[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?/#) != nil
+    }
+
+    /// Same guard for the platform segment. Only the two macOS builds are
+    /// accepted: Mila is a macOS app, so a manifest key naming a Linux or
+    /// Windows build is either a bug or a redirect attempt.
+    static func isPlausiblePlatform(_ platform: String) -> Bool {
+        platform == "darwin-arm64" || platform == "darwin-x64"
+    }
+
+    // MARK: - Platform selection
+
+    /// Which manifest key describes the build for this Mac.
+    ///
+    /// `install.sh` derives it from `uname -m`, plus one correction: when the
+    /// shell is itself running as x86_64 under Rosetta on an Apple Silicon Mac
+    /// it fetches the **arm64** build anyway, because the native binary is the
+    /// right one for the machine. A Swift process has the same problem — a
+    /// Mila built for x86_64 running translated would otherwise install a
+    /// translated CLI — and the same answer: `sysctl.proc_translated`.
+    ///
+    /// `isTranslated` is a parameter so the Rosetta branch is testable on a
+    /// machine that isn't running under Rosetta.
+    static func platformKey(machine: String = currentMachine(),
+                            isTranslated: Bool = isRunningTranslated()) -> String? {
+        switch machine {
+        case "arm64", "aarch64":
+            return "darwin-arm64"
+        case "x86_64", "amd64":
+            // Translated x86_64 on an arm64 Mac: take the native build.
+            return isTranslated ? "darwin-arm64" : "darwin-x64"
+        default:
+            return nil
+        }
+    }
+
+    /// `uname -m`, without shelling out.
+    static func currentMachine() -> String {
+        var info = utsname()
+        guard uname(&info) == 0 else { return "" }
+        let capacity = MemoryLayout.size(ofValue: info.machine)
+        return withUnsafePointer(to: &info.machine) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                String(cString: $0)
+            }
+        }
+    }
+
+    /// True when this process is an x86_64 binary running under Rosetta 2.
+    /// `sysctl.proc_translated` is absent on Intel Macs and on native arm64
+    /// processes, which both read as "not translated".
+    static func isRunningTranslated() -> Bool {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname("sysctl.proc_translated", &value, &size, nil, 0) == 0 else {
+            return false
+        }
+        return value == 1
+    }
+
+    // MARK: - On-disk layout
+
+    /// `~/Library/Application Support`, with the same temp-directory fallback
+    /// `LLMRunner.sandboxDirectory()` uses. Mila is not app-sandboxed, so this
+    /// is the real user-domain path.
+    static func applicationSupportRoot() -> URL {
+        FileManager.default.urls(for: .applicationSupportDirectory,
+                                 in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+    }
+
+    /// Directory holding Mila-managed executables. Sibling of the
+    /// `llm-sandbox` directory `LLMRunner` already owns, under the same
+    /// `Mila` root, so everything Mila puts on this machine outside the
+    /// recordings folder stays in one place a user can delete.
+    static func binDirectory(appSupportRoot: URL = applicationSupportRoot()) -> URL {
+        appSupportRoot
+            .appendingPathComponent("Mila", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+    }
+
+    /// The managed CLI itself. This exact path is what
+    /// `environmentAdditions(executable:managedBinary:token:)` compares
+    /// against, and what `LLMRunner.resolveExecutable` prefers.
+    static func binaryURL(appSupportRoot: URL = applicationSupportRoot()) -> URL {
+        binDirectory(appSupportRoot: appSupportRoot)
+            .appendingPathComponent("claude", isDirectory: false)
+    }
+
+    /// Where a download is assembled before it is verified. Separate from
+    /// `binDirectory` so an interrupted or failed download can never be found
+    /// by `resolveExecutable` — an unverified binary must not be reachable by
+    /// anything that would run it.
+    static func stagingDirectory(appSupportRoot: URL = applicationSupportRoot()) -> URL {
+        binDirectory(appSupportRoot: appSupportRoot)
+            .appendingPathComponent("staging", isDirectory: true)
+    }
+
+    /// True when a managed binary is present and executable.
+    static func isInstalled(fileManager: FileManager = .default,
+                            appSupportRoot: URL = applicationSupportRoot()) -> Bool {
+        fileManager.isExecutableFile(atPath: binaryURL(appSupportRoot: appSupportRoot).path)
+    }
+
+    // MARK: - Token injection
+
+    /// Name of the environment variable the CLI reads a long-lived OAuth token
+    /// from. Confirmed present in the shipped binary (`strings` on the official
+    /// 2.1.260 build) and it is what `claude setup-token` mints a token *for*.
+    static let oauthTokenEnvironmentKey = "CLAUDE_CODE_OAUTH_TOKEN"
+
+    /// The one rule that decides whether Mila's stored token travels to a child
+    /// process: **only when the executable being run is Mila's own managed
+    /// binary.**
+    ///
+    /// Both halves of that matter, and they fail in opposite directions:
+    ///
+    ///   * Injecting too *narrowly* breaks the feature — the whole point of the
+    ///     managed install is that the token Mila minted is the credential the
+    ///     binary Mila installed uses.
+    ///   * Injecting too *broadly* breaks other people's setups, silently and
+    ///     confusingly. A user with their own `claude` on `PATH` is already
+    ///     logged in, quite possibly to a different account or through a
+    ///     corporate SSO. Handing that binary a `CLAUDE_CODE_OAUTH_TOKEN`
+    ///     overrides the login they chose, with no UI anywhere saying so.
+    ///     A system CLI is left exactly as it was.
+    ///
+    /// Nothing is ever *removed* from the environment, including an inherited
+    /// `CLAUDE_CODE_OAUTH_TOKEN` the user set themselves: that is their
+    /// deliberate configuration for their own binary, and unsetting it would be
+    /// the same overreach in the other direction.
+    ///
+    /// Paths are compared after `standardizedFileURL` resolution so
+    /// `…/bin/claude` and `…/bin/./claude` are the same file. A user who points
+    /// the "Executable" override *at* the managed binary therefore still gets
+    /// the token, which is the right answer — it is the same file.
+    ///
+    /// `token` is passed in rather than read here so this stays pure: the
+    /// Keychain read happens at the call site, and only when it can matter.
+    static func environmentAdditions(executable: URL,
+                                     managedBinary: URL,
+                                     token: String?) -> [String: String] {
+        guard executable.standardizedFileURL.path == managedBinary.standardizedFileURL.path else {
+            return [:]
+        }
+        guard let token, !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return [:]
+        }
+        return [oauthTokenEnvironmentKey: token]
+    }
+
+    // MARK: - Release manifest
+
+    /// The subset of `manifest.json` Mila reads.
+    ///
+    /// The real document carries a `platforms` map keyed by the platform string
+    /// (`darwin-arm64`, `linux-x64-musl`, …), each entry holding a `checksum`
+    /// (SHA-256, lowercase hex) and a `size`. Everything else in the document —
+    /// `commit`, `buildDate`, signature-enforcement flags — is ignored, and
+    /// ignoring it is what keeps this decoding robust across manifest changes.
+    struct ReleaseManifest: Decodable, Equatable {
+        struct Platform: Decodable, Equatable {
+            let checksum: String
+            let size: Int64?
+        }
+        let version: String?
+        let platforms: [String: Platform]
+
+        /// The checksum for `platform`, validated to be a well-formed SHA-256.
+        ///
+        /// A malformed value is treated as *absent* rather than passed through:
+        /// a truncated or non-hex "checksum" that we then compared against
+        /// would fail every time, which reads to a user as "the download is
+        /// corrupt" when the truth is "the manifest is". `install.sh` applies
+        /// the same `^[a-f0-9]{64}$` guard for the same reason.
+        func checksum(for platform: String) -> String? {
+            guard let raw = platforms[platform]?.checksum else { return nil }
+            let value = raw.lowercased()
+            guard value.count == 64,
+                  value.allSatisfy({ $0.isHexDigit && !$0.isUppercase }) else { return nil }
+            return value
+        }
+
+        func expectedSize(for platform: String) -> Int64? {
+            guard let size = platforms[platform]?.size, size > 0 else { return nil }
+            return size
+        }
+    }
+}

--- a/Mila/Actions/ClaudeSetupTokenParser.swift
+++ b/Mila/Actions/ClaudeSetupTokenParser.swift
@@ -118,6 +118,13 @@ struct ClaudeSetupTokenParser {
         buffer += chunk
         if buffer.count > Self.bufferLimit {
             buffer = String(buffer.suffix(Self.bufferLimit))
+            // Truncation can evict already-reported rejections from the
+            // window; `rejectionsSeen` must shrink with them or the count
+            // stays ahead of what is visible and the NEXT rejection gets
+            // swallowed (`rejections.count > rejectionsSeen` never fires).
+            let retained = Self.rejectionMessages(
+                in: Self.dewrap(Self.sanitize(buffer), width: width)).count
+            rejectionsSeen = min(rejectionsSeen, retained)
         }
         let text = Self.dewrap(Self.sanitize(buffer), width: width)
         let flat = Self.normalized(text)

--- a/Mila/Actions/ClaudeSetupTokenParser.swift
+++ b/Mila/Actions/ClaudeSetupTokenParser.swift
@@ -147,6 +147,23 @@ struct ClaudeSetupTokenParser {
         return events
     }
 
+    /// Last-chance scan, for use once the child has exited.
+    ///
+    /// The stream is over, so the buffer is everything the CLI ever printed and
+    /// a match at its end can no longer be a half-arrived read. This is what
+    /// keeps the boundary rule in `token(in:)` from costing a legitimate
+    /// success when the CLI's very last bytes are the token itself, with no
+    /// trailing newline.
+    ///
+    /// Returns nil if a token was already reported, so a caller cannot deliver
+    /// the same credential twice.
+    mutating func finalToken() -> String? {
+        let text = Self.dewrap(Self.sanitize(buffer), width: width)
+        guard let token = Self.token(in: text, allowUnterminated: true),
+              emitted.insert("token").inserted else { return nil }
+        return token
+    }
+
     // MARK: - Text handling
 
     /// Strip ANSI escape sequences and control characters, and fold carriage
@@ -260,12 +277,34 @@ struct ClaudeSetupTokenParser {
     private static let tokenPattern = try? NSRegularExpression(
         pattern: "sk-ant-[A-Za-z0-9_-]{16,}")
 
-    static func token(in text: String) -> String? {
+    /// The first token in `text`, or nil.
+    ///
+    /// **A match that runs to the very end of the buffer is refused** unless
+    /// `allowUnterminated` is set, and that rule is the whole point of this
+    /// function. A pty hands out arbitrary reads, so a chunk boundary can fall
+    /// in the middle of a token — and because a *prefix* of a token is itself
+    /// token-shaped (`sk-ant-` plus at least 16 more characters), the naive
+    /// match happily returns the half that has arrived. That is the worst
+    /// possible outcome: the flow reports success and stores a truncated
+    /// credential which fails on first use, far from here.
+    ///
+    /// The match is greedy, so an end position *before* `endIndex` proves the
+    /// next character cannot be part of the token — the value is complete. Any
+    /// real token is followed by a newline, so this costs at most one more read
+    /// before it fires.
+    ///
+    /// `allowUnterminated` exists for exactly one caller: the last-chance scan
+    /// once the child has exited (`finalToken`). At EOF the buffer is complete,
+    /// so a match at the end can no longer be a partial read.
+    static func token(in text: String, allowUnterminated: Bool = false) -> String? {
         guard let tokenPattern else { return nil }
         let range = NSRange(text.startIndex..., in: text)
-        guard let match = tokenPattern.firstMatch(in: text, range: range),
-              let matchRange = Range(match.range, in: text) else { return nil }
-        return String(text[matchRange])
+        for match in tokenPattern.matches(in: text, range: range) {
+            guard let matchRange = Range(match.range, in: text) else { continue }
+            if matchRange.upperBound == text.endIndex && !allowUnterminated { continue }
+            return String(text[matchRange])
+        }
+        return nil
     }
 
     /// Replace anything token-shaped with a description of it.

--- a/Mila/Actions/ClaudeSetupTokenParser.swift
+++ b/Mila/Actions/ClaudeSetupTokenParser.swift
@@ -1,0 +1,318 @@
+import Foundation
+
+/// Reads `claude setup-token`'s output and says what just happened.
+///
+/// Pure and incremental: feed it whatever bytes arrived, get back the events
+/// they completed. Everything interesting about the guided login — did the
+/// authorization URL appear, is the CLI waiting for a code, was the code
+/// rejected, did a token come back — is decided here, over a `String`, so the
+/// whole flow can be tested against recorded transcripts without a pty, a
+/// subprocess, or a network.
+///
+/// ## What the output actually looks like
+///
+/// `setup-token` is not a line-oriented program. It is an Ink (React-for-the-
+/// terminal) TUI, and that shapes every rule below. Captured from the real CLI
+/// (v2.1.260) under a pty:
+///
+/// ```text
+/// Welcome to Claude Code v2.1.260
+///
+/// This will guide you through long-lived (1-year) auth token setup for your
+/// Claude account. Claude subscription required.
+///
+/// · Opening browser to sign in…
+///
+/// Browser didn't open? Use the url below to sign in (c to copy)
+///
+/// https://claude.com/cai/oauth/authorize?code=true&client_id=…&state=…
+///
+/// Hold Shift (Option in iTerm2, Fn in Terminal.app) while selecting to use your
+/// terminal's native copy
+///
+/// Paste code here if prompted >
+/// ```
+///
+/// Three consequences:
+///
+/// 1. **It is full of escape sequences**, including cursor movement used to
+///    redraw a spinner in place. `sanitize` strips them; what survives is text.
+/// 2. **It hard-wraps to the terminal width**, and it will happily wrap the
+///    authorization URL mid-query-string. Mila asks for a 400-column pty
+///    precisely so that doesn't happen (the URL is ~330 characters), but
+///    `dewrap` rejoins wrapped lines anyway — the width is a property of a
+///    remote program's layout code, not a contract.
+/// 3. **Whitespace is not reliable.** Ink positions words with cursor escapes
+///    rather than spaces, so a line that reads `Paste code here` on screen can
+///    arrive as `Pastecodehere` once the positioning is stripped. Every marker
+///    is therefore matched against a whitespace-free, lowercased normalization
+///    of the text — never against the literal phrase.
+///
+/// ## What is NOT known
+///
+/// The success path could not be observed: completing it requires authorizing
+/// in a browser and pasting a real code, which mints a real credential. So the
+/// token pattern below is derived from the prefix the shipped binary carries
+/// (`sk-ant-oat…`) rather than from a captured success transcript. If a future
+/// version stops printing the token, `token` simply never fires — and
+/// `ClaudeSetupTokenSession` reports "the CLI finished but Mila didn't find a
+/// token" instead of claiming success. That failure is loud on purpose.
+struct ClaudeSetupTokenParser {
+
+    /// Something the CLI did that the UI has to react to.
+    enum Event: Equatable {
+        /// The CLI said it is opening a browser itself. Mila uses this to avoid
+        /// opening a *second* tab on the same authorization URL.
+        case browserOpenedByCLI
+        /// The authorization URL, validated to be on an Anthropic host.
+        case authorizationURL(URL)
+        /// The CLI is waiting for the code to be pasted.
+        case awaitingCode
+        /// A submitted code was rejected. The CLI stays alive and re-prompts,
+        /// so this is recoverable — the sheet shows the message and lets the
+        /// user paste again.
+        case codeRejected(String)
+        /// A token was found in the output.
+        case token(String)
+    }
+
+    /// Columns Mila requests for the pty. 400 was verified against the real CLI:
+    /// at 80 the authorization URL wraps across five lines, at 400 it prints on
+    /// one. Not "very large" — a width the TUI pads to would make every line
+    /// enormous — just comfortably past the longest thing it prints.
+    static let terminalWidth = 400
+
+    private let width: Int
+    private var buffer = ""
+    private var emitted: Set<String> = []
+    private var rejectionsSeen = 0
+
+    init(terminalWidth: Int = ClaudeSetupTokenParser.terminalWidth) {
+        self.width = terminalWidth
+    }
+
+    /// Bound on the retained transcript. The CLI redraws a spinner, so output
+    /// grows without bound while it waits; keeping a window is what stops a
+    /// user who leaves the sheet open from accumulating megabytes. Sized well
+    /// past any single screen the TUI draws, so a marker can't be cut in half.
+    private static let bufferLimit = 64 * 1024
+
+    /// Everything seen so far, cleaned up and with anything token-shaped
+    /// replaced.
+    ///
+    /// This is the ONLY way the transcript leaves the parser, and the redaction
+    /// deliberately happens here — over the accumulated buffer — rather than
+    /// per arriving chunk. A pty hands out arbitrary 8 KB reads, so a token can
+    /// straddle two of them; redacting each chunk as it arrives would match
+    /// neither half and copy the credential into the transcript in two pieces.
+    ///
+    /// The raw bytes do live in `buffer` while the flow runs — the token has to
+    /// be found before it can be redacted, so that is unavoidable. What is
+    /// guaranteed is that nothing outside this type ever sees them.
+    var redactedTranscript: String {
+        Self.redact(Self.dewrap(Self.sanitize(buffer), width: width))
+    }
+
+    /// Feed newly-arrived output. Returns the events it completed, in order.
+    mutating func consume(_ chunk: String) -> [Event] {
+        buffer += chunk
+        if buffer.count > Self.bufferLimit {
+            buffer = String(buffer.suffix(Self.bufferLimit))
+        }
+        let text = Self.dewrap(Self.sanitize(buffer), width: width)
+        let flat = Self.normalized(text)
+
+        var events: [Event] = []
+
+        if flat.contains("openingbrowser"), emitted.insert("browser").inserted {
+            events.append(.browserOpenedByCLI)
+        }
+        if let url = Self.authorizationURL(in: text), emitted.insert("url").inserted {
+            events.append(.authorizationURL(url))
+        }
+        if flat.contains("pastecodehere"), emitted.insert("await").inserted {
+            events.append(.awaitingCode)
+        }
+        // Rejections repeat: the CLI re-prompts rather than exiting, so the
+        // second bad paste has to be visible too. Counted rather than
+        // remembered as a flag.
+        let rejections = Self.rejectionMessages(in: text)
+        if rejections.count > rejectionsSeen {
+            events += rejections[rejectionsSeen...].map { Event.codeRejected($0) }
+            rejectionsSeen = rejections.count
+        }
+        if let token = Self.token(in: text), emitted.insert("token").inserted {
+            events.append(.token(token))
+        }
+        return events
+    }
+
+    // MARK: - Text handling
+
+    /// Strip ANSI escape sequences and control characters, and fold carriage
+    /// returns into newlines so a redrawn line reads as its own line rather
+    /// than being glued to the previous one.
+    static func sanitize(_ text: String) -> String {
+        var result = text
+        for pattern in escapePatterns {
+            result = pattern.stringByReplacingMatches(
+                in: result,
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: "")
+        }
+        result = result.replacingOccurrences(of: "\r\n", with: "\n")
+        result = result.replacingOccurrences(of: "\r", with: "\n")
+        // Everything else below space, except tab and newline, is TUI
+        // machinery (bells, backspaces) that would otherwise sit inside a
+        // token or URL match.
+        return String(result.unicodeScalars.filter { scalar in
+            scalar == "\n" || scalar == "\t" || scalar.value >= 0x20
+        })
+    }
+
+    private static let escapePatterns: [NSRegularExpression] = {
+        // OSC first: its payload can contain characters the CSI pattern would
+        // match, so removing CSI first would leave the OSC terminator behind.
+        let patterns = [
+            "\u{1B}\\][^\u{07}\u{1B}]*(?:\u{07}|\u{1B}\\\\)",  // OSC … BEL / ST
+            "\u{1B}\\[[0-9;?]*[ -/]*[@-~]",                    // CSI
+            "\u{1B}[@-Z\\\\-_]"                                // two-character
+        ]
+        return patterns.compactMap { try? NSRegularExpression(pattern: $0) }
+    }()
+
+    /// Rejoin lines the TUI hard-wrapped.
+    ///
+    /// A wrap is inferred from the shape the wrapper leaves: a line that filled
+    /// the terminal exactly, ends in a non-space, and is followed by a line
+    /// that starts with a non-space. Prose that happens to fit that pattern
+    /// gets joined too, which is harmless — marker matching ignores whitespace
+    /// — while a URL split across five lines is put back together, which is the
+    /// case that matters.
+    static func dewrap(_ text: String, width: Int) -> String {
+        guard width > 0 else { return text }
+        var lines: [String] = []
+        for line in text.components(separatedBy: "\n") {
+            if let previous = lines.last,
+               previous.count >= width,
+               let tail = previous.last, !tail.isWhitespace,
+               let head = line.first, !head.isWhitespace {
+                lines[lines.count - 1] = previous + line
+            } else {
+                lines.append(line)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Lowercased, with every whitespace character removed. This is the only
+    /// form marker phrases are matched against — see the note about Ink
+    /// positioning words with escapes instead of spaces.
+    static func normalized(_ text: String) -> String {
+        String(text.lowercased().unicodeScalars.filter { !CharacterSet.whitespacesAndNewlines.contains($0) })
+    }
+
+    // MARK: - Extraction
+
+    /// Hosts an authorization URL may be on.
+    ///
+    /// An allowlist rather than "whatever URL appeared", because this URL is
+    /// handed to `NSWorkspace.open` — Mila is deciding to send the user's
+    /// browser somewhere, and "the subprocess said so" is not a good enough
+    /// reason on its own. Matching is on a dot boundary so `claude.ai.evil.com`
+    /// is not a match.
+    static let authorizationHosts = ["claude.ai", "claude.com", "anthropic.com"]
+
+    static func isAcceptableAuthorizationURL(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https" else { return false }
+        guard url.user == nil, url.password == nil else { return false }
+        guard let host = url.host?.lowercased() else { return false }
+        return authorizationHosts.contains { host == $0 || host.hasSuffix(".\($0)") }
+    }
+
+    private static let urlPattern = try? NSRegularExpression(
+        pattern: "https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+")
+
+    /// First acceptable `https://…` in the text. "First" rather than "last"
+    /// because the authorization URL is printed once, before anything else the
+    /// CLI might link to (a docs URL in an error message, say).
+    static func authorizationURL(in text: String) -> URL? {
+        guard let urlPattern else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        for match in urlPattern.matches(in: text, range: range) {
+            guard let matchRange = Range(match.range, in: text) else { continue }
+            // Trailing punctuation belongs to the sentence, not the URL.
+            let candidate = String(text[matchRange])
+                .trimmingCharacters(in: CharacterSet(charactersIn: ".,);:'\""))
+            guard let url = URL(string: candidate),
+                  isAcceptableAuthorizationURL(url) else { continue }
+            return url
+        }
+        return nil
+    }
+
+    /// Shape of the credential `setup-token` mints.
+    ///
+    /// Anchored on `sk-ant-`, which the shipped binary carries as the prefix
+    /// family for its key types (`sk-ant-oat…` is the OAuth one). The length
+    /// floor keeps the prefix appearing in prose — a help string, an error
+    /// message naming the format — from being mistaken for a credential.
+    private static let tokenPattern = try? NSRegularExpression(
+        pattern: "sk-ant-[A-Za-z0-9_-]{16,}")
+
+    static func token(in text: String) -> String? {
+        guard let tokenPattern else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = tokenPattern.firstMatch(in: text, range: range),
+              let matchRange = Range(match.range, in: text) else { return nil }
+        return String(text[matchRange])
+    }
+
+    /// Replace anything token-shaped with a description of it.
+    ///
+    /// Everything that shows or logs a transcript goes through this. The
+    /// subprocess output *is* where the credential appears, so "don't log the
+    /// token" cannot be a discipline applied at each log site — it has to be a
+    /// property of the only string those sites are given. See
+    /// `ClaudeSetupTokenSession.redactedTranscript`.
+    static func redact(_ text: String) -> String {
+        guard let tokenPattern else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return tokenPattern.stringByReplacingMatches(in: text,
+                                                     range: range,
+                                                     withTemplate: "sk-ant-<redacted>")
+    }
+
+    /// Rejected-code messages, in order.
+    ///
+    /// Observed shape, by pasting a deliberately invalid code:
+    ///
+    ///     OAuth error: Invalid code. Please make sure the full code was copied
+    ///     Press Enter to retry.
+    ///
+    /// The message is taken from the sanitized (not normalized) text so the
+    /// user sees the CLI's own words with their spaces intact; the *detection*
+    /// still goes through the normalized form, because that is the only
+    /// whitespace-independent way to find the marker.
+    static func rejectionMessages(in text: String) -> [String] {
+        let flat = normalized(text)
+        guard flat.contains("oautherror") || flat.contains("invalidcode") else { return [] }
+        var messages: [String] = []
+        for line in text.components(separatedBy: "\n") {
+            let normalizedLine = normalized(line)
+            guard normalizedLine.contains("oautherror") || normalizedLine.contains("invalidcode") else {
+                continue
+            }
+            // Drop the "Press Enter to retry." tail: Mila drives the retry, so
+            // telling the user to press Enter points at a keyboard that isn't
+            // attached to anything they can see.
+            var message = line
+            if let cut = message.range(of: "Press Enter", options: .caseInsensitive) {
+                message = String(message[..<cut.lowerBound])
+            }
+            let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { messages.append(trimmed) }
+        }
+        return messages
+    }
+}

--- a/Mila/Actions/ClaudeSetupTokenParser.swift
+++ b/Mila/Actions/ClaudeSetupTokenParser.swift
@@ -117,14 +117,24 @@ struct ClaudeSetupTokenParser {
     mutating func consume(_ chunk: String) -> [Event] {
         buffer += chunk
         if buffer.count > Self.bufferLimit {
-            buffer = String(buffer.suffix(Self.bufferLimit))
             // Truncation can evict already-reported rejections from the
             // window; `rejectionsSeen` must shrink with them or the count
             // stays ahead of what is visible and the NEXT rejection gets
             // swallowed (`rejections.count > rejectionsSeen` never fires).
-            let retained = Self.rejectionMessages(
+            //
+            // Shrink by the number EVICTED — the difference across the
+            // truncation — not by clamping to what is retained: a clamp
+            // counts a brand-new rejection that arrived in this very chunk
+            // as if it had been reported already, and swallows it. Eviction
+            // takes the oldest text first, and the oldest rejections are
+            // exactly the first-reported ones, so the subtraction and the
+            // count stay aligned.
+            let before = Self.rejectionMessages(
                 in: Self.dewrap(Self.sanitize(buffer), width: width)).count
-            rejectionsSeen = min(rejectionsSeen, retained)
+            buffer = String(buffer.suffix(Self.bufferLimit))
+            let after = Self.rejectionMessages(
+                in: Self.dewrap(Self.sanitize(buffer), width: width)).count
+            rejectionsSeen = max(0, rejectionsSeen - max(0, before - after))
         }
         let text = Self.dewrap(Self.sanitize(buffer), width: width)
         let flat = Self.normalized(text)

--- a/Mila/Actions/ClaudeSetupTokenSession.swift
+++ b/Mila/Actions/ClaudeSetupTokenSession.swift
@@ -1,0 +1,576 @@
+import Foundation
+import os
+
+private let setupLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                 category: "ClaudeSetup")
+
+/// A running child process Mila is talking to interactively.
+///
+/// The seam exists because the real thing needs a pseudo-terminal, and a unit
+/// test must not need one. `FakeInteractiveProcess` in the tests replays a
+/// recorded transcript through the same three callbacks, so the state machine
+/// that reacts to them is exercised for real.
+///
+/// Callbacks may arrive on any thread; `ClaudeSetupTokenSession` hops to the
+/// main actor before touching state.
+protocol ClaudeInteractiveProcess: AnyObject {
+    /// Called with each chunk of output as it arrives. Chunks are arbitrary —
+    /// they split mid-line and mid-escape-sequence — which is why the parser
+    /// accumulates rather than matching per chunk.
+    var onOutput: ((String) -> Void)? { get set }
+    /// Called once when the child exits, with its status.
+    var onExit: ((Int32) -> Void)? { get set }
+    func start() throws
+    /// Send text to the child's stdin. The caller includes any newline.
+    func write(_ text: String)
+    /// Ask the child to stop. Must be safe to call more than once, and after
+    /// the child has already exited.
+    func terminate()
+}
+
+/// Where the guided setup currently is. One enum for the whole flow — install
+/// and login — because that is what the Settings row renders, and splitting it
+/// would just mean reassembling it there.
+enum ClaudeSetupState: Equatable {
+    case idle
+    /// Downloading the binary. `progress` is 0…1, or negative while the total
+    /// size is unknown.
+    case installing(progress: Double)
+    /// `setup-token` is running; the authorization URL hasn't appeared yet.
+    case signingIn
+    /// The browser step. The URL is carried so the sheet can offer "open it
+    /// again" without re-reading the transcript.
+    case awaitingCode(URL)
+    /// A code was submitted and the CLI is checking it.
+    case verifying
+    case ready
+    case failed(String)
+
+    /// Whether the flow is doing something the user should wait for. Drives the
+    /// spinner and the disabled state of the setup button.
+    var isBusy: Bool {
+        switch self {
+        case .installing, .signingIn, .verifying: return true
+        case .idle, .awaitingCode, .ready, .failed: return false
+        }
+    }
+
+    /// Log token. States that carry a payload deliberately drop it: the URL has
+    /// a `state` parameter tied to a live OAuth exchange, and the failure
+    /// reason can quote the CLI. Neither belongs in a world-readable log.
+    var logToken: String {
+        switch self {
+        case .idle:         return "idle"
+        case .installing:   return "installing"
+        case .signingIn:    return "signing-in"
+        case .awaitingCode: return "awaiting-code"
+        case .verifying:    return "verifying"
+        case .ready:        return "ready"
+        case .failed:       return "failed"
+        }
+    }
+}
+
+/// Drives `claude setup-token` from launch to captured token.
+///
+/// ## The flow, and why each part is where it is
+///
+/// `setup-token` prints an authorization URL, waits for the user to authorize
+/// in a browser, takes the resulting code on stdin, and prints a long-lived
+/// token. Mila's job is to notice each of those moments and put a UI in front
+/// of them. What makes that awkward is that the CLI is a TUI which produces
+/// **no output at all** unless stdin is a terminal — verified: run with stdin
+/// on a pipe it sits silently forever — so the transport has to be a pty.
+///
+/// The parsing lives in `ClaudeSetupTokenParser` (pure), the pty lives in
+/// `PTYProcess` (untestable by nature), and this type is the state machine
+/// between them — which is the part with the interesting bugs, and the part
+/// the tests drive over recorded transcripts.
+///
+/// ## The token never reaches a log
+///
+/// The child's output *is* where the credential appears. So no code path here
+/// logs output, and the only transcript that leaves this object goes through
+/// `ClaudeSetupTokenParser.redact`. Failure messages built from CLI text are
+/// redacted the same way before they are put into `.failed`, because a failure
+/// message is rendered in the UI and could otherwise carry a token from a
+/// partially-successful run.
+@MainActor
+final class ClaudeSetupTokenSession {
+
+    /// How long to wait for the authorization URL after launching. The CLI
+    /// prints it within a second in practice; this bound exists so a binary
+    /// that hangs at startup fails visibly instead of leaving a spinner up.
+    static let urlTimeout: TimeInterval = 90
+
+    /// How long the user has to complete the browser half. Deliberately long —
+    /// this includes a corporate SSO round trip, possibly a password manager
+    /// and an MFA prompt — but not unbounded, so an abandoned sheet eventually
+    /// releases the child process.
+    static let authorizationTimeout: TimeInterval = 15 * 60
+
+    /// How long to wait for a token after a code is submitted.
+    static let verifyTimeout: TimeInterval = 120
+
+    /// The three bounds above, in an injectable bundle.
+    ///
+    /// Injectable because a bound nobody has watched fire is a bound nobody
+    /// knows works. The production values are minutes long by necessity — a
+    /// real sign-in includes a human reading a browser page — so a test that
+    /// used them would either take 90 seconds or, far more likely, not exist.
+    /// With this seam the timeout path is driven in milliseconds.
+    struct Timeouts {
+        var url: TimeInterval = ClaudeSetupTokenSession.urlTimeout
+        var authorization: TimeInterval = ClaudeSetupTokenSession.authorizationTimeout
+        var verify: TimeInterval = ClaudeSetupTokenSession.verifyTimeout
+
+        static let production = Timeouts()
+    }
+
+    private(set) var state: ClaudeSetupState = .idle {
+        didSet {
+            guard state != oldValue else { return }
+            setupLog.notice("claude setup state=\(self.state.logToken, privacy: .public)")
+            onStateChange?(state)
+        }
+    }
+
+    /// Published upward. The settings object republishes it for SwiftUI; the
+    /// tests read it directly.
+    var onStateChange: ((ClaudeSetupState) -> Void)?
+
+    /// Called with the authorization URL when Mila should open a browser
+    /// itself. **Not** called when the CLI reported opening one — see
+    /// `handle(_:)`. AppKit stays out of this file so the flow is testable.
+    var onOpenURL: ((URL) -> Void)?
+
+    /// Called exactly once with a captured token. The session does not store
+    /// it: persistence is the settings object's job, and keeping the credential
+    /// out of this object's fields keeps it out of anything that inspects them.
+    var onToken: ((String) -> Void)?
+
+    /// The transcript, with anything token-shaped replaced. Safe to show in a
+    /// UI or attach to a diagnostic; deliberately the only accessor.
+    var redactedTranscript: String { parser.redactedTranscript }
+
+    /// Why the last submitted code was refused, if it was. Read by the sheet,
+    /// cleared when the next code is submitted.
+    private(set) var lastRejection: String?
+
+    private let timeouts: Timeouts
+    private let makeProcess: () -> ClaudeInteractiveProcess
+    private var process: ClaudeInteractiveProcess?
+    private var parser = ClaudeSetupTokenParser()
+    private var deadline: Task<Void, Never>?
+    private var finished = false
+    private var authorizationURL: URL?
+    private var cliOpenedBrowser = false
+
+    init(timeouts: Timeouts = .production,
+         makeProcess: @escaping () -> ClaudeInteractiveProcess) {
+        self.timeouts = timeouts
+        self.makeProcess = makeProcess
+    }
+
+    /// Convenience for production: run the managed binary's `setup-token`.
+    static func managed(binary: URL) -> ClaudeSetupTokenSession {
+        let environment = loginEnvironment(binary: binary)
+        return ClaudeSetupTokenSession {
+            PTYProcess(executable: binary,
+                       arguments: ["setup-token"],
+                       environment: environment)
+        }
+    }
+
+    /// The environment the login child runs in: everything `LLMRunner` would
+    /// normally give the managed binary, **minus any OAuth token**.
+    ///
+    /// This is the one child that must not inherit the credential. Every other
+    /// invocation of the managed binary wants it (that is the whole point of
+    /// `ClaudeManagedInstall.environmentAdditions`), but `setup-token` exists
+    /// to *mint* a credential — handing it the one it is about to replace
+    /// invites the CLI to treat the session as already authenticated, and a
+    /// "sign in again" that silently hands back the OLD token is the failure
+    /// mode hardest to notice: the UI would say Signed in, the Test would pass,
+    /// and the credential the user was trying to replace would still be the
+    /// live one. An inherited value the user set themselves is dropped for the
+    /// same reason — for the duration of this one child only.
+    static func loginEnvironment(
+        binary: URL,
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = LLMRunner.childEnvironment(for: binary,
+                                                     base: base,
+                                                     managedToken: { nil })
+        environment.removeValue(forKey: ClaudeManagedInstall.oauthTokenEnvironmentKey)
+        return environment
+    }
+
+    // MARK: - Driving
+
+    func start() {
+        guard case .idle = state else { return }
+        finished = false
+        parser = ClaudeSetupTokenParser()
+        lastRejection = nil
+        authorizationURL = nil
+        cliOpenedBrowser = false
+        state = .signingIn
+
+        let child = makeProcess()
+        child.onOutput = { [weak self] chunk in
+            Task { @MainActor in self?.ingest(chunk) }
+        }
+        child.onExit = { [weak self] status in
+            Task { @MainActor in self?.childExited(status: status) }
+        }
+        process = child
+        do {
+            try child.start()
+        } catch {
+            fail("Couldn't start the Claude CLI: \(error.localizedDescription)")
+            return
+        }
+        arm(timeouts.url,
+            reason: "Claude didn't produce a sign-in link. Try Reinstall, or set the CLI up in a terminal.")
+    }
+
+    /// Send the code the user pasted.
+    ///
+    /// Trimmed because a code copied out of a browser routinely brings a
+    /// trailing newline or a stray space with it, and the CLI compares the
+    /// whole line. The newline is ours to add: this is a pty, so the child's
+    /// line discipline is what turns the write into a submitted line.
+    func submit(code: String) {
+        guard case .awaitingCode = state else { return }
+        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        lastRejection = nil
+        state = .verifying
+        process?.write(trimmed + "\n")
+        arm(timeouts.verify,
+            reason: "Claude didn't respond after the code was submitted.")
+    }
+
+    /// User closed the sheet or pressed Cancel.
+    func cancel() {
+        guard !finished else { return }
+        finish()
+        state = .idle
+    }
+
+    // MARK: - Reacting
+
+    private func ingest(_ chunk: String) {
+        guard !finished else { return }
+        for event in parser.consume(chunk) {
+            // Re-checked per event, not just once before the loop. One chunk
+            // can complete several events, and any of them can be terminal —
+            // a rejection with no authorization URL fails the flow, and the
+            // same chunk can also carry something token-shaped. Checking only
+            // on entry let the later event run against an already-finished
+            // session, which turned a `.failed` into `.ready` and handed the
+            // caller a token from a run that had just been reported as broken.
+            guard !finished else { return }
+            handle(event)
+        }
+    }
+
+    private func handle(_ event: ClaudeSetupTokenParser.Event) {
+        switch event {
+        case .browserOpenedByCLI:
+            // The CLI opens the browser itself ("· Opening browser to sign
+            // in…"). Mila opening the same URL again would give the user two
+            // tabs of the same OAuth request, so the sheet's "Open in browser"
+            // button becomes the manual fallback instead of an automatic
+            // second attempt.
+            cliOpenedBrowser = true
+
+        case .authorizationURL(let url):
+            authorizationURL = url
+            if case .signingIn = state { state = .awaitingCode(url) }
+            if !cliOpenedBrowser { onOpenURL?(url) }
+            arm(timeouts.authorization,
+                reason: "Sign-in timed out. Start setup again when you're ready.")
+
+        case .awaitingCode:
+            if let authorizationURL, case .signingIn = state {
+                state = .awaitingCode(authorizationURL)
+            }
+
+        case .codeRejected(let message):
+            // Recoverable: the CLI re-prompts rather than exiting, so go back
+            // to awaiting a code with the CLI's own explanation attached.
+            guard let authorizationURL else {
+                fail(ClaudeSetupTokenParser.redact(message))
+                return
+            }
+            lastRejection = ClaudeSetupTokenParser.redact(message)
+            state = .awaitingCode(authorizationURL)
+            arm(timeouts.authorization,
+                reason: "Sign-in timed out. Start setup again when you're ready.")
+
+        case .token(let token):
+            onToken?(token)
+            finish()
+            state = .ready
+        }
+    }
+
+    private func childExited(status: Int32) {
+        guard !finished else { return }
+        // Reaching here means the CLI ended without a token. Exit 0 is the
+        // interesting case: it says the CLI thinks it succeeded while Mila
+        // found nothing token-shaped in what it printed — the one scenario the
+        // parser's doc comment warns about. Claiming success there would leave
+        // a user "signed in" with no credential, so it is a failure with a
+        // message that says what actually happened.
+        if status == 0 {
+            fail("Claude finished sign-in but didn't print a token Mila could read. Your CLI version may differ; you can still run `claude setup-token` in a terminal.")
+        } else {
+            fail("Claude's sign-in exited with status \(status).")
+        }
+    }
+
+    private func fail(_ reason: String) {
+        finish()
+        state = .failed(reason)
+    }
+
+    /// Stop the child and the deadline. Idempotent — every terminal path calls
+    /// it, including ones that race the child's own exit.
+    private func finish() {
+        finished = true
+        deadline?.cancel()
+        deadline = nil
+        process?.terminate()
+        process = nil
+    }
+
+    /// Replace the phase deadline. Cancelling the previous one is what makes
+    /// these bounds *per phase* rather than cumulative: arriving at the next
+    /// step is what buys more time.
+    private func arm(_ seconds: TimeInterval, reason: String) {
+        deadline?.cancel()
+        deadline = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            guard !Task.isCancelled, let self, !self.finished else { return }
+            self.fail(reason)
+        }
+    }
+}
+
+// MARK: - Pseudo-terminal transport
+
+/// Runs a child process with a pseudo-terminal on all three standard streams.
+///
+/// ## Why a pty and not a pipe
+///
+/// `claude setup-token` produces **nothing** on a pipe. Not an error, not a
+/// prompt — it waits, silently, forever. (Verified against v2.1.260: 25s with
+/// stdin on `/dev/null` produced zero bytes; the same command on a pty printed
+/// its full UI immediately.) It is an Ink TUI and gates its entire render on
+/// stdin being a terminal, so there is no non-interactive mode to fall back to.
+///
+/// macOS has no pty helper in Foundation, so this is the SUS/POSIX dance:
+/// `posix_openpt` → `grantpt` → `unlockpt` → `ptsname` → `open`. `Process`
+/// then gets the slave side on stdin/stdout/stderr, which is enough for
+/// `isatty(0)` — the thing the TUI actually checks.
+///
+/// ## Subprocess rules
+///
+/// Follows `.claude/rules/python-subprocess.md` and `BlockingWork` (#251):
+///
+///  * `terminationHandler` is installed **before** `run()`, so the exit is
+///    observed without a thread of ours blocked on it.
+///  * The master-fd reader blocks until EOF, so it gets a **dedicated thread**
+///    rather than a slot in the shared pool.
+///  * The only wait is the SIGKILL escalation, and it is **bounded**.
+///  * Writes go to a dedicated thread too: a pty master write can block when
+///    the child isn't draining, and this is called from the main actor.
+final class PTYProcess: ClaudeInteractiveProcess {
+
+    var onOutput: ((String) -> Void)?
+    var onExit: ((Int32) -> Void)?
+
+    private let executable: URL
+    private let arguments: [String]
+    private let columns: Int
+    private let workingDirectory: URL?
+    private let environment: [String: String]
+
+    private var process: Process?
+    private var masterFD: Int32 = -1
+    private let exited = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+
+    init(executable: URL,
+         arguments: [String],
+         columns: Int = ClaudeSetupTokenParser.terminalWidth,
+         workingDirectory: URL? = nil,
+         environment: [String: String]? = nil) {
+        self.executable = executable
+        self.arguments = arguments
+        self.columns = columns
+        self.workingDirectory = workingDirectory
+        self.environment = environment ?? LLMRunner.childEnvironment(for: executable)
+    }
+
+    /// `TIOCSWINSZ`, i.e. `_IOW('t', 103, struct winsize)` from
+    /// `<sys/ttycom.h>`, computed rather than imported: Swift's C importer does
+    /// not surface the `_IOW` macro, so the constant has to be assembled from
+    /// the same pieces the macro uses — the "argument travels into the kernel"
+    /// flag, the encoded argument size, the group character, and the number.
+    private static var setWindowSizeRequest: UInt {
+        let intoKernel: UInt = 0x8000_0000
+        let encodedSize = UInt(MemoryLayout<winsize>.size & 0x1fff) << 16
+        return intoKernel | encodedSize | (UInt(UInt8(ascii: "t")) << 8) | 103
+    }
+
+    enum PTYError: LocalizedError {
+        case openFailed(String)
+        var errorDescription: String? {
+            switch self {
+            case .openFailed(let detail): return "Couldn't open a terminal for the CLI (\(detail))."
+            }
+        }
+    }
+
+    func start() throws {
+        let master = posix_openpt(O_RDWR | O_NOCTTY)
+        guard master >= 0 else { throw PTYError.openFailed("posix_openpt") }
+        guard grantpt(master) == 0, unlockpt(master) == 0 else {
+            close(master)
+            throw PTYError.openFailed("grantpt/unlockpt")
+        }
+        guard let name = ptsname(master) else {
+            close(master)
+            throw PTYError.openFailed("ptsname")
+        }
+        let slave = open(name, O_RDWR | O_NOCTTY)
+        guard slave >= 0 else {
+            close(master)
+            throw PTYError.openFailed("open(slave)")
+        }
+
+        // A wide window so the TUI doesn't hard-wrap the authorization URL.
+        // The parser can rejoin wrapped lines, but not wrapping in the first
+        // place is the cheaper correctness. See `ClaudeSetupTokenParser`.
+        var size = winsize(ws_row: 50, ws_col: UInt16(clamping: columns),
+                           ws_xpixel: 0, ws_ypixel: 0)
+        _ = withUnsafeMutablePointer(to: &size) {
+            ioctl(master, Self.setWindowSizeRequest, UnsafeMutableRawPointer($0))
+        }
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.environment = environment
+        // Same reasoning as `LLMRunner.executeProcess`: a child that scans its
+        // working directory makes macOS attribute the access to Mila's bundle
+        // ID and prompts the user about folders Mila never asked for. The LLM
+        // sandbox is a directory Mila owns that holds nothing.
+        process.currentDirectoryURL = workingDirectory ?? LLMRunner.sandboxDirectory()
+
+        let slaveHandle = FileHandle(fileDescriptor: slave, closeOnDealloc: false)
+        process.standardInput = slaveHandle
+        process.standardOutput = slaveHandle
+        process.standardError = slaveHandle
+
+        // Before `run()`, per the subprocess rules: the exit is observed by
+        // Foundation's own reaping source, costing us no blocked thread.
+        process.terminationHandler = { [weak self] finished in
+            guard let self else { return }
+            self.exited.signal()
+            self.onExit?(finished.terminationStatus)
+        }
+
+        do {
+            try process.run()
+        } catch {
+            close(slave)
+            close(master)
+            throw error
+        }
+
+        // Close OUR copy of the slave. The child holds its own; keeping this
+        // one open would mean the master never sees EOF when the child exits,
+        // and the reader thread below would block forever.
+        close(slave)
+
+        lock.withLock {
+            self.process = process
+            self.masterFD = master
+        }
+        startReader(master)
+    }
+
+    /// Drain the pty master until EOF, on a thread of its own.
+    ///
+    /// `read` blocks, so this must not be a pooled thread (#246). Decoding is
+    /// per-chunk and lossy-tolerant: a chunk can split a multi-byte character,
+    /// and dropping the odd replacement character costs nothing here — every
+    /// marker this feeds is ASCII.
+    private func startReader(_ fd: Int32) {
+        BlockingWork.onDedicatedThread(named: "io.island.mila.claude-setup.pty") { [weak self] in
+            var buffer = [UInt8](repeating: 0, count: 8192)
+            while true {
+                let count = read(fd, &buffer, buffer.count)
+                if count <= 0 { break }   // EOF, or the master was closed
+                let data = Data(buffer[0..<count])
+                let text = String(decoding: data, as: UTF8.self)
+                self?.onOutput?(text)
+            }
+        }
+    }
+
+    func write(_ text: String) {
+        let fd = lock.withLock { masterFD }
+        guard fd >= 0 else { return }
+        let bytes = Array(text.utf8)
+        BlockingWork.onDedicatedThread(named: "io.island.mila.claude-setup.write") {
+            var offset = 0
+            while offset < bytes.count {
+                let written = bytes[offset...].withUnsafeBufferPointer { pointer in
+                    Darwin.write(fd, pointer.baseAddress, pointer.count)
+                }
+                if written <= 0 { break }
+                offset += written
+            }
+        }
+    }
+
+    func terminate() {
+        let (process, fd) = lock.withLock { (self.process, self.masterFD) }
+        guard let process else {
+            if fd >= 0 { closeMaster() }
+            return
+        }
+        guard process.isRunning else {
+            closeMaster()
+            return
+        }
+        process.terminate()
+        // Bounded escalation on a thread of its own — never an unbounded wait,
+        // and never on the shared pool. If the CLI ignores SIGTERM (a TUI
+        // restoring the terminal can take a moment) it gets killed.
+        BlockingWork.onDedicatedThread(named: "io.island.mila.claude-setup.reap") { [weak self] in
+            if self?.exited.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = self?.exited.wait(timeout: .now() + 3)
+            }
+            // Closing the master unblocks the reader thread's `read` even if a
+            // grandchild inherited the slave and is holding it open.
+            self?.closeMaster()
+        }
+    }
+
+    private func closeMaster() {
+        let fd = lock.withLock { () -> Int32 in
+            let current = masterFD
+            masterFD = -1
+            return current
+        }
+        if fd >= 0 { close(fd) }
+    }
+}

--- a/Mila/Actions/ClaudeSetupTokenSession.swift
+++ b/Mila/Actions/ClaudeSetupTokenSession.swift
@@ -319,6 +319,17 @@ final class ClaudeSetupTokenSession {
 
     private func childExited(status: Int32) {
         guard !finished else { return }
+        // Last chance before this counts as a failure. While output was
+        // streaming, the parser refused any token sitting at the very end of
+        // the buffer, because a chunk boundary there could mean half a
+        // credential. The stream is over now, so that ambiguity is gone and a
+        // trailing token is safe to take.
+        if let token = parser.finalToken() {
+            onToken?(token)
+            finish()
+            state = .ready
+            return
+        }
         // Reaching here means the CLI ended without a token. Exit 0 is the
         // interesting case: it says the CLI thinks it succeeded while Mila
         // found nothing token-shaped in what it printed — the one scenario the

--- a/Mila/Actions/LLMRunner.swift
+++ b/Mila/Actions/LLMRunner.swift
@@ -1790,18 +1790,51 @@ enum LLMRunner {
         return FileManager.default.temporaryDirectory
     }
 
-    private static func resolveExecutable(tool: LLMTool,
-                                          override: String?) throws -> URL {
+    /// Which binary a run actually launches.
+    ///
+    /// Order: **explicit override → Mila's managed install → `$PATH` and the
+    /// well-known directories.**
+    ///
+    /// The managed install (issue #271) goes ahead of the search because it is
+    /// the one binary Mila can make promises about: it verified the publisher's
+    /// signature before installing it, and it holds a credential minted for it
+    /// specifically. A user who pressed "Set up Claude" and *also* happens to
+    /// have a stale `claude` earlier on `PATH` should get the one Mila set up,
+    /// or the button did nothing they can see.
+    ///
+    /// The explicit override still wins over both, and that is deliberate. It
+    /// is a path the user typed into Settings → AI Provider → Executable,
+    /// which is Mila's own "run this one instead" control; a managed install
+    /// that silently overrode it would make that field impossible to use and
+    /// would break the documented escape hatch for custom installs and shims.
+    /// Nothing is lost by honouring it — an override that points *at* the
+    /// managed binary resolves to the same file, and
+    /// `ClaudeManagedInstall.environmentAdditions` compares resolved paths, so
+    /// that case still gets the token.
+    ///
+    /// `managedBinary` and `lookup` are parameters with production defaults so
+    /// the ordering is unit-testable without a real install or a real `$PATH`.
+    static func resolveExecutable(tool: LLMTool,
+                                  override: String?,
+                                  managedBinary: URL? = ClaudeManagedInstall.binaryURL(),
+                                  fileManager: FileManager = .default,
+                                  lookup: (String) -> URL? = { lookupOnPath($0) }) throws -> URL {
         // Absolute path override wins — handy for users with custom installs
         // or who want to point at a wrapper script (e.g. an asdf shim).
         if let override, !override.isEmpty {
             let url = URL(fileURLWithPath: (override as NSString).expandingTildeInPath)
-            guard FileManager.default.isExecutableFile(atPath: url.path) else {
+            guard fileManager.isExecutableFile(atPath: url.path) else {
                 throw LLMRunnerError.executableNotFound(override)
             }
             return url
         }
-        if let resolved = lookupOnPath(tool.executableName) {
+        // Only `.claude` has a managed install; the other CLIs are still
+        // whatever the user installed themselves.
+        if tool == .claude, let managedBinary,
+           fileManager.isExecutableFile(atPath: managedBinary.path) {
+            return managedBinary
+        }
+        if let resolved = lookup(tool.executableName) {
             return resolved
         }
         throw LLMRunnerError.executableNotFound(tool.executableName)
@@ -1832,9 +1865,25 @@ enum LLMRunner {
     /// directory`. We prepend the resolved executable's own directory (its
     /// sibling `node` lives there for nvm/npm installs) plus the well-known
     /// version-manager bins, then the inherited PATH — de-duped, order kept.
+    ///
+    /// It is also the ONE place Mila's managed Claude credential is handed to a
+    /// child (issue #271), and the only place it should ever be. Putting it
+    /// here rather than at each call site means every invocation route — the
+    /// auto-title, the summary, a Send action, a Live AI tick, the Settings
+    /// test — gets the same rule for free, and a route added later cannot
+    /// forget to apply it or apply it too widely. The rule itself
+    /// (`ClaudeManagedInstall.environmentAdditions`) is: inject only when the
+    /// executable being launched *is* the managed binary, so a user's own
+    /// `claude` with its own login is left exactly as it was.
+    ///
+    /// `managedToken` is a closure, not a value, so the Keychain is read only
+    /// when the paths match — a run of `cursor-agent` or a system `claude`
+    /// touches the Keychain not at all.
     static func childEnvironment(
         for executable: URL,
-        base: [String: String] = ProcessInfo.processInfo.environment
+        base: [String: String] = ProcessInfo.processInfo.environment,
+        managedBinary: URL? = ClaudeManagedInstall.binaryURL(),
+        managedToken: () -> String? = { KeychainClaudeTokenStore().load() }
     ) -> [String: String] {
         var env = base
         let inherited = base["PATH"]?.split(separator: ":").map(String.init) ?? []
@@ -1844,6 +1893,15 @@ enum LLMRunner {
         var seen = Set<String>()
         let merged = ordered.filter { !$0.isEmpty && seen.insert($0).inserted }
         env["PATH"] = merged.joined(separator: ":")
+        if let managedBinary,
+           executable.standardizedFileURL.path == managedBinary.standardizedFileURL.path {
+            for (key, value) in ClaudeManagedInstall.environmentAdditions(
+                executable: executable,
+                managedBinary: managedBinary,
+                token: managedToken()) {
+                env[key] = value
+            }
+        }
         return env
     }
 

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -360,6 +360,10 @@ struct MilaApp: App {
     /// weakly.
     @StateObject private var obsidianVaultSettings: ObsidianVaultSettings
     @StateObject private var mcpAccessSettings: MCPAccessSettings
+    /// Managed Claude CLI install + guided login (issue #271). App-wide because
+    /// the Settings scene renders it and `LLMRunner` runs against what it
+    /// installed; a second instance would mean two views of one install.
+    @StateObject private var claudeSetupSettings: ClaudeSetupSettings
     @StateObject private var obsidianExporter: ObsidianExporter
     @StateObject private var voiceMemosSettings: VoiceMemosSettings
     @StateObject private var voiceMemosImporter: VoiceMemosImporter
@@ -572,6 +576,13 @@ struct MilaApp: App {
         store.onStoreLocationDiscoverabilityChanged = { [weak mcpAccess] in
             mcpAccess?.refreshMirror()
         }
+        // Settings → AI Provider → "Set up Claude" (issue #271). `openURL` is
+        // injected rather than reached for inside the model: that keeps AppKit
+        // out of the settings layer, and it is the seam the tests use to prove
+        // the guided login never opens a browser under test.
+        let claudeSetup = ClaudeSetupSettings(openURL: { url in
+            NSWorkspace.shared.open(url)
+        })
         let obsidian = ObsidianExporter(settings: obsidianSettings)
         // Write the note once the summary state is final. Gated on `pending`
         // so a launch-time backfill sweep never re-files the back-catalogue.
@@ -897,6 +908,7 @@ struct MilaApp: App {
         _recordingSummarizer = StateObject(wrappedValue: summarizer)
         _obsidianVaultSettings = StateObject(wrappedValue: obsidianSettings)
         _mcpAccessSettings = StateObject(wrappedValue: mcpAccess)
+        _claudeSetupSettings = StateObject(wrappedValue: claudeSetup)
         _obsidianExporter = StateObject(wrappedValue: obsidian)
         // Voice Memos (iPhone) folder integration. Settings are opt-in and
         // default-off; the importer wires up its FSEvents watcher + initial
@@ -990,6 +1002,7 @@ struct MilaApp: App {
                 }
                 .environmentObject(obsidianVaultSettings)
                 .environmentObject(mcpAccessSettings)
+                .environmentObject(claudeSetupSettings)
                 .environmentObject(obsidianExporter)
         }
         .commands {
@@ -1055,6 +1068,7 @@ struct MilaApp: App {
                 .environmentObject(updater)
                 .environmentObject(obsidianVaultSettings)
                 .environmentObject(mcpAccessSettings)
+                .environmentObject(claudeSetupSettings)
                 .environmentObject(obsidianExporter)
         }
         // Settings used to be pinned to 700×560 by a rigid `.frame` inside

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -219,6 +219,11 @@ final class ClaudeSetupSettings: ObservableObject {
         previous?.cancel()
         installGeneration += 1
         let generation = installGeneration
+        // Go busy SYNCHRONOUSLY, before the queued task gets a turn: while it
+        // waits out its predecessor the row must show work in progress, not an
+        // idle state whose buttons (another retry, Sign out, Sign in) would
+        // race the queued install and be overwritten when the wait ends.
+        state = isInstalled ? .signingIn : .installing(progress: -1)
         installTask = Task { @MainActor [weak self] in
             // Serialize on the predecessor: a cancelled install can slip past
             // its final cancellation check and still be writing the binary and
@@ -231,6 +236,9 @@ final class ClaudeSetupSettings: ObservableObject {
                 guard await self.performInstall(generation: generation) else { return }
             }
             guard generation == self.installGeneration else { return }
+            // Release the placeholder set above — `startSignIn`'s own busy
+            // guard would otherwise see it and refuse the flow it announces.
+            if case .signingIn = self.state { self.state = .idle }
             self.startSignIn()
         }
     }
@@ -247,6 +255,8 @@ final class ClaudeSetupSettings: ObservableObject {
         previous?.cancel()
         installGeneration += 1
         let generation = installGeneration
+        // Synchronously busy for the same reason as `setUp()`.
+        state = .installing(progress: -1)
         installTask = Task { @MainActor [weak self] in
             // Same serialization as `setUp()` — see the comment there.
             await previous?.value
@@ -412,6 +422,11 @@ final class ClaudeSetupSettings: ObservableObject {
     /// credential still in the keychain would be a lie the user cannot see
     /// through.
     func signOut(removeBinary: Bool = false) {
+        // Signing out is an unambiguous "stop": disown and cancel any queued
+        // or running install so it cannot put back a binary (or a busy state)
+        // the user is in the middle of removing.
+        installTask?.cancel()
+        installGeneration += 1
         let removed = tokenStore.delete()
         guard removed else {
             signOutFailed = true

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -127,6 +127,12 @@ final class ClaudeSetupSettings: ObservableObject {
     private let systemCLILookup: () -> URL?
 
     private var installTask: Task<Void, Never>?
+    /// Which install currently owns the published state. A cancelled install
+    /// can outlive its cancellation (blocked in `installer.install` until the
+    /// transfer notices), and its terminal writes must not level a replacement
+    /// install the user started in the meantime. Bumped by every new install
+    /// and by every cancel; a task whose generation is stale writes nothing.
+    private var installGeneration = 0
 
     init(defaults: UserDefaults = .standard,
          tokenStore: ClaudeTokenStoring = KeychainClaudeTokenStore(),
@@ -210,11 +216,14 @@ final class ClaudeSetupSettings: ObservableObject {
     func setUp() {
         guard !state.isBusy else { return }
         installTask?.cancel()
+        installGeneration += 1
+        let generation = installGeneration
         installTask = Task { @MainActor [weak self] in
             guard let self else { return }
             if !self.isInstalled {
-                guard await self.performInstall() else { return }
+                guard await self.performInstall(generation: generation) else { return }
             }
+            guard generation == self.installGeneration else { return }
             self.startSignIn()
         }
     }
@@ -228,20 +237,25 @@ final class ClaudeSetupSettings: ObservableObject {
     func reinstall() {
         guard !state.isBusy else { return }
         installTask?.cancel()
+        installGeneration += 1
+        let generation = installGeneration
         installTask = Task { @MainActor [weak self] in
-            _ = await self?.performInstall()
+            _ = await self?.performInstall(generation: generation)
         }
     }
 
-    private func performInstall() async -> Bool {
+    private func performInstall(generation: Int) async -> Bool {
+        guard generation == installGeneration else { return false }
         state = .installing(progress: -1)
         do {
             let result = try await installer.install { progress in
                 Task { @MainActor [weak self] in
-                    guard let self, case .installing = self.state else { return }
+                    guard let self, generation == self.installGeneration,
+                          case .installing = self.state else { return }
                     self.state = .installing(progress: progress)
                 }
             }
+            guard generation == installGeneration else { return false }
             installedVersion = result.version
             defaults.set(result.version, forKey: Keys.installedVersion)
             refreshInstalledState()
@@ -253,9 +267,10 @@ final class ClaudeSetupSettings: ObservableObject {
             state = .idle
             return true
         } catch is CancellationError {
-            state = .idle
+            if generation == installGeneration { state = .idle }
             return false
         } catch {
+            guard generation == installGeneration else { return false }
             // A cancelled URLSession task surfaces as `URLError.cancelled`,
             // not `CancellationError` — either way the user asked for it, so
             // it must not render as a failure.
@@ -340,6 +355,10 @@ final class ClaudeSetupSettings: ObservableObject {
     /// from.
     func cancelSignIn() {
         installTask?.cancel()
+        // Disown the cancelled task's future writes as well as cancelling it:
+        // it may be parked inside `installer.install` past the cancel, and its
+        // eventual terminal state belongs to nobody now.
+        installGeneration += 1
         session?.cancel()
         session = nil
         switch state {

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -18,6 +18,11 @@ enum ClaudeSetupStatus: Equatable {
     /// this exact binary and credential — see `ClaudeSetupSettings.status` for
     /// why that is not the same as "we have a token".
     case signedIn(verified: Bool)
+    /// The user already has their own `claude` (npm, the official installer,
+    /// anything `LLMRunner`'s search finds) and no managed copy is installed.
+    /// That setup is complete as far as Mila is concerned — it must not read
+    /// as "Not set up" just because *this* button didn't produce it.
+    case usingSystemCLI(verified: Bool)
     case working(String)
     case problem(String)
 
@@ -26,6 +31,8 @@ enum ClaudeSetupStatus: Equatable {
         case .notSetUp:              return "Not set up"
         case .installedNotSignedIn:  return "Installed, not signed in"
         case .signedIn(let verified): return verified ? "Signed in and working" : "Signed in"
+        case .usingSystemCLI(let verified):
+            return verified ? "Using your Claude CLI — working" : "Using your Claude CLI"
         case .working(let what):     return what
         case .problem(let message):  return message
         }
@@ -36,15 +43,18 @@ enum ClaudeSetupStatus: Equatable {
         case .notSetUp:             return "circle.dashed"
         case .installedNotSignedIn: return "person.crop.circle.badge.questionmark"
         case .signedIn(let verified): return verified ? "checkmark.circle.fill" : "checkmark.circle"
+        case .usingSystemCLI(let verified): return verified ? "checkmark.circle.fill" : "checkmark.circle"
         case .working:              return "arrow.triangle.2.circlepath"
         case .problem:              return "exclamationmark.triangle.fill"
         }
     }
 
-    /// True when Mila can run the managed CLI right now.
+    /// True when Mila can run a Claude CLI right now (managed or the user's own).
     var isReady: Bool {
-        if case .signedIn = self { return true }
-        return false
+        switch self {
+        case .signedIn, .usingSystemCLI: return true
+        default: return false
+        }
     }
 }
 
@@ -70,6 +80,11 @@ final class ClaudeSetupSettings: ObservableObject {
     @Published private(set) var isInstalled: Bool = false
     @Published private(set) var installedVersion: String?
     @Published private(set) var hasToken: Bool = false
+
+    /// Where a non-managed `claude` was found, if anywhere — the same search
+    /// `LLMRunner` performs minus the managed copy. Drives `.usingSystemCLI`,
+    /// and shown as the caption path so the user knows which binary Mila runs.
+    @Published private(set) var systemCLIPath: String?
 
     /// Outcome of the most recent Test run, kept for the row's detail text.
     /// Not persisted — `verified` below is the durable half.
@@ -105,6 +120,11 @@ final class ClaudeSetupSettings: ObservableObject {
     private let openURL: (URL) -> Void
     /// Injected so the Test button can be exercised without running a CLI.
     private let runTest: (URL, TimeInterval) async -> LLMTestResult
+    /// Injected so tests control whether a "system" claude exists. The default
+    /// is `LLMRunner`'s own search with the managed copy excluded, so this
+    /// answers exactly one question: what would Mila run if we hadn't
+    /// installed anything?
+    private let systemCLILookup: () -> URL?
 
     private var installTask: Task<Void, Never>?
 
@@ -114,13 +134,17 @@ final class ClaudeSetupSettings: ObservableObject {
          appSupportRoot: URL = ClaudeManagedInstall.applicationSupportRoot(),
          fileManager: FileManager = .default,
          openURL: @escaping (URL) -> Void = { _ in },
-         runTest: ((URL, TimeInterval) async -> LLMTestResult)? = nil) {
+         runTest: ((URL, TimeInterval) async -> LLMTestResult)? = nil,
+         systemCLILookup: (() -> URL?)? = nil) {
         self.defaults = defaults
         self.tokenStore = tokenStore
         self.appSupportRoot = appSupportRoot
         self.fileManager = fileManager
         self.installer = installer ?? ClaudeBinaryInstaller(appSupportRoot: appSupportRoot)
         self.openURL = openURL
+        self.systemCLILookup = systemCLILookup ?? {
+            try? LLMRunner.resolveExecutable(tool: .claude, override: nil, managedBinary: nil)
+        }
         self.runTest = runTest ?? { binary, timeout in
             // The real probe: the smallest useful thing the CLI can do. It goes
             // through `LLMRunner`, so it exercises the same executable
@@ -160,7 +184,13 @@ final class ClaudeSetupSettings: ObservableObject {
         case .idle, .ready:  break
         }
         if isTesting { return .working("Testing…") }
-        guard isInstalled else { return .notSetUp }
+        guard isInstalled else {
+            // No managed copy — but a claude the user installed themselves is
+            // a complete setup, not an absent one. The managed flow stays
+            // available as an optional extra in that state.
+            if systemCLIPath != nil { return .usingSystemCLI(verified: verified) }
+            return .notSetUp
+        }
         guard hasToken else { return .installedNotSignedIn }
         if verified { return .signedIn(verified: true) }
         if let result = lastTestResult, result.succeeded { return .signedIn(verified: true) }
@@ -226,6 +256,13 @@ final class ClaudeSetupSettings: ObservableObject {
             state = .idle
             return false
         } catch {
+            // A cancelled URLSession task surfaces as `URLError.cancelled`,
+            // not `CancellationError` — either way the user asked for it, so
+            // it must not render as a failure.
+            if Task.isCancelled {
+                state = .idle
+                return false
+            }
             let message = (error as? LocalizedError)?.errorDescription
                 ?? error.localizedDescription
             state = .failed(message)
@@ -246,7 +283,17 @@ final class ClaudeSetupSettings: ObservableObject {
         let session = ClaudeSetupTokenSession.managed(binary: binary)
         session.onStateChange = { [weak self] newState in
             guard let self else { return }
-            self.state = newState
+            // The session reports `.ready` right after delivering the token —
+            // but `onToken` runs first, and `store(_:)` may have just recorded
+            // a Keychain failure there. That failure is the truer state: the
+            // session only knows the CLI handed a token over, not whether it
+            // could be kept. Copying `.ready` over it would silently bury the
+            // one error the user has to act on.
+            if case .ready = newState, case .failed = self.state {
+                // keep the failure; fall through so the session is still released
+            } else {
+                self.state = newState
+            }
             switch newState {
             case .ready, .failed, .idle:
                 // Released on the NEXT main-actor turn, not here. This property
@@ -284,13 +331,20 @@ final class ClaudeSetupSettings: ObservableObject {
         session?.submit(code: code)
     }
 
-    /// Abandon an in-progress sign-in.
+    /// Abandon whatever the Cancel button is looking at: an in-progress
+    /// download, a sign-in, or an install that would chain into one.
+    ///
+    /// Cancelling `installTask` matters even mid-download: without it the
+    /// transfer keeps running, and `setUp()`'s task would then proceed to
+    /// `startSignIn()` and open a browser the user has already walked away
+    /// from.
     func cancelSignIn() {
+        installTask?.cancel()
         session?.cancel()
         session = nil
         switch state {
-        case .signingIn, .awaitingCode, .verifying: state = .idle
-        case .idle, .installing, .ready, .failed: break
+        case .signingIn, .awaitingCode, .verifying, .installing: state = .idle
+        case .idle, .ready, .failed: break
         }
     }
 
@@ -342,14 +396,21 @@ final class ClaudeSetupSettings: ObservableObject {
 
     // MARK: - Test
 
-    /// Run one trivial prompt through the managed binary and record whether it
-    /// worked. Bounded — a hung CLI must not leave the row spinning.
+    /// The binary a Test run (and `LLMRunner` itself) would use: the managed
+    /// copy when installed, otherwise the user's own CLI if one was found.
+    var effectiveBinaryPath: String? {
+        if isInstalled { return managedBinaryPath }
+        return systemCLIPath
+    }
+
+    /// Run one trivial prompt through the effective binary and record whether
+    /// it worked. Bounded — a hung CLI must not leave the row spinning.
     func test() async {
-        guard !isTesting, isInstalled else { return }
+        guard !isTesting, let binaryPath = effectiveBinaryPath else { return }
         isTesting = true
         lastTestResult = nil
         defer { isTesting = false }
-        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot)
+        let binary = URL(fileURLWithPath: binaryPath)
         let result = await runTest(binary, Self.testTimeout)
         lastTestResult = result
         if result.succeeded {
@@ -372,6 +433,7 @@ final class ClaudeSetupSettings: ObservableObject {
             installedVersion = defaults.string(forKey: Keys.installedVersion)
         }
         hasToken = tokenStore.load() != nil
+        systemCLIPath = systemCLILookup()?.path
     }
 
     /// Restore the persisted "this setup was proven to work" flag — but only if
@@ -385,18 +447,33 @@ final class ClaudeSetupSettings: ObservableObject {
     /// persisted Python path still equals the configured one.
     private func restoreVerification() {
         guard defaults.bool(forKey: Keys.verified) else { return }
-        guard isInstalled, hasToken else { return }
-        guard defaults.string(forKey: Keys.verifiedBinaryPath) == managedBinaryPath else { return }
-        let recordedVersion = defaults.string(forKey: Keys.verifiedVersion)
-        guard recordedVersion == installedVersion else { return }
-        verified = true
+        let recordedPath = defaults.string(forKey: Keys.verifiedBinaryPath)
+        if isInstalled {
+            guard hasToken else { return }
+            guard recordedPath == managedBinaryPath else { return }
+            let recordedVersion = defaults.string(forKey: Keys.verifiedVersion)
+            guard recordedVersion == installedVersion else { return }
+            verified = true
+        } else if let systemCLIPath {
+            // The user's own CLI carries its own login (`~/.claude`), so there
+            // is no token requirement here. The proof is only about identity:
+            // the binary that passed the Test is still the one Mila would run.
+            guard recordedPath == systemCLIPath else { return }
+            verified = true
+        }
     }
 
     private func recordVerification() {
         verified = true
         defaults.set(true, forKey: Keys.verified)
-        defaults.set(managedBinaryPath, forKey: Keys.verifiedBinaryPath)
-        defaults.set(installedVersion, forKey: Keys.verifiedVersion)
+        defaults.set(effectiveBinaryPath, forKey: Keys.verifiedBinaryPath)
+        if isInstalled {
+            defaults.set(installedVersion, forKey: Keys.verifiedVersion)
+        } else {
+            // A system CLI has no managed version to pin the proof to; leaving
+            // a stale managed version here would block the restore above.
+            defaults.removeObject(forKey: Keys.verifiedVersion)
+        }
     }
 
     private func clearVerification() {

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -215,10 +215,17 @@ final class ClaudeSetupSettings: ObservableObject {
     /// The one button. Installs if needed, then starts the guided login.
     func setUp() {
         guard !state.isBusy else { return }
-        installTask?.cancel()
+        let previous = installTask
+        previous?.cancel()
         installGeneration += 1
         let generation = installGeneration
         installTask = Task { @MainActor [weak self] in
+            // Serialize on the predecessor: a cancelled install can slip past
+            // its final cancellation check and still be writing the binary and
+            // its bookkeeping. Starting the next install only after the old
+            // one fully unwinds removes every reverse-completion interleaving
+            // — the generation alone orders state ownership, not disk writes.
+            await previous?.value
             guard let self else { return }
             if !self.isInstalled {
                 guard await self.performInstall(generation: generation) else { return }
@@ -236,10 +243,13 @@ final class ClaudeSetupSettings: ObservableObject {
     /// failure presses this and gets the current release.
     func reinstall() {
         guard !state.isBusy else { return }
-        installTask?.cancel()
+        let previous = installTask
+        previous?.cancel()
         installGeneration += 1
         let generation = installGeneration
         installTask = Task { @MainActor [weak self] in
+            // Same serialization as `setUp()` — see the comment there.
+            await previous?.value
             _ = await self?.performInstall(generation: generation)
         }
     }

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -1,0 +1,415 @@
+import Foundation
+import Combine
+import os
+
+private let setupSettingsLog = os.Logger(subsystem: "io.island.whisper.IslandWhisper",
+                                         category: "ClaudeSetup")
+
+/// What the Settings row says about the managed Claude install, at a glance.
+///
+/// Three resting states, matching the three things that can actually be true —
+/// nothing installed, installed but no credential, both — plus the transient
+/// and broken cases. Kept as one enum so the row cannot render a combination
+/// that doesn't exist (a "Signed in" badge with no binary, say).
+enum ClaudeSetupStatus: Equatable {
+    case notSetUp
+    case installedNotSignedIn
+    /// `verified` is true only when a Test run has actually succeeded against
+    /// this exact binary and credential — see `ClaudeSetupSettings.status` for
+    /// why that is not the same as "we have a token".
+    case signedIn(verified: Bool)
+    case working(String)
+    case problem(String)
+
+    var label: String {
+        switch self {
+        case .notSetUp:              return "Not set up"
+        case .installedNotSignedIn:  return "Installed, not signed in"
+        case .signedIn(let verified): return verified ? "Signed in and working" : "Signed in"
+        case .working(let what):     return what
+        case .problem(let message):  return message
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .notSetUp:             return "circle.dashed"
+        case .installedNotSignedIn: return "person.crop.circle.badge.questionmark"
+        case .signedIn(let verified): return verified ? "checkmark.circle.fill" : "checkmark.circle"
+        case .working:              return "arrow.triangle.2.circlepath"
+        case .problem:              return "exclamationmark.triangle.fill"
+        }
+    }
+
+    /// True when Mila can run the managed CLI right now.
+    var isReady: Bool {
+        if case .signedIn = self { return true }
+        return false
+    }
+}
+
+/// App-wide state for the one-button Claude setup (issue #271).
+///
+/// Owns three things that have to agree with each other: whether a managed
+/// binary is on disk, whether a token is in the Keychain, and whether the pair
+/// has been proven to work. Everything else — the download, the pty login, the
+/// keychain — happens behind the seams this object is constructed with, so a
+/// test can drive the whole surface with no network, no subprocess and no
+/// keychain.
+///
+/// Follows the conventions in `CLAUDE.md`: namespaced `claudeSetup.*` defaults
+/// keys, a persisted `verified` flag restored only when the parameters it was
+/// recorded against still match, and a computed `status` that consults the
+/// persisted verification before any in-memory result.
+@MainActor
+final class ClaudeSetupSettings: ObservableObject {
+
+    // MARK: - Published state
+
+    @Published private(set) var state: ClaudeSetupState = .idle
+    @Published private(set) var isInstalled: Bool = false
+    @Published private(set) var installedVersion: String?
+    @Published private(set) var hasToken: Bool = false
+
+    /// Outcome of the most recent Test run, kept for the row's detail text.
+    /// Not persisted — `verified` below is the durable half.
+    @Published private(set) var lastTestResult: LLMTestResult?
+    @Published private(set) var isTesting = false
+
+    /// Set when a sign-out could not remove the credential. The UI must keep
+    /// showing "signed in" in that case: an affordance that claims to have
+    /// removed a credential it did not remove is the one state to never show.
+    @Published private(set) var signOutFailed = false
+
+    /// The live login flow, non-nil only while a sign-in is in progress.
+    /// The sheet binds to this object; `session?.lastRejection` is what it
+    /// renders under the code field.
+    @Published private(set) var session: ClaudeSetupTokenSession?
+
+    // MARK: - Verification (persisted)
+
+    /// "A Test run succeeded, and nothing has changed since." Restored from
+    /// defaults on launch, but only when the *parameters* it was recorded
+    /// against still hold — see `restoreVerification`.
+    @Published private(set) var verified = false
+
+    // MARK: - Seams
+
+    private let defaults: UserDefaults
+    private let tokenStore: ClaudeTokenStoring
+    private let installer: ClaudeBinaryInstaller
+    private let appSupportRoot: URL
+    private let fileManager: FileManager
+    /// Injected so tests never open a browser, and so `NSWorkspace` (AppKit)
+    /// stays out of the model layer.
+    private let openURL: (URL) -> Void
+    /// Injected so the Test button can be exercised without running a CLI.
+    private let runTest: (URL, TimeInterval) async -> LLMTestResult
+
+    private var installTask: Task<Void, Never>?
+
+    init(defaults: UserDefaults = .standard,
+         tokenStore: ClaudeTokenStoring = KeychainClaudeTokenStore(),
+         installer: ClaudeBinaryInstaller? = nil,
+         appSupportRoot: URL = ClaudeManagedInstall.applicationSupportRoot(),
+         fileManager: FileManager = .default,
+         openURL: @escaping (URL) -> Void = { _ in },
+         runTest: ((URL, TimeInterval) async -> LLMTestResult)? = nil) {
+        self.defaults = defaults
+        self.tokenStore = tokenStore
+        self.appSupportRoot = appSupportRoot
+        self.fileManager = fileManager
+        self.installer = installer ?? ClaudeBinaryInstaller(appSupportRoot: appSupportRoot)
+        self.openURL = openURL
+        self.runTest = runTest ?? { binary, timeout in
+            // The real probe: the smallest useful thing the CLI can do. It goes
+            // through `LLMRunner`, so it exercises the same executable
+            // resolution and the same environment — including the token
+            // injection — that a real summary would.
+            await LLMRunner.diagnose(tool: .claude,
+                                     prompt: "Reply with the single word OK.",
+                                     transcript: "",
+                                     executablePathOverride: binary.path,
+                                     timeout: timeout,
+                                     feature: .settingsTest)
+        }
+        refreshInstalledState()
+        restoreVerification()
+    }
+
+    // MARK: - Status
+
+    /// The single value the Settings row renders.
+    ///
+    /// Order matters, and it is the order `DiarizationSettings.status` uses:
+    /// a transient state wins (the user is watching something happen), then the
+    /// persisted verification, then the plain facts on disk. Consulting
+    /// `lastTestResult` before `verified` would mean a launch with no in-memory
+    /// result showed "Signed in" for a setup that was proven working yesterday
+    /// — the persisted answer is the better one, and it is the one that
+    /// survives a relaunch.
+    var status: ClaudeSetupStatus {
+        switch state {
+        case .installing(let progress):
+            let percent = progress >= 0 ? " \(Int(progress * 100))%" : ""
+            return .working("Downloading Claude\(percent)")
+        case .signingIn:     return .working("Opening sign-in…")
+        case .awaitingCode:  return .working("Waiting for the code from your browser")
+        case .verifying:     return .working("Checking the code…")
+        case .failed(let reason): return .problem(reason)
+        case .idle, .ready:  break
+        }
+        if isTesting { return .working("Testing…") }
+        guard isInstalled else { return .notSetUp }
+        guard hasToken else { return .installedNotSignedIn }
+        if verified { return .signedIn(verified: true) }
+        if let result = lastTestResult, result.succeeded { return .signedIn(verified: true) }
+        return .signedIn(verified: false)
+    }
+
+    /// Whether the managed binary is what `LLMRunner` will pick. Shown as a
+    /// caption so a user with their own `claude` on `PATH` understands which
+    /// one Mila is actually running.
+    var managedBinaryPath: String {
+        ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot).path
+    }
+
+    // MARK: - Install
+
+    /// The one button. Installs if needed, then starts the guided login.
+    func setUp() {
+        guard !state.isBusy else { return }
+        installTask?.cancel()
+        installTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            if !self.isInstalled {
+                guard await self.performInstall() else { return }
+            }
+            self.startSignIn()
+        }
+    }
+
+    /// Re-download the binary, keeping any existing credential.
+    ///
+    /// The v1 update story: there is no background updater and no version
+    /// check against the release feed, because the failure this has to cover is
+    /// "my CLI stopped working", not "my CLI is 3 days old". A user who sees a
+    /// failure presses this and gets the current release.
+    func reinstall() {
+        guard !state.isBusy else { return }
+        installTask?.cancel()
+        installTask = Task { @MainActor [weak self] in
+            _ = await self?.performInstall()
+        }
+    }
+
+    private func performInstall() async -> Bool {
+        state = .installing(progress: -1)
+        do {
+            let result = try await installer.install { progress in
+                Task { @MainActor [weak self] in
+                    guard let self, case .installing = self.state else { return }
+                    self.state = .installing(progress: progress)
+                }
+            }
+            installedVersion = result.version
+            defaults.set(result.version, forKey: Keys.installedVersion)
+            refreshInstalledState()
+            // A new binary invalidates the proof: the Test that passed was
+            // against the *previous* one. `restoreVerification`'s parameter
+            // check would catch this on the next launch anyway; clearing it now
+            // means the UI doesn't claim a verification it no longer has.
+            clearVerification()
+            state = .idle
+            return true
+        } catch is CancellationError {
+            state = .idle
+            return false
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+            state = .failed(message)
+            return false
+        }
+    }
+
+    // MARK: - Sign in
+
+    /// Start (or restart) the guided login against the installed binary.
+    func startSignIn() {
+        guard isInstalled else {
+            state = .failed("Claude isn't installed yet.")
+            return
+        }
+        guard !state.isBusy else { return }
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot)
+        let session = ClaudeSetupTokenSession.managed(binary: binary)
+        session.onStateChange = { [weak self] newState in
+            guard let self else { return }
+            self.state = newState
+            switch newState {
+            case .ready, .failed, .idle:
+                // Released on the NEXT main-actor turn, not here. This property
+                // holds the only strong reference to the session, and this
+                // closure is called from inside the session's own `state`
+                // `didSet` — so clearing it inline drops the last reference to
+                // an object with a method still on the stack. It survives today
+                // only because every caller reaches the session through
+                // optional chaining on a weak `self`, which happens to hold a
+                // temporary strong reference for the duration. That is a
+                // property of the call sites, not of this code, and a refactor
+                // there would turn this into a use-after-free with no local
+                // evidence of why.
+                //
+                // The identity guard matters as much as the deferral: a user
+                // who presses "Try again" on a failure starts a NEW session
+                // before this task runs, and an unguarded `session = nil` would
+                // tear down the sign-in they just started.
+                Task { @MainActor [weak self, weak session] in
+                    guard let self, self.session === session else { return }
+                    self.session = nil
+                }
+            case .installing, .signingIn, .awaitingCode, .verifying:
+                break
+            }
+        }
+        session.onOpenURL = { [weak self] url in self?.openURL(url) }
+        session.onToken = { [weak self] token in self?.store(token) }
+        self.session = session
+        session.start()
+    }
+
+    /// Send the code the user pasted out of their browser.
+    func submit(code: String) {
+        session?.submit(code: code)
+    }
+
+    /// Abandon an in-progress sign-in.
+    func cancelSignIn() {
+        session?.cancel()
+        session = nil
+        switch state {
+        case .signingIn, .awaitingCode, .verifying: state = .idle
+        case .idle, .installing, .ready, .failed: break
+        }
+    }
+
+    /// Persist a captured token.
+    ///
+    /// The token is never logged, never put in `UserDefaults`, and is not held
+    /// as a property of this object: it goes straight to the store, and
+    /// everything afterwards works off `hasToken`.
+    private func store(_ token: String) {
+        guard tokenStore.save(token) else {
+            state = .failed("Mila couldn't save the Claude credential to your Keychain.")
+            return
+        }
+        hasToken = true
+        // A fresh credential has not been proven to work yet — the Test button
+        // is what turns "Signed in" into "Signed in and working".
+        clearVerification()
+        setupSettingsLog.notice("claude setup token stored")
+    }
+
+    // MARK: - Sign out
+
+    /// Remove the stored credential, and optionally the binary with it.
+    ///
+    /// The delete is verified before any UI state changes. `ClaudeTokenStoring`
+    /// exists in that shape for this method: flipping to "signed out" over a
+    /// credential still in the keychain would be a lie the user cannot see
+    /// through.
+    func signOut(removeBinary: Bool = false) {
+        let removed = tokenStore.delete()
+        guard removed else {
+            signOutFailed = true
+            hasToken = true
+            setupSettingsLog.error("claude setup sign-out failed — credential still present")
+            return
+        }
+        signOutFailed = false
+        hasToken = false
+        clearVerification()
+        lastTestResult = nil
+        if removeBinary {
+            _ = installer.removeManagedBinary()
+            defaults.removeObject(forKey: Keys.installedVersion)
+            installedVersion = nil
+        }
+        refreshInstalledState()
+        state = .idle
+    }
+
+    // MARK: - Test
+
+    /// Run one trivial prompt through the managed binary and record whether it
+    /// worked. Bounded — a hung CLI must not leave the row spinning.
+    func test() async {
+        guard !isTesting, isInstalled else { return }
+        isTesting = true
+        lastTestResult = nil
+        defer { isTesting = false }
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: appSupportRoot)
+        let result = await runTest(binary, Self.testTimeout)
+        lastTestResult = result
+        if result.succeeded {
+            recordVerification()
+        } else {
+            clearVerification()
+        }
+    }
+
+    /// Bound on the Test run. Short: this prompt asks for one word, so anything
+    /// slower than this is a broken setup rather than a slow model.
+    static let testTimeout: TimeInterval = 90
+
+    // MARK: - Persistence
+
+    private func refreshInstalledState() {
+        isInstalled = ClaudeManagedInstall.isInstalled(fileManager: fileManager,
+                                                       appSupportRoot: appSupportRoot)
+        if installedVersion == nil {
+            installedVersion = defaults.string(forKey: Keys.installedVersion)
+        }
+        hasToken = tokenStore.load() != nil
+    }
+
+    /// Restore the persisted "this setup was proven to work" flag — but only if
+    /// every parameter it was recorded against still matches.
+    ///
+    /// The parameters are the binary path, the installed version, and the
+    /// continued presence of a credential. Any of them changing means the proof
+    /// was about a different setup: a reinstall brings new bytes, and a
+    /// sign-out removes the credential the test passed with. This mirrors
+    /// `DiarizationSettings`, which restores its verified flag only when the
+    /// persisted Python path still equals the configured one.
+    private func restoreVerification() {
+        guard defaults.bool(forKey: Keys.verified) else { return }
+        guard isInstalled, hasToken else { return }
+        guard defaults.string(forKey: Keys.verifiedBinaryPath) == managedBinaryPath else { return }
+        let recordedVersion = defaults.string(forKey: Keys.verifiedVersion)
+        guard recordedVersion == installedVersion else { return }
+        verified = true
+    }
+
+    private func recordVerification() {
+        verified = true
+        defaults.set(true, forKey: Keys.verified)
+        defaults.set(managedBinaryPath, forKey: Keys.verifiedBinaryPath)
+        defaults.set(installedVersion, forKey: Keys.verifiedVersion)
+    }
+
+    private func clearVerification() {
+        verified = false
+        defaults.set(false, forKey: Keys.verified)
+        defaults.removeObject(forKey: Keys.verifiedBinaryPath)
+        defaults.removeObject(forKey: Keys.verifiedVersion)
+    }
+
+    enum Keys {
+        static let installedVersion = "claudeSetup.installedVersion"
+        static let verified = "claudeSetup.verified"
+        static let verifiedBinaryPath = "claudeSetup.verifiedBinaryPath"
+        static let verifiedVersion = "claudeSetup.verifiedVersion"
+    }
+}

--- a/Mila/Models/ClaudeSetupSettings.swift
+++ b/Mila/Models/ClaudeSetupSettings.swift
@@ -255,7 +255,13 @@ final class ClaudeSetupSettings: ObservableObject {
                     self.state = .installing(progress: progress)
                 }
             }
-            guard generation == installGeneration else { return false }
+            // The disk has changed no matter who owns the flow now: a cancel
+            // that raced the last stretch of the install cannot un-write
+            // `moveIntoPlace`. Everything that MIRRORS disk — the version
+            // default, the installed flags, the now-invalid verification —
+            // must therefore be recorded even for a superseded generation, or
+            // Settings describes a machine that no longer exists (and keeps a
+            // "verified" claim about bytes that were just replaced).
             installedVersion = result.version
             defaults.set(result.version, forKey: Keys.installedVersion)
             refreshInstalledState()
@@ -264,6 +270,9 @@ final class ClaudeSetupSettings: ObservableObject {
             // check would catch this on the next launch anyway; clearing it now
             // means the UI doesn't claim a verification it no longer has.
             clearVerification()
+            // Only the flow-owned writes stay generation-guarded: the spinner
+            // state and the chained sign-in belong to whoever runs NOW.
+            guard generation == installGeneration else { return false }
             state = .idle
             return true
         } catch is CancellationError {

--- a/Mila/Models/ClaudeTokenStore.swift
+++ b/Mila/Models/ClaudeTokenStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Where the managed Claude OAuth token lives.
+///
+/// A protocol for two reasons. The obvious one is that a unit test can supply
+/// an in-memory double instead of touching the login keychain. The other is
+/// that it forces the *verified* shape on every operation: `save` and `delete`
+/// return whether the store actually ends up in the state that was asked for.
+/// A delete that silently failed is the bug this shape exists to prevent — the
+/// UI would flip to "signed out" over a credential that is still sitting in the
+/// keychain.
+protocol ClaudeTokenStoring {
+    func load() -> String?
+    /// Returns true only if the token can be read back afterwards.
+    @discardableResult func save(_ token: String) -> Bool
+    /// Returns true only if nothing can be read back afterwards.
+    @discardableResult func delete() -> Bool
+}
+
+/// Keychain-backed store, on top of the app's existing `KeychainHelper` (the
+/// same generic-password service the OpenAI API key uses — see
+/// `LLMSettings.openAIAPIKey`).
+///
+/// **UserDefaults is not an option here and never becomes one.** This is a
+/// long-lived credential for the user's Claude account: `defaults read` would
+/// print it, it would ride along in a preferences backup, and it would sit in a
+/// plist that any process running as the user can read without prompting.
+///
+/// `key` is injectable so tests can use their own item and never read or
+/// clobber the real one — the same treatment `LLMSettings` gives
+/// `apiKeyKeychainKey`.
+struct KeychainClaudeTokenStore: ClaudeTokenStoring {
+
+    /// Keychain account name. Namespaced like every other `claudeSetup.*` key,
+    /// though this one is a keychain item and not a defaults key.
+    static let defaultKey = "claudeSetup.oauthToken"
+
+    let key: String
+
+    init(key: String = KeychainClaudeTokenStore.defaultKey) {
+        self.key = key
+    }
+
+    func load() -> String? {
+        guard let value = KeychainHelper.load(key: key),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    @discardableResult
+    func save(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        KeychainHelper.save(key: key, value: trimmed)
+        // Read back rather than trust the write. `KeychainHelper.save` swallows
+        // its `OSStatus`, and a keychain write can fail for reasons that have
+        // nothing to do with this app (a locked keychain, a duplicate item left
+        // by an older build).
+        return load() == trimmed
+    }
+
+    @discardableResult
+    func delete() -> Bool {
+        KeychainHelper.delete(key: key)
+        return load() == nil
+    }
+}

--- a/Mila/Models/ClaudeTokenStore.swift
+++ b/Mila/Models/ClaudeTokenStore.swift
@@ -62,6 +62,8 @@ struct KeychainClaudeTokenStore: ClaudeTokenStoring {
     @discardableResult
     func delete() -> Bool {
         KeychainHelper.delete(key: key)
-        return load() == nil
+        // `load() == nil` is NOT the check: it treats a read error as absence.
+        // Deletion of a credential succeeds only on positive proof of absence.
+        return KeychainHelper.isAbsent(key: key)
     }
 }

--- a/Mila/Models/KeychainHelper.swift
+++ b/Mila/Models/KeychainHelper.swift
@@ -39,4 +39,21 @@ enum KeychainHelper {
         ]
         SecItemDelete(query as CFDictionary)
     }
+
+    /// True only when the keychain positively reports the item absent.
+    ///
+    /// Not the same question as `load(key:) == nil`: `load` collapses every
+    /// non-success status to nil, so a read *error* (a locked keychain, say)
+    /// looks identical to "not there". A deletion verified through `load`
+    /// could therefore claim success over a credential still sitting in the
+    /// keychain. Only `errSecItemNotFound` is proof of absence.
+    static func isAbsent(key: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "io.island.mila.Mila",
+            kSecAttrAccount as String: key,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecItemNotFound
+    }
 }

--- a/Mila/Views/ClaudeSetupSection.swift
+++ b/Mila/Views/ClaudeSetupSection.swift
@@ -1,0 +1,334 @@
+import SwiftUI
+import AppKit
+
+/// Settings → AI Provider → "Set up Claude": the one-button managed install
+/// (issue #271).
+///
+/// Lives in its own file rather than inside `SettingsView.swift` because the
+/// section is a self-contained flow — install, guided login, test, sign out —
+/// with its own sheet, and `SettingsView.swift` is already long. The cost is
+/// that the private layout helpers there (`AICaption`, `aiLabelWidth`) are not
+/// visible here, so the few bits of chrome this needs are restated below with
+/// the same metrics.
+///
+/// ## Why this section exists at all
+///
+/// Everything it does was previously possible: install the CLI with a
+/// `curl … | bash` line, run `claude setup-token` in a terminal, and let
+/// `LLMRunner`'s `$PATH` search (#196) find the result. The section is here for
+/// the users who will not do that — for whom "open Terminal" is where the
+/// feature ends. So the design rule throughout is that no step asks the user to
+/// leave Mila except the one that genuinely cannot happen anywhere else:
+/// authorizing in their browser.
+struct ClaudeSetupSection: View {
+
+    @EnvironmentObject private var setup: ClaudeSetupSettings
+
+    /// The pasted code. Held here rather than in the settings object because it
+    /// is view state with a lifetime of exactly one sheet — and because a
+    /// half-typed authorization code has no business being reachable from the
+    /// app-wide model.
+    @State private var code = ""
+    @State private var showRemoveConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            statusRow
+            if case .installing(let progress) = setup.state {
+                installProgress(progress)
+            }
+            buttons
+            caption
+            if let result = setup.lastTestResult, !result.succeeded {
+                testFailure(result)
+            }
+            if setup.signOutFailed {
+                signOutWarning
+            }
+        }
+        .sheet(isPresented: sheetPresented) { codeSheet }
+        .confirmationDialog("Remove Claude from Mila?",
+                            isPresented: $showRemoveConfirmation,
+                            titleVisibility: .visible) {
+            Button("Sign out only") { setup.signOut() }
+            Button("Sign out and delete the binary", role: .destructive) {
+                setup.signOut(removeBinary: true)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Signing out removes the Claude credential from your Keychain. Deleting the binary also removes Mila's copy of the Claude CLI — a `claude` you installed yourself is never touched.")
+        }
+    }
+
+    // MARK: - Header and status
+
+    private var header: some View {
+        Text("Set up Claude")
+            .font(.callout.weight(.semibold))
+    }
+
+    private var statusRow: some View {
+        HStack(spacing: 6) {
+            Image(systemName: setup.status.symbolName)
+                .foregroundStyle(statusColor)
+                // A spinner would be more literal for `.working`, but the row
+                // has to hold its height across every state or the buttons
+                // below it jump on each transition.
+                .symbolRenderingMode(.hierarchical)
+            Text(setup.status.label)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .accessibilityIdentifier("ai.provider.claudeSetup.status")
+        .accessibilityElement(children: .combine)
+    }
+
+    private var statusColor: Color {
+        switch setup.status {
+        case .signedIn(let verified): return verified ? .green : .secondary
+        case .problem:                return .orange
+        case .working:                return .secondary
+        case .notSetUp,
+             .installedNotSignedIn:   return .secondary
+        }
+    }
+
+    private func installProgress(_ progress: Double) -> some View {
+        Group {
+            if progress >= 0 {
+                ProgressView(value: progress)
+            } else {
+                // Negative means the server did not send a length. An
+                // indeterminate bar is honest about that; a bar pinned at 0
+                // reads as a stalled download.
+                ProgressView()
+            }
+        }
+        .progressViewStyle(.linear)
+        .frame(maxWidth: captionWidth)
+    }
+
+    // MARK: - Buttons
+
+    /// One primary action whose label follows the state, plus the maintenance
+    /// actions once there is something to maintain. Deliberately not five
+    /// buttons at once: before setup there is exactly one thing to do.
+    @ViewBuilder
+    private var buttons: some View {
+        HStack(spacing: 8) {
+            switch setup.status {
+            case .notSetUp:
+                Button("Set up Claude") { setup.setUp() }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("ai.provider.claudeSetup.setUp")
+
+            case .installedNotSignedIn:
+                Button("Sign in to Claude") { setup.startSignIn() }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("ai.provider.claudeSetup.signIn")
+                reinstallButton
+
+            case .signedIn:
+                testButton
+                reinstallButton
+                Button("Sign out…") { showRemoveConfirmation = true }
+                    .accessibilityIdentifier("ai.provider.claudeSetup.signOut")
+
+            case .working:
+                Button("Cancel") { setup.cancelSignIn() }
+                    .accessibilityIdentifier("ai.provider.claudeSetup.cancel")
+
+            case .problem:
+                // A failure is the one state where "try the whole thing again"
+                // is the likeliest next action, so it gets the prominent slot
+                // regardless of how far the previous attempt got.
+                Button("Try again") { setup.setUp() }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("ai.provider.claudeSetup.retry")
+                if setup.isInstalled { reinstallButton }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var testButton: some View {
+        Button {
+            Task { await setup.test() }
+        } label: {
+            if setup.isTesting {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("Testing…")
+                }
+            } else {
+                Text("Test")
+            }
+        }
+        .disabled(setup.isTesting)
+        .accessibilityIdentifier("ai.provider.claudeSetup.test")
+    }
+
+    private var reinstallButton: some View {
+        Button("Reinstall") { setup.reinstall() }
+            .disabled(setup.state.isBusy)
+            .accessibilityIdentifier("ai.provider.claudeSetup.reinstall")
+    }
+
+    // MARK: - Captions
+
+    private var caption: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Mila downloads Anthropic's official Claude CLI, checks its Apple code signature before running it, and keeps it in its own folder. Your Claude subscription signs in through your browser.")
+            if setup.isInstalled {
+                Text(verbatim: setup.managedBinaryPath)
+                    .font(.caption2.monospaced())
+                    .textSelection(.enabled)
+                if let version = setup.installedVersion {
+                    Text("Version \(version)")
+                }
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: captionWidth, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func testFailure(_ result: LLMTestResult) -> some View {
+        // The Test button's own failure text. Kept to the setup error or the
+        // tail of stderr: this row is a status line, not the AI Provider test
+        // panel, which is where the full command and output already live.
+        Text(result.setupError ?? shortFailure(result))
+            .font(.caption)
+            .foregroundStyle(.orange)
+            .frame(maxWidth: captionWidth, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
+    }
+
+    private func shortFailure(_ result: LLMTestResult) -> String {
+        if result.timedOut { return "The test timed out." }
+        let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !stderr.isEmpty { return String(stderr.suffix(300)) }
+        return "The test exited with status \(result.exitCode.map(String.init) ?? "unknown")."
+    }
+
+    private var signOutWarning: some View {
+        Label {
+            Text("Mila could not remove the credential from your Keychain, so you are still signed in. Open Keychain Access and delete the \"\(KeychainClaudeTokenStore.defaultKey)\" item.")
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+        }
+        .frame(maxWidth: captionWidth, alignment: .leading)
+    }
+
+    // MARK: - Code sheet
+
+    /// The sheet is driven by the flow's own state, not by whether a session
+    /// object exists. The session is cleared on terminal states, and tying the
+    /// sheet to its lifetime would make dismissal depend on deallocation order.
+    private var sheetPresented: Binding<Bool> {
+        Binding(
+            get: {
+                switch setup.state {
+                case .awaitingCode, .verifying: return true
+                default: return false
+                }
+            },
+            set: { presented in
+                // Dismissing the sheet abandons the login; the child process
+                // has to go with it, or a pty sits waiting on a code nobody is
+                // going to type.
+                if !presented { setup.cancelSignIn() }
+            }
+        )
+    }
+
+    private var authorizationURL: URL? {
+        if case .awaitingCode(let url) = setup.state { return url }
+        return nil
+    }
+
+    private var isVerifying: Bool {
+        if case .verifying = setup.state { return true }
+        return false
+    }
+
+    private var codeSheet: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Finish signing in to Claude")
+                .font(.headline)
+
+            Text("Your browser should have opened Anthropic's sign-in page. Approve the request there, then copy the code it gives you and paste it below.")
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let authorizationURL {
+                Button("Open the sign-in page again") {
+                    NSWorkspace.shared.open(authorizationURL)
+                }
+                .buttonStyle(.link)
+                .accessibilityIdentifier("ai.provider.claudeSetup.reopenURL")
+            }
+
+            TextField("Paste the code here", text: $code)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .disabled(isVerifying)
+                .onSubmit(submit)
+                .accessibilityIdentifier("ai.provider.claudeSetup.code")
+
+            if let rejection = setup.session?.lastRejection {
+                Label {
+                    Text(rejection)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { setup.cancelSignIn() }
+                Button {
+                    submit()
+                } label: {
+                    if isVerifying {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small)
+                            Text("Checking…")
+                        }
+                    } else {
+                        Text("Continue")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isVerifying || code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityIdentifier("ai.provider.claudeSetup.submitCode")
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+
+    private func submit() {
+        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isVerifying else { return }
+        setup.submit(code: trimmed)
+        // Clear immediately: the code has been handed to the CLI, and leaving
+        // it in a `@State` string keeps a one-time credential alive in the view
+        // hierarchy for as long as Settings stays open.
+        code = ""
+    }
+
+    /// Matches `aiCaptionWidth` in `SettingsView.swift`, which is private to
+    /// that file.
+    private let captionWidth: CGFloat = 520
+}

--- a/Mila/Views/ClaudeSetupSection.swift
+++ b/Mila/Views/ClaudeSetupSection.swift
@@ -88,6 +88,10 @@ struct ClaudeSetupSection: View {
     private var statusColor: Color {
         switch setup.status {
         case .signedIn(let verified): return verified ? .green : .secondary
+        // Green even before a Test run: the user's own CLI being found IS the
+        // good state — rendering it grey made a working setup read as a chore
+        // still to do.
+        case .usingSystemCLI:         return .green
         case .problem:                return .orange
         case .working:                return .secondary
         case .notSetUp,
@@ -136,9 +140,25 @@ struct ClaudeSetupSection: View {
                 Button("Sign out…") { showRemoveConfirmation = true }
                     .accessibilityIdentifier("ai.provider.claudeSetup.signOut")
 
+            case .usingSystemCLI:
+                // Nothing to fix here, so no prominent button: Test to prove
+                // the login, and the managed install as an opt-in extra (it
+                // takes precedence once installed).
+                testButton
+                Button("Install Mila's own copy…") { setup.setUp() }
+                    .accessibilityIdentifier("ai.provider.claudeSetup.installManaged")
+
             case .working:
-                Button("Cancel") { setup.cancelSignIn() }
-                    .accessibilityIdentifier("ai.provider.claudeSetup.cancel")
+                if setup.isTesting {
+                    // A Test run is bounded (90s) and has no cancel path, so
+                    // showing a Cancel here would be a button that does
+                    // nothing. The spinner-labelled test button is the honest
+                    // rendering of this state.
+                    testButton
+                } else {
+                    Button("Cancel") { setup.cancelSignIn() }
+                        .accessibilityIdentifier("ai.provider.claudeSetup.cancel")
+                }
 
             case .problem:
                 // A failure is the one state where "try the whole thing again"
@@ -180,7 +200,14 @@ struct ClaudeSetupSection: View {
 
     private var caption: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text("Mila downloads Anthropic's official Claude CLI, checks its Apple code signature before running it, and keeps it in its own folder. Your Claude subscription signs in through your browser.")
+            if case .usingSystemCLI = setup.status, let path = setup.systemCLIPath {
+                Text("Mila found the Claude CLI you already installed and uses it as-is. Installing Mila's own copy is optional; it would take over from this one.")
+                Text(verbatim: path)
+                    .font(.caption2.monospaced())
+                    .textSelection(.enabled)
+            } else {
+                Text("Mila downloads Anthropic's official Claude CLI, checks its Apple code signature before running it, and keeps it in its own folder. Your Claude subscription signs in through your browser.")
+            }
             if setup.isInstalled {
                 Text(verbatim: setup.managedBinaryPath)
                     .font(.caption2.monospaced())

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1439,6 +1439,16 @@ private struct AIProviderSettingsTab: View {
 
                 if settings.tool != .none {
                     Divider()
+                    // The managed install belongs above the manual fields: for
+                    // a user who takes this path the Executable box below is
+                    // something they should never have to touch, and putting
+                    // the button underneath it implies the opposite order.
+                    // Claude-only — it is the only CLI Anthropic publishes a
+                    // signed, checksummed release feed for (issue #271).
+                    if settings.tool == .claude {
+                        ClaudeSetupSection()
+                        Divider()
+                    }
                     if settings.isOpenAICompatible { endpointFields } else { cliFields }
                     timeoutRow
                     Divider()

--- a/MilaTests/ClaudeBinaryInstallerTests.swift
+++ b/MilaTests/ClaudeBinaryInstallerTests.swift
@@ -279,6 +279,12 @@ final class ClaudeBinaryInstallerTests: XCTestCase {
 
         let contents = try Data(contentsOf: installedBinary)
         XCTAssertEqual(contents, downloader.payload)
+        // The old file above was written 0644. `replaceItemAt` preserves the
+        // DESTINATION's permissions by default, so without the re-chmod in
+        // `moveIntoPlace` this reinstall would produce a non-executable binary
+        // that `isInstalled` and `resolveExecutable` both refuse.
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installedBinary.path),
+                      "a reinstall over a non-executable leftover must still produce an executable binary")
     }
 
     func test_removal_reports_whether_the_binary_is_actually_gone() throws {

--- a/MilaTests/ClaudeBinaryInstallerTests.swift
+++ b/MilaTests/ClaudeBinaryInstallerTests.swift
@@ -1,0 +1,361 @@
+import XCTest
+@testable import Mila
+
+/// Serves a scripted release feed. No network: the installer's transport is a
+/// protocol precisely so the download/verify/install ordering can be driven
+/// over fixtures.
+private final class FakeDownloader: ClaudeBinaryDownloading {
+    var version = "2.1.263"
+    var manifestJSON: String?
+    var payload = Data("#!/bin/sh\necho claude\n".utf8)
+    /// Bytes actually written, which may differ from `payload` to simulate a
+    /// truncated transfer.
+    var truncateTo: Int?
+    var dataError: Error?
+    var downloadError: Error?
+    private(set) var requestedURLs: [URL] = []
+    private(set) var progressReports: [Double] = []
+
+    func data(from url: URL) async throws -> Data {
+        requestedURLs.append(url)
+        if let dataError { throw dataError }
+        if url.lastPathComponent == "latest" { return Data(version.utf8) }
+        if let manifestJSON { return Data(manifestJSON.utf8) }
+        throw ClaudeInstallError.versionLookupFailed("no manifest scripted")
+    }
+
+    func downloadFile(from url: URL,
+                      to destination: URL,
+                      progress: @escaping (Double) -> Void) async throws {
+        requestedURLs.append(url)
+        if let downloadError { throw downloadError }
+        progress(0.5)
+        progress(1.0)
+        progressReports = [0.5, 1.0]
+        let bytes = truncateTo.map { Data(payload.prefix($0)) } ?? payload
+        try bytes.write(to: destination)
+    }
+}
+
+/// Reports whatever identity the test wants, so the REFUSAL paths can be
+/// exercised — a unit test cannot produce a genuinely Anthropic-signed Mach-O,
+/// and a check only ever run on the happy path is a check nobody has seen fail.
+private final class FakeVerifier: ClaudeSignatureVerifying {
+    var identity: ClaudeSignatureIdentity
+    var error: Error?
+    private(set) var examined: [URL] = []
+
+    init(identity: ClaudeSignatureIdentity) { self.identity = identity }
+
+    static var anthropic: ClaudeSignatureIdentity {
+        ClaudeSignatureIdentity(teamIdentifier: ClaudeManagedInstall.anthropicTeamIdentifier,
+                                signingIdentifier: ClaudeManagedInstall.claudeSigningIdentifier,
+                                isValid: true)
+    }
+
+    func identity(ofBinaryAt url: URL) throws -> ClaudeSignatureIdentity {
+        examined.append(url)
+        if let error { throw error }
+        return identity
+    }
+}
+
+/// Download → size → checksum → signature → install (issue #271).
+///
+/// The ordering is the point: nothing reaches the path `LLMRunner` resolves
+/// until every check has passed, and a refused download leaves nothing on disk.
+final class ClaudeBinaryInstallerTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeBinaryInstallerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private var installedBinary: URL { ClaudeManagedInstall.binaryURL(appSupportRoot: root) }
+    private var staging: URL { ClaudeManagedInstall.stagingDirectory(appSupportRoot: root) }
+
+    /// A manifest listing BOTH macOS builds, so the suite passes on an Apple
+    /// Silicon and an Intel test host alike.
+    private func manifest(checksum: String, size: Int64?) -> String {
+        let sizeField = size.map { "\"size\": \($0)," } ?? ""
+        return """
+        {"version": "2.1.263",
+         "platforms": {
+           "darwin-arm64": {\(sizeField) "checksum": "\(checksum)"},
+           "darwin-x64":   {\(sizeField) "checksum": "\(checksum)"}}}
+        """
+    }
+
+    private func makeInstaller(downloader: FakeDownloader,
+                               verifier: FakeVerifier) -> ClaudeBinaryInstaller {
+        ClaudeBinaryInstaller(downloader: downloader,
+                              verifier: verifier,
+                              fileManager: .default,
+                              appSupportRoot: root)
+    }
+
+    // MARK: - Happy path
+
+    func test_a_verified_download_is_installed_and_executable() async throws {
+        let downloader = FakeDownloader()
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest,
+                                           size: Int64(downloader.payload.count))
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        var seen: [Double] = []
+        let result = try await makeInstaller(downloader: downloader, verifier: verifier)
+            .install { seen.append($0) }
+
+        XCTAssertEqual(result.version, "2.1.263")
+        XCTAssertEqual(result.binary.path, installedBinary.path)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installedBinary.path))
+        XCTAssertEqual(seen, [0.5, 1.0], "progress is reported while downloading")
+        XCTAssertEqual(verifier.examined.count, 1, "the signature was actually checked")
+
+        // The staged copy is gone: the only survivor is the installed binary.
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: staging.path)) ?? []
+        XCTAssertTrue(leftovers.isEmpty, "staging is empty after a successful install, got \(leftovers)")
+    }
+
+    func test_the_signature_is_checked_before_anything_is_installed() async throws {
+        let downloader = FakeDownloader()
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest, size: nil)
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+
+        // The file the verifier looked at was the STAGED one, not the installed
+        // path — i.e. verification happened before the move.
+        let examined = try XCTUnwrap(verifier.examined.first)
+        XCTAssertNotEqual(examined.path, installedBinary.path)
+        XCTAssertTrue(examined.path.hasPrefix(staging.path))
+    }
+
+    // MARK: - Refusals
+
+    func test_a_checksum_mismatch_refuses_and_leaves_nothing_behind() async throws {
+        let downloader = FakeDownloader()
+        downloader.manifestJSON = manifest(checksum: String(repeating: "a", count: 64), size: nil)
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a checksum refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .checksumMismatch = error else {
+                return XCTFail("expected checksumMismatch, got \(error)")
+            }
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installedBinary.path),
+                       "an unverified binary must never reach the resolution path")
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: staging.path)) ?? []
+        XCTAssertTrue(leftovers.isEmpty, "the staged file is deleted too, got \(leftovers)")
+        XCTAssertTrue(verifier.examined.isEmpty, "a bad checksum short-circuits before signing")
+    }
+
+    func test_a_truncated_download_is_reported_as_a_short_transfer() async throws {
+        let downloader = FakeDownloader()
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest,
+                                           size: Int64(downloader.payload.count))
+        downloader.truncateTo = 4
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a size refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .sizeMismatch(let expected, let actual) = error else {
+                return XCTFail("expected sizeMismatch, got \(error)")
+            }
+            XCTAssertEqual(actual, 4)
+            XCTAssertEqual(expected, Int64(downloader.payload.count))
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installedBinary.path))
+    }
+
+    /// A correctly-signed binary from the wrong publisher — the case a checksum
+    /// served by the same compromised host could not catch.
+    func test_a_binary_signed_by_someone_else_is_refused() async throws {
+        let downloader = FakeDownloader()
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest, size: nil)
+        let verifier = FakeVerifier(identity: ClaudeSignatureIdentity(
+            teamIdentifier: "XXXXXXXXXX",
+            signingIdentifier: "com.example.not-claude",
+            isValid: true))
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a publisher refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .wrongPublisher = error else {
+                return XCTFail("expected wrongPublisher, got \(error)")
+            }
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installedBinary.path))
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: staging.path)) ?? []
+        XCTAssertTrue(leftovers.isEmpty)
+    }
+
+    func test_an_unsigned_or_broken_signature_is_refused() async throws {
+        let downloader = FakeDownloader()
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest, size: nil)
+        let verifier = FakeVerifier(identity: ClaudeSignatureIdentity(
+            teamIdentifier: ClaudeManagedInstall.anthropicTeamIdentifier,
+            signingIdentifier: ClaudeManagedInstall.claudeSigningIdentifier,
+            isValid: false))
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a signature refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .signatureInvalid = error else {
+                return XCTFail("expected signatureInvalid, got \(error)")
+            }
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installedBinary.path))
+    }
+
+    /// An HTML error page from a captive portal, rather than a version string.
+    func test_a_junk_version_response_fails_before_any_url_is_built_from_it() async throws {
+        let downloader = FakeDownloader()
+        downloader.version = "<!DOCTYPE html><html>Access denied</html>"
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a version-lookup refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .versionLookupFailed = error else {
+                return XCTFail("expected versionLookupFailed, got \(error)")
+            }
+        }
+        XCTAssertEqual(downloader.requestedURLs.count, 1, "no manifest fetch was attempted")
+    }
+
+    func test_a_manifest_without_this_platform_is_refused() async throws {
+        let downloader = FakeDownloader()
+        downloader.manifestJSON = """
+        {"version": "2.1.263", "platforms": {"linux-x64": {"checksum": "\(String(repeating: "a", count: 64))"}}}
+        """
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        do {
+            _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+            XCTFail("expected a manifest refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .manifestMissingPlatform = error else {
+                return XCTFail("expected manifestMissingPlatform, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Reinstall and removal
+
+    func test_reinstalling_replaces_an_existing_binary() async throws {
+        try FileManager.default.createDirectory(at: installedBinary.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: installedBinary)
+
+        let downloader = FakeDownloader()
+        downloader.payload = Data("#!/bin/sh\necho new\n".utf8)
+        let digest = ClaudeBinaryVerification.sha256Hex(of: downloader.payload)
+        downloader.manifestJSON = manifest(checksum: digest, size: nil)
+        let verifier = FakeVerifier(identity: FakeVerifier.anthropic)
+
+        _ = try await makeInstaller(downloader: downloader, verifier: verifier).install()
+
+        let contents = try Data(contentsOf: installedBinary)
+        XCTAssertEqual(contents, downloader.payload)
+    }
+
+    func test_removal_reports_whether_the_binary_is_actually_gone() throws {
+        try FileManager.default.createDirectory(at: installedBinary.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: installedBinary)
+
+        let installer = ClaudeBinaryInstaller(downloader: FakeDownloader(),
+                                              verifier: FakeVerifier(identity: FakeVerifier.anthropic),
+                                              fileManager: .default,
+                                              appSupportRoot: root)
+        XCTAssertTrue(installer.removeManagedBinary())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installedBinary.path))
+        XCTAssertTrue(installer.removeManagedBinary(), "removing nothing still ends with nothing there")
+    }
+
+    // MARK: - Verification primitives
+
+    func test_accept_distinguishes_a_broken_signature_from_a_wrong_publisher() {
+        XCTAssertNil(ClaudeBinaryVerification.accept(FakeVerifier.anthropic))
+
+        let broken = ClaudeSignatureIdentity(teamIdentifier: ClaudeManagedInstall.anthropicTeamIdentifier,
+                                             signingIdentifier: ClaudeManagedInstall.claudeSigningIdentifier,
+                                             isValid: false)
+        guard case .signatureInvalid? = ClaudeBinaryVerification.accept(broken) else {
+            return XCTFail("a broken signature and a wrong publisher send users to different places")
+        }
+
+        // Anthropic's team, but a different product from that team.
+        let otherProduct = ClaudeSignatureIdentity(
+            teamIdentifier: ClaudeManagedInstall.anthropicTeamIdentifier,
+            signingIdentifier: "com.anthropic.something-else",
+            isValid: true)
+        guard case .wrongPublisher? = ClaudeBinaryVerification.accept(otherProduct) else {
+            return XCTFail("the signing identifier pins WHICH Anthropic binary this is")
+        }
+    }
+
+    func test_the_designated_requirement_anchors_to_apple_and_pins_both_identities() {
+        let requirement = ClaudeBinaryVerification.designatedRequirement
+        XCTAssertTrue(requirement.contains("anchor apple generic"),
+                      "without the anchor, a self-signed binary claiming the team ID would pass")
+        XCTAssertTrue(requirement.contains(ClaudeManagedInstall.anthropicTeamIdentifier))
+        XCTAssertTrue(requirement.contains(ClaudeManagedInstall.claudeSigningIdentifier))
+    }
+
+    func test_digest_comparison_is_case_insensitive_and_length_strict() {
+        let digest = String(repeating: "ab", count: 32)
+        XCTAssertTrue(ClaudeBinaryVerification.digestsMatch(digest, digest.uppercased()))
+        XCTAssertFalse(ClaudeBinaryVerification.digestsMatch(digest, String(digest.dropLast())))
+        XCTAssertFalse(ClaudeBinaryVerification.digestsMatch("", ""))
+    }
+
+    func test_streaming_and_in_memory_hashes_agree() throws {
+        // The binary is hashed in chunks to keep ~200 MB out of memory; that
+        // must produce the same digest as hashing the bytes directly.
+        let payload = Data((0..<(3 * (1 << 20) + 17)).map { UInt8($0 % 251) })
+        let file = root.appendingPathComponent("payload.bin")
+        try payload.write(to: file)
+
+        XCTAssertEqual(try ClaudeBinaryVerification.sha256Hex(ofFileAt: file),
+                       ClaudeBinaryVerification.sha256Hex(of: payload))
+    }
+
+    /// The real transport refuses an off-host URL before it opens a connection,
+    /// so this needs no network.
+    func test_the_real_downloader_refuses_an_untrusted_url() async {
+        let downloader = URLSessionClaudeDownloader()
+        do {
+            _ = try await downloader.data(from: URL(string: "https://evil.example.com/latest")!)
+            XCTFail("expected a refusal")
+        } catch let error as ClaudeInstallError {
+            guard case .untrustedURL = error else {
+                return XCTFail("expected untrustedURL, got \(error)")
+            }
+        } catch {
+            XCTFail("expected ClaudeInstallError, got \(error)")
+        }
+    }
+}

--- a/MilaTests/ClaudeManagedInstallTests.swift
+++ b/MilaTests/ClaudeManagedInstallTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import Mila
+
+/// The pure rules behind the managed Claude install (issue #271): which release
+/// artifact is fetched, which URLs Mila will talk to, which binary a run picks,
+/// and — the one with teeth — which child processes are handed the stored
+/// credential.
+///
+/// Nothing here touches the network, the Keychain or a real `claude`.
+final class ClaudeManagedInstallTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeManagedInstallTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// A file that `isExecutableFile` will accept, so resolution tests exercise
+    /// the real check rather than a stub.
+    @discardableResult
+    private func makeExecutable(_ url: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("#!/bin/sh\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: url.path)
+        return url
+    }
+
+    // MARK: - Version and platform guards
+
+    func test_version_guard_accepts_release_and_prerelease_shapes() {
+        XCTAssertTrue(ClaudeManagedInstall.isPlausibleVersion("2.1.263"))
+        XCTAssertTrue(ClaudeManagedInstall.isPlausibleVersion("0.0.1"))
+        XCTAssertTrue(ClaudeManagedInstall.isPlausibleVersion("2.1.263-beta.1"))
+    }
+
+    /// The guard exists because the version string comes off the network and is
+    /// then interpolated into a URL path. Traversal is the case that matters.
+    func test_version_guard_refuses_traversal_and_junk() {
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion("2.1.263/../../evil"))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion("../../etc"))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion("<!DOCTYPE html>"))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion(""))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion("2.1"))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion("v2.1.263"))
+        XCTAssertFalse(ClaudeManagedInstall.isPlausibleVersion(String(repeating: "1", count: 200)))
+    }
+
+    func test_manifest_and_binary_urls_match_the_official_installer_layout() throws {
+        let manifest = try XCTUnwrap(ClaudeManagedInstall.manifestURL(version: "2.1.263"))
+        XCTAssertEqual(manifest.absoluteString,
+                       "https://downloads.claude.ai/claude-code-releases/2.1.263/manifest.json")
+
+        let binary = try XCTUnwrap(ClaudeManagedInstall.binaryDownloadURL(version: "2.1.263",
+                                                                         platform: "darwin-arm64"))
+        XCTAssertEqual(binary.absoluteString,
+                       "https://downloads.claude.ai/claude-code-releases/2.1.263/darwin-arm64/claude")
+
+        XCTAssertEqual(ClaudeManagedInstall.latestVersionURL.absoluteString,
+                       "https://downloads.claude.ai/claude-code-releases/latest")
+    }
+
+    func test_url_builders_refuse_a_bad_version_or_platform() {
+        XCTAssertNil(ClaudeManagedInstall.manifestURL(version: "../evil"))
+        XCTAssertNil(ClaudeManagedInstall.binaryDownloadURL(version: "2.1.263",
+                                                            platform: "linux-x64"))
+        XCTAssertNil(ClaudeManagedInstall.binaryDownloadURL(version: "2.1.263",
+                                                            platform: "../../etc"))
+    }
+
+    func test_only_https_on_the_release_host_is_trusted() {
+        XCTAssertTrue(ClaudeManagedInstall.isTrusted(
+            URL(string: "https://downloads.claude.ai/claude-code-releases/latest")!))
+
+        // http, a lookalike subdomain, a different host, and a userinfo trick.
+        XCTAssertFalse(ClaudeManagedInstall.isTrusted(
+            URL(string: "http://downloads.claude.ai/claude-code-releases/latest")!))
+        XCTAssertFalse(ClaudeManagedInstall.isTrusted(
+            URL(string: "https://downloads.claude.ai.evil.com/x")!))
+        XCTAssertFalse(ClaudeManagedInstall.isTrusted(
+            URL(string: "https://evil.com/claude-code-releases/latest")!))
+        XCTAssertFalse(ClaudeManagedInstall.isTrusted(
+            URL(string: "https://downloads.claude.ai@evil.com/x")!))
+    }
+
+    /// Mirrors `install.sh`: arm64 natively, x64 natively, and — the correction
+    /// that is easy to miss — the NATIVE arm64 build when an x86_64 process is
+    /// running translated under Rosetta on Apple Silicon.
+    func test_platform_key_follows_the_machine_including_rosetta() {
+        XCTAssertEqual(ClaudeManagedInstall.platformKey(machine: "arm64", isTranslated: false),
+                       "darwin-arm64")
+        XCTAssertEqual(ClaudeManagedInstall.platformKey(machine: "x86_64", isTranslated: false),
+                       "darwin-x64")
+        XCTAssertEqual(ClaudeManagedInstall.platformKey(machine: "x86_64", isTranslated: true),
+                       "darwin-arm64")
+        XCTAssertNil(ClaudeManagedInstall.platformKey(machine: "ppc", isTranslated: false))
+    }
+
+    // MARK: - Manifest decoding
+
+    func test_manifest_reads_the_platform_checksum_and_ignores_unknown_fields() throws {
+        let json = """
+        {
+          "version": "2.1.263",
+          "commit": "deadbeef",
+          "somethingNew": {"we": "ignore"},
+          "platforms": {
+            "darwin-arm64": {"checksum": "\(String(repeating: "a", count: 64))", "size": 1234},
+            "linux-x64": {"checksum": "\(String(repeating: "b", count: 64))", "size": 99}
+          }
+        }
+        """
+        let manifest = try JSONDecoder().decode(ClaudeManagedInstall.ReleaseManifest.self,
+                                                from: Data(json.utf8))
+        XCTAssertEqual(manifest.checksum(for: "darwin-arm64"), String(repeating: "a", count: 64))
+        XCTAssertEqual(manifest.expectedSize(for: "darwin-arm64"), 1234)
+        XCTAssertNil(manifest.checksum(for: "darwin-x64"), "platform absent from the manifest")
+    }
+
+    /// A malformed checksum reads as ABSENT, not as a value to compare against —
+    /// otherwise every download "fails verification" and the message blames the
+    /// download rather than the manifest.
+    func test_manifest_treats_a_malformed_checksum_as_missing() throws {
+        let json = """
+        {"platforms": {"darwin-arm64": {"checksum": "not-a-digest", "size": 10},
+                       "darwin-x64": {"checksum": "\(String(repeating: "z", count: 64))", "size": 10}}}
+        """
+        let manifest = try JSONDecoder().decode(ClaudeManagedInstall.ReleaseManifest.self,
+                                                from: Data(json.utf8))
+        XCTAssertNil(manifest.checksum(for: "darwin-arm64"), "too short and non-hex")
+        XCTAssertNil(manifest.checksum(for: "darwin-x64"), "right length but not hex")
+    }
+
+    // MARK: - Executable resolution order
+
+    func test_managed_install_is_preferred_over_the_path_search() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let onPath = try makeExecutable(root.appendingPathComponent("usr-local-bin/claude"))
+
+        let resolved = try LLMRunner.resolveExecutable(tool: .claude,
+                                                       override: nil,
+                                                       managedBinary: managed,
+                                                       lookup: { _ in onPath })
+        XCTAssertEqual(resolved.path, managed.path,
+                       "a user who pressed Set up Claude must get the binary Mila installed")
+    }
+
+    func test_path_search_is_used_when_nothing_is_managed() throws {
+        let onPath = try makeExecutable(root.appendingPathComponent("usr-local-bin/claude"))
+        let missing = root.appendingPathComponent("managed/claude")
+
+        let resolved = try LLMRunner.resolveExecutable(tool: .claude,
+                                                       override: nil,
+                                                       managedBinary: missing,
+                                                       lookup: { _ in onPath })
+        XCTAssertEqual(resolved.path, onPath.path)
+    }
+
+    /// The override is Mila's own "run this one instead" control. A managed
+    /// install that silently beat it would make the field impossible to use.
+    func test_explicit_override_still_beats_the_managed_install() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let custom = try makeExecutable(root.appendingPathComponent("custom/claude-shim"))
+
+        let resolved = try LLMRunner.resolveExecutable(tool: .claude,
+                                                       override: custom.path,
+                                                       managedBinary: managed,
+                                                       lookup: { _ in nil })
+        XCTAssertEqual(resolved.path, custom.path)
+    }
+
+    /// Only `.claude` has a managed install; the other CLIs are whatever the
+    /// user installed. Without this the managed `claude` would be launched as
+    /// `cursor-agent`.
+    func test_other_tools_ignore_the_managed_binary() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let cursor = try makeExecutable(root.appendingPathComponent("usr-local-bin/cursor-agent"))
+
+        let resolved = try LLMRunner.resolveExecutable(tool: .cursor,
+                                                       override: nil,
+                                                       managedBinary: managed,
+                                                       lookup: { _ in cursor })
+        XCTAssertEqual(resolved.path, cursor.path)
+    }
+
+    func test_resolution_throws_when_there_is_nothing_to_run() {
+        let missing = root.appendingPathComponent("managed/claude")
+        XCTAssertThrowsError(try LLMRunner.resolveExecutable(tool: .claude,
+                                                             override: nil,
+                                                             managedBinary: missing,
+                                                             lookup: { _ in nil }))
+    }
+
+    // MARK: - Token injection
+
+    func test_token_is_injected_only_for_the_managed_binary() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+
+        let env = LLMRunner.childEnvironment(for: managed,
+                                             base: ["PATH": "/usr/bin"],
+                                             managedBinary: managed,
+                                             managedToken: { "sk-ant-oat-secret" })
+        XCTAssertEqual(env[ClaudeManagedInstall.oauthTokenEnvironmentKey], "sk-ant-oat-secret")
+    }
+
+    /// The failure that would be silent and confusing: overriding the login a
+    /// user already has on their own `claude`, possibly for a different account.
+    func test_a_system_claude_never_receives_milas_token() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let system = try makeExecutable(root.appendingPathComponent("usr-local-bin/claude"))
+
+        let env = LLMRunner.childEnvironment(for: system,
+                                             base: ["PATH": "/usr/bin"],
+                                             managedBinary: managed,
+                                             managedToken: { "sk-ant-oat-secret" })
+        XCTAssertNil(env[ClaudeManagedInstall.oauthTokenEnvironmentKey])
+    }
+
+    /// The user's own deliberate configuration is left alone — Mila neither
+    /// overwrites nor unsets it for a binary that is not the managed one.
+    func test_an_inherited_token_is_left_untouched_for_a_system_binary() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let system = try makeExecutable(root.appendingPathComponent("usr-local-bin/claude"))
+
+        let env = LLMRunner.childEnvironment(
+            for: system,
+            base: ["PATH": "/usr/bin",
+                   ClaudeManagedInstall.oauthTokenEnvironmentKey: "user-set-value"],
+            managedBinary: managed,
+            managedToken: { "sk-ant-oat-secret" })
+        XCTAssertEqual(env[ClaudeManagedInstall.oauthTokenEnvironmentKey], "user-set-value")
+    }
+
+    /// The Keychain read is behind a closure so it happens only when it can
+    /// matter. A run of `cursor-agent` or a system `claude` must not prompt or
+    /// touch the keychain at all.
+    func test_the_keychain_is_not_read_when_the_binary_is_not_managed() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let system = try makeExecutable(root.appendingPathComponent("usr-local-bin/claude"))
+
+        var reads = 0
+        _ = LLMRunner.childEnvironment(for: system,
+                                       base: ["PATH": "/usr/bin"],
+                                       managedBinary: managed,
+                                       managedToken: { reads += 1; return "sk-ant-oat-secret" })
+        XCTAssertEqual(reads, 0, "no keychain access for a binary Mila did not install")
+
+        _ = LLMRunner.childEnvironment(for: managed,
+                                       base: ["PATH": "/usr/bin"],
+                                       managedBinary: managed,
+                                       managedToken: { reads += 1; return "sk-ant-oat-secret" })
+        XCTAssertEqual(reads, 1, "read exactly once for the managed binary")
+    }
+
+    func test_no_token_no_variable() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+
+        XCTAssertNil(LLMRunner.childEnvironment(for: managed,
+                                                base: ["PATH": "/usr/bin"],
+                                                managedBinary: managed,
+                                                managedToken: { nil })[
+            ClaudeManagedInstall.oauthTokenEnvironmentKey])
+
+        XCTAssertNil(LLMRunner.childEnvironment(for: managed,
+                                                base: ["PATH": "/usr/bin"],
+                                                managedBinary: managed,
+                                                managedToken: { "   " })[
+            ClaudeManagedInstall.oauthTokenEnvironmentKey])
+    }
+
+    /// An "Executable" override pointing AT the managed binary is the same file,
+    /// so it still gets the credential — the comparison is on resolved paths,
+    /// not on how the URL was spelled.
+    func test_an_unstandardized_path_to_the_managed_binary_still_matches() throws {
+        let managed = try makeExecutable(root.appendingPathComponent("managed/claude"))
+        let awkward = root.appendingPathComponent("managed/./claude")
+
+        let additions = ClaudeManagedInstall.environmentAdditions(executable: awkward,
+                                                                  managedBinary: managed,
+                                                                  token: "sk-ant-oat-secret")
+        XCTAssertEqual(additions[ClaudeManagedInstall.oauthTokenEnvironmentKey],
+                       "sk-ant-oat-secret")
+    }
+
+    // MARK: - Layout
+
+    func test_the_managed_binary_lives_under_milas_own_bin_directory() {
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: root)
+        XCTAssertEqual(binary.path, root.appendingPathComponent("Mila/bin/claude").path)
+    }
+
+    /// Staging must not be reachable by resolution: an unverified download must
+    /// never be findable by anything that would run it.
+    func test_staging_is_not_the_resolved_binary_path() {
+        let staging = ClaudeManagedInstall.stagingDirectory(appSupportRoot: root)
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: root)
+        XCTAssertNotEqual(staging.path, binary.deletingLastPathComponent().path)
+        XCTAssertFalse(binary.path.hasPrefix(staging.path))
+    }
+}

--- a/MilaTests/ClaudeSetupSettingsTests.swift
+++ b/MilaTests/ClaudeSetupSettingsTests.swift
@@ -64,13 +64,18 @@ final class ClaudeSetupSettingsTests: XCTestCase {
     }
 
     private func makeSettings(tokenStore: ClaudeTokenStoring,
-                              testResult: LLMTestResult = LLMTestResult(succeeded: true))
+                              testResult: LLMTestResult = LLMTestResult(succeeded: true),
+                              systemCLI: URL? = nil)
     -> ClaudeSetupSettings {
         ClaudeSetupSettings(defaults: defaults,
                             tokenStore: tokenStore,
                             appSupportRoot: root,
                             openURL: { _ in XCTFail("no browser should open in a test") },
-                            runTest: { _, _ in testResult })
+                            runTest: { _, _ in testResult },
+                            // Explicit even when nil: the production default
+                            // searches the real machine, and a claude on the
+                            // test host's PATH must not leak into these tests.
+                            systemCLILookup: { systemCLI })
     }
 
     // MARK: - Status
@@ -79,6 +84,73 @@ final class ClaudeSetupSettingsTests: XCTestCase {
         let settings = makeSettings(tokenStore: InMemoryTokenStore())
         XCTAssertEqual(settings.status, .notSetUp)
         XCTAssertFalse(settings.status.isReady)
+    }
+
+    /// A claude the user installed themselves is a complete setup: the row
+    /// must show it as good (and ready), not as "Not set up".
+    func test_a_system_cli_shows_as_using_your_cli_not_as_not_set_up() {
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(),
+                                    systemCLI: URL(fileURLWithPath: "/opt/somewhere/claude"))
+        XCTAssertEqual(settings.status, .usingSystemCLI(verified: false))
+        XCTAssertTrue(settings.status.isReady)
+        XCTAssertEqual(settings.systemCLIPath, "/opt/somewhere/claude")
+    }
+
+    /// The managed copy is what `LLMRunner` prefers, so once it exists the row
+    /// must describe IT — even when a system claude is also present.
+    func test_a_managed_install_takes_precedence_over_a_system_cli() throws {
+        try installFakeBinary()
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(),
+                                    systemCLI: URL(fileURLWithPath: "/opt/somewhere/claude"))
+        XCTAssertEqual(settings.status, .installedNotSignedIn)
+    }
+
+    /// Test against the system CLI: verifies, persists, and restores — but
+    /// only for the same binary path the proof was recorded against.
+    func test_a_passing_test_verifies_the_system_cli_and_survives_relaunch() async {
+        let cli = URL(fileURLWithPath: "/opt/somewhere/claude")
+        var testedPath: String?
+        let settings = ClaudeSetupSettings(defaults: defaults,
+                                           tokenStore: InMemoryTokenStore(),
+                                           appSupportRoot: root,
+                                           openURL: { _ in XCTFail("no browser in tests") },
+                                           runTest: { binary, _ in
+                                               testedPath = binary.path
+                                               return LLMTestResult(succeeded: true)
+                                           },
+                                           systemCLILookup: { cli })
+
+        await settings.test()
+
+        XCTAssertEqual(testedPath, cli.path, "the Test must run the system CLI when no managed copy exists")
+        XCTAssertEqual(settings.status, .usingSystemCLI(verified: true))
+
+        let relaunched = makeSettings(tokenStore: InMemoryTokenStore(), systemCLI: cli)
+        XCTAssertEqual(relaunched.status, .usingSystemCLI(verified: true),
+                       "verification recorded for the system CLI must restore on relaunch")
+
+        let differentCLI = makeSettings(tokenStore: InMemoryTokenStore(),
+                                        systemCLI: URL(fileURLWithPath: "/usr/other/claude"))
+        XCTAssertEqual(differentCLI.status, .usingSystemCLI(verified: false),
+                       "a proof about one binary must not transfer to a different one")
+    }
+
+    /// With neither binary present, Test must be a no-op rather than a run
+    /// against a path that does not exist.
+    func test_test_does_nothing_with_no_binary_anywhere() async {
+        var ran = false
+        let settings = ClaudeSetupSettings(defaults: defaults,
+                                           tokenStore: InMemoryTokenStore(),
+                                           appSupportRoot: root,
+                                           openURL: { _ in XCTFail("no browser in tests") },
+                                           runTest: { _, _ in
+                                               ran = true
+                                               return LLMTestResult(succeeded: true)
+                                           },
+                                           systemCLILookup: { nil })
+        await settings.test()
+        XCTAssertFalse(ran)
+        XCTAssertNil(settings.lastTestResult)
     }
 
     func test_status_is_installed_but_not_signed_in_without_a_token() throws {

--- a/MilaTests/ClaudeSetupSettingsTests.swift
+++ b/MilaTests/ClaudeSetupSettingsTests.swift
@@ -1,0 +1,293 @@
+import XCTest
+@testable import Mila
+
+/// In-memory `ClaudeTokenStoring`, plus a switch to make `delete` fail — the
+/// case the sign-out affordance exists to handle honestly.
+private final class InMemoryTokenStore: ClaudeTokenStoring {
+    private var token: String?
+    var refuseDelete = false
+    var refuseSave = false
+
+    init(token: String? = nil) { self.token = token }
+
+    func load() -> String? { token }
+
+    @discardableResult
+    func save(_ token: String) -> Bool {
+        guard !refuseSave else { return false }
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        self.token = trimmed
+        return true
+    }
+
+    @discardableResult
+    func delete() -> Bool {
+        guard !refuseDelete else { return false }
+        token = nil
+        return true
+    }
+}
+
+/// `ClaudeSetupSettings` — the status the Settings row renders, the persisted
+/// verification, and sign-out (issue #271).
+@MainActor
+final class ClaudeSetupSettingsTests: XCTestCase {
+
+    private var root: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeSetupSettingsTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        // Isolated suite, per CLAUDE.md: never `.standard`.
+        suiteName = "ClaudeSetupSettingsTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// Put an executable at the managed path, so `isInstalled` is answered by
+    /// the real filesystem check rather than a stub.
+    private func installFakeBinary() throws {
+        let binary = ClaudeManagedInstall.binaryURL(appSupportRoot: root)
+        try FileManager.default.createDirectory(at: binary.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("#!/bin/sh\n".utf8).write(to: binary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                              ofItemAtPath: binary.path)
+    }
+
+    private func makeSettings(tokenStore: ClaudeTokenStoring,
+                              testResult: LLMTestResult = LLMTestResult(succeeded: true))
+    -> ClaudeSetupSettings {
+        ClaudeSetupSettings(defaults: defaults,
+                            tokenStore: tokenStore,
+                            appSupportRoot: root,
+                            openURL: { _ in XCTFail("no browser should open in a test") },
+                            runTest: { _, _ in testResult })
+    }
+
+    // MARK: - Status
+
+    func test_status_is_not_set_up_with_no_binary() {
+        let settings = makeSettings(tokenStore: InMemoryTokenStore())
+        XCTAssertEqual(settings.status, .notSetUp)
+        XCTAssertFalse(settings.status.isReady)
+    }
+
+    func test_status_is_installed_but_not_signed_in_without_a_token() throws {
+        try installFakeBinary()
+        let settings = makeSettings(tokenStore: InMemoryTokenStore())
+        XCTAssertEqual(settings.status, .installedNotSignedIn)
+        XCTAssertFalse(settings.status.isReady)
+    }
+
+    /// A token alone is "signed in", not "signed in and working" — nothing has
+    /// been run yet.
+    func test_status_is_signed_in_unverified_with_a_token_but_no_test() throws {
+        try installFakeBinary()
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        XCTAssertEqual(settings.status, .signedIn(verified: false))
+        XCTAssertTrue(settings.status.isReady)
+    }
+
+    func test_a_passing_test_upgrades_the_status_to_verified() async throws {
+        try installFakeBinary()
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+
+        await settings.test()
+
+        XCTAssertTrue(settings.verified)
+        XCTAssertEqual(settings.status, .signedIn(verified: true))
+    }
+
+    func test_a_failing_test_clears_the_verification() async throws {
+        try installFakeBinary()
+        let settings = makeSettings(
+            tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"),
+            testResult: LLMTestResult(succeeded: false, setupError: "nope"))
+
+        await settings.test()
+
+        XCTAssertFalse(settings.verified)
+        XCTAssertEqual(settings.status, .signedIn(verified: false))
+    }
+
+    // MARK: - Persisted verification
+
+    /// The `DiarizationSettings` pattern: the persisted flag is restored only
+    /// when every parameter it was recorded against still holds.
+    func test_verification_survives_a_relaunch_when_nothing_changed() async throws {
+        try installFakeBinary()
+        defaults.set("2.1.263", forKey: ClaudeSetupSettings.Keys.installedVersion)
+
+        let first = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        await first.test()
+        XCTAssertTrue(first.verified)
+
+        // A fresh object over the same defaults and the same install.
+        let relaunched = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        XCTAssertTrue(relaunched.verified, "the proof was about this exact setup")
+        XCTAssertEqual(relaunched.status, .signedIn(verified: true))
+    }
+
+    func test_verification_is_not_restored_after_the_version_changed() async throws {
+        try installFakeBinary()
+        defaults.set("2.1.263", forKey: ClaudeSetupSettings.Keys.installedVersion)
+
+        let first = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        await first.test()
+        XCTAssertTrue(first.verified)
+
+        // A reinstall brought different bytes: the Test that passed was against
+        // the previous binary.
+        defaults.set("2.2.0", forKey: ClaudeSetupSettings.Keys.installedVersion)
+        let relaunched = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        XCTAssertFalse(relaunched.verified)
+    }
+
+    func test_verification_is_not_restored_without_a_credential() async throws {
+        try installFakeBinary()
+        let first = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        await first.test()
+        XCTAssertTrue(first.verified)
+
+        let relaunched = makeSettings(tokenStore: InMemoryTokenStore(token: nil))
+        XCTAssertFalse(relaunched.verified)
+        XCTAssertEqual(relaunched.status, .installedNotSignedIn)
+    }
+
+    func test_verification_is_not_restored_without_a_binary() async throws {
+        try installFakeBinary()
+        let first = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        await first.test()
+        XCTAssertTrue(first.verified)
+
+        try FileManager.default.removeItem(at: ClaudeManagedInstall.binaryURL(appSupportRoot: root))
+        let relaunched = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+        XCTAssertFalse(relaunched.verified)
+        XCTAssertEqual(relaunched.status, .notSetUp)
+    }
+
+    // MARK: - Sign out
+
+    func test_signing_out_removes_the_credential_and_drops_the_verification() async throws {
+        try installFakeBinary()
+        let store = InMemoryTokenStore(token: "sk-ant-oat-x")
+        let settings = makeSettings(tokenStore: store)
+        await settings.test()
+        XCTAssertTrue(settings.verified)
+
+        settings.signOut()
+
+        XCTAssertNil(store.load())
+        XCTAssertFalse(settings.hasToken)
+        XCTAssertFalse(settings.verified)
+        XCTAssertFalse(settings.signOutFailed)
+        XCTAssertEqual(settings.status, .installedNotSignedIn,
+                       "the binary is still installed — only the credential went")
+    }
+
+    /// The one state that must never be shown: "signed out" over a credential
+    /// that is still in the Keychain.
+    func test_a_failed_sign_out_keeps_showing_signed_in() throws {
+        try installFakeBinary()
+        let store = InMemoryTokenStore(token: "sk-ant-oat-x")
+        store.refuseDelete = true
+        let settings = makeSettings(tokenStore: store)
+
+        settings.signOut()
+
+        XCTAssertTrue(settings.signOutFailed)
+        XCTAssertTrue(settings.hasToken)
+        XCTAssertEqual(settings.status, .signedIn(verified: false),
+                       "the UI must not claim a removal that did not happen")
+        XCTAssertNotNil(store.load())
+    }
+
+    func test_signing_out_can_also_delete_the_binary() throws {
+        try installFakeBinary()
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(token: "sk-ant-oat-x"))
+
+        settings.signOut(removeBinary: true)
+
+        XCTAssertEqual(settings.status, .notSetUp)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: ClaudeManagedInstall.binaryURL(appSupportRoot: root).path))
+        XCTAssertNil(settings.installedVersion)
+    }
+
+    // MARK: - The credential never reaches UserDefaults
+
+    /// `defaults read` must not print this, and it must not ride along in a
+    /// preferences backup.
+    func test_no_defaults_key_ever_holds_the_token() async throws {
+        try installFakeBinary()
+        let secret = "sk-ant-oat01-" + String(repeating: "Z9y8X7w6", count: 8)
+        let settings = makeSettings(tokenStore: InMemoryTokenStore(token: secret))
+        await settings.test()
+        settings.signOut()
+
+        let dump = defaults.dictionaryRepresentation()
+        for (key, value) in dump {
+            XCTAssertFalse("\(value)".contains(secret),
+                           "the credential must never be written to defaults (key \(key))")
+        }
+    }
+
+    // MARK: - Keychain store
+
+    /// The real store against the real Keychain, on an isolated item — the same
+    /// treatment `MilaConfigTests` and `OpenAICompatibleTests` give theirs.
+    func test_keychain_store_round_trips_and_verifies_its_delete() throws {
+        let key = "ClaudeSetupSettingsTests.\(UUID().uuidString).token"
+        let store = KeychainClaudeTokenStore(key: key)
+        defer { KeychainHelper.delete(key: key) }
+
+        XCTAssertNil(store.load(), "nothing stored yet")
+
+        guard store.save("sk-ant-oat01-round-trip") else {
+            throw XCTSkip("the login keychain is not writable in this environment")
+        }
+        XCTAssertEqual(store.load(), "sk-ant-oat01-round-trip")
+
+        XCTAssertTrue(store.delete())
+        XCTAssertNil(store.load())
+        XCTAssertTrue(store.delete(), "deleting nothing still ends with nothing there")
+    }
+
+    func test_keychain_store_trims_and_refuses_an_empty_token() throws {
+        let key = "ClaudeSetupSettingsTests.\(UUID().uuidString).token"
+        let store = KeychainClaudeTokenStore(key: key)
+        defer { KeychainHelper.delete(key: key) }
+
+        XCTAssertFalse(store.save("   "), "an empty credential is not a credential")
+        XCTAssertNil(store.load())
+
+        guard store.save("  sk-ant-oat01-padded \n") else {
+            throw XCTSkip("the login keychain is not writable in this environment")
+        }
+        XCTAssertEqual(store.load(), "sk-ant-oat01-padded",
+                       "a code copied out of a browser brings whitespace with it")
+    }
+
+    /// The app's real credential lives under a namespaced Keychain account, and
+    /// the production store is the Keychain one.
+    ///
+    /// Asserted by construction rather than by writing: this is the ONE item a
+    /// test must never touch, because clobbering it would sign the developer
+    /// running the suite out of their own Mila.
+    func test_the_production_store_is_the_keychain_one_under_a_namespaced_key() {
+        XCTAssertEqual(KeychainClaudeTokenStore.defaultKey, "claudeSetup.oauthToken")
+
+        let production: ClaudeTokenStoring = KeychainClaudeTokenStore()
+        XCTAssertTrue(production is KeychainClaudeTokenStore,
+                      "the default credential store must be Keychain-backed, never UserDefaults")
+    }
+}

--- a/MilaTests/ClaudeSetupTokenParserTests.swift
+++ b/MilaTests/ClaudeSetupTokenParserTests.swift
@@ -125,15 +125,45 @@ final class ClaudeSetupTokenParserTests: XCTestCase {
     }
 
     /// A pty hands out arbitrary reads, so a token routinely straddles two
-    /// chunks. The parser accumulates for exactly this reason.
-    func test_a_token_split_across_two_chunks_is_still_captured() {
+    /// chunks. The parser accumulates for exactly this reason — and must not
+    /// report the half that has arrived.
+    ///
+    /// This is the case that makes the rule necessary: a PREFIX of a token is
+    /// itself token-shaped, so a naive match returns a truncated credential,
+    /// the flow reports success, and the token fails on first use far from
+    /// here. Caught by CI on the first run of this suite.
+    func test_a_token_split_across_two_chunks_is_never_reported_truncated() {
         var parser = ClaudeSetupTokenParser()
         let half = Self.token.count / 2
         let first = String(Self.token.prefix(half))
         let second = String(Self.token.dropFirst(half))
 
-        XCTAssertTrue(parser.consume("Token: " + first).isEmpty, "no token yet")
-        XCTAssertTrue(parser.consume(second + "\n").contains(.token(Self.token)))
+        let early = parser.consume("Token: " + first)
+        XCTAssertFalse(early.contains { if case .token = $0 { return true } else { return false } },
+                       "half a credential is not a credential")
+
+        XCTAssertTrue(parser.consume(second + "\n").contains(.token(Self.token)),
+                      "the WHOLE token is reported once it has all arrived")
+    }
+
+    /// The flip side of the rule: a token that is genuinely the last thing the
+    /// CLI printed, with no trailing newline, must still be recoverable once
+    /// the stream has ended — otherwise the boundary rule would turn a real
+    /// success into "didn't print a token".
+    func test_a_trailing_token_is_recovered_by_the_end_of_stream_scan() {
+        var parser = ClaudeSetupTokenParser()
+        XCTAssertNil(parser.consume("Your token: \(Self.token)")
+            .first { if case .token = $0 { return true } else { return false } },
+                     "refused while more bytes could still arrive")
+
+        XCTAssertEqual(parser.finalToken(), Self.token,
+                       "accepted once the stream is known to be over")
+    }
+
+    func test_the_end_of_stream_scan_will_not_deliver_the_same_token_twice() {
+        var parser = ClaudeSetupTokenParser()
+        XCTAssertTrue(parser.consume("Your token: \(Self.token)\n").contains(.token(Self.token)))
+        XCTAssertNil(parser.finalToken(), "already reported during streaming")
     }
 
     /// The prefix appearing in prose — a help string describing the format —

--- a/MilaTests/ClaudeSetupTokenParserTests.swift
+++ b/MilaTests/ClaudeSetupTokenParserTests.swift
@@ -226,6 +226,25 @@ final class ClaudeSetupTokenParserTests: XCTestCase {
                        "only the NEW rejection is re-emitted")
     }
 
+    /// The Bugbot scenario from PR #272: one rejection is reported, then a
+    /// long quiet stretch of output overflows the 64 KiB window, and the
+    /// user's SECOND bad paste arrives in the same chunk that triggers the
+    /// truncation. The eviction of the first rejection must not be confused
+    /// with the arrival of the second — the new rejection has to be emitted,
+    /// or the sheet sits on "verifying" until the timeout.
+    func test_a_rejection_arriving_with_the_truncation_is_still_reported() {
+        var parser = ClaudeSetupTokenParser()
+        let first = parser.consume("OAuth error: Invalid code. One\n")
+        XCTAssertEqual(first.filter { if case .codeRejected = $0 { return true } else { return false } }.count, 1)
+
+        // Enough filler to push the first rejection out of the window, with
+        // the second rejection riding in the SAME chunk.
+        let filler = String(repeating: "x", count: 70 * 1024)
+        let events = parser.consume(filler + "\nOAuth error: Invalid code. Two\n")
+        XCTAssertEqual(events.filter { if case .codeRejected = $0 { return true } else { return false } }.count, 1,
+                       "a rejection that arrives in the chunk that overflows the buffer must still be emitted")
+    }
+
     // MARK: - Full transcript
 
     /// The whole observed shape at once, with escapes and a spinner redraw, fed

--- a/MilaTests/ClaudeSetupTokenParserTests.swift
+++ b/MilaTests/ClaudeSetupTokenParserTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+@testable import Mila
+
+/// `ClaudeSetupTokenParser` reading `claude setup-token`'s output (issue #271).
+///
+/// The transcripts here are shaped like the real thing: an Ink TUI that emits
+/// ANSI escapes, redraws lines in place, hard-wraps to the terminal width, and
+/// positions words with cursor moves instead of spaces. Every rule in the
+/// parser exists because of one of those, so the fixtures reproduce them rather
+/// than testing against tidy text the real CLI never produces.
+final class ClaudeSetupTokenParserTests: XCTestCase {
+
+    /// A realistic authorization URL — long enough to wrap at any sane terminal
+    /// width, with the query-string punctuation that a naive URL regex trips on.
+    private static let authURL =
+        "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+        + "&response_type=code&redirect_uri=https%3A%2F%2Fconsole.anthropic.com%2Foauth%2Fcode%2Fcallback"
+        + "&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference"
+        + "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256"
+        + "&state=n1Uv9KpQ7rTfXbZ2"
+
+    private static let token = "sk-ant-oat01-" + String(repeating: "A1b2C3d4", count: 8)
+
+    // MARK: - Sanitizing
+
+    func test_ansi_escapes_and_control_characters_are_stripped() {
+        let raw = "\u{1B}[2K\u{1B}[1G\u{1B}[36m· Opening browser to sign in…\u{1B}[39m\u{07}\r\n"
+        let clean = ClaudeSetupTokenParser.sanitize(raw)
+        XCTAssertFalse(clean.contains("\u{1B}"), "no escape sequences survive")
+        XCTAssertFalse(clean.contains("\u{07}"), "no bell")
+        XCTAssertTrue(clean.contains("Opening browser to sign in"))
+    }
+
+    func test_osc_sequences_are_removed_before_csi() {
+        // An OSC payload can contain characters the CSI pattern matches, so
+        // order matters: strip OSC first or its terminator is left behind.
+        let raw = "\u{1B}]0;claude — setup-token\u{07}\u{1B}[1mReady\u{1B}[0m"
+        let clean = ClaudeSetupTokenParser.sanitize(raw)
+        XCTAssertEqual(clean, "Ready")
+    }
+
+    func test_carriage_returns_become_newlines_so_redrawn_lines_stay_separate() {
+        let clean = ClaudeSetupTokenParser.sanitize("Loading.\rLoading..\rLoading...")
+        XCTAssertEqual(clean.components(separatedBy: "\n").count, 3)
+    }
+
+    // MARK: - Wrapping
+
+    func test_a_url_hard_wrapped_by_the_tui_is_rejoined() {
+        let width = 40
+        let url = Self.authURL
+        // Chop it the way a terminal would: exactly `width` columns per line.
+        var wrapped: [String] = []
+        var remaining = Substring(url)
+        while !remaining.isEmpty {
+            let piece = remaining.prefix(width)
+            wrapped.append(String(piece))
+            remaining = remaining.dropFirst(width)
+        }
+        XCTAssertGreaterThan(wrapped.count, 3, "fixture really is wrapped")
+
+        let text = "Use the url below to sign in\n" + wrapped.joined(separator: "\n")
+        let dewrapped = ClaudeSetupTokenParser.dewrap(text, width: width)
+        XCTAssertTrue(dewrapped.contains(url), "the URL is put back together")
+    }
+
+    func test_dewrap_leaves_ordinary_short_lines_alone() {
+        let text = "one\ntwo\nthree"
+        XCTAssertEqual(ClaudeSetupTokenParser.dewrap(text, width: 400), text)
+    }
+
+    // MARK: - Marker detection
+
+    /// Ink positions words with cursor escapes rather than spaces, so a line
+    /// that reads "Paste code here" on screen can arrive with no spaces at all.
+    func test_markers_match_even_when_the_tui_ate_the_spaces() {
+        var parser = ClaudeSetupTokenParser()
+        let events = parser.consume("Pastecodehere ifprompted >")
+        XCTAssertTrue(events.contains(.awaitingCode))
+    }
+
+    func test_the_authorization_url_is_detected_and_reported_once() throws {
+        var parser = ClaudeSetupTokenParser()
+        let first = parser.consume("Browser didn't open? Use the url below (c to copy)\n\(Self.authURL)\n")
+        guard case .authorizationURL(let url)? = first.first(where: {
+            if case .authorizationURL = $0 { return true } else { return false }
+        }) else {
+            return XCTFail("expected an authorizationURL event, got \(first)")
+        }
+        XCTAssertEqual(url.absoluteString, Self.authURL)
+
+        // More output arrives; the URL must not be announced a second time.
+        let second = parser.consume("Paste code here if prompted >")
+        XCTAssertFalse(second.contains { if case .authorizationURL = $0 { return true } else { return false } })
+    }
+
+    /// The URL is handed to `NSWorkspace.open`, so "the subprocess said so" is
+    /// not on its own a good enough reason to send a browser somewhere.
+    func test_a_url_on_an_unrelated_host_is_not_treated_as_the_authorization_url() {
+        var parser = ClaudeSetupTokenParser()
+        let events = parser.consume("See https://evil.example.com/authorize?x=1 for details\n")
+        XCTAssertFalse(events.contains { if case .authorizationURL = $0 { return true } else { return false } })
+    }
+
+    func test_a_lookalike_host_is_refused() {
+        XCTAssertFalse(ClaudeSetupTokenParser.isAcceptableAuthorizationURL(
+            URL(string: "https://claude.ai.evil.com/oauth")!))
+        XCTAssertFalse(ClaudeSetupTokenParser.isAcceptableAuthorizationURL(
+            URL(string: "http://claude.ai/oauth")!), "https only")
+        XCTAssertTrue(ClaudeSetupTokenParser.isAcceptableAuthorizationURL(
+            URL(string: "https://console.anthropic.com/oauth")!), "subdomain on a listed host")
+    }
+
+    func test_the_cli_opening_its_own_browser_is_reported() {
+        var parser = ClaudeSetupTokenParser()
+        XCTAssertTrue(parser.consume("· Opening browser to sign in…\n").contains(.browserOpenedByCLI))
+    }
+
+    // MARK: - Token capture
+
+    func test_a_token_is_captured() {
+        var parser = ClaudeSetupTokenParser()
+        let events = parser.consume("Your token:\n\(Self.token)\n")
+        XCTAssertTrue(events.contains(.token(Self.token)))
+    }
+
+    /// A pty hands out arbitrary reads, so a token routinely straddles two
+    /// chunks. The parser accumulates for exactly this reason.
+    func test_a_token_split_across_two_chunks_is_still_captured() {
+        var parser = ClaudeSetupTokenParser()
+        let half = Self.token.count / 2
+        let first = String(Self.token.prefix(half))
+        let second = String(Self.token.dropFirst(half))
+
+        XCTAssertTrue(parser.consume("Token: " + first).isEmpty, "no token yet")
+        XCTAssertTrue(parser.consume(second + "\n").contains(.token(Self.token)))
+    }
+
+    /// The prefix appearing in prose — a help string describing the format —
+    /// must not be mistaken for a credential.
+    func test_the_bare_prefix_in_prose_is_not_a_token() {
+        var parser = ClaudeSetupTokenParser()
+        let events = parser.consume("Tokens start with sk-ant- and are issued once.\n")
+        XCTAssertFalse(events.contains { if case .token = $0 { return true } else { return false } })
+    }
+
+    // MARK: - Redaction
+
+    func test_the_transcript_never_carries_the_token() {
+        var parser = ClaudeSetupTokenParser()
+        _ = parser.consume("Welcome\n\(Self.authURL)\nYour token:\n\(Self.token)\n")
+        let transcript = parser.redactedTranscript
+        XCTAssertFalse(transcript.contains(Self.token), "the credential must not survive")
+        XCTAssertTrue(transcript.contains("sk-ant-<redacted>"))
+        XCTAssertTrue(transcript.contains(Self.authURL), "everything else is preserved")
+    }
+
+    /// Redaction runs over the accumulated buffer, not per arriving chunk —
+    /// otherwise a split token matches neither half and both halves are copied
+    /// into the transcript.
+    func test_a_token_split_across_chunks_is_still_redacted() {
+        var parser = ClaudeSetupTokenParser()
+        let half = Self.token.count / 2
+        _ = parser.consume("Token: " + String(Self.token.prefix(half)))
+        _ = parser.consume(String(Self.token.dropFirst(half)) + "\n")
+        XCTAssertFalse(parser.redactedTranscript.contains(Self.token))
+    }
+
+    // MARK: - Rejections
+
+    func test_a_rejected_code_is_reported_with_the_clis_own_words() {
+        var parser = ClaudeSetupTokenParser()
+        let events = parser.consume("""
+            OAuth error: Invalid code. Please make sure the full code was copied
+            Press Enter to retry.
+            """)
+        guard case .codeRejected(let message)? = events.first(where: {
+            if case .codeRejected = $0 { return true } else { return false }
+        }) else {
+            return XCTFail("expected a codeRejected event, got \(events)")
+        }
+        XCTAssertTrue(message.contains("Invalid code"))
+        XCTAssertFalse(message.contains("Press Enter"),
+                       "Mila drives the retry — that instruction points at nothing")
+    }
+
+    /// The CLI re-prompts rather than exiting, so a second bad paste has to be
+    /// visible too. Counted, not remembered as a flag.
+    func test_a_second_rejection_is_reported_again() {
+        var parser = ClaudeSetupTokenParser()
+        let first = parser.consume("OAuth error: Invalid code. One\n")
+        XCTAssertEqual(first.filter { if case .codeRejected = $0 { return true } else { return false } }.count, 1)
+
+        let second = parser.consume("OAuth error: Invalid code. Two\n")
+        XCTAssertEqual(second.filter { if case .codeRejected = $0 { return true } else { return false } }.count, 1,
+                       "only the NEW rejection is re-emitted")
+    }
+
+    // MARK: - Full transcript
+
+    /// The whole observed shape at once, with escapes and a spinner redraw, fed
+    /// in the awkward chunk boundaries a pty actually produces.
+    func test_a_realistic_transcript_produces_the_expected_event_sequence() {
+        var parser = ClaudeSetupTokenParser()
+        var events: [ClaudeSetupTokenParser.Event] = []
+        let chunks = [
+            "\u{1B}[2J\u{1B}[HWelcome to Claude Code v2.1.260\r\n\r\n",
+            "This will guide you through long-lived (1-year) auth token setup.\r\n\r\n",
+            "\u{1B}[36m·\u{1B}[39m Opening browser to sign in…\r",
+            "\u{1B}[2K\u{1B}[1GBrowser didn't open? Use the url below to sign in (c to copy)\r\n\r\n",
+            Self.authURL + "\r\n\r\n",
+            "Paste code here if prompted >"
+        ]
+        for chunk in chunks { events += parser.consume(chunk) }
+
+        XCTAssertTrue(events.contains(.browserOpenedByCLI))
+        XCTAssertTrue(events.contains { if case .authorizationURL = $0 { return true } else { return false } })
+        XCTAssertTrue(events.contains(.awaitingCode))
+        XCTAssertFalse(events.contains { if case .token = $0 { return true } else { return false } })
+    }
+}

--- a/MilaTests/ClaudeSetupTokenSessionTests.swift
+++ b/MilaTests/ClaudeSetupTokenSessionTests.swift
@@ -160,6 +160,31 @@ final class ClaudeSetupTokenSessionTests: XCTestCase {
         XCTAssertTrue(captured.isEmpty)
     }
 
+    /// A token printed as the CLI's very last bytes, with no trailing newline,
+    /// is held back while the stream is live (it could be half a read) and
+    /// taken once the child exits. Without the end-of-stream scan this exact
+    /// run would be reported as "finished but printed no token".
+    func test_a_token_in_the_final_bytes_is_captured_when_the_child_exits() async {
+        let (session, fake) = makeSession()
+        var captured: [String] = []
+        session.onToken = { captured.append($0) }
+
+        session.start()
+        fake.emit("\(Self.authURL)\n")
+        await settle()
+        session.submit(code: "the-code")
+
+        fake.emit("\nYour token: \(Self.token)")   // no trailing newline
+        await settle()
+        XCTAssertEqual(session.state, .verifying, "held back while more bytes could arrive")
+
+        fake.exit(0)
+        await settle()
+
+        XCTAssertEqual(session.state, .ready)
+        XCTAssertEqual(captured, [Self.token], "the whole token, exactly once")
+    }
+
     func test_a_nonzero_exit_fails_with_the_status() async {
         let (session, fake) = makeSession()
         session.start()

--- a/MilaTests/ClaudeSetupTokenSessionTests.swift
+++ b/MilaTests/ClaudeSetupTokenSessionTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+@testable import Mila
+
+/// A `claude setup-token` stand-in that replays a scripted transcript through
+/// the same three callbacks the real pty transport uses.
+///
+/// This is the seam that makes the guided login testable at all: the real
+/// transport needs a pseudo-terminal and a real CLI, and running the real
+/// `setup-token` mints a real credential and opens a real browser.
+final class FakeInteractiveProcess: ClaudeInteractiveProcess {
+    var onOutput: ((String) -> Void)?
+    var onExit: ((Int32) -> Void)?
+
+    private(set) var didStart = false
+    private(set) var didTerminate = false
+    private(set) var written: [String] = []
+    /// Set to make `start()` throw, standing in for a missing or broken binary.
+    var startError: Error?
+
+    func start() throws {
+        if let startError { throw startError }
+        didStart = true
+    }
+
+    func write(_ text: String) { written.append(text) }
+    func terminate() { didTerminate = true }
+
+    // Driving helpers, used by the tests.
+    func emit(_ chunk: String) { onOutput?(chunk) }
+    func exit(_ status: Int32) { onExit?(status) }
+}
+
+/// The state machine between the parser and the pty (issue #271): idle →
+/// installing → awaitingCode → verifying → ready, and every way out of it.
+@MainActor
+final class ClaudeSetupTokenSessionTests: XCTestCase {
+
+    private static let authURL =
+        "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a&state=n1Uv9KpQ"
+    private static let token = "sk-ant-oat01-" + String(repeating: "A1b2C3d4", count: 8)
+
+    /// Let queued main-actor work (the `Task { @MainActor … }` hops in
+    /// `ingest`/`childExited`) run before asserting.
+    private func settle(_ turns: Int = 20) async {
+        for _ in 0..<turns { await Task.yield() }
+    }
+
+    /// Poll until `predicate` holds or the bound elapses. Used only for the
+    /// timeout tests, where the thing under test is a real `Task.sleep`.
+    private func wait(upTo seconds: TimeInterval,
+                      for predicate: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if predicate() { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    private func makeSession(
+        timeouts: ClaudeSetupTokenSession.Timeouts = .production
+    ) -> (ClaudeSetupTokenSession, FakeInteractiveProcess) {
+        let fake = FakeInteractiveProcess()
+        let session = ClaudeSetupTokenSession(timeouts: timeouts) { fake }
+        return (session, fake)
+    }
+
+    // MARK: - Happy path
+
+    func test_the_full_flow_reaches_ready_and_hands_back_the_token() async {
+        let (session, fake) = makeSession()
+        var opened: [URL] = []
+        var captured: [String] = []
+        session.onOpenURL = { opened.append($0) }
+        session.onToken = { captured.append($0) }
+
+        session.start()
+        XCTAssertTrue(fake.didStart)
+        XCTAssertEqual(session.state, .signingIn)
+
+        fake.emit("Browser didn't open? Use the url below\n\(Self.authURL)\n")
+        await settle()
+        XCTAssertEqual(session.state, .awaitingCode(URL(string: Self.authURL)!))
+        XCTAssertEqual(opened.map(\.absoluteString), [Self.authURL],
+                       "the CLI did not report opening a browser, so Mila opens one")
+
+        session.submit(code: "  the-pasted-code  ")
+        XCTAssertEqual(session.state, .verifying)
+        XCTAssertEqual(fake.written, ["the-pasted-code\n"],
+                       "trimmed, and newline-terminated so the pty submits the line")
+
+        fake.emit("\nSuccess! Your token:\n\(Self.token)\n")
+        await settle()
+        XCTAssertEqual(session.state, .ready)
+        XCTAssertEqual(captured, [Self.token])
+        XCTAssertTrue(fake.didTerminate, "the child is released once the token is captured")
+    }
+
+    /// The CLI opens the browser itself. Mila opening the same URL again gives
+    /// the user two tabs of one OAuth request.
+    func test_mila_does_not_open_a_second_tab_when_the_cli_opened_one() async {
+        let (session, fake) = makeSession()
+        var opened: [URL] = []
+        session.onOpenURL = { opened.append($0) }
+
+        session.start()
+        fake.emit("· Opening browser to sign in…\n\(Self.authURL)\n")
+        await settle()
+
+        XCTAssertTrue(opened.isEmpty, "no second browser tab")
+        XCTAssertEqual(session.state, .awaitingCode(URL(string: Self.authURL)!))
+    }
+
+    // MARK: - Rejection
+
+    func test_a_rejected_code_returns_to_awaiting_and_keeps_the_child_alive() async {
+        let (session, fake) = makeSession()
+        session.start()
+        fake.emit("\(Self.authURL)\nPaste code here >")
+        await settle()
+
+        session.submit(code: "wrong")
+        XCTAssertEqual(session.state, .verifying)
+
+        fake.emit("\nOAuth error: Invalid code. Please make sure the full code was copied\nPress Enter to retry.\n")
+        await settle()
+
+        XCTAssertEqual(session.state, .awaitingCode(URL(string: Self.authURL)!),
+                       "recoverable — the CLI re-prompts rather than exiting")
+        XCTAssertEqual(session.lastRejection?.contains("Invalid code"), true)
+        XCTAssertFalse(fake.didTerminate, "the child must stay alive for the retry")
+
+        // The retry succeeds.
+        session.submit(code: "right")
+        XCTAssertNil(session.lastRejection, "cleared when a new code is submitted")
+        fake.emit("\nYour token:\n\(Self.token)\n")
+        await settle()
+        XCTAssertEqual(session.state, .ready)
+    }
+
+    // MARK: - Failure paths
+
+    /// Exit 0 with nothing token-shaped printed is the scenario the parser's
+    /// doc comment warns about. Claiming success would leave a user "signed in"
+    /// with no credential, so it is a loud failure.
+    func test_exit_zero_without_a_token_is_a_failure_not_a_success() async {
+        let (session, fake) = makeSession()
+        var captured: [String] = []
+        session.onToken = { captured.append($0) }
+
+        session.start()
+        fake.emit("\(Self.authURL)\n")
+        await settle()
+        fake.exit(0)
+        await settle()
+
+        guard case .failed(let reason) = session.state else {
+            return XCTFail("expected failure, got \(session.state)")
+        }
+        XCTAssertTrue(reason.contains("didn't print a token"))
+        XCTAssertTrue(captured.isEmpty)
+    }
+
+    func test_a_nonzero_exit_fails_with_the_status() async {
+        let (session, fake) = makeSession()
+        session.start()
+        fake.exit(3)
+        await settle()
+
+        guard case .failed(let reason) = session.state else {
+            return XCTFail("expected failure, got \(session.state)")
+        }
+        XCTAssertTrue(reason.contains("3"))
+    }
+
+    func test_a_binary_that_cannot_be_launched_fails_immediately() async {
+        let fake = FakeInteractiveProcess()
+        fake.startError = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT))
+        let session = ClaudeSetupTokenSession { fake }
+
+        session.start()
+        await settle()
+        guard case .failed = session.state else {
+            return XCTFail("expected failure, got \(session.state)")
+        }
+    }
+
+    /// The bound that stops a CLI hanging at startup from leaving a spinner up
+    /// forever. Driven with a millisecond timeout via the injectable seam.
+    func test_the_url_timeout_fails_the_flow() async {
+        let (session, fake) = makeSession(
+            timeouts: .init(url: 0.05, authorization: 60, verify: 60))
+        session.start()
+
+        await wait(upTo: 3) { if case .failed = session.state { return true }; return false }
+        guard case .failed(let reason) = session.state else {
+            return XCTFail("expected a timeout failure, got \(session.state)")
+        }
+        XCTAssertTrue(reason.contains("sign-in link"))
+        XCTAssertTrue(fake.didTerminate, "a timed-out child is released")
+    }
+
+    func test_the_verify_timeout_fails_the_flow() async {
+        let (session, fake) = makeSession(
+            timeouts: .init(url: 60, authorization: 60, verify: 0.05))
+        session.start()
+        fake.emit("\(Self.authURL)\n")
+        await settle()
+        session.submit(code: "some-code")
+
+        await wait(upTo: 3) { if case .failed = session.state { return true }; return false }
+        guard case .failed(let reason) = session.state else {
+            return XCTFail("expected a timeout failure, got \(session.state)")
+        }
+        XCTAssertTrue(reason.contains("after the code was submitted"))
+    }
+
+    /// Deadlines are per phase, not cumulative: arriving at the next step buys
+    /// more time. A short URL bound must not fire once the URL has appeared.
+    func test_reaching_the_next_phase_cancels_the_previous_deadline() async {
+        let (session, fake) = makeSession(
+            timeouts: .init(url: 0.05, authorization: 60, verify: 60))
+        session.start()
+        fake.emit("\(Self.authURL)\n")
+        await settle()
+        XCTAssertEqual(session.state, .awaitingCode(URL(string: Self.authURL)!))
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(session.state, .awaitingCode(URL(string: Self.authURL)!),
+                       "the URL deadline was disarmed when the URL arrived")
+    }
+
+    // MARK: - Cancellation
+
+    func test_cancelling_releases_the_child_and_returns_to_idle() async {
+        let (session, fake) = makeSession()
+        session.start()
+        fake.emit("\(Self.authURL)\n")
+        await settle()
+
+        session.cancel()
+        XCTAssertEqual(session.state, .idle)
+        XCTAssertTrue(fake.didTerminate)
+
+        // A late exit from the child it already gave up on must not resurrect a
+        // failure over the top of the idle state.
+        fake.exit(1)
+        await settle()
+        XCTAssertEqual(session.state, .idle)
+    }
+
+    // MARK: - The login child runs without a credential
+
+    /// `setup-token` mints a credential; it must not be handed the one it is
+    /// about to replace. Every other invocation of the managed binary WANTS the
+    /// token, so this is a deliberate exception, and it is the one place a
+    /// re-login could silently return the old credential instead of a new one.
+    func test_the_login_child_never_inherits_an_oauth_token() {
+        let binary = ClaudeManagedInstall.binaryURL()
+        let env = ClaudeSetupTokenSession.loginEnvironment(
+            binary: binary,
+            base: ["PATH": "/usr/bin",
+                   ClaudeManagedInstall.oauthTokenEnvironmentKey: "sk-ant-oat-stale"])
+
+        XCTAssertNil(env[ClaudeManagedInstall.oauthTokenEnvironmentKey],
+                     "a sign-in must start from no credential at all")
+        XCTAssertNotNil(env["PATH"], "the rest of the environment is still built normally")
+    }
+
+    // MARK: - The token never reaches a log or a UI string
+
+    func test_the_transcript_and_every_log_token_are_free_of_the_credential() async {
+        let (session, fake) = makeSession()
+        session.start()
+        fake.emit("\(Self.authURL)\nYour token:\n\(Self.token)\n")
+        await settle()
+
+        XCTAssertFalse(session.redactedTranscript.contains(Self.token),
+                       "the only transcript that leaves the session is redacted")
+
+        // `logToken` is what actually reaches os.Logger. No case may carry a
+        // payload — not the URL (it has a live OAuth `state`), not the failure
+        // reason (it can quote the CLI).
+        let states: [ClaudeSetupState] = [
+            .idle,
+            .installing(progress: 0.5),
+            .signingIn,
+            .awaitingCode(URL(string: Self.authURL)!),
+            .verifying,
+            .ready,
+            .failed("boom \(Self.token)")
+        ]
+        for state in states {
+            XCTAssertFalse(state.logToken.contains(Self.token))
+            XCTAssertFalse(state.logToken.contains("claude.com"))
+            XCTAssertFalse(state.logToken.contains("boom"))
+        }
+    }
+
+    /// One chunk can complete several events, and a terminal one must end the
+    /// flow there. Before this was pinned, a chunk carrying BOTH a fatal
+    /// rejection and something token-shaped ran the token event afterwards —
+    /// turning a reported failure into `.ready` and handing back a credential
+    /// from a run that had just been called broken.
+    func test_a_terminal_event_stops_the_rest_of_the_same_chunk() async {
+        let (session, fake) = makeSession()
+        var captured: [String] = []
+        session.onToken = { captured.append($0) }
+
+        session.start()
+        // No authorization URL has appeared, so the rejection is fatal — and
+        // the very same chunk also contains a token-shaped string.
+        fake.emit("OAuth error: Invalid code. Leftover: \(Self.token)\n")
+        await settle()
+
+        guard case .failed = session.state else {
+            return XCTFail("a fatal rejection must stay failed, got \(session.state)")
+        }
+        XCTAssertTrue(captured.isEmpty,
+                      "no credential may be handed back from a failed run")
+    }
+
+    /// A failure message is rendered in the UI, so a token echoed by the CLI
+    /// into an error must be redacted before it becomes one.
+    func test_a_failure_message_built_from_cli_text_is_redacted() async {
+        let (session, fake) = makeSession()
+        session.start()
+        // A rejection before any URL is a hard failure, and it carries the
+        // CLI's own words into `.failed`.
+        fake.emit("OAuth error: Invalid code near \(Self.token)\n")
+        await settle()
+
+        guard case .failed(let reason) = session.state else {
+            return XCTFail("expected failure, got \(session.state)")
+        }
+        XCTAssertFalse(reason.contains(Self.token))
+        XCTAssertTrue(reason.contains("sk-ant-<redacted>"))
+    }
+}


### PR DESCRIPTION
Closes #271

## What & why

Setting up Claude currently means a terminal: pipe an install script to a shell, run `claude setup-token`, then hope Mila's `PATH` search finds the result. For a large share of Mila's users that is where the feature ends — and it ends quietly, with the first title suggestion coming back as "Could not find claude on PATH".

This adds **Settings → AI Provider → Set up Claude**: one button that installs Anthropic's official CLI, signs the user in through their browser, and reports honestly what state the setup is in.

**Install.** The release resolution replicates `https://claude.ai/install.sh` rather than piping it to a shell — `GET /latest`, `/<version>/manifest.json` for the per-platform SHA-256 and size, `/<version>/<platform>/claude` — over URLSession, HTTPS to `downloads.claude.ai` only, with off-host redirects refused rather than followed. I verified this derivation against the real installer script while working on it: base URL, path layout, the `.platforms["<platform>"].checksum`/`.size` keys, the `darwin-arm64`/`darwin-x64` naming, the Rosetta `proc_translated` override, and the version-shape regex all match.

**Verify before executing.** Download → size → checksum → signature → install, and staging is deliberately *not* on the path `LLMRunner` resolves, so there is no window where a half-verified binary is reachable by anything that would run it. The checksum and the signature are not redundant: the checksum catches a truncated transfer, the signature keeps proving authorship if the manifest and binary come from the same compromised host. The requirement is anchored (`anchor apple generic` + team ID + signing identifier) — comparing identity strings read back from an unanchored signature would compare attacker-chosen values. Failures refuse with a readable reason and offer no "install anyway".

**Login.** Driven over a pty, because `claude setup-token` emits nothing at all on a pipe (it is an Ink TUI gating its render on `isatty(0)`). The parser handles what that implies: ANSI escapes, hard wrapping, and words positioned with cursor moves instead of spaces. The authorization URL is checked against an allowlist of Anthropic hosts before `NSWorkspace` opens it. The pty transport follows `.claude/rules/python-subprocess.md` and #251 — `terminationHandler` before `run()`, blocking reader/writer on dedicated threads, bounded SIGTERM→SIGKILL escalation, no unbounded wait.

**Token.** Keychain only, with verified writes and deletes. It never reaches UserDefaults, a log line, or a UI string: `ClaudeSetupState.logToken` drops every payload, and failure text built from CLI output is redacted first. The env is never logged and `LLMTestResult.command` is only path + args, so the injected token cannot reach the test panel either.

**Resolution + injection.** Order is override → managed install → `$PATH` search (#196). The managed binary beats the search because it is the one Mila can make promises about; the explicit Settings override still beats both, since that field is the documented escape hatch. The token is injected in exactly one place under one rule — only when the executable being launched *is* the managed binary — so a user's own `claude` with its own login (possibly a different account, possibly corporate SSO) is untouched, and nothing is ever removed from the environment.

## Bugs found in the pre-existing work-in-progress

This finishes an interrupted implementation. Three real defects in the inherited code, each now pinned by a test:

1. **A terminal state could be overwritten within one chunk.** `ingest` checked `finished` once before its event loop instead of per event. A chunk carrying both a fatal rejection and a token-shaped string ran the token event afterwards — turning a reported failure into `.ready` and handing back a credential from a run just called broken.
2. **The login child inherited the token it was about to replace.** `PTYProcess` defaulted to the normal child environment, so `setup-token` ran holding the existing credential. A "sign in again" that silently returns the OLD token is the failure hardest to notice: the UI says Signed in and the Test passes. It now runs with no credential at all.
3. **The session cleared its own only strong reference from inside its `didSet`.** It survived only because every caller happened to reach it via optional chaining on a weak `self` — a property of the call sites, not of the code. Now released on the next main-actor turn, guarded on identity so "Try again" doesn't tear down the sign-in it just started.
4. **A token split across a pty read boundary was reported truncated.** Found by CI on the first run of the new parser suite — the assertion I expected to be trivially true was not. A *prefix* of a token is itself token-shaped (`sk-ant-` plus sixteen more characters), so a chunk boundary mid-token made the match succeed on the half that had arrived: the flow stored a truncated credential and reported success, and the failure would have surfaced much later as an auth error with the Settings row still saying "Signed in". A match running to the end of the buffer is now refused while the stream is live (the match is greedy, so ending earlier proves the value is complete), with a last-chance scan at child exit so a token that genuinely is the final bytes is still recovered — exactly once.

Also fixed a compile break: a bare `/regex/` literal, which needs the `BareSlashRegexLiterals` upcoming-feature flag that `project.yml` does not set at Swift 5.10. Switched to the `#/…/#` extended-delimiter form.

## How it was tested

**Verified.** `make build` — BUILD SUCCEEDED. `make package-test` — passed, 101 MilaKit tests, 0 failures. **CI is green on this branch**: `unit-and-ui-tests`, `build-and-test`, `e2e`, `diarize`, `remote-transcription-e2e`, both mock meeting jobs, `UI layout tests` and `Linked issue` all pass. The first CI run failed on one of the new tests, which is how bug 4 above was found; the fix and its regression tests are in the final commit and the suite is green.

Five new suites, none of which touch the network or execute a real `claude`: release-URL and version-guard rules, manifest decoding, executable-resolution precedence, the token-injection rule (including that the Keychain is not read for a non-managed binary), the install ordering and every refusal path (checksum, size, wrong publisher, broken signature, junk version), the parser over realistic escape-laden transcripts, the state machine end to end (URL detection, paste, capture, rejection-and-retry, exit-0-without-token, launch failure, cancellation, and both timeouts via an injectable seam), the persisted verify-status rules, sign-out verification, and a walk of the whole defaults suite asserting no value contains a token.

**Not verified — needs manual checking on a real Mac.** I could not exercise the parts that require a real credential, and deliberately did not run `claude setup-token` (it opens a browser on the developer's machine). Running `make test` locally was ruled out, so CI is where the new suites execute — they now pass there.

### Needs manual verification

1. **Button → install.** Settings → AI Provider → Tool → "Claude (claude CLI)". With no managed install, the row should read *Not set up*. Press **Set up Claude**; a progress bar should run and the binary should appear at `~/Library/Application Support/Mila/bin/claude`.
2. **Signature gate actually refuses.** Replace that file with any other signed binary (or an ad-hoc-signed one) and press **Reinstall**… then confirm a genuine tampered download is refused — easiest check is that a corrupted staged file produces the checksum error rather than an install.
3. **Real browser login.** The sheet should appear, the browser should open Anthropic's page exactly once (not twice), and pasting the code should move the row to *Signed in*. Try pasting a deliberately wrong code first: it should show the CLI's own rejection and let you retry without restarting.
4. **Token round-trip.** Confirm a `claudeSetup.oauthToken` item exists in Keychain Access, and that `defaults read io.island.whisper.IslandWhisper` shows no token anywhere.
5. **Test button.** Press **Test**; it should reach *Signed in and working*, and survive a Settings reopen (persisted verification).
6. **A system `claude` is untouched.** With your own `claude` on `PATH` and its own login, confirm it still works and never receives `CLAUDE_CODE_OAUTH_TOKEN`.
7. **Sign out.** Should remove the Keychain item and flip to *Installed, not signed in*; "sign out and delete the binary" should return the row to *Not set up*.

## Open risks

- **The success transcript is unobserved.** The token pattern is derived from the `sk-ant-oat…` prefix the shipped binary carries, not from a captured successful run. If a future CLI version stops printing the token, the flow fails loudly ("finished but didn't print a token Mila could read") rather than claiming success — but it does fail, and item 3 above is the only way to confirm it currently works.
- **The parser is coupled to a TUI's layout.** Markers are matched whitespace-insensitively and wrapped lines are rejoined precisely because that layout is not a contract, but a sufficiently different future `setup-token` UI would need re-pinning.
- **Compressed artifacts.** The official installer can serve `claude.zst`; Mila fetches the uncompressed `claude`, which exists today. If a future release ships only the compressed form, install would need to handle it.
- **No auto-update for the managed binary.** Deliberate for v1 — "Reinstall" is the recovery path, since the failure to cover is "my CLI stopped working", not "my CLI is three days old".

## Checklist

- [x] Builds locally (`make build`); `make package-test` passes; `make test` was not run locally (per the constraints this work was done under) — CI's `unit-and-ui-tests` job runs it and is green.
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog — not added; this is not a release bump, and `RELEASE_NOTES/` is written at version-bump time

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added managed Claude CLI installation with download validation, progress reporting, and secure replacement of existing installations.
  - Added Claude setup controls in Settings for installation, guided sign-in, testing, reinstalling, and signing out.
  - Added support for detecting and using an existing system-installed Claude CLI.
  - Added secure Keychain storage for Claude credentials.
  - Claude launches now prefer Mila’s managed installation and use its stored credential.

- **Bug Fixes**
  - Improved sign-in prompts, authorization links, cancellations, timeouts, credential redaction, and overlapping installation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Downloads and executes a third-party binary, stores long-lived OAuth credentials in Keychain, and changes which `claude` process runs with injected secrets—mitigated by pinned hosts, signature requirements, and path-scoped token injection.
> 
> **Overview**
> Adds **Settings → AI Provider → Set up Claude**: one flow to download Anthropic’s official `claude` binary, verify it, sign in via browser, and persist the OAuth token—without asking users to use Terminal.
> 
> **Install pipeline** mirrors `install.sh` against `downloads.claude.ai` (version → manifest → binary), streams the ~200 MB artifact to a **staging** path, then enforces **size → SHA-256 → Developer ID signature** before anything lands at `~/Library/Application Support/Mila/bin/claude`. Off-host redirects are refused; failed installs remove staged bytes.
> 
> **Login** runs `claude setup-token` over a **pty** (the CLI is silent on pipes). A parser strips TUI escapes, dewraps URLs, allowlists authorization hosts, and redacts tokens from transcripts; `ClaudeSetupTokenSession` drives browser open, code paste, timeouts, and cancellation.
> 
> **Runtime wiring**: `LLMRunner.resolveExecutable` now prefers **override → managed `claude` → PATH**; `childEnvironment` injects `CLAUDE_CODE_OAUTH_TOKEN` **only** when the launched executable is the managed binary (Keychain read is lazy). `setup-token` explicitly runs **without** an inherited token so re-auth cannot silently reuse the old credential.
> 
> **UI/state**: `ClaudeSetupSettings` + `ClaudeSetupSection` cover install progress, sign-in sheet, Test/Reinstall/Sign out, system-CLI detection, and persisted “verified” status. Tokens live in **Keychain** via `KeychainClaudeTokenStore`; `KeychainHelper.isAbsent` verifies deletes.
> 
> Extensive new unit tests cover install refusals, resolution/injection rules, parser edge cases, and settings persistence—without network or a real `claude`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62bfbb396e6e9fbcfbce9eff0efaa786ecfbe8da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->