### PR TITLE
fix(live-ai): end the final-tick drain on a stranded slot instead of spinning

### DIFF
--- a/Mila/Actions/LiveAISession.swift
+++ b/Mila/Actions/LiveAISession.swift
@@ -262,7 +262,45 @@ final class LiveAISession: ObservableObject {
         // task clears `inFlight` from its `defer` before potentially
         // scheduling another (immediate, since isFinalizing) kick, so
         // looping until `inFlight` is nil drains everything.
+        //
+        // `drained` is what makes that loop terminate rather than spin
+        // (issue #259). `await handle.value` on a task that has ALREADY
+        // finished returns without suspending, so a slot left pointing at a
+        // finished task does not hang this loop -- it makes it re-read the
+        // same handle and burn a core at full tilt, on the main actor, for
+        // as long as the caller lets it. A stall would at least look like a
+        // stall; this looks like a fan.
+        //
+        // Awaiting a handle proves it has finished, so finding that SAME
+        // handle still in the slot on the next read means nothing will ever
+        // clear it: the tick's `defer` skipped its clearing branch, i.e. the
+        // invariant #242 established is broken. That is the fact worth
+        // knowing, so it is logged rather than quietly swallowed -- ending
+        // the drain is damage control, not a fix. It is a log and not an
+        // `assertionFailure` on purpose: the state is recoverable, and
+        // trapping would turn a survivable strand into a debug-build crash.
+        //
+        // Clearing the slot rather than only breaking is what unwedges the
+        // session: `scheduleKick` coalesces every later tick behind a
+        // non-nil `inFlight`, so leaving the dead handle in place would keep
+        // Live AI silently dead. Only the identity just awaited is cleared,
+        // so a fresh tick that took the slot while we were suspended is a
+        // different handle -- awaited on the next turn of the loop, never
+        // clobbered. Same rule as the tick's own `defer`. `isThinking` is
+        // deliberately left alone: it belongs to the tick, the next one sets
+        // and clears it, and `cancel()` (which stop time runs) resets it.
+        var drained: Task<Void, Never>?
         while let handle = inFlight {
+            if handle == drained {
+                liveAILog.error("""
+                    awaitFinalTick: tick slot still holds a finished task \
+                    (issue #259) -- the tick defer's invariant is broken. \
+                    Clearing the slot to end the drain.
+                    """)
+                inFlight = nil
+                break
+            }
+            drained = handle
             _ = await handle.value
         }
     }

