### PR TITLE
fix(models): make model deletion stick — and make it safe to ship

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2025,23 +2025,36 @@ struct MilaApp: App {
     /// button, and any too-eager Record press during the window finds
     /// the model already loaded.
     private func prewarmDefaultModel() {
-        // Skip prewarm under UI tests. No UI test relies on a launch-time
-        // warm — the transcription E2E tests pass `--ui-test-tiny-model-path=`
-        // and load on demand — so warming the (potentially multi-GB) default
-        // model here just burns CPU/IO on every UI-test launch and creates a
-        // whisper/Metal context that XCTest never frees (it exits via
-        // `exit()`, bypassing `gracefulShutdown()`), which is what prints the
-        // ggml-metal teardown backtrace at process exit.
-        guard !isRunningUITests else { return }
+        // Skip prewarm under any XCTest hosting (UI or unit tests). No test
+        // relies on a launch-time warm — the transcription E2E tests pass
+        // `--ui-test-tiny-model-path=` and load on demand — so warming the
+        // (potentially multi-GB) default model here just burns CPU/IO on
+        // every test launch and creates a whisper/Metal context that XCTest
+        // never frees (it exits via `exit()`, bypassing `gracefulShutdown()`),
+        // which is what prints the ggml-metal teardown backtrace at process
+        // exit. This used to be guarded by `--uitests` alone, which covers
+        // XCUITest, but `MilaTests` is an app-hosted unit test bundle
+        // (`TEST_HOST` = Mila.app in project.yml) — SwiftUI's `.task`
+        // modifiers, prewarm included, run there too, just without that flag.
+        guard !isRunningUnderXCTest else { return }
         // No local weights to warm when the remote backend is selected.
         guard !remoteTranscriptionSettings.isActive else { return }
         transcription.prewarm(language: languageSettings.current.rawValue)
     }
 
-    /// True when the process was launched by an XCUITest run. Keyed off the
-    /// `--uitests` / `--ui-test-*` launch arguments the UI test targets pass.
-    private var isRunningUITests: Bool {
+    /// True when the process is hosting an XCTest run — either an XCUITest
+    /// (keyed off the `--uitests` / `--ui-test-*` launch arguments the UI
+    /// test targets pass) or an app-hosted unit test bundle (`MilaTests`),
+    /// which loads `XCTestCase` directly into this process via
+    /// `BUNDLE_LOADER`/`TEST_HOST` — no launch argument marks that case, so
+    /// `XCTestCase`'s presence is the only reliable signal.
+    /// `XCTestConfigurationFilePath`, the usual env-var check for "is this
+    /// process under XCTest," is present but empty for app-hosted unit
+    /// tests on this toolchain — verified empirically, not a documented
+    /// contract — so it can't be used here.
+    private var isRunningUnderXCTest: Bool {
         CommandLine.arguments.contains { $0 == "--uitests" || $0.hasPrefix("--ui-test") }
+            || NSClassFromString("XCTestCase") != nil
     }
 
     /// Pre-download the two default models on first launch:
@@ -2056,7 +2069,12 @@ struct MilaApp: App {
         // local weights. (The Models tab still offers manual downloads, and
         // switching back to local re-triggers this on next launch.)
         guard !remoteTranscriptionSettings.isActive else { return }
-        modelManager.setSelected(WhisperModel.ivritLarge)
+        // Don't re-select a model the user explicitly deleted — that would
+        // silently revert their delete every launch, same as skipping its
+        // auto-download below.
+        if !modelManager.isDeclined(WhisperModel.ivritLarge) {
+            modelManager.setSelected(WhisperModel.ivritLarge)
+        }
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
             if !modelManager.isInstalled(model)
                 && !modelManager.isDeclined(model)

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2064,6 +2064,15 @@ struct MilaApp: App {
     /// same `URLSession` so they don't actually saturate the network, and
     /// the in-app banner shows whichever is currently selected.
     private func ensureDefaultModelsInstalled() {
+        // Skip entirely under XCTest hosting (unit or UI) — same rationale
+        // as `prewarmDefaultModel()`: `MilaTests` is app-hosted, so this
+        // `.task` runs for real during ordinary unit test runs too. Without
+        // this guard it calls `setSelected`/`download` on the production
+        // `ModelManager`, which is backed by `UserDefaults.standard` (see
+        // `MilaApp.body`'s `ModelManager(modelsDirectory:)` call) — every
+        // `xcodebuild test` invocation would mutate the real app's declined
+        // models / selected model and could kick off real network downloads.
+        guard !isRunningUnderXCTest else { return }
         // Skip the multi-GB local model downloads + CoreML prep entirely for
         // users who've opted into the remote backend — they don't need any
         // local weights. (The Models tab still offers manual downloads, and

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2058,7 +2058,9 @@ struct MilaApp: App {
         guard !remoteTranscriptionSettings.isActive else { return }
         modelManager.setSelected(WhisperModel.ivritLarge)
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {
-            if !modelManager.isInstalled(model) && modelManager.downloads[model.name] == nil {
+            if !modelManager.isInstalled(model)
+                && !modelManager.isDeclined(model)
+                && modelManager.downloads[model.name] == nil {
                 modelManager.download(model)
             }
         }

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -2078,10 +2078,17 @@ struct MilaApp: App {
         // local weights. (The Models tab still offers manual downloads, and
         // switching back to local re-triggers this on next launch.)
         guard !remoteTranscriptionSettings.isActive else { return }
-        // Don't re-select a model the user explicitly deleted — that would
-        // silently revert their delete every launch, same as skipping its
-        // auto-download below.
-        if !modelManager.isDeclined(WhisperModel.ivritLarge) {
+        // Establish the default selection only on a fresh install. Re-asserting
+        // it on every launch overwrote whatever the user picked in Settings →
+        // Models (#266); once deletion started sticking (#263) it also kept
+        // re-selecting a model that is no longer on disk, which is the first
+        // step into the dead end in #264. `ModelManager.init` already restores
+        // a persisted selection on its own, so there is nothing to do here
+        // once the user has made one. The declined check still guards the
+        // fresh-install case — a user can delete a model without ever having
+        // explicitly chosen one.
+        if !modelManager.hasPersistedSelection,
+           !modelManager.isDeclined(WhisperModel.ivritLarge) {
             modelManager.setSelected(WhisperModel.ivritLarge)
         }
         for model in [WhisperModel.ivritLarge, WhisperModel.openaiTurbo] {

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -110,6 +110,15 @@ final class ModelManager: NSObject, ObservableObject {
     /// model, since that's an explicit request for it.
     @Published private(set) var declinedModelNames: Set<String>
 
+    /// True when `selectedModelName` was restored from a choice the user
+    /// actually persisted via `setSelected(_:)`, rather than defaulted to the
+    /// catalog's `ivritLarge`. Launch-time bootstrap consults this so it only
+    /// ever *establishes* a default selection on a fresh install: re-asserting
+    /// one on every launch is what silently reverted the user's Settings →
+    /// Models choice, and — once deletion started sticking — kept re-selecting
+    /// a model that is no longer on disk (#264, #266).
+    private(set) var hasPersistedSelection: Bool
+
     /// Test-only hook: stub `URLProtocol` classes to install on the download
     /// session's configuration, so tests can exercise `download(_:)` without
     /// making a real network request. `nil` in production.
@@ -118,8 +127,11 @@ final class ModelManager: NSObject, ObservableObject {
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForResource = 60 * 60
-        if let sessionProtocolClasses {
-            config.protocolClasses = sessionProtocolClasses
+        // Explicit `self.` — the same closure already needs it for
+        // `delegate: self`, and implicit `self` in a `lazy var` initializer
+        // is not something to rely on.
+        if let stubs = self.sessionProtocolClasses {
+            config.protocolClasses = stubs
         }
         return URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }()
@@ -132,6 +144,7 @@ final class ModelManager: NSObject, ObservableObject {
         self.sessionProtocolClasses = sessionProtocolClasses
         let lastUsed = defaults.string(forKey: "selectedModelName")
         self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
+        self.hasPersistedSelection = lastUsed != nil
         let declined = defaults.array(forKey: Self.declinedModelsKey) as? [String] ?? []
         self.declinedModelNames = Set(declined)
         super.init()
@@ -145,6 +158,7 @@ final class ModelManager: NSObject, ObservableObject {
 
     func setSelected(_ model: WhisperModel) {
         selectedModelName = model.name
+        hasPersistedSelection = true
         defaults.set(model.name, forKey: "selectedModelName")
     }
 
@@ -225,10 +239,26 @@ final class ModelManager: NSObject, ObservableObject {
         defaults.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
     }
 
+    /// Remove a model's weights from disk and record that the removal was
+    /// deliberate.
+    ///
+    /// The `.bin` and its sibling `<name>-encoder.mlmodelc` are one install,
+    /// so they are one delete: leaving the ~1.1 GB CoreML encoder behind meant
+    /// the user reclaimed far less disk than the confirmation dialog promised,
+    /// with no UI anywhere that could see or remove the orphan (#265).
+    ///
+    /// Ordering matters. `refreshInstalled()` and `setDeclined(true,…)` run as
+    /// soon as the `.bin` is gone and *before* the encoder removal that can
+    /// throw — otherwise a failure there would leave the app believing the
+    /// model is still installed and was never declined, which is exactly the
+    /// state that silently re-downloads it on the next launch (#263).
     func delete(_ model: WhisperModel) throws {
         try FileManager.default.removeItem(at: url(for: model))
         refreshInstalled()
         setDeclined(true, for: model)
+        if isCoreMLInstalled(model), let coreML = coreMLDirectory(for: model) {
+            try FileManager.default.removeItem(at: coreML)
+        }
     }
 
     func download(_ model: WhisperModel) {

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -99,6 +99,7 @@ final class ModelManager: NSObject, ObservableObject {
     @Published var lastDownloadErrors: [String: String] = [:]
 
     private let modelsDirectory: URL
+    private let defaults: UserDefaults
     private static let declinedModelsKey = "model.declinedNames"
 
     /// Names of models the user explicitly deleted via Settings. Consulted
@@ -109,19 +110,29 @@ final class ModelManager: NSObject, ObservableObject {
     /// model, since that's an explicit request for it.
     @Published private(set) var declinedModelNames: Set<String>
 
+    /// Test-only hook: stub `URLProtocol` classes to install on the download
+    /// session's configuration, so tests can exercise `download(_:)` without
+    /// making a real network request. `nil` in production.
+    private let sessionProtocolClasses: [AnyClass]?
+
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForResource = 60 * 60
+        if let sessionProtocolClasses {
+            config.protocolClasses = sessionProtocolClasses
+        }
         return URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }()
     private var observers: [Int: WhisperModel] = [:]
     private var didShutDownSession = false
 
-    init(modelsDirectory: URL) {
+    init(modelsDirectory: URL, defaults: UserDefaults = .standard, sessionProtocolClasses: [AnyClass]? = nil) {
         self.modelsDirectory = modelsDirectory
-        let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
+        self.defaults = defaults
+        self.sessionProtocolClasses = sessionProtocolClasses
+        let lastUsed = defaults.string(forKey: "selectedModelName")
         self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
-        let declined = UserDefaults.standard.array(forKey: Self.declinedModelsKey) as? [String] ?? []
+        let declined = defaults.array(forKey: Self.declinedModelsKey) as? [String] ?? []
         self.declinedModelNames = Set(declined)
         super.init()
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
@@ -134,7 +145,7 @@ final class ModelManager: NSObject, ObservableObject {
 
     func setSelected(_ model: WhisperModel) {
         selectedModelName = model.name
-        UserDefaults.standard.set(model.name, forKey: "selectedModelName")
+        defaults.set(model.name, forKey: "selectedModelName")
     }
 
     /// The model the app should use when transcribing audio in `languageCode`.
@@ -211,7 +222,7 @@ final class ModelManager: NSObject, ObservableObject {
         } else {
             declinedModelNames.remove(model.name)
         }
-        UserDefaults.standard.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
+        defaults.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
     }
 
     func delete(_ model: WhisperModel) throws {

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -99,6 +99,16 @@ final class ModelManager: NSObject, ObservableObject {
     @Published var lastDownloadErrors: [String: String] = [:]
 
     private let modelsDirectory: URL
+    private static let declinedModelsKey = "model.declinedNames"
+
+    /// Names of models the user explicitly deleted via Settings. Consulted
+    /// by `MilaApp.ensureDefaultModelsInstalled()` so a deliberate delete
+    /// doesn't come back on the next launch — `isInstalled` alone can't
+    /// distinguish "never downloaded" from "downloaded, then removed on
+    /// purpose." Cleared the moment `download(_:)` is called again for that
+    /// model, since that's an explicit request for it.
+    @Published private(set) var declinedModelNames: Set<String>
+
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForResource = 60 * 60
@@ -111,6 +121,8 @@ final class ModelManager: NSObject, ObservableObject {
         self.modelsDirectory = modelsDirectory
         let lastUsed = UserDefaults.standard.string(forKey: "selectedModelName")
         self.selectedModelName = lastUsed ?? WhisperModel.ivritLarge.name
+        let declined = UserDefaults.standard.array(forKey: Self.declinedModelsKey) as? [String] ?? []
+        self.declinedModelNames = Set(declined)
         super.init()
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         refreshInstalled()
@@ -179,6 +191,10 @@ final class ModelManager: NSObject, ObservableObject {
         return installed.contains(model.name)
     }
 
+    func isDeclined(_ model: WhisperModel) -> Bool {
+        declinedModelNames.contains(model.name)
+    }
+
     func refreshInstalled() {
         let fm = FileManager.default
         var found: Set<String> = []
@@ -189,14 +205,25 @@ final class ModelManager: NSObject, ObservableObject {
         modelLogger.log("refreshInstalled: dir=\(self.modelsDirectory.path, privacy: .public) found=\(found, privacy: .public)")
     }
 
+    private func setDeclined(_ declined: Bool, for model: WhisperModel) {
+        if declined {
+            declinedModelNames.insert(model.name)
+        } else {
+            declinedModelNames.remove(model.name)
+        }
+        UserDefaults.standard.set(Array(declinedModelNames), forKey: Self.declinedModelsKey)
+    }
+
     func delete(_ model: WhisperModel) throws {
         try FileManager.default.removeItem(at: url(for: model))
         refreshInstalled()
+        setDeclined(true, for: model)
     }
 
     func download(_ model: WhisperModel) {
         guard downloads[model.name] == nil else { return }
         guard !didShutDownSession else { return }
+        setDeclined(false, for: model)
         // A fresh attempt supersedes the previous failure report for THIS
         // model only — a concurrent sibling download's error must survive.
         lastDownloadErrors[model.name] = nil

--- a/Mila/Transcription/ModelManager.swift
+++ b/Mila/Transcription/ModelManager.swift
@@ -256,9 +256,41 @@ final class ModelManager: NSObject, ObservableObject {
         try FileManager.default.removeItem(at: url(for: model))
         refreshInstalled()
         setDeclined(true, for: model)
+        // A CoreML fetch for this model may be in flight right now: Settings
+        // offers Delete the moment the `.bin` lands, which is exactly when
+        // `ensureCoreMLInstalled()`/the post-install hook has started the
+        // ~1.1 GB encoder download. Left running it would finish and move the
+        // encoder into place *after* the delete — recreating the very orphan
+        // #265 exists to remove, except now permanent, because the model is
+        // declined so nothing re-checks the pair and no UI can see it.
+        cancelCoreMLDownload(model)
         if isCoreMLInstalled(model), let coreML = coreMLDirectory(for: model) {
             try FileManager.default.removeItem(at: coreML)
         }
+    }
+
+    /// Stop an in-flight CoreML encoder fetch for `model` and forget the UI
+    /// state that went with it, so a deleted model can't keep showing
+    /// download progress.
+    private func cancelCoreMLDownload(_ model: WhisperModel) {
+        guard let task = coreMLTasks.removeValue(forKey: model.name) else { return }
+        task.cancel()
+        coreMLObservers.removeValue(forKey: task.taskIdentifier)
+        coreMLDownloads.removeValue(forKey: model.name)
+    }
+
+    /// Whether an encoder download that has just finished should still be
+    /// installed.
+    ///
+    /// Cancellation alone cannot answer this: by the time `delete(_:)` runs,
+    /// the fetch may already be past its last cancellation point, with the
+    /// bytes on disk and only the final move left. Every step of
+    /// `finishCoreMLDownload` is an `await` that hands the main actor back,
+    /// so the state it read on entry can be stale by the time it commits.
+    /// An encoder is worth installing only next to weights that are still
+    /// there and still wanted.
+    func shouldInstallCoreML(for model: WhisperModel) -> Bool {
+        !isDeclined(model) && isInstalled(model)
     }
 
     func download(_ model: WhisperModel) {
@@ -281,6 +313,11 @@ final class ModelManager: NSObject, ObservableObject {
     private var coreMLObservers: [Int: WhisperModel] = [:]
     @Published private(set) var coreMLDownloads: [String: Double] = [:]
 
+    /// The in-flight CoreML fetch per model, kept so `delete(_:)` can stop
+    /// one. Keyed by name rather than task id because the caller that needs
+    /// to cancel knows the model, not the task.
+    private var coreMLTasks: [String: URLSessionDownloadTask] = [:]
+
     /// Download + extract the `<model>-encoder.mlmodelc.zip` from
     /// `model.coreMLURL` and place the resulting `.mlmodelc` directory
     /// next to the `.bin`. No-op if the model has no CoreML build or
@@ -294,6 +331,7 @@ final class ModelManager: NSObject, ObservableObject {
         coreMLDownloads[model.name] = 0
         let task = session.downloadTask(with: coreMLURL)
         coreMLObservers[task.taskIdentifier] = model
+        coreMLTasks[model.name] = task
         task.resume()
     }
 
@@ -318,6 +356,7 @@ final class ModelManager: NSObject, ObservableObject {
         didShutDownSession = true
         observers.removeAll()
         downloads.removeAll()
+        coreMLTasks.removeAll()
         session.invalidateAndCancel()
     }
 
@@ -388,7 +427,10 @@ extension ModelManager: URLSessionDownloadDelegate {
         Task { @MainActor in
             // Demultiplex: is this the .bin or the CoreML zip?
             if let model = self.coreMLObservers.removeValue(forKey: id) {
-                defer { self.coreMLDownloads.removeValue(forKey: model.name) }
+                defer {
+                    self.coreMLDownloads.removeValue(forKey: model.name)
+                    self.coreMLTasks.removeValue(forKey: model.name)
+                }
                 await self.finishCoreMLDownload(model: model, tempCopy: tempCopy, moveErr: moveErr)
                 return
             }
@@ -460,6 +502,7 @@ extension ModelManager: URLSessionDownloadDelegate {
                 self.lastDownloadErrors[model.name] = "\(model.displayName): download failed (\(error.localizedDescription))"
             } else if let model = self.coreMLObservers.removeValue(forKey: id) {
                 self.coreMLDownloads.removeValue(forKey: model.name)
+                self.coreMLTasks.removeValue(forKey: model.name)
                 modelLogger.error("CoreML download \(model.name, privacy: .public): network/task failure: \(error.localizedDescription, privacy: .public)")
             }
         }
@@ -532,6 +575,16 @@ extension ModelManager: URLSessionDownloadDelegate {
         // ggerganov and our HF repo use the flat layout, but be defensive).
         guard let mlmodelc = ModelManager.findMLModelcDirectory(in: extractRoot) else {
             modelLogger.error("CoreML download \(model.name, privacy: .public): no .mlmodelc directory inside the zip")
+            return
+        }
+
+        // Re-check before committing: `delete(_:)` may have run during any of
+        // the awaits above. `extractRoot` is cleaned up by the `defer`, so
+        // returning here leaves nothing behind. This guard has to come before
+        // the removal below — bailing out after clearing `destDir` would
+        // destroy an encoder we were not asked to touch.
+        guard shouldInstallCoreML(for: model) else {
+            modelLogger.notice("CoreML download \(model.name, privacy: .public): discarding finished encoder — the model was deleted while it downloaded")
             return
         }
 

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -689,8 +689,16 @@ final class TranscriptionService: ObservableObject {
                 return
             }
             guard modelManager.isInstalled(model) else {
-                lastError = "Whisper model is still downloading. Try again once it's ready."
-                serviceLog.log("skipped: model \(model.name, privacy: .public) not installed yet")
+                // "Still downloading" is only true while the model is on its
+                // way in. Once deletion sticks (#263), a model the user
+                // deleted is never coming back on its own, so that message
+                // would promise a wait that never ends and would hide the one
+                // recovery there is (#264).
+                let declined = modelManager.isDeclined(model)
+                lastError = declined
+                    ? "\(model.displayName) was deleted. Download it again in Settings → Models."
+                    : "Whisper model is still downloading. Try again once it's ready."
+                serviceLog.log("skipped: model \(model.name, privacy: .public) not installed yet (declined=\(declined, privacy: .public))")
                 markFailed(recording)
                 return
             }

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -1185,7 +1185,7 @@ private struct ModelRow: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Using this model again will require re-downloading it (\(byteCountString(model.sizeBytes))).")
+            Text(deleteConfirmationMessage)
         }
         .alert(
             "Couldn't delete model",
@@ -1196,6 +1196,18 @@ private struct ModelRow: View {
             actions: { Button("OK") { deleteError = nil } },
             message: { Text(deleteError ?? "") }
         )
+    }
+
+    /// Deleting takes the `.bin` *and* its sibling `-encoder.mlmodelc` — they
+    /// are installed as a pair and reclaimed as a pair (#265) — so the figure
+    /// quoted here has to be both, not just the `.bin`. For `ivritLarge`
+    /// that's the difference between promising ~2.9 GB and the ~4.0 GB a
+    /// re-download actually costs.
+    private var deleteConfirmationMessage: String {
+        var total = model.sizeBytes
+        if model.coreMLURL != nil { total += model.coreMLSizeBytes }
+        return "This also removes the model's CoreML encoder. Using it again "
+            + "will require re-downloading both (\(byteCountString(total)))."
     }
 
     private func byteCountString(_ bytes: Int64) -> String {

--- a/MilaTests/DictationControllerTests.swift
+++ b/MilaTests/DictationControllerTests.swift
@@ -12,32 +12,24 @@ final class DictationControllerTests: XCTestCase {
     private var service: TranscriptionService!
     private var hotkeys: HotkeySettings!
     private var defaultsSuite: UserDefaults!
-    private var savedSelection: String?
 
     override func setUp() async throws {
         try await super.setUp()
         tempRoot = TestSupport.makeTempRoot(label: "DictationControllerTests")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        UserDefaults().removePersistentDomain(forName: "DictationControllerTests")
+        defaultsSuite = UserDefaults(suiteName: "DictationControllerTests")
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"), defaults: defaultsSuite)
         try TestSupport.installFakeModel(into: manager, model: .ivritLarge)
         try TestSupport.installFakeModel(into: manager, model: .openaiTurbo)
         stub = StubWhisperEngine()
         service = TranscriptionService(store: store, modelManager: manager, diarizationSettings: DiarizationSettings(defaults: .init(suiteName: "DictationControllerTests.diarization")!), remoteSettings: TestSupport.isolatedRemoteSettings(label: "DictationControllerTests"), engine: stub)
-
-        UserDefaults().removePersistentDomain(forName: "DictationControllerTests")
-        defaultsSuite = UserDefaults(suiteName: "DictationControllerTests")
         hotkeys = HotkeySettings(defaults: defaultsSuite)
     }
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         defaultsSuite.removePersistentDomain(forName: "DictationControllerTests")
         try await super.tearDown()
     }

--- a/MilaTests/LiveSidecarHandoffOrderingTests.swift
+++ b/MilaTests/LiveSidecarHandoffOrderingTests.swift
@@ -47,7 +47,6 @@ final class LiveSidecarHandoffOrderingTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
 
     private let suitePrefix = "LiveSidecarHandoffOrderingTests"
-    private var savedSelection: String?
 
     override func setUp() async throws {
         try await super.setUp()
@@ -59,8 +58,9 @@ final class LiveSidecarHandoffOrderingTests: XCTestCase {
         store = RecordingStore(rootDirectory: tempRoot)
         try FileManager.default.createDirectory(at: store.recordingsDirectory,
                                                 withIntermediateDirectories: true)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: suitePrefix)
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -96,11 +96,6 @@ final class LiveSidecarHandoffOrderingTests: XCTestCase {
         // Always restore write permission, or the temp tree can't be removed.
         setRecordingsDirWritable(true)
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         for suffix in ["diarization", "language", "llm"] {
             UserDefaults().removePersistentDomain(forName: "\(suitePrefix).\(suffix)")
         }

--- a/MilaTests/LiveSpeakerNamingTests.swift
+++ b/MilaTests/LiveSpeakerNamingTests.swift
@@ -350,7 +350,6 @@ final class LiveSpeakerNamingStopRecordingTests: XCTestCase {
     private var fires: [Fire] = []
 
     private let suitePrefix = "LiveSpeakerNamingStopRecordingTests"
-    private var savedSelection: String?
 
     /// A voice no stored profile matches, so the only way its name can reach
     /// a profile is the live-naming path under test.
@@ -364,8 +363,9 @@ final class LiveSpeakerNamingStopRecordingTests: XCTestCase {
         store = RecordingStore(rootDirectory: tempRoot)
         try FileManager.default.createDirectory(at: store.recordingsDirectory,
                                                 withIntermediateDirectories: true)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: suitePrefix)
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -444,11 +444,6 @@ final class LiveSpeakerNamingStopRecordingTests: XCTestCase {
         controller?.onRecordingFinalized = nil
         store?.onSpeakerNamed = nil
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         for suffix in ["diarization", "language", "llm", "voice"] {
             UserDefaults().removePersistentDomain(forName: "\(suitePrefix).\(suffix)")
         }

--- a/MilaTests/LiveTranscriberTests.swift
+++ b/MilaTests/LiveTranscriberTests.swift
@@ -23,7 +23,9 @@ final class LiveTranscriberTests: XCTestCase {
         tempRoot = TestSupport.makeTempRoot(label: "LiveTranscriberTests")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: "LiveTranscriberTests")
         try TestSupport.installFakeModel(into: manager)
         stub = StubWhisperEngine()
         service = TranscriptionService(

--- a/MilaTests/LiveTranscriptLineDeleteTests.swift
+++ b/MilaTests/LiveTranscriptLineDeleteTests.swift
@@ -50,7 +50,6 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
     private var controller: QuickActionsController!
 
     private let suitePrefix = "LiveTranscriptLineDeleteTests"
-    private var savedSelection: String?
 
     override func setUp() async throws {
         try await super.setUp()
@@ -64,8 +63,9 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
         store = RecordingStore(rootDirectory: tempRoot)
         try FileManager.default.createDirectory(at: store.recordingsDirectory,
                                                 withIntermediateDirectories: true)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: suitePrefix)
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -116,11 +116,6 @@ final class LiveTranscriptLineDeleteTests: XCTestCase {
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         for suffix in ["diarization", "language", "llm", "liveAI"] {
             UserDefaults().removePersistentDomain(forName: "\(suitePrefix).\(suffix)")
         }

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -191,6 +191,97 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
         XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
     }
+
+    // MARK: - CoreML encoder is deleted with the model (#265)
+
+    /// Installs a stand-in `<name>-encoder.mlmodelc` next to the `.bin`, the
+    /// way a finished CoreML download would.
+    private func installFakeCoreMLEncoder(_ mgr: ModelManager,
+                                          for model: WhisperModel) throws -> URL {
+        let dir = try XCTUnwrap(mgr.coreMLDirectory(for: model))
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("not-a-real-encoder".utf8)
+            .write(to: dir.appendingPathComponent("model.espresso.net"))
+        XCTAssertTrue(mgr.isCoreMLInstalled(model))
+        return dir
+    }
+
+    func test_delete_also_removes_the_coreml_encoder() throws {
+        let mgr = makeManager()
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        mgr.refreshInstalled()
+        let encoder = try installFakeCoreMLEncoder(mgr, for: .ivritLarge)
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: encoder.path),
+                       "Deleting a model must reclaim its ~1.1GB CoreML encoder too — "
+                       + "the confirmation dialog quotes the size of both")
+        XCTAssertFalse(mgr.isCoreMLInstalled(.ivritLarge))
+        XCTAssertFalse(mgr.isInstalled(.ivritLarge))
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+    }
+
+    func test_delete_leaves_another_models_coreml_encoder_alone() throws {
+        let mgr = makeManager()
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .openaiTurbo))
+        mgr.refreshInstalled()
+        let deleted = try installFakeCoreMLEncoder(mgr, for: .ivritLarge)
+        let kept = try installFakeCoreMLEncoder(mgr, for: .openaiTurbo)
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: deleted.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: kept.path),
+                      "Deleting one model must not touch the other's encoder")
+        XCTAssertTrue(mgr.isCoreMLInstalled(.openaiTurbo))
+    }
+
+    func test_delete_succeeds_when_the_model_has_no_coreml_encoder_on_disk() throws {
+        let mgr = makeManager()
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        mgr.refreshInstalled()
+        XCTAssertFalse(mgr.isCoreMLInstalled(.ivritLarge))
+
+        XCTAssertNoThrow(try mgr.delete(.ivritLarge))
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+    }
+
+    // MARK: - Default selection is established once, not re-asserted (#264, #266)
+
+    func test_fresh_install_has_no_persisted_selection() {
+        let mgr = makeManager()
+        XCTAssertFalse(mgr.hasPersistedSelection,
+                       "A catalog default is not a user choice — launch-time bootstrap "
+                       + "uses this to tell 'never picked' from 'picked this'")
+        XCTAssertEqual(mgr.selectedModelName, WhisperModel.ivritLarge.name)
+    }
+
+    func test_persisted_selection_is_remembered_across_reload() {
+        let mgr = makeManager()
+        mgr.setSelected(.openaiTurbo)
+        XCTAssertTrue(mgr.hasPersistedSelection)
+
+        let reloaded = makeManager()
+
+        XCTAssertTrue(reloaded.hasPersistedSelection,
+                      "Once the user has chosen a model, every later launch must see "
+                      + "that choice rather than re-establishing the default over it")
+        XCTAssertEqual(reloaded.selectedModelName, WhisperModel.openaiTurbo.name)
+    }
+
+    func test_deleting_a_model_does_not_invent_a_persisted_selection() throws {
+        let mgr = makeManager()
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        mgr.refreshInstalled()
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertFalse(mgr.hasPersistedSelection,
+                       "Deleting is not choosing — a user who never picked a model "
+                       + "must still get the fresh-install default path")
+    }
 }
 
 /// Returns a tiny 200 response for any request — lets `ModelManager.download(_:)`

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -248,6 +248,53 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
     }
 
+    // MARK: - A finished encoder download can't resurrect a deleted model
+
+    /// Settings offers Delete the moment the `.bin` lands — which is exactly
+    /// when the encoder auto-download is running. If that fetch is left alone
+    /// it finishes and reinstates the ~1.1GB encoder after the delete.
+    func test_delete_cancels_an_in_flight_coreml_download() throws {
+        let mgr = makeManager(sessionProtocolClasses: [StubModelDownloadURLProtocol.self])
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        mgr.refreshInstalled()
+
+        mgr.downloadCoreML(.ivritLarge)
+        XCTAssertNotNil(mgr.coreMLDownloads[WhisperModel.ivritLarge.name],
+                        "precondition: an encoder fetch is in flight")
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertNil(mgr.coreMLDownloads[WhisperModel.ivritLarge.name],
+                     "Deleting a model must stop its encoder fetch — otherwise it completes "
+                     + "and moves the encoder into place behind the delete, and the model is "
+                     + "declined so nothing ever re-checks the pair")
+        mgr.shutdown()
+    }
+
+    /// The half cancellation cannot cover: by the time `delete(_:)` runs the
+    /// fetch may already be past its last cancellation point, with only the
+    /// final move left. `finishCoreMLDownload` re-reads this before committing.
+    func test_finished_encoder_is_discarded_when_the_model_was_deleted() throws {
+        let mgr = makeManager()
+        try Data("not-a-real-model".utf8).write(to: mgr.url(for: .ivritLarge))
+        mgr.refreshInstalled()
+        XCTAssertTrue(mgr.shouldInstallCoreML(for: .ivritLarge),
+                      "precondition: weights present and wanted")
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertFalse(mgr.shouldInstallCoreML(for: .ivritLarge),
+                       "An encoder that finishes after the delete must be dropped, not moved "
+                       + "into place — that is the #265 orphan recreated through a race")
+    }
+
+    func test_encoder_is_not_installed_without_its_weights() {
+        let mgr = makeManager()
+        XCTAssertFalse(mgr.isInstalled(.ivritLarge))
+        XCTAssertFalse(mgr.shouldInstallCoreML(for: .ivritLarge),
+                       "An encoder with no .bin beside it is ~1.1GB of unusable disk")
+    }
+
     // MARK: - Default selection is established once, not re-asserted (#264, #266)
 
     func test_fresh_install_has_no_persisted_selection() {

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -6,36 +6,31 @@ import CryptoKit
 final class ModelManagerTests: XCTestCase {
 
     private var tempRoot: URL!
-
-    private var savedSelection: String?
-    private var savedDeclined: [String]?
+    private var defaults: UserDefaults!
+    private let suite = "ModelManagerTests"
 
     override func setUp() {
         super.setUp()
         tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelManagerTests-\(UUID())", isDirectory: true)
         try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
-        savedDeclined = UserDefaults.standard.array(forKey: "model.declinedNames") as? [String]
+        UserDefaults().removePersistentDomain(forName: suite)
+        defaults = UserDefaults(suiteName: suite)
     }
 
     override func tearDown() {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
-        if let savedDeclined {
-            UserDefaults.standard.set(savedDeclined, forKey: "model.declinedNames")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "model.declinedNames")
-        }
+        defaults.removePersistentDomain(forName: suite)
         super.tearDown()
     }
 
+    private func makeManager(sessionProtocolClasses: [AnyClass]? = nil) -> ModelManager {
+        ModelManager(modelsDirectory: tempRoot, defaults: defaults,
+                     sessionProtocolClasses: sessionProtocolClasses)
+    }
+
     func test_catalog_contains_ivrit_large_as_default_selected_model() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         XCTAssertNotNil(mgr.selectedModel())
         XCTAssertEqual(mgr.selectedModelName, WhisperModel.ivritLarge.name,
                        "Default selection should be the ivrit.ai large-v3 Hebrew model")
@@ -96,14 +91,14 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_url_for_model_lives_under_models_directory() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let url = mgr.url(for: WhisperModel.ivritLarge)
         XCTAssertEqual(url.deletingLastPathComponent().path, tempRoot.path)
         XCTAssertEqual(url.lastPathComponent, "ivrit-ai-whisper-large-v3.bin")
     }
 
     func test_install_state_reflects_files_in_directory() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         XCTAssertFalse(mgr.isInstalled(.ivritLarge))
 
         let path = mgr.url(for: .ivritLarge)
@@ -116,11 +111,11 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_set_selected_persists_choice() {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         mgr.setSelected(.openaiTurbo)
         XCTAssertEqual(mgr.selectedModelName, WhisperModel.openaiTurbo.name)
 
-        let reloaded = ModelManager(modelsDirectory: tempRoot)
+        let reloaded = makeManager()
         XCTAssertEqual(reloaded.selectedModelName, WhisperModel.openaiTurbo.name)
     }
 
@@ -132,7 +127,7 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_model_for_language_falls_back_to_selected_when_best_not_installed() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         // Install only the OpenAI turbo, then ask for the Hebrew best model.
         let openaiPath = mgr.url(for: .openaiTurbo)
         try Data("not-a-real-model".utf8).write(to: openaiPath)
@@ -145,7 +140,7 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_delete_marks_model_declined() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -158,20 +153,20 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func test_declined_status_persists_across_reload() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
         try mgr.delete(.ivritLarge)
 
-        let reloaded = ModelManager(modelsDirectory: tempRoot)
+        let reloaded = makeManager()
 
         XCTAssertTrue(reloaded.isDeclined(.ivritLarge),
                       "Declined status must survive process relaunch, same as selectedModelName")
     }
 
     func test_download_clears_declined_status() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager(sessionProtocolClasses: [StubModelDownloadURLProtocol.self])
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -179,14 +174,14 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
 
         mgr.download(.ivritLarge)
-        mgr.shutdown() // cancel the in-flight network task; we only care about the declined-set side effect
+        mgr.shutdown() // stop the stubbed task; we only care about the declined-set side effect
 
         XCTAssertFalse(mgr.isDeclined(.ivritLarge),
                        "An explicit download request means the user wants the model again")
     }
 
     func test_declining_one_model_does_not_affect_another() throws {
-        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let mgr = makeManager()
         let path = mgr.url(for: .ivritLarge)
         try Data("not-a-real-model".utf8).write(to: path)
         mgr.refreshInstalled()
@@ -196,4 +191,19 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertTrue(mgr.isDeclined(.ivritLarge))
         XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
     }
+}
+
+/// Returns a tiny 200 response for any request — lets `ModelManager.download(_:)`
+/// exercise its declined-status side effect without a real network fetch.
+private final class StubModelDownloadURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("stub-model-bytes".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
 }

--- a/MilaTests/ModelManagerTests.swift
+++ b/MilaTests/ModelManagerTests.swift
@@ -8,6 +8,7 @@ final class ModelManagerTests: XCTestCase {
     private var tempRoot: URL!
 
     private var savedSelection: String?
+    private var savedDeclined: [String]?
 
     override func setUp() {
         super.setUp()
@@ -15,6 +16,7 @@ final class ModelManagerTests: XCTestCase {
             .appendingPathComponent("ModelManagerTests-\(UUID())", isDirectory: true)
         try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        savedDeclined = UserDefaults.standard.array(forKey: "model.declinedNames") as? [String]
     }
 
     override func tearDown() {
@@ -23,6 +25,11 @@ final class ModelManagerTests: XCTestCase {
             UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
         } else {
             UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        if let savedDeclined {
+            UserDefaults.standard.set(savedDeclined, forKey: "model.declinedNames")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "model.declinedNames")
         }
         super.tearDown()
     }
@@ -135,5 +142,58 @@ final class ModelManagerTests: XCTestCase {
         // Hebrew best is ivritLarge (not installed) so we should fall back.
         let resolved = mgr.model(for: "he")
         XCTAssertEqual(resolved, .openaiTurbo)
+    }
+
+    func test_delete_marks_model_declined() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge))
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge),
+                      "Deleting a model must mark it declined so launch-time auto-download skips it")
+    }
+
+    func test_declined_status_persists_across_reload() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+
+        let reloaded = ModelManager(modelsDirectory: tempRoot)
+
+        XCTAssertTrue(reloaded.isDeclined(.ivritLarge),
+                      "Declined status must survive process relaunch, same as selectedModelName")
+    }
+
+    func test_download_clears_declined_status() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+        try mgr.delete(.ivritLarge)
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+
+        mgr.download(.ivritLarge)
+        mgr.shutdown() // cancel the in-flight network task; we only care about the declined-set side effect
+
+        XCTAssertFalse(mgr.isDeclined(.ivritLarge),
+                       "An explicit download request means the user wants the model again")
+    }
+
+    func test_declining_one_model_does_not_affect_another() throws {
+        let mgr = ModelManager(modelsDirectory: tempRoot)
+        let path = mgr.url(for: .ivritLarge)
+        try Data("not-a-real-model".utf8).write(to: path)
+        mgr.refreshInstalled()
+
+        try mgr.delete(.ivritLarge)
+
+        XCTAssertTrue(mgr.isDeclined(.ivritLarge))
+        XCTAssertFalse(mgr.isDeclined(.openaiTurbo))
     }
 }

--- a/MilaTests/QuickActionsControllerTests.swift
+++ b/MilaTests/QuickActionsControllerTests.swift
@@ -24,16 +24,15 @@ final class QuickActionsControllerTests: XCTestCase {
     private var languageDefaults: UserDefaults!
     private let languageSuite = "QuickActionsControllerTests.language"
 
-    private var savedSelection: String?
-
     override func setUp() async throws {
         try await super.setUp()
         tempRoot = TestSupport.makeTempRoot(label: "QuickActionsControllerTests")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
 
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: "QuickActionsControllerTests")
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -54,11 +53,6 @@ final class QuickActionsControllerTests: XCTestCase {
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
         languageDefaults?.removePersistentDomain(forName: languageSuite)
         try await super.tearDown()
     }

--- a/MilaTests/TestSupport.swift
+++ b/MilaTests/TestSupport.swift
@@ -124,6 +124,22 @@ enum TestSupport {
     /// a clean suite (which has no `transcription.backend` key, so it defaults
     /// to `.local`) makes the stub authoritative regardless of host state.
     @MainActor
+    /// A `ModelManager` whose `selectedModelName` and `model.declinedNames`
+    /// live in a per-`label` suite rather than `UserDefaults.standard`.
+    ///
+    /// `installFakeModel(into:)` calls `setSelected(_:)`, so every suite that
+    /// uses it writes model preferences — and a manager built with the
+    /// production default writes them into the real
+    /// `io.island.whisper.IslandWhisper` domain, the same one the installed
+    /// Mila.app reads (#268).
+    @MainActor
+    static func isolatedModelManager(modelsDirectory: URL, label: String) -> ModelManager {
+        let suiteName = "\(label).models"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        return ModelManager(modelsDirectory: modelsDirectory, defaults: suite)
+    }
+
     static func isolatedRemoteSettings(label: String) -> RemoteTranscriptionSettings {
         let suiteName = "\(label).remote"
         let suite = UserDefaults(suiteName: suiteName)!

--- a/MilaTests/TestSupport.swift
+++ b/MilaTests/TestSupport.swift
@@ -124,6 +124,13 @@ enum TestSupport {
     /// a clean suite (which has no `transcription.backend` key, so it defaults
     /// to `.local`) makes the stub authoritative regardless of host state.
     @MainActor
+    static func isolatedRemoteSettings(label: String) -> RemoteTranscriptionSettings {
+        let suiteName = "\(label).remote"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        return RemoteTranscriptionSettings(defaults: suite)
+    }
+
     /// A `ModelManager` whose `selectedModelName` and `model.declinedNames`
     /// live in a per-`label` suite rather than `UserDefaults.standard`.
     ///
@@ -138,13 +145,6 @@ enum TestSupport {
         let suite = UserDefaults(suiteName: suiteName)!
         suite.removePersistentDomain(forName: suiteName)
         return ModelManager(modelsDirectory: modelsDirectory, defaults: suite)
-    }
-
-    static func isolatedRemoteSettings(label: String) -> RemoteTranscriptionSettings {
-        let suiteName = "\(label).remote"
-        let suite = UserDefaults(suiteName: suiteName)!
-        suite.removePersistentDomain(forName: suiteName)
-        return RemoteTranscriptionSettings(defaults: suite)
     }
 }
 

--- a/MilaTests/TranscriptionServicePrewarmTests.swift
+++ b/MilaTests/TranscriptionServicePrewarmTests.swift
@@ -23,7 +23,9 @@ final class TranscriptionServicePrewarmTests: XCTestCase {
         tempRoot = TestSupport.makeTempRoot(label: "TranscriptionServicePrewarmTests")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        manager = TestSupport.isolatedModelManager(
+            modelsDirectory: tempRoot.appendingPathComponent("Models"),
+            label: "TranscriptionServicePrewarmTests")
         try TestSupport.installFakeModel(into: manager)
         stub = StubWhisperEngine()
         service = TranscriptionService(

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -10,8 +10,7 @@ final class TranscriptionServiceTests: XCTestCase {
     private var manager: ModelManager!
     private var stub: StubWhisperEngine!
     private var service: TranscriptionService!
-
-    private var savedSelection: String?
+    private var modelDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -19,8 +18,9 @@ final class TranscriptionServiceTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
 
         store = RecordingStore(rootDirectory: tempRoot)
-        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
-        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        UserDefaults().removePersistentDomain(forName: "TranscriptionServiceTests.models")
+        modelDefaults = UserDefaults(suiteName: "TranscriptionServiceTests.models")
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"), defaults: modelDefaults)
         try TestSupport.installFakeModel(into: manager)
 
         stub = StubWhisperEngine()
@@ -37,11 +37,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
     override func tearDown() async throws {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "selectedModelName")
-        }
+        modelDefaults.removePersistentDomain(forName: "TranscriptionServiceTests.models")
         try await super.tearDown()
     }
 

--- a/MilaTests/TranscriptionServiceTests.swift
+++ b/MilaTests/TranscriptionServiceTests.swift
@@ -652,6 +652,44 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertTrue(calls.isEmpty)
     }
 
+    /// A model the user deleted is never coming back on its own now that
+    /// deletion sticks (#263), so the error must name the one recovery there
+    /// is instead of promising a download that will never finish (#264).
+    func test_deleted_model_error_points_at_settings_not_a_download() async throws {
+        try manager.delete(.ivritLarge)
+        XCTAssertTrue(manager.isDeclined(.ivritLarge))
+
+        let fixture = try TestRecordingFixture.make(in: store, title: "Deleted model")
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let message = try XCTUnwrap(service.lastError)
+        XCTAssertTrue(message.contains("Settings"),
+                      "The dead end is only escapable via Settings → Models, so say so: \(message)")
+        XCTAssertFalse(message.lowercased().contains("downloading"),
+                       "Nothing is downloading — the user deleted it: \(message)")
+    }
+
+    /// The other branch: weights that are genuinely missing rather than
+    /// deliberately deleted still get the "it's on its way" message, which is
+    /// what a first launch mid-download actually looks like.
+    func test_missing_but_undeleted_model_still_reports_a_download_in_flight() async throws {
+        // Remove the file behind the manager's back — nothing records a
+        // deliberate delete, so this is the not-declined case.
+        try FileManager.default.removeItem(at: manager.url(for: .ivritLarge))
+        manager.refreshInstalled()
+        XCTAssertFalse(manager.isInstalled(.ivritLarge))
+        XCTAssertFalse(manager.isDeclined(.ivritLarge))
+
+        let fixture = try TestRecordingFixture.make(in: store, title: "Mid-download")
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        let message = try XCTUnwrap(service.lastError)
+        XCTAssertTrue(message.contains("still downloading"),
+                      "A model that was never deleted is still on its way in: \(message)")
+    }
+
     // MARK: - transcribeOnce (dictation path)
 
     func test_transcribe_once_returns_concatenated_segment_text() async {


### PR DESCRIPTION
Closes #263
Closes #264
Closes #265
Closes #266
Closes #267
Closes #268

Relay of **@celarent7's fork PR #269** (`celarent7/mila@38f580b`) onto an `island-io` branch, plus the two issues that cannot ship after it. Every workflow on #269 sits at `action_required` (outside-contributor approval), so it has never been compiled by our CI — same situation, same remedy as #236/#238 → #253.

@celarent7's five code commits are cherry-picked unchanged and still carry them as author (`git log --format='%an'`); the two commits on top are mine.

## What & why

### The relayed work (#263, #266, #267, #268) — @celarent7

- **#263** — `ModelManager` persists a `declinedModelNames` set (`model.declinedNames`). `delete(_:)` marks a model declined, `download(_:)` clears it, and launch-time bootstrap skips declined models. `isInstalled` alone could never tell "never downloaded" from "deleted on purpose", so every launch — and every update, which is just a launch — silently re-fetched a multi-GB file the user had thrown away.
- **#266** — the `setSelected(ivritLarge)` call in `ensureDefaultModelsInstalled()` gains the same declined guard as the download loop below it.
- **#267** — the `GGML_ASSERT([rsets->data count] == 0)` crash on every `xcodebuild test`. The prewarm guard only knew about XCUITest's `--uitests` flag, but `MilaTests` is an app-hosted bundle (`TEST_HOST` = Mila.app), so SwiftUI's launch `.task`s run there for real, with no launch argument marking it. The guard is now `isRunningUnderXCTest` and also checks `NSClassFromString("XCTestCase") != nil`.
- **#268** — `ModelManager` takes an injectable `UserDefaults`, matching `DiarizationSettings`/`HotkeySettings`, so the three suites that drive it stop writing into the real `io.island.whisper.IslandWhisper` domain.

### Why #264 and #265 had to come with it

Both were *harmless* before #263, and only because the bug was there: the deleted model came back on the next launch, which quietly repaired the orphan and the dead end alike. Once deletion sticks, both become permanent. Merging #269 on its own would introduce them into the stable release being cut right after this.

- **#265 — a permanent 1.17 GB orphan.** `delete(_:)` removed only `<name>.bin`; the sibling `<name>-encoder.mlmodelc` stayed on disk (1,174,466,438 B for ivritLarge, 1,173,393,014 B for openaiTurbo), invisible to every screen in the app and unreachable by any UI — `ensureCoreMLInstalled()` gates on `isInstalled(model)`, so nothing looked at it again either. `delete(_:)` now takes the pair.

  The confirmation dialog is part of the fix, not decoration: it promised the user they were freeing the `.bin`'s size, and after this change the honest re-download figure is `sizeBytes + coreMLSizeBytes` — ~4.0 GB for ivritLarge, not ~2.9 GB. Leaving that copy alone would have made it *more* wrong, not less.

  The order inside `delete(_:)` is deliberate and commented: `refreshInstalled()` and `setDeclined(true, …)` run as soon as the `.bin` is gone and **before** the encoder removal that can throw. A throw after a partial delete must not leave the app believing the model is still installed and was never declined — that is precisely the state that silently re-downloads it, i.e. #263 again.

- **#264 — the dead end.** Two halves, and #269 covers neither completely.

  *Selection.* #269 stops `setSelected(ivritLarge)` for a **declined** model. #264 asks for more: only set a default when there is **no persisted selection at all**. `ModelManager.init` already restores a persisted selection on its own, so re-asserting one every launch was pure overwrite — it clobbered the user's Settings → Models choice (#266) and, once deletion stuck, kept re-selecting a model that is no longer on disk. New `hasPersistedSelection` records which of the two the in-memory value came from, so the bootstrap establishes a default exactly once, on a fresh install. The declined guard stays: a user can delete a model without ever having explicitly chosen one.

  *The message.* "Whisper model is still downloading. Try again once it's ready." is true while a missing model is on its way in. For a deleted one it promises a wait that never ends and hides the only recovery there is. It is now conditional on `isDeclined(_:)` and names Settings → Models. Both branches are tested.

### Review of the relayed work

Not a rubber stamp — it had never been compiled by our CI, so I read every line. Two things I checked specifically, plus what changed:

- **The `isRunningUnderXCTest` widening also skips `ensureDefaultModelsInstalled()`. Nothing depended on that running.** It is `private` to `MilaApp`, so no test can call it; the only Models-related UI tests (`DetailLayoutUITests`) just navigate the Settings section; and under `--ui-test-tiny-model-path=` the test override makes `isInstalled` return true, so the download loop was already a no-op. It is in fact a strict improvement: on `main` the *unguarded* `ensureCoreMLInstalled()` sees `isInstalled == true` (override) and `isCoreMLInstalled == false`, so **every UI-test and unit-test launch could start a real ~1.1 GB CoreML fetch**. Now it cannot.
- **The injectable `URLSession` protocol classes are more surface than #268 asked for, and they earn it.** Without them `test_download_clears_declined_status` fires a real request at HuggingFace from a unit test. They are inert in production (`nil` leaves the config untouched), and the pattern has direct precedent in this codebase — `setTestModelOverride` in the same file, and `ClaudeBinaryDownloading` ("the installer's transport is a protocol precisely so the download/verify/install ordering can be driven over fixtures"). Kept.
- **One change to their code:** the `lazy var session` initializer now writes `self.sessionProtocolClasses` explicitly. The same closure already needs `self` for `delegate: self`, and implicit `self` in a `lazy var` initializer is not worth relying on when CI is the only compiler available here.
- **`docs/plans/2026-09-04-sticky-model-deletion.md` is not relayed.** It was written before the last three commits and the shipped code contradicts it in the load-bearing place — it specifies `UserDefaults.standard` with a save/restore hack and states "no new `UserDefaults` suite", which is the opposite of what #268 required and what shipped. A plan doc in `docs/plans/` describing the rejected design is worse than none. The reasoning it captured is in the commit messages and here.

### #268, finished

#268 names three suites, but the pollution is not confined to tests that call `setSelected`/`delete`/`download` directly: `TestSupport.installFakeModel(into:)` calls `setSelected(_:)`, and **six further suites use it**, each building its `ModelManager` on the production `UserDefaults.standard`. Fixing only the three named suites would have closed #268 with its stated symptom still reproducible on the next `make test`. New `TestSupport.isolatedModelManager(modelsDirectory:label:)` follows the `isolatedRemoteSettings(label:)` pattern already in that file. Four of the six carried the same save-and-restore-around-`.standard` hack #268 calls out as not-real-isolation; that is now dead code and gone.

The three suites #269 already converted keep their explicit suites — each also uses that `UserDefaults` instance for something else (HotkeySettings, teardown, the download-stub overload), so the helper would not have replaced it.

## How it was tested

**Nothing here was compiled or run locally.** This session has no Swift toolchain and no Mac — `download.swift.org` is proxy-blocked — so CI is the only compiler that has ever seen this code. The diff was re-read adversarially instead, and changes were batched into one push rather than probing CI incrementally. @celarent7 ran their four commits locally on a Mac (#269's test plan: ModelManagerTests 14/14, DictationControllerTests 3/3, TranscriptionServiceTests 39/39, no `GGML_ASSERT`, no writes to the real preferences domain); my two commits on top have not been run anywhere but CI.

New coverage:

- `ModelManagerTests` — `delete` removes the CoreML encoder; leaves another model's encoder alone; succeeds when there is no encoder on disk; a fresh install has no persisted selection; a persisted selection survives reload; deleting is not choosing.
- `TranscriptionServiceTests` — a deleted model's error points at Settings and never says "downloading"; a model that is merely missing still reports a download in flight.

Not unit-testable: `ensureDefaultModelsInstalled()` is `private` to `MilaApp`, so the launch-bootstrap behaviour itself is covered only through `ModelManager`'s `hasPersistedSelection`/`isDeclined` contract.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible in this environment; see above. CI is the gate.**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, release notes are cut per-release

---

Fork PR #269 by @celarent7 is superseded by this and will be closed with credit; their authorship is preserved in the commits here and will be carried into the squash commit with `Co-Authored-By`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-launch model selection, multi-GB download/delete paths, and CoreML install races; mistakes could re-download deleted models or corrupt persisted preferences, though behavior is heavily covered by new unit tests.
> 
> **Overview**
> **Model deletion and launch bootstrap** now treat a user delete as permanent: `ModelManager` persists **declined** model names, skips auto-download for them, and only sets the default ivrit model when there is **no persisted user selection** and the model was not declined. Deleting removes the **`.bin` and CoreML encoder** together, cancels in-flight encoder downloads, and drops a finished encoder install if the model was deleted mid-fetch.
> 
> **Launch / XCTest** widens the prewarm skip from UI-test flags to any **app-hosted XCTest** (`XCTestCase` loaded), and applies the same guard to **`ensureDefaultModelsInstalled()`** so unit tests do not prewarm whisper, mutate real `UserDefaults`, or start multi-GB downloads.
> 
> **UX and transcription errors**: Settings delete copy quotes **bin + encoder** size; when transcription runs against a missing model, the message points to **Settings → Models** if the model was declined vs “still downloading” otherwise.
> 
> **Tests** inject isolated `UserDefaults` (and optional `URLProtocol` stubs) via `TestSupport.isolatedModelManager` and expanded `ModelManagerTests` / `TranscriptionServiceTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d97e7ea4dc2e30b11de03fa2a3f41353176ff1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->