### PR TITLE
chore: disable CodeRabbit auto-reviews now that Bugbot is the reviewer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Cursor Bugbot is this repo's automated reviewer (see .cursor/BUGBOT.md,
+# introduced in #221). The CodeRabbit GitHub App is still installed at the
+# org level, and with no config file present it auto-reviews every PR with
+# its defaults. This file turns automatic reviews off; on-demand reviews
+# (`@coderabbitai review`) remain available.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Closes #273

## What & why

[#221](https://github.com/island-io/mila/pull/221) switched this repo's automated review to Cursor Bugbot and removed `.coderabbit.yaml` — but the `coderabbitai` GitHub App is still installed on the `island-io` org, and with no config file present it falls back to its defaults and auto-reviews every PR (see the "Configuration used: defaults" stamps on [#272](https://github.com/island-io/mila/pull/272)'s CodeRabbit reviews, posted today alongside Bugbot's).

This adds a minimal `.coderabbit.yaml` that disables automatic reviews (`reviews.auto_review.enabled: false`) while keeping on-demand reviews (`@coderabbitai review`) available. If an org admin later uninstalls the app entirely, this file is harmless.

## How it was tested

Config-only change — no code paths to build or test. The YAML matches CodeRabbit's published schema (referenced via the `yaml-language-server` header in the file). Verification is observational: PRs opened after this merges should get no unprompted `coderabbitai[bot]` review.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — N/A, no source changes; the file is not part of any build target
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — N/A, not user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuXG9Jk86g13yhTPxLkqqU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuXG9Jk86g13yhTPxLkqqU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with no runtime or application code paths affected.
> 
> **Overview**
> Adds a minimal **`.coderabbit.yaml`** so the org-installed CodeRabbit app stops auto-reviewing every PR (which happens when no config exists and defaults apply). **`reviews.auto_review.enabled`** is set to **`false`**; **`@coderabbitai review`** on-demand reviews still work. Comments in the file document that **Cursor Bugbot** is the primary automated reviewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a02d412d2d51de27ff9a7f24998cdba512b1609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automatic CodeRabbit reviews are now disabled.
  * On-demand CodeRabbit reviews remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->