--- a/MilaTests/LiveAIFinalTickDrainTests.swift
+++ b/MilaTests/LiveAIFinalTickDrainTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import XCTest
+@testable import Mila
+
+/// `LiveAISession.awaitFinalTick()` must END when the tick slot is stranded,
+/// rather than spin on it (issue #259).
+///
+/// The drain is `while let handle = inFlight { _ = await handle.value }`.
+/// `await` on a task that has ALREADY finished resumes immediately, so a slot
+/// left pointing at a finished task does not make that loop hang -- it makes
+/// it re-read the same handle forever, at full tilt, on the main actor. The
+/// cause (a stranded slot) is already bad: `scheduleKick` coalesces every
+/// later tick behind a non-nil `inFlight`, so Live AI is silently dead for the
+/// rest of the meeting. This loop turns that silent stall into a spinning
+/// core, which on a laptop mid-meeting is audible and expensive.
+///
+/// #242's `defer` clears the slot on every exit path, so the strand is not
+/// reachable in the app today; this pins the guard that keeps the loop
+/// terminating if some future exit path stops going through it.
+///
+/// Nothing here bets on a clock. #256 was a 30s bound in this area that turned
+/// out to be a lost wakeup in the test's own helper, and the lesson taken from
+/// it (see `LiveAIDeletedLineSessionTests.waitUntil`) is that a positive wait
+/// cannot tell a wedge from a loaded runner. Every wait below awaits the exact
+/// task it is reasoning about and then reads `inFlightTickForTesting` -- the
+/// seam #257 added for precisely this question.
+@MainActor
+final class LiveAIFinalTickDrainTests: XCTestCase {
+
+    func test_awaitFinalTick_ends_on_a_stranded_slot_and_clears_it() async {
+        let (session, calls) = makeSession(suite: "LiveAIFinalTickDrainTests.stranded")
+
+        // Launch a tick. `feed` is synchronous on the main actor and `kick()`
+        // fills the slot before it returns, so the handle is readable here.
+        session.feed(transcript: "[00:00] One.", immediate: true)
+        guard let stranded = session.inFlightTickForTesting else {
+            XCTFail("precondition: an immediate feed must launch a tick")
+            return
+        }
+
+        // Strand the slot the way the production code could: cancel the TICK,
+        // not the session. `LiveAISession.cancel()` cancels the task AND
+        // clears `inFlight` itself, whereas a tick cancelled from anywhere
+        // else takes the `defer`'s `if !Task.isCancelled` branch and skips the
+        // clear -- leaving the slot holding a task that has finished. That
+        // asymmetry is deliberate (a cancelled tick must never clobber the
+        // newer handle `start()` may have put in the slot), and it is the one
+        // real seam through which the state in #259 can exist. Nothing is
+        // faked and no write seam is needed: `inFlightTickForTesting` hands
+        // back the task, and cancelling a task is something any holder can do.
+        stranded.cancel()
+        _ = await stranded.value   // the tick body, `defer` included, is done
+        guard let slot = session.inFlightTickForTesting else {
+            XCTFail("precondition: the slot must still hold the finished tick")
+            return
+        }
+        XCTAssertEqual(slot, stranded,
+                       "precondition: the slot must still hold the tick that just finished")
+
+        // The property under test: this call has to come back. On the pre-#259
+        // loop it never does and never suspends either, so there is no honest
+        // timeout to wrap it in -- a watchdog task cannot run while the drain
+        // holds the main actor without yielding. Reaching the next line is the
+        // assertion.
+        await session.awaitFinalTick()
+
+        XCTAssertNil(session.inFlightTickForTesting,
+                     "the drain must clear the dead handle, not merely stop looking at it")
+
+        // Clearing it is what un-wedges the session, which is why the guard
+        // clears rather than only breaking: with the strand gone, a later feed
+        // gets a tick of its own instead of being coalesced behind a task that
+        // will never complete again.
+        let before = calls.value.count
+        session.feed(transcript: "[00:00] One.\n[00:05] Two.", immediate: true)
+        XCTAssertNotNil(session.inFlightTickForTesting,
+                        "a later tick must be able to run once the strand is cleared")
+        await settle(session)
+        XCTAssertGreaterThan(calls.value.count, before,
+                             "the later tick must actually reach the runner")
+    }
+
+    // MARK: - Helpers
+    //
+    // Deliberately the same shape as `LiveAIDeletedLineSessionTests`, minus
+    // the gate: this suite never needs a tick held open inside the runner.
+
+    private final class Calls {
+        var value: [LiveAISession.LLMCall] = []
+    }
+
+    private func makeSession(suite: String) -> (LiveAISession, Calls) {
+        UserDefaults().removePersistentDomain(forName: "\(suite).llm")
+        UserDefaults().removePersistentDomain(forName: "\(suite).live")
+        let llm = LLMSettings(defaults: UserDefaults(suiteName: "\(suite).llm")!)
+        llm.tool = .claude
+        let live = LiveAISettings(defaults: UserDefaults(suiteName: "\(suite).live")!)
+        live.enabled = true
+        live.llmMinIntervalSeconds = 0
+
+        let calls = Calls()
+        let session = LiveAISession(llmSettings: llm, liveAISettings: live)
+        session.performCall = { call in
+            calls.value.append(call)
+            return #"{"summary":"ok","items":[]}"#
+        }
+        session.start()
+        return (session, calls)
+    }
+
+    /// Settle whatever tick is outstanding by awaiting the task itself, so no
+    /// tick outlives the test. Stops as soon as the slot stops changing, so a
+    /// strand ends this loop too -- the same shape as
+    /// `LiveAIDeletedLineSessionTests.waitUntilIdle`, and the same shape the
+    /// production drain now uses.
+    private func settle(_ session: LiveAISession) async {
+        var previous: Task<Void, Never>?
+        while let tick = session.inFlightTickForTesting {
+            if let previous, previous == tick { break }
+            _ = await tick.value
+            previous = tick
+        }
+    }
+}


### PR DESCRIPTION
Closes #259

## What & why

`LiveAISession.awaitFinalTick()` drains with

```swift
while let handle = inFlight { _ = await handle.value }
```

`await` on a task that has **already finished** resumes without suspending. So a slot left pointing at a finished task does not make this loop *hang* — it makes it re-read the same handle forever, at full tilt, on the main actor. A stall would at least look like a stall; this looks like a fan.

The cause is already bad on its own: a stranded slot means `scheduleKick` coalesces every later tick behind a task that will never clear, i.e. Live AI is silently dead for the rest of the meeting (#242's comment spells this out). This loop turns that silent stall into a spinning core.

**Verified against `main` before writing anything:** the loop shape and #242's `defer` both still match the issue's description, so the report is not stale. The `defer` clears the slot on every exit path, so **the spin is not reachable today** — the guard exists for the day some new exit path stops going through it. (Worth recording: `awaitFinalTick()` currently has no production call site either — #86 moved the final summary to `finalizeTail` — so it is the class's stop-time drain API, exercised by `LiveAIThrottleTests`. That makes this change lower-risk, and does not change the argument for the guard.)

### The fix

Remember the handle just awaited; compare identity on the next read.

Awaiting a handle *proves* it finished, so finding that same handle still in the slot means nothing is ever going to clear it — the tick `defer`'s invariant is broken. Three deliberate choices:

- **Log, don't assert.** Reaching this state is the thing actually worth knowing, so it is not swallowed silently. But it is recoverable, and an `assertionFailure` would turn a survivable strand into a debug-build crash (and would trap the regression test that pins the behaviour).
- **Clear the slot, don't just `break`.** Breaking alone leaves Live AI wedged, since `scheduleKick` coalesces behind a non-nil `inFlight`. Clearing ends the drain *and* lets later ticks run again.
- **Only the identity just awaited is cleared.** A fresh tick that took the slot while we were suspended is a different handle, so it is awaited on the next turn of the loop rather than clobbered — the same rule the tick's own `defer` follows, for the same reason. `isThinking` is deliberately untouched: it belongs to the tick, the next one sets and clears it, and `cancel()` (which stop time runs) resets it.

The healthy path is unchanged: the guard can only fire when the *same* handle is seen twice, and each `kick()` creates a new task.

### The test

`MilaTests/LiveAIFinalTickDrainTests.swift` strands the slot the one way production could: it cancels the **tick handle**, not the session. `LiveAISession.cancel()` cancels the task *and* clears `inFlight` itself, whereas a tick cancelled from anywhere else takes the `defer`'s `if !Task.isCancelled` branch and skips the clear. Nothing is faked and no write seam was added — `inFlightTickForTesting` (#257) hands back the task, and cancelling a task is something any holder can do.

It then asserts the drain returns, that the dead handle was cleared, and that a later feed gets a tick of its own (the behavioural consequence of clearing rather than breaking).

**No wall-clock bound anywhere**, per the lesson on #256: every wait awaits the exact task it is reasoning about and then reads the slot. One consequence is worth stating plainly rather than hiding: if this guard is ever removed, the test does not fail — it **hangs**, because that is precisely the defect. A loop that never yields cannot be watched by a watchdog task, since nothing else on the main actor gets to run. A timeout here would be a bet on a clock, which is the mistake #256 was.

## How it was tested

**Nothing was compiled or run locally** — this environment has no Swift toolchain and no Mac (`download.swift.org` is blocked), so CI is the only compiler. The diff was re-read adversarially instead, and every construct it uses was copied from a form already compiling on `main`:

- the `Task` identity comparison mirrors `LiveAIDeletedLineSessionTests.waitUntilIdle`'s `previous == tick` (`Task`'s `Equatable` is pointer identity, so a copied handle compares equal — this PR is the first thing to actually *exercise* that branch);
- the multi-line `liveAILog.error("""…""")` literal matches the existing one in the same file line-for-line in shape and indentation;
- the test's `makeSession` / `Calls` / settle helpers are the shapes in `LiveAIDeletedLineSessionTests`, minus the gate this suite does not need.

The suite is picked up automatically (`project.yml` globs `MilaTests`). If my read of the strand is wrong in either direction, the test fails loudly on its precondition guards rather than hanging.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible here (no Swift toolchain / no Mac); relying on CI**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, defensive fix with no user-visible behaviour change

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive stop-time drain guard with no intended behavior change on healthy paths; `awaitFinalTick()` is rarely used in production per existing notes.
> 
> **Overview**
> **Fixes a main-actor spin in `LiveAISession.awaitFinalTick()`** when `inFlight` still points at a tick task that has already finished (issue #259). The drain loop now tracks the last awaited handle; seeing the same handle again means the tick `defer` never cleared the slot, so it **logs an error**, **clears `inFlight`**, and exits instead of busy-looping.
> 
> That clear is intentional so later `scheduleKick` calls are not coalesced behind a dead task (which would silently stall Live AI). The normal drain path is unchanged.
> 
> Adds **`LiveAIFinalTickDrainTests`** to reproduce a stranded slot by cancelling the tick (not `cancel()` on the session), assert `awaitFinalTick()` returns and clears the slot, and verify a subsequent feed can run another tick—without wall-clock timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47699e051c1e3c4ba7e2f6a9070a8179eda7f6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->