### PR TITLE
fix(speakers): a re-transcribe re-attaches a name to the contribution it already made

### DIFF
--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -828,6 +828,18 @@ struct MilaApp: App {
             }
         }
 
+        // A pass that produced segments re-keyed every `SPEAKER_NN`, so the
+        // service clears `speakerNames` wholesale — and that clear fires no
+        // hook, leaving every name's voice-profile contribution with no label
+        // left to un-name. This hands those pairs to the matcher wired just
+        // below, which runs immediately after it: a name that comes back by
+        // voice is then re-attached to the contribution the profile already
+        // holds, instead of folding a second observation of the same
+        // recording in beside a stranded one (island-io/mila#260).
+        svc.onPassClearedSpeakerNames = { [offlineEmbedder] recordingID, previousNames in
+            offlineEmbedder.notePassClearedSpeakerNames(previousNames, for: recordingID)
+        }
+
         // Batch voice matching: after any transcription completes, embed
         // each speaker's longest segment and match against stored voice
         // profiles. Uses embedSpeakers (embedding model only, ~0.5s)

--- a/Mila/Models/ObservedVoiceSnapshots.swift
+++ b/Mila/Models/ObservedVoiceSnapshots.swift
@@ -194,7 +194,7 @@ final class ObservedVoiceSnapshots {
         guard var observations = byRecording[recordingID],
               let source = observations.removeValue(forKey: sourceRawID) else { return }
         if let target = observations[targetRawID] {
-            if let combined = Self.combining(target, source) {
+            if let combined = Self.combined(target, source) {
                 observations[targetRawID] = combined
             } else {
                 // Dimension mismatch (a model change between the two
@@ -209,7 +209,18 @@ final class ObservedVoiceSnapshots {
     }
 
     /// Weighted mean of two observations, weighting by their sample counts.
-    private static func combining(_ a: Observation, _ b: Observation) -> Observation? {
+    /// `nil` when they cannot be combined (different embedding dimensions, an
+    /// empty centroid, or a non-finite result) — a caller must then keep one
+    /// and drop the other rather than persist a centroid of two spaces.
+    ///
+    /// The fold matches `SpeakerProfileStore.updateProfile`'s, which is what
+    /// makes "add A then add B" and "add mean(A, B) with the summed count"
+    /// interchangeable — so a caller holding several observations that went
+    /// into ONE profile under ONE name can combine them into the single entry
+    /// whose subtraction reverses all of them exactly. `absorb` uses it for a
+    /// merge; `OfflineVoiceEmbedder` uses it to carry a name's contribution
+    /// across a re-transcribe (island-io/mila#260).
+    static func combined(_ a: Observation, _ b: Observation) -> Observation? {
         guard a.observedCentroid.count == b.observedCentroid.count,
               !a.observedCentroid.isEmpty else { return nil }
         let total = a.observedCount + b.observedCount

--- a/Mila/Models/OfflineVoiceEmbedder.swift
+++ b/Mila/Models/OfflineVoiceEmbedder.swift
@@ -16,6 +16,37 @@ struct SpeakerAudioSpan: Equatable, Sendable {
     let end: Double
 }
 
+/// The `speakerNames` a batch pass cleared off one recording, paired with the
+/// voice-profile contribution each of those names had already made.
+///
+/// File scope rather than nested in `OfflineVoiceEmbedder`, for the same
+/// reason as `SpeakerAudioSpan`: a global actor propagates to nested types,
+/// and this value is captured by the extraction task, which is not
+/// main-actor isolated. It therefore holds plain data rather than
+/// `ObservedVoiceSnapshots.Observation` — the conversion happens on the main
+/// actor at both ends.
+struct ClearedSpeakerNames: Sendable {
+    /// One name's contribution to its profile from this recording: what
+    /// `onSpeakerNamed` folded in, and so exactly what un-naming would take
+    /// back out.
+    struct Contribution: Sendable, Equatable {
+        let centroid: [Float]
+        let count: Int
+        let profileName: String?
+    }
+
+    let recordingID: UUID
+    /// EVERY name the row carried before the pass — including the ones whose
+    /// observation is no longer held. Membership is what says "this
+    /// recording has already contributed to that profile", which is the fact
+    /// that must suppress a second fold; being able to re-point the
+    /// observation is a further, optional improvement on top.
+    let names: Set<String>
+    /// The subset whose observation survived, ready to be re-pointed at
+    /// whichever new id the re-match resolves the name to.
+    let contributions: [String: Contribution]
+}
+
 /// Voice recognition for recordings the **live** diarizer pool never covered:
 /// imports, batch-transcribed files, and anything recorded before the feature
 /// was switched on.
@@ -34,6 +65,11 @@ struct SpeakerAudioSpan: Equatable, Sendable {
 ///  * `matchAfterPass` — a batch transcription finished. Extract every
 ///    speaker, snapshot them, and auto-name the ones that match a stored
 ///    profile.
+///  * `notePassClearedSpeakerNames` — the same pass, one step earlier: the
+///    names it dropped off the row. Fed straight back into the `matchAfterPass`
+///    that follows it, so a name coming back by voice re-attaches to the
+///    contribution the profile already holds instead of adding another
+///    (island-io/mila#260).
 ///
 /// **Extracted from `MilaApp.init` for the same reason as
 /// `RecognisedSpeakerAssigner`: closures in an `App`'s initializer are
@@ -71,6 +107,18 @@ final class OfflineVoiceEmbedder {
     /// In-flight extractions, keyed by a token so each clears its own entry.
     /// Exists for `awaitPending()` — see there.
     private var pending: [UUID: Task<Void, Never>] = [:]
+
+    /// What the pass whose completion is being announced right now took off
+    /// the row, waiting for the `matchAfterPass` that follows it.
+    ///
+    /// **One slot, and it is not a cache.** `TranscriptionService`
+    /// announces the cleared names and the completion back to back with
+    /// nothing between them (`announceCompletion`), and `matchAfterPass`
+    /// consumes this unconditionally before doing anything else — so it is
+    /// written and read inside one synchronous span. A value still sitting
+    /// here when the next pass reports in belongs to a pass whose match never
+    /// ran, and is dropped rather than applied to a different recording.
+    private var clearedByPass: ClearedSpeakerNames?
 
     init(store: RecordingStore,
          snapshots: ObservedVoiceSnapshots,
@@ -144,6 +192,76 @@ final class OfflineVoiceEmbedder {
         }
     }
 
+    // MARK: - Carrying a pass's cleared names into the re-match
+
+    /// Wire to `TranscriptionService.onPassClearedSpeakerNames`.
+    ///
+    /// **What is being repaired.** A pass that produced segments re-keys every
+    /// `SPEAKER_NN`, so the service clears `speakerNames` wholesale. Each of
+    /// those names had folded an observation into a voice profile
+    /// (`onSpeakerNamed`), and clearing the label fires nothing — so that
+    /// contribution sits in the profile with nothing left to un-name, and
+    /// #237's correction can never reach it. `matchAfterPass` then re-embeds
+    /// every speaker, matches them against the same profiles and names them
+    /// again, folding a SECOND observation of the same recording into the
+    /// same profile. This method is what lets the second step recognise the
+    /// first one's leftovers as its own (island-io/mila#260).
+    ///
+    /// **It resolves the observations now, not later.** They are keyed to the
+    /// ids the names were attached to, and `matchAfterPass` drops every one
+    /// of them (`snapshots.invalidate`) before it does anything else. This
+    /// call runs while they are all still there.
+    ///
+    /// **Several ids under one name are combined, not listed.** Naming two
+    /// clusters "Alice" — which the auto-match itself can do, two ids over
+    /// one profile — folded twice into one profile, and the weighted mean
+    /// carrying the summed count is the single entry whose subtraction
+    /// reverses both. That is the same equivalence `ObservedVoiceSnapshots`
+    /// relies on for a merge. When two observations cannot be combined at all
+    /// (different embedding dimensions, i.e. a model change mid-recording),
+    /// the first is kept and the second dropped: under-correcting, the same
+    /// choice `absorb` makes.
+    ///
+    /// Nothing is written here. The worst this call can do is leave a stale
+    /// value in one slot, which the next `matchAfterPass` discards.
+    func notePassClearedSpeakerNames(_ previousNames: [String: String], for recordingID: UUID) {
+        clearedByPass = nil
+        guard settings.isConfigured, !previousNames.isEmpty else { return }
+        var observations: [String: ObservedVoiceSnapshots.Observation] = [:]
+        // Sorted: `Dictionary` order is unspecified per process, and which
+        // observation "goes first" decides which survives a dimension clash.
+        for (rawID, name) in previousNames.sorted(by: { $0.key < $1.key }) {
+            guard let observed = snapshots.observation(forSpeaker: rawID, in: recordingID) else { continue }
+            guard let existing = observations[name] else {
+                observations[name] = observed
+                continue
+            }
+            if let combined = ObservedVoiceSnapshots.combined(existing, observed) {
+                observations[name] = combined
+            } else {
+                embedLog.log("cleared-name carry: cannot combine two observations of one name — the second is dropped")
+            }
+        }
+        let contributions = observations.mapValues {
+            ClearedSpeakerNames.Contribution(centroid: $0.observedCentroid,
+                                             count: $0.observedCount,
+                                             profileName: $0.profileName)
+        }
+        clearedByPass = ClearedSpeakerNames(recordingID: recordingID,
+                                            names: Set(previousNames.values),
+                                            contributions: contributions)
+    }
+
+    /// Consume the slot. Unconditional: a value for a different recording is
+    /// a pass whose match never ran, and applying it here would credit one
+    /// recording's contribution to another's speakers.
+    private func takeClearedNames(for recordingID: UUID) -> ClearedSpeakerNames? {
+        let held = clearedByPass
+        clearedByPass = nil
+        guard let held, held.recordingID == recordingID else { return nil }
+        return held
+    }
+
     // MARK: - Auto-matching after a batch pass
 
     /// Wire to `TranscriptionService.onTranscriptionCompleted`.
@@ -162,20 +280,52 @@ final class OfflineVoiceEmbedder {
     /// never be replaced). Dropping it and re-extracting is the fix; the
     /// skip guard is gone.
     ///
-    /// **What removing that guard costs, and why it is worth it.** The guard
-    /// also happened to prevent a second fold into a profile for one
-    /// recording. That is now reachable by exactly one route: an explicit
-    /// re-transcribe of a live VAD recording, whose speakers `finish` already
-    /// learned from the pool. Chunk mode does not reach it (its live diarizer
-    /// never runs, so the snapshot `finish` takes is empty) and a VAD
-    /// recording that is not re-transcribed never runs a batch pass at all.
-    /// On that one route the second observation is a genuinely different
-    /// extract from a re-clustered segmentation, folded at `sampleCount: 1`
-    /// — not the #204 pathology, which re-folded the *identical* centroid on
-    /// every recording and inflated `sampleCount` without adding
-    /// information. A stale embedding resolving to the wrong person is the
-    /// worse failure, so this is the trade taken deliberately.
+    /// **The second fold, and how it is avoided.** Removing that guard also
+    /// removed the thing that prevented a profile receiving two observations
+    /// of one recording, and the pass's own `speakerNames` clear is what
+    /// makes them two: the label that accounted for the first one is gone by
+    /// the time this runs, so re-matching by voice and naming the speaker
+    /// again folds a fresh observation in beside a stranded one that nothing
+    /// can ever take back out (island-io/mila#260).
+    ///
+    /// So a name that was on the row before the pass is not treated as a new
+    /// name at all. `notePassClearedSpeakerNames` hands those names over —
+    /// with the observation each one folded in, resolved before the
+    /// invalidation above — and when the re-match resolves a speaker to one
+    /// of them, this **re-attaches the label to the contribution the profile
+    /// already holds**: the snapshot entry for the new id is re-pointed at
+    /// that observation, and the name goes on through
+    /// `RecordingStore.reattachSpeakerName`, which fires no
+    /// `onSpeakerNamed`. Un-naming that speaker afterwards then subtracts
+    /// exactly what naming it added, once — the invariant #253 and #237 are
+    /// about. Each cleared name can be claimed by at most ONE new id; a
+    /// second id matching the same profile is a genuinely new contribution
+    /// and folds normally.
+    ///
+    /// **Nothing here subtracts, and nothing here deletes.** The retire that
+    /// `RecordingStore.update(_:retiringSpeakerNames:)` performs for the
+    /// re-diarize path is deliberately not used on this one, in either
+    /// direction: before the re-match it would take away the weight — and
+    /// shift the centroid — that the lookup is about to resolve through, and
+    /// delete outright any profile whose only content came from this
+    /// recording; after it there is nothing left to subtract, since the
+    /// snapshot has been invalidated and refilled. A cleared name the
+    /// re-match does NOT bring back therefore keeps its contribution as
+    /// residue, exactly as on `main`. That is the under-correcting side, on
+    /// purpose: residue is recoverable (delete the profile and let it
+    /// re-learn), a profile deleted because a voice match came up short is
+    /// not, and this is a batch write the user is not watching.
+    ///
+    /// **The `speakerNames.isEmpty` guard still means what it says**: only a
+    /// recording the pass left unlabelled is auto-named. The carry does not
+    /// change that — it travels beside the row rather than on it, precisely
+    /// so the pass can go on clearing names it has re-keyed. A future change
+    /// that preserves names ON the row has to revisit both together.
     func matchAfterPass(recordingID: UUID) {
+        // Taken first: the contributions it names resolve through
+        // observations that are still keyed to the pre-pass ids, and the very
+        // next line drops all of them.
+        let cleared = takeClearedNames(for: recordingID)
         snapshots.invalidate(recordingID)
         guard settings.isConfigured, !profiles.profiles.isEmpty, let store else { return }
         guard let rec = store.recordings.first(where: { $0.id == recordingID }),
@@ -200,8 +350,15 @@ final class OfflineVoiceEmbedder {
                                                  profileName: nil as String?) }
                 self.snapshots.merge(observed, for: recordingID)
                 let threshold = self.matchThreshold()
+                // The names this recording had already folded into profiles,
+                // before the pass cleared the labels that accounted for them.
+                // Claimed at most once each: the second speaker to match one
+                // of these profiles is a new contribution, not the old one
+                // coming back.
+                var unclaimed = cleared?.names ?? []
                 // Sorted: `Dictionary` order is unspecified per process, and
-                // this drives `.srt` rewrites and log lines.
+                // this drives `.srt` rewrites, log lines, and which id claims
+                // a cleared name when two of them match it.
                 for rawID in embeddings.keys.sorted() {
                     // A label the user typed while the embed was in flight
                     // wins over a recogniser's guess. Overwriting it would
@@ -212,8 +369,38 @@ final class OfflineVoiceEmbedder {
                     guard let centroid = embeddings[rawID],
                           let profile = self.profiles.match(embedding: centroid,
                                                             threshold: threshold) else { continue }
-                    store.setSpeakerName(profile.name, forSpeaker: rawID,
-                                         recordingID: recordingID)
+                    guard unclaimed.remove(profile.name) != nil else {
+                        store.setSpeakerName(profile.name, forSpeaker: rawID,
+                                             recordingID: recordingID)
+                        continue
+                    }
+                    // A name from before the pass, back on a new id. The
+                    // profile already carries this recording's contribution
+                    // under it, so the snapshot is re-pointed at THAT
+                    // observation — what the profile actually received, which
+                    // is what a later un-name has to subtract — and the label
+                    // is written without firing the fold. When the
+                    // observation is no longer held (evicted, or never
+                    // taken), the fresh one stays in the snapshot: its count
+                    // matches what the profile received, so the un-name still
+                    // reverses the right amount.
+                    if let contribution = cleared?.contributions[profile.name] {
+                        self.snapshots.merge([(id: rawID,
+                                               observedCentroid: contribution.centroid,
+                                               observedCount: contribution.count,
+                                               profileName: contribution.profileName)],
+                                             for: recordingID)
+                    }
+                    store.reattachSpeakerName(profile.name, toSpeaker: rawID,
+                                              recordingID: recordingID)
+                    embedLog.log("a name cleared by the pass came back on \(rawID, privacy: .public) — re-attached to the contribution already in the profile")
+                }
+                if !unclaimed.isEmpty {
+                    // Their contributions stay where they are. Subtracting
+                    // them here would delete a profile this recording is the
+                    // only evidence for, on the strength of a voice match
+                    // that came up short — see the note on this method.
+                    embedLog.log("\(unclaimed.count, privacy: .public) name(s) cleared by the pass did not come back — their profile contributions are left in place")
                 }
             }
         }

--- a/Mila/Models/OfflineVoiceEmbedder.swift
+++ b/Mila/Models/OfflineVoiceEmbedder.swift
@@ -36,14 +36,22 @@ struct ClearedSpeakerNames: Sendable {
     }
 
     let recordingID: UUID
-    /// EVERY name the row carried before the pass — including the ones whose
-    /// observation is no longer held. Membership is what says "this
-    /// recording has already contributed to that profile", which is the fact
-    /// that must suppress a second fold; being able to re-point the
-    /// observation is a further, optional improvement on top.
-    let names: Set<String>
-    /// The subset whose observation survived, ready to be re-pointed at
-    /// whichever new id the re-match resolves the name to.
+    /// **Only the names whose observation is still held**, keyed by name.
+    ///
+    /// A name the row carried whose observation is gone is deliberately
+    /// absent, not listed separately. Knowing "this recording already
+    /// contributed to that profile" is not enough to act on: suppressing the
+    /// re-match's fold without also re-pointing the snapshot at the
+    /// observation the profile actually received would leave the snapshot
+    /// claiming an observation the profile never got, and a later un-name
+    /// would subtract a vector that was never added — a drifted centroid,
+    /// which is worse than the residue it was avoiding. So the carry exists
+    /// exactly where it can be completed, and every other name takes the
+    /// ordinary path.
+    ///
+    /// That is not a rare gap. `ObservedVoiceSnapshots` is in-memory only, so
+    /// **after any relaunch this map is empty** while the row's names (which
+    /// are persisted) are not.
     let contributions: [String: Contribution]
 }
 
@@ -222,6 +230,14 @@ final class OfflineVoiceEmbedder {
     /// the first is kept and the second dropped: under-correcting, the same
     /// choice `absorb` makes.
     ///
+    /// **A name with no observation left is simply not carried.** The whole
+    /// point of the carry is to keep the profile and the snapshot describing
+    /// the same contribution; with nothing to re-point, suppressing the
+    /// re-match's fold would break exactly that agreement. Those names fall
+    /// through to `setSpeakerName` and behave as they did before this
+    /// existed. It is the common case, not the corner: the snapshots do not
+    /// survive a relaunch and the names do.
+    ///
     /// Nothing is written here. The worst this call can do is leave a stale
     /// value in one slot, which the next `matchAfterPass` discards.
     func notePassClearedSpeakerNames(_ previousNames: [String: String], for recordingID: UUID) {
@@ -248,7 +264,6 @@ final class OfflineVoiceEmbedder {
                                              profileName: $0.profileName)
         }
         clearedByPass = ClearedSpeakerNames(recordingID: recordingID,
-                                            names: Set(previousNames.values),
                                             contributions: contributions)
     }
 
@@ -288,19 +303,30 @@ final class OfflineVoiceEmbedder {
     /// again folds a fresh observation in beside a stranded one that nothing
     /// can ever take back out (island-io/mila#260).
     ///
-    /// So a name that was on the row before the pass is not treated as a new
-    /// name at all. `notePassClearedSpeakerNames` hands those names over —
-    /// with the observation each one folded in, resolved before the
-    /// invalidation above — and when the re-match resolves a speaker to one
-    /// of them, this **re-attaches the label to the contribution the profile
-    /// already holds**: the snapshot entry for the new id is re-pointed at
-    /// that observation, and the name goes on through
+    /// So a name that was on the row before the pass — and whose observation
+    /// is still held — is not treated as a new name at all.
+    /// `notePassClearedSpeakerNames` hands those pairs over, resolved before
+    /// the invalidation above, and when the re-match resolves a speaker to
+    /// one of them this **re-attaches the label to the contribution the
+    /// profile already holds**: the snapshot entry for the new id is
+    /// re-pointed at that observation, and the name goes on through
     /// `RecordingStore.reattachSpeakerName`, which fires no
     /// `onSpeakerNamed`. Un-naming that speaker afterwards then subtracts
     /// exactly what naming it added, once — the invariant #253 and #237 are
     /// about. Each cleared name can be claimed by at most ONE new id; a
     /// second id matching the same profile is a genuinely new contribution
     /// and folds normally.
+    ///
+    /// **Suppressing the fold and re-pointing the snapshot are one act, never
+    /// one without the other.** The pair is what makes the correction
+    /// reversible; half of it is worse than neither. A cleared name whose
+    /// observation is NOT held therefore takes the ordinary path and folds,
+    /// which is what `main` does — the profile ends up carrying this
+    /// recording twice and the older contribution is residue. That is the
+    /// common case rather than a corner: `ObservedVoiceSnapshots` is
+    /// in-memory only, so every re-transcribe after a relaunch arrives with
+    /// the names (persisted, on the row) and none of the observations. See
+    /// the note at the fold below for the arithmetic of getting this wrong.
     ///
     /// **Nothing here subtracts, and nothing here deletes.** The retire that
     /// `RecordingStore.update(_:retiringSpeakerNames:)` performs for the
@@ -350,12 +376,13 @@ final class OfflineVoiceEmbedder {
                                                  profileName: nil as String?) }
                 self.snapshots.merge(observed, for: recordingID)
                 let threshold = self.matchThreshold()
-                // The names this recording had already folded into profiles,
-                // before the pass cleared the labels that accounted for them.
-                // Claimed at most once each: the second speaker to match one
-                // of these profiles is a new contribution, not the old one
-                // coming back.
-                var unclaimed = cleared?.names ?? []
+                // The contributions this recording made under names the pass
+                // cleared, still available to be re-pointed. Claimed at most
+                // once each — the second speaker to match one of these
+                // profiles is a new contribution, not the old one coming
+                // back — and a name that is not in here takes the ordinary
+                // path below.
+                var carryable = cleared?.contributions ?? [:]
                 // Sorted: `Dictionary` order is unspecified per process, and
                 // this drives `.srt` rewrites, log lines, and which id claims
                 // a cleared name when two of them match it.
@@ -369,38 +396,49 @@ final class OfflineVoiceEmbedder {
                     guard let centroid = embeddings[rawID],
                           let profile = self.profiles.match(embedding: centroid,
                                                             threshold: threshold) else { continue }
-                    guard unclaimed.remove(profile.name) != nil else {
+                    // **The suppression and the re-point are one act.**
+                    // Naming without folding is only correct while the
+                    // snapshot is simultaneously pointed at the observation
+                    // the profile DID receive: that pair is what a later
+                    // un-name reverses. With no contribution to point it at
+                    // — the state after every relaunch, since the snapshots
+                    // are in-memory and the names are not — suppressing the
+                    // fold would leave the snapshot claiming this pass's
+                    // fresh observation while the profile holds the old one,
+                    // and un-naming would subtract a vector that was never
+                    // added: a centroid drifted by
+                    // `n·(c_old − c_fresh)/(S − n)`, which is the invisible
+                    // corruption this whole feature exists to prevent, and
+                    // strictly worse than the duplicate fold it was trying to
+                    // avoid. So without the evidence to do better, this
+                    // degrades to what `main` does: fold, stay reconcilable,
+                    // leave the older contribution as residue.
+                    guard let contribution = carryable.removeValue(forKey: profile.name) else {
                         store.setSpeakerName(profile.name, forSpeaker: rawID,
                                              recordingID: recordingID)
                         continue
                     }
-                    // A name from before the pass, back on a new id. The
-                    // profile already carries this recording's contribution
-                    // under it, so the snapshot is re-pointed at THAT
-                    // observation — what the profile actually received, which
-                    // is what a later un-name has to subtract — and the label
-                    // is written without firing the fold. When the
-                    // observation is no longer held (evicted, or never
-                    // taken), the fresh one stays in the snapshot: its count
-                    // matches what the profile received, so the un-name still
-                    // reverses the right amount.
-                    if let contribution = cleared?.contributions[profile.name] {
-                        self.snapshots.merge([(id: rawID,
-                                               observedCentroid: contribution.centroid,
-                                               observedCount: contribution.count,
-                                               profileName: contribution.profileName)],
-                                             for: recordingID)
-                    }
+                    // A name from before the pass, back on a new id, with the
+                    // contribution it accounted for still in hand. The
+                    // snapshot is re-pointed at THAT observation — what the
+                    // profile actually received, and so what a later un-name
+                    // has to subtract — and the label is written without
+                    // firing the fold.
+                    self.snapshots.merge([(id: rawID,
+                                           observedCentroid: contribution.centroid,
+                                           observedCount: contribution.count,
+                                           profileName: contribution.profileName)],
+                                         for: recordingID)
                     store.reattachSpeakerName(profile.name, toSpeaker: rawID,
                                               recordingID: recordingID)
                     embedLog.log("a name cleared by the pass came back on \(rawID, privacy: .public) — re-attached to the contribution already in the profile")
                 }
-                if !unclaimed.isEmpty {
+                if !carryable.isEmpty {
                     // Their contributions stay where they are. Subtracting
                     // them here would delete a profile this recording is the
                     // only evidence for, on the strength of a voice match
                     // that came up short — see the note on this method.
-                    embedLog.log("\(unclaimed.count, privacy: .public) name(s) cleared by the pass did not come back — their profile contributions are left in place")
+                    embedLog.log("\(carryable.count, privacy: .public) carried contribution(s) went unclaimed — the pass did not bring those names back, and they are left in place")
                 }
             }
         }

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -488,10 +488,19 @@ final class RecordingStore: ObservableObject {
     /// re-matches them against the stored profiles — so a retire there would
     /// subtract the weight the re-match is about to look the speaker up by,
     /// and a profile whose only content came from that recording would be
-    /// deleted before the pass could restore its name. That path needs the
-    /// retire and the re-match designed together (see #254); the re-diarize
-    /// path has no re-match behind it, since it carries the names rather than
+    /// deleted before the pass could restore its name. The re-diarize path
+    /// has no re-match behind it, since it carries the names rather than
     /// re-deriving them.
+    ///
+    /// **That still holds after island-io/mila#260 closed the other half.**
+    /// The re-transcribe path fixes its stranding from the *naming* side
+    /// instead: when the re-match brings a pre-pass name back,
+    /// `matchAfterPass` re-attaches the label to the contribution the profile
+    /// already holds (`reattachSpeakerName`) rather than folding a second one
+    /// in, and it subtracts nothing at any point. A name the re-match does
+    /// NOT bring back is left as residue, on purpose — retiring it here would
+    /// delete a profile whose only weight came from this recording, on the
+    /// evidence of a failed voice match rather than a user's correction.
     ///
     /// **The one destructive case, and why it is left exact.** A retire
     /// subtracts exactly what naming that id added, so a profile holding
@@ -653,6 +662,54 @@ final class RecordingStore: ObservableObject {
             recordings[idx].speakerNames.removeValue(forKey: rawID)
             onSpeakerUnnamed?(recordingID, rawID, previousName)
         }
+        persist()
+        if recordings[idx].status == .completed {
+            TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)
+        }
+    }
+
+    /// Put a name back on a raw id a pass re-keyed, **without firing
+    /// `onSpeakerNamed`** — because the profile named here already holds this
+    /// recording's contribution, and folding a second one in is the bug this
+    /// exists to stop (island-io/mila#260).
+    ///
+    /// **The situation.** A batch pass re-keys every `SPEAKER_NN`, so
+    /// `TranscriptionService` clears `speakerNames` wholesale. The profile
+    /// contributions those names justified stay on disk, keyed to nothing.
+    /// `OfflineVoiceEmbedder.matchAfterPass` then re-embeds every speaker and
+    /// re-matches them against the stored profiles *by voice*; when a name
+    /// this recording carried BEFORE the pass comes back that way, the right
+    /// answer is to re-attach the label to the contribution that is already
+    /// there — not to add another one beside it. Going through
+    /// `setSpeakerName` would fold the fresh observation in on top, leaving
+    /// the profile holding two observations of one recording, one of them
+    /// permanently unreachable. So this is the label half only; the embedder
+    /// owns the observation half (it re-points the snapshot entry at the
+    /// contribution the profile actually received) and the two are called
+    /// together.
+    ///
+    /// **Not a general "quiet setter".** It refuses to touch an id that
+    /// already carries a name, so it can never silently replace one — a
+    /// replacement is a profile correction and belongs on `setSpeakerName`,
+    /// which fires both hooks. And it is only ever correct where the caller
+    /// has established that the profile already carries this recording's
+    /// contribution under `name`. There is exactly one such caller;
+    /// `OfflineVoiceEmbedderTests` pins both halves.
+    ///
+    /// The **other** direction — a name a re-key drops for good — is
+    /// `update(_:retiringSpeakerNames:)`, which fires `onSpeakerUnnamed` so
+    /// the contribution comes back out. Deliberately not used on the
+    /// re-transcribe path: see that method's note and #260.
+    func reattachSpeakerName(_ name: String, toSpeaker rawID: String, recordingID: UUID) {
+        guard let idx = recordings.firstIndex(where: { $0.id == recordingID }) else { return }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        // Never over-write. An id that already has a name has one because
+        // something else set it — the user typing while the pass ran, most
+        // likely — and replacing it here would drop that name with no
+        // `onSpeakerUnnamed` to correct the profile it went into.
+        guard recordings[idx].speakerNames[rawID] == nil else { return }
+        recordings[idx].speakerNames[rawID] = trimmed
         persist()
         if recordings[idx].status == .completed {
             TranscriptExporter.writeSRT(for: recordings[idx], in: recordingsDirectory)

--- a/Mila/Models/RecordingStore.swift
+++ b/Mila/Models/RecordingStore.swift
@@ -691,10 +691,16 @@ final class RecordingStore: ObservableObject {
     /// **Not a general "quiet setter".** It refuses to touch an id that
     /// already carries a name, so it can never silently replace one — a
     /// replacement is a profile correction and belongs on `setSpeakerName`,
-    /// which fires both hooks. And it is only ever correct where the caller
-    /// has established that the profile already carries this recording's
-    /// contribution under `name`. There is exactly one such caller;
-    /// `OfflineVoiceEmbedderTests` pins both halves.
+    /// which fires both hooks. And it is only correct where the caller has
+    /// both established that the profile already carries this recording's
+    /// contribution under `name` **and** pointed the snapshot for `rawID` at
+    /// that same contribution. Suppressing the fold without re-pointing
+    /// leaves the snapshot describing an observation the profile never
+    /// received, and the un-name then subtracts a vector that was never
+    /// added — a drifted centroid, worse than the duplicate fold it avoids.
+    /// A caller that cannot do both must use `setSpeakerName`. There is
+    /// exactly one such caller; `OfflineVoiceEmbedderTests` pins both halves,
+    /// including the fall-through.
     ///
     /// The **other** direction — a name a re-key drops for good — is
     /// `update(_:retiringSpeakerNames:)`, which fires `onSpeakerUnnamed` so

--- a/Mila/Transcription/TranscriptionService.swift
+++ b/Mila/Transcription/TranscriptionService.swift
@@ -145,6 +145,33 @@ final class TranscriptionService: ObservableObject {
     /// exists). For first-time transcription it's `false`.
     var onTranscriptionCompleted: ((Recording, _ wasRetranscription: Bool) -> Void)?
 
+    /// Hook fired for the same recordings as `onTranscriptionCompleted`, and
+    /// immediately BEFORE it, carrying the `speakerNames` map the pass just
+    /// cleared off the row (empty when the pass had none to clear).
+    ///
+    /// **Why it exists.** A pass that produced segments re-keyed every
+    /// `SPEAKER_NN`, so the names bound to the old ids are dropped wholesale
+    /// (see `mergePassResult`). Each of those names had folded an observation
+    /// into a voice profile, and once the label is gone there is nothing left
+    /// to un-name: the contribution is stranded in that profile permanently
+    /// (island-io/mila#260). Whoever repairs that needs the pairs the row is
+    /// about to lose, and this is the only moment they still exist —
+    /// `onTranscriptionCompleted` carries the row as written, names already
+    /// gone.
+    ///
+    /// **Ordering is the contract.** `MilaApp` wires this to
+    /// `OfflineVoiceEmbedder`, whose `matchAfterPass` — driven off
+    /// `onTranscriptionCompleted` — invalidates the recording's observations
+    /// as its first act. The pairs must therefore arrive before that hook
+    /// runs, while the observations backing them are still keyed to the old
+    /// ids. Both fire from `announceCompletion`, which is the whole reason it
+    /// exists as one function rather than two call sites that can drift.
+    ///
+    /// Nothing here is required for correctness of the pass itself: an
+    /// unwired hook (tests, or a build that never installs it) leaves the
+    /// behaviour exactly as it was before #260.
+    var onPassClearedSpeakerNames: ((_ recordingID: UUID, _ previousNames: [String: String]) -> Void)?
+
     /// Auto-drop gate for accidental short+empty captures (issue #61). Wired
     /// by `MilaApp` to the user's `recordings.minDuration` threshold. Given a
     /// just-finished recording's duration + transcript, returns `true` when
@@ -989,6 +1016,16 @@ final class TranscriptionService: ObservableObject {
             // `mergePassResult` for the full field-ownership table. `nil` means
             // the row is gone (hard-deleted / trash emptied / just auto-dropped
             // above); there is nothing to write and nothing to follow up on.
+            //
+            // What the LIVE row's `speakerNames` held at the instant the
+            // clear below dropped them — captured inside the merge closure so
+            // it is provably the same row that was written, not a re-read that
+            // could have moved. Each pair had folded an observation into a
+            // voice profile; announcing them is what lets
+            // `OfflineVoiceEmbedder` re-attach the label to that contribution
+            // instead of leaving it stranded (island-io/mila#260). Stays empty
+            // for a pass that cleared nothing.
+            var clearedSpeakerNames: [String: String] = [:]
             guard let persisted = mergePassResult(id: recording.id, {
                 $0.status = working.status
                 $0.segments = working.segments
@@ -1002,6 +1039,7 @@ final class TranscriptionService: ObservableObject {
                 // so the user's speaker names must survive it untouched (they're
                 // hand-typed work, and the next successful pass re-keys anyway).
                 if !enrichedSegments.isEmpty {
+                    clearedSpeakerNames = $0.speakerNames
                     $0.speakerNames = working.speakerNames
                 }
             }) else {
@@ -1026,7 +1064,9 @@ final class TranscriptionService: ObservableObject {
                         """)
                 } else {
                     TranscriptExporter.writeSRT(for: persisted, in: store.recordingsDirectory)
-                    onTranscriptionCompleted?(persisted, hadSummaryBeforeRun)
+                    announceCompletion(persisted,
+                                       clearedSpeakerNames: clearedSpeakerNames,
+                                       wasRetranscription: hadSummaryBeforeRun)
                 }
                 // Shrink storage: transcode the WAV to m4a now that
                 // transcription + diarization are done reading it. Runs in
@@ -1099,6 +1139,28 @@ final class TranscriptionService: ObservableObject {
 
     private func markFailed(_ recording: Recording) {
         mergePassResult(id: recording.id) { $0.status = .failed }
+    }
+
+    /// Tell the app a pass finished: the names it cleared first, the
+    /// completion second.
+    ///
+    /// **One function so the order cannot drift.** `MilaApp` wires
+    /// `onTranscriptionCompleted` to `OfflineVoiceEmbedder.matchAfterPass`,
+    /// which invalidates the recording's observed embeddings as its first act
+    /// — so the pairs `onPassClearedSpeakerNames` carries have to arrive
+    /// while those observations are still keyed to the ids the names were
+    /// attached to. Swapping these two lines does not fail loudly: the carry
+    /// is simply missed and every named speaker's profile contribution is
+    /// stranded again, silently, which is island-io/mila#260. Both hooks run
+    /// synchronously, so nothing interleaves between them.
+    ///
+    /// `TranscriptionServiceSpeakerCarryTests` pins the order and the payload
+    /// through a real pass.
+    func announceCompletion(_ persisted: Recording,
+                            clearedSpeakerNames: [String: String],
+                            wasRetranscription: Bool) {
+        onPassClearedSpeakerNames?(persisted.id, clearedSpeakerNames)
+        onTranscriptionCompleted?(persisted, wasRetranscription)
     }
 
     /// Persist the result of a transcription pass by merging it onto the row

--- a/MilaTests/OfflineVoiceEmbedderTests.swift
+++ b/MilaTests/OfflineVoiceEmbedderTests.swift
@@ -68,6 +68,12 @@ final class OfflineVoiceEmbedderTests: XCTestCase {
     private let aliceStored: [Float] = [1, 0, 0, 0]
     private let aliceSpeaking: [Float] = [0.99, 0.01, 0, 0]
     private let strangerSpeaking: [Float] = [0, 1, 0, 0]
+    /// The same person, extracted again from a re-clustered segmentation:
+    /// close enough to match her profile, far enough from `aliceSpeaking`
+    /// that carrying the wrong one of the two is visible in the centroid.
+    private let aliceSpeakingAgain: [Float] = [0.9, 0.4, 0, 0]
+    /// A second cluster of hers in the same pass — also over the threshold.
+    private let aliceSpeakingThird: [Float] = [0.95, 0.2, 0, 0]
 
     override func setUp() async throws {
         try await super.setUp()
@@ -92,6 +98,9 @@ final class OfflineVoiceEmbedderTests: XCTestCase {
         let embedder: OfflineVoiceEmbedder
         let probe: EmbedProbe
         let recordingID: UUID
+        /// Only its hooks are used: `announceCompletion` is what fires them,
+        /// in the order the production pass fires them. No whisper runs here.
+        let service: TranscriptionService
     }
 
     private func makeSettings() -> VoiceRecognitionSettings {
@@ -154,10 +163,84 @@ final class OfflineVoiceEmbedderTests: XCTestCase {
                                    embedding: observed.observedCentroid,
                                    sampleCount: observed.observedCount)
         }
+        // …and the `onSpeakerUnnamed` half, verbatim too. Every claim this
+        // suite makes about a contribution being reversible is checked by
+        // actually reversing it, through the same hook the popover uses.
+        store.onSpeakerUnnamed = { recordingID, rawID, previousName in
+            guard settings.isConfigured else { return }
+            guard let observed = snapshots.observation(forSpeaker: rawID, in: recordingID) else { return }
+            profiles.subtractObservation(name: previousName,
+                                         embedding: observed.observedCentroid,
+                                         sampleCount: observed.observedCount)
+        }
+
+        // A real `TranscriptionService`, for its completion announcement
+        // only: `runPass` drives the two hooks through it rather than calling
+        // the embedder in an order this test picked, which is the ordering
+        // island-io/mila#260 turns on.
+        let suite = "OfflineVoiceEmbedderTests.\(UUID())"
+        suiteNames.append("\(suite).diarization")
+        suiteNames.append("\(suite).remote")
+        let service = TranscriptionService(
+            store: store,
+            modelManager: ModelManager(modelsDirectory: root.appendingPathComponent("Models")),
+            diarizationSettings: DiarizationSettings(
+                defaults: UserDefaults(suiteName: "\(suite).diarization")!),
+            remoteSettings: TestSupport.isolatedRemoteSettings(label: suite),
+            engine: StubWhisperEngine())
+        // `MilaApp.init`'s wiring of the two pass hooks, verbatim.
+        service.onPassClearedSpeakerNames = { [embedder] recordingID, previousNames in
+            embedder.notePassClearedSpeakerNames(previousNames, for: recordingID)
+        }
+        service.onTranscriptionCompleted = { [embedder] rec, _ in
+            embedder.matchAfterPass(recordingID: rec.id)
+        }
 
         return World(store: store, profiles: profiles, snapshots: snapshots,
                      settings: settings, embedder: embedder, probe: probe,
-                     recordingID: rec.id)
+                     recordingID: rec.id, service: service)
+    }
+
+    /// Everything a batch pass does *after* whisper returns, in production
+    /// order: the store write that puts the pass's segments on the row and
+    /// clears the speaker names it re-keyed, then
+    /// `TranscriptionService.announceCompletion` — the function that fires
+    /// the cleared-names hook and the completion hook, in that order.
+    ///
+    /// Only the pass OUTPUT is supplied by hand. The half simulated here (the
+    /// service capturing the names as it clears them, and announcing them
+    /// before the completion) is driven through a real pass, with a real
+    /// store write, in `TranscriptionServiceSpeakerCarryTests` — simulating
+    /// both halves in one place is how the missing hook in island-io/mila#254
+    /// stayed hidden.
+    private func runPass(_ w: World, producing segments: [TranscriptSegment]) async {
+        var updated = row(w)
+        let cleared = updated.speakerNames
+        updated.segments = segments
+        updated.speakerNames = [:]
+        updated.status = .completed
+        w.store.update(updated)
+        w.service.announceCompletion(updated,
+                                     clearedSpeakerNames: cleared,
+                                     wasRetranscription: true)
+        await w.embedder.awaitPending()
+    }
+
+    /// Component-wise, with room for the float error of a fold followed by
+    /// its subtraction.
+    private func assertCentroid(_ actual: [Float]?, _ expected: [Float],
+                                _ message: String,
+                                file: StaticString = #filePath, line: UInt = #line) {
+        guard let actual else {
+            XCTFail("no centroid: \(message)", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual.count, expected.count, message, file: file, line: line)
+        guard actual.count == expected.count else { return }
+        for i in actual.indices {
+            XCTAssertEqual(actual[i], expected[i], accuracy: 1e-4,
+                           "\(message) — component \(i)", file: file, line: line)
+        }
     }
 
     private func writeAudio(named name: String, in store: RecordingStore) throws {
@@ -505,5 +588,217 @@ final class OfflineVoiceEmbedderTests: XCTestCase {
 
         XCTAssertEqual(w.probe.callCount, 0)
         XCTAssertNil(row(w).speakerNames["SPEAKER_00"])
+    }
+
+    // MARK: - A re-transcribe swaps a contribution, it does not add one
+    //
+    // The pass clears `speakerNames` wholesale and fires no hook, so every
+    // name's voice-profile contribution is left with no label to un-name;
+    // the re-match then names the speaker again and folds a SECOND
+    // observation of the same recording into the same profile
+    // (island-io/mila#260). These pin the repair, and — just as importantly —
+    // pin that the repair never subtracts and never deletes.
+
+    /// Alice as she stands from earlier recordings, plus this recording's own
+    /// contribution: named by hand, learned on demand, which is how a profile
+    /// comes to hold one observation of one recording.
+    private func nameAliceHere(_ w: World, priorSamples: Int) async {
+        if priorSamples > 0 {
+            w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: priorSamples)
+        }
+        w.probe.returns(["SPEAKER_00": aliceSpeaking])
+        w.store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+        w.embedder.learnNamedSpeaker(recordingID: w.recordingID,
+                                     rawID: "SPEAKER_00", name: "Alice")
+        await w.embedder.awaitPending()
+    }
+
+    /// **The bug this closes.** Alice arrives carrying 3 samples from earlier
+    /// recordings and this recording takes her to 4. A re-transcribe clears
+    /// her label, strands that 4th contribution — nothing left to un-name —
+    /// and then hands her a 5th by matching her voice and naming her again.
+    ///
+    /// **Discriminating in both directions.**
+    ///
+    /// * `main` → 5 after the pass, and un-naming leaves 4: one contribution
+    ///   stranded under a label that no longer exists.
+    /// * Suppress the second fold but leave the fresh observation in the
+    ///   snapshot → 4, but the un-name subtracts an embedding the profile
+    ///   never received, so her centroid lands at `[1.03, -0.13, 0, 0]`
+    ///   instead of back on `[1, 0, 0, 0]`.
+    /// * This fix → 4, and the un-name returns her to exactly her
+    ///   pre-recording weight *and* her pre-recording centroid.
+    func test_a_name_the_pass_cleared_comes_back_without_a_second_contribution() async throws {
+        let w = try makeWorld(threshold: 0.7)
+        await nameAliceHere(w, priorSamples: 3)
+        let named = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(named.sampleCount, 4,
+                       "precondition: her 3 earlier samples plus this recording's one")
+
+        // The re-transcribe: a new clustering, new ids, names cleared, and a
+        // fresh extraction of the same voice.
+        w.probe.returns(["SPEAKER_01": aliceSpeakingAgain])
+        await runPass(w, producing: [segment("SPEAKER_01", 0, 5),
+                                     segment("SPEAKER_01", 5, 20)])
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_01"], "Alice",
+                       "her name comes back on the id the re-match resolved it to")
+        let afterPass = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(afterPass.sampleCount, 4,
+                       "and brings no second contribution with it")
+        assertCentroid(afterPass.embedding, named.embedding,
+                       "her centroid is untouched by a pass that told us nothing new")
+
+        // The whole point: the correction #237 exists for can now reach it.
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_01", recordingID: w.recordingID)
+
+        let afterUnname = try XCTUnwrap(w.profiles.profile(named: "Alice"),
+                                        "her earlier recordings are untouched")
+        XCTAssertEqual(afterUnname.sampleCount, 3,
+                       "un-naming returns her to exactly her pre-recording weight")
+        assertCentroid(afterUnname.embedding, aliceStored,
+                       "…and to her pre-recording centroid, which only holds if what came "
+                       + "back out is the observation that actually went in")
+    }
+
+    /// The deliberate under-correction, and the reason this path does not use
+    /// `RecordingStore.update(_:retiringSpeakerNames:)`: a cleared name whose
+    /// voice the re-match cannot find keeps its contribution. Retiring it
+    /// would subtract the only weight Alice's profile has and delete her —
+    /// on the evidence of a similarity score, not of a user saying "that
+    /// isn't her". Residue is recoverable; a deleted voice is not.
+    func test_a_cleared_name_the_rematch_cannot_find_keeps_its_contribution() async throws {
+        let w = try makeWorld(threshold: 0.7)
+        // Her profile's ONLY evidence is this recording — the ordinary state
+        // of one created by naming a speaker once.
+        await nameAliceHere(w, priorSamples: 0)
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 1,
+                       "precondition: one sample, from here")
+
+        // The re-clustered pass produces a speaker who sounds nothing like her.
+        w.probe.returns(["SPEAKER_01": strangerSpeaking])
+        await runPass(w, producing: [segment("SPEAKER_01", 0, 5),
+                                     segment("SPEAKER_01", 5, 20)])
+
+        XCTAssertNil(row(w).speakerNames["SPEAKER_01"],
+                     "a voice that does not match is not handed her name")
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"),
+                                  "her profile must survive a re-transcribe that failed to "
+                                  + "recognise her — deleting it here is the destructive fix #260 rejects")
+        XCTAssertEqual(alice.sampleCount, 1)
+        assertCentroid(alice.embedding, aliceSpeaking, "and it still holds her voice")
+    }
+
+    /// The negative control. A pass with no names to clear must go on folding
+    /// what it learns — this is how a batch-transcribed recording contributes
+    /// to a profile at all, and suppressing it unconditionally would silently
+    /// stop voice recognition improving.
+    func test_a_pass_with_no_cleared_names_still_folds_what_it_learns() async throws {
+        let w = try makeWorld(threshold: 0.7)
+        w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 3)
+        w.probe.returns(["SPEAKER_00": aliceSpeaking])
+
+        await runPass(w, producing: [segment("SPEAKER_00", 0, 5),
+                                     segment("SPEAKER_00", 5, 20)])
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_00"], "Alice")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 4,
+                       "a recording that had contributed nothing to her profile must still add to it")
+    }
+
+    /// A cleared name is claimed by at most ONE new speaker. Two clusters can
+    /// legitimately match one profile (`SpeakerCorrectionActionsTests`'
+    /// `test_auto_naming_two_clusters_after_one_profile_keeps_them_separate`),
+    /// and the second one is a genuinely new contribution: it folds, and it
+    /// is reversible on its own.
+    ///
+    /// Discriminating: treat the claim as a set membership test rather than a
+    /// claim and both speakers re-attach — the profile stays at 4 and both
+    /// snapshot entries point at the SAME observation, so un-naming the two
+    /// of them subtracts it twice and lands on 2.
+    func test_only_one_new_speaker_claims_a_cleared_name() async throws {
+        let w = try makeWorld(threshold: 0.7)
+        await nameAliceHere(w, priorSamples: 3)
+
+        w.probe.returns(["SPEAKER_01": aliceSpeakingAgain,
+                         "SPEAKER_02": aliceSpeakingThird])
+        await runPass(w, producing: [segment("SPEAKER_01", 0, 5),
+                                     segment("SPEAKER_02", 5, 20)])
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_01"], "Alice")
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_02"], "Alice")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "the claim covers one of them; the other is a new observation and folds")
+
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_02", recordingID: w.recordingID)
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_01", recordingID: w.recordingID)
+
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(alice.sampleCount, 3,
+                       "un-naming both takes back exactly the two contributions this recording made")
+        assertCentroid(alice.embedding, aliceStored, "and nothing else")
+    }
+
+    /// Two ids named Alice folded twice into one profile, so what the pass
+    /// carries across for her is the combined observation — the single entry
+    /// whose subtraction reverses both. Carrying only one of them (or none)
+    /// leaves her at 4 after the un-name instead of 3.
+    func test_two_ids_that_shared_a_name_carry_one_combined_contribution() async throws {
+        let w = try makeWorld(segments: [segment("SPEAKER_00", 0, 5),
+                                         segment("SPEAKER_02", 5, 12),
+                                         segment("SPEAKER_00", 12, 30)],
+                              threshold: 0.7)
+        w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 3)
+        // The live pool over-segmented her; both fragments were named at stop.
+        w.snapshots.record([(id: "SPEAKER_00", observedCentroid: aliceSpeaking,
+                             observedCount: 1, profileName: nil),
+                            (id: "SPEAKER_02", observedCentroid: aliceSpeaking,
+                             observedCount: 1, profileName: nil)], for: w.recordingID)
+        for raw in ["SPEAKER_00", "SPEAKER_02"] {
+            w.store.setSpeakerName("Alice", forSpeaker: raw, recordingID: w.recordingID)
+        }
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "precondition: two named fragments, two contributions")
+
+        // The pass puts her in one cluster.
+        w.probe.returns(["SPEAKER_01": aliceSpeakingAgain])
+        await runPass(w, producing: [segment("SPEAKER_01", 0, 5),
+                                     segment("SPEAKER_01", 5, 20)])
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_01"], "Alice")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "no third contribution")
+
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_01", recordingID: w.recordingID)
+
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(alice.sampleCount, 3,
+                       "one un-name gives back BOTH of this recording's contributions")
+        assertCentroid(alice.embedding, aliceStored, "exactly")
+    }
+
+    /// The carry is scoped to the recording it was announced for. A note left
+    /// behind by a pass whose match never ran must not suppress a fold on the
+    /// next recording — that would credit one recording's contribution to a
+    /// speaker in another, and leave the first one's stranded anyway.
+    ///
+    /// Driven through the embedder directly rather than `runPass`, because
+    /// the point is the slot surviving into a *different* recording's match:
+    /// `announceCompletion` always notes before it matches, so the pairing is
+    /// what has to be checked, not the ordering.
+    func test_a_carry_left_by_another_recording_is_not_applied_here() async throws {
+        let w = try makeWorld(threshold: 0.7)
+        w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 3)
+        w.probe.returns(["SPEAKER_00": aliceSpeaking])
+
+        // A pass on some other recording cleared "Alice", and its match never
+        // reached the embedder.
+        w.embedder.notePassClearedSpeakerNames(["SPEAKER_00": "Alice"], for: UUID())
+        w.embedder.matchAfterPass(recordingID: w.recordingID)
+        await w.embedder.awaitPending()
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_00"], "Alice")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 4,
+                       "this recording has contributed nothing to her yet, so its observation folds in")
     }
 }

--- a/MilaTests/OfflineVoiceEmbedderTests.swift
+++ b/MilaTests/OfflineVoiceEmbedderTests.swift
@@ -791,14 +791,66 @@ final class OfflineVoiceEmbedderTests: XCTestCase {
         w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 3)
         w.probe.returns(["SPEAKER_00": aliceSpeaking])
 
-        // A pass on some other recording cleared "Alice", and its match never
+        // A pass on some other recording cleared "Alice" there, backed by an
+        // observation of a completely different voice, and its match never
         // reached the embedder.
-        w.embedder.notePassClearedSpeakerNames(["SPEAKER_00": "Alice"], for: UUID())
+        let elsewhere = UUID()
+        w.snapshots.record([(id: "SPEAKER_00", observedCentroid: strangerSpeaking,
+                             observedCount: 1, profileName: nil)], for: elsewhere)
+        w.embedder.notePassClearedSpeakerNames(["SPEAKER_00": "Alice"], for: elsewhere)
         w.embedder.matchAfterPass(recordingID: w.recordingID)
         await w.embedder.awaitPending()
 
         XCTAssertEqual(row(w).speakerNames["SPEAKER_00"], "Alice")
         XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 4,
                        "this recording has contributed nothing to her yet, so its observation folds in")
+        assertCentroid(w.snapshots.observation(forSpeaker: "SPEAKER_00", in: w.recordingID)?.observedCentroid,
+                       aliceSpeaking,
+                       "and the snapshot holds THIS recording's voice — applying the other "
+                       + "recording's carry would have put a stranger's under her name")
+    }
+
+    /// **The state after every relaunch.** `ObservedVoiceSnapshots` lives
+    /// only in memory, while `speakerNames` and the profiles are on disk — so
+    /// a re-transcribe following a restart arrives with the name and with no
+    /// observation to re-point. This is the ordinary path, not an eviction
+    /// corner, which is why the branch matters.
+    ///
+    /// **Discriminating.** Suppressing the fold here would leave the snapshot
+    /// holding this pass's FRESH observation while the profile still holds
+    /// the old one, so un-naming would subtract a vector the profile never
+    /// received: `[1.03, -0.13, 0, 0]` at 3 samples, a centroid that is no
+    /// longer the mean of anything. Folding instead keeps the two sides
+    /// describing the same observation — the profile carries this recording
+    /// twice, which is what `main` does and is recoverable, and every
+    /// subtraction stays exact.
+    func test_a_cleared_name_with_no_held_observation_folds_instead() async throws {
+        let w = try makeWorld(speakerNames: ["SPEAKER_00": "Alice"], threshold: 0.7)
+        // Her profile as it comes back off disk: her earlier recordings, plus
+        // this recording's contribution from before the relaunch…
+        w.profiles.updateProfile(name: "Alice", embedding: aliceStored, sampleCount: 3)
+        w.profiles.updateProfile(name: "Alice", embedding: aliceSpeaking, sampleCount: 1)
+        // …and no observations at all, because nothing repopulates them.
+        XCTAssertEqual(w.snapshots.heldRecordingCount, 0,
+                       "precondition: the snapshots did not survive the relaunch")
+        let beforePass = try XCTUnwrap(w.profiles.profile(named: "Alice")).embedding
+
+        w.probe.returns(["SPEAKER_01": aliceSpeakingAgain])
+        await runPass(w, producing: [segment("SPEAKER_01", 0, 5),
+                                     segment("SPEAKER_01", 5, 20)])
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_01"], "Alice")
+        XCTAssertEqual(w.profiles.profile(named: "Alice")?.sampleCount, 5,
+                       "with nothing to re-point, the fold must happen: the profile and the "
+                       + "snapshot have to describe the same observation")
+
+        w.store.setSpeakerName(nil, forSpeaker: "SPEAKER_01", recordingID: w.recordingID)
+
+        let alice = try XCTUnwrap(w.profiles.profile(named: "Alice"))
+        XCTAssertEqual(alice.sampleCount, 4,
+                       "the un-name takes back exactly the observation that was just folded in")
+        assertCentroid(alice.embedding, beforePass,
+                       "…and her centroid returns to where the pass found it, rather than drifting "
+                       + "by a vector she never received")
     }
 }

--- a/MilaTests/SpeakerCorrectionActionsTests.swift
+++ b/MilaTests/SpeakerCorrectionActionsTests.swift
@@ -571,6 +571,62 @@ final class SpeakerCorrectionActionsTests: XCTestCase {
                        "no row, no re-key, no correction")
     }
 
+    // MARK: - Re-attaching a name a pass cleared (island-io/mila#260)
+
+    /// `reattachSpeakerName` is the label half of the re-transcribe repair:
+    /// the profile it names ALREADY holds this recording's contribution (the
+    /// pass cleared the label that accounted for it), so writing the name
+    /// must not fold a second observation in. Going through `setSpeakerName`
+    /// here would do exactly that — which is the assertion that makes this
+    /// discriminating, since the snapshot below would resolve and create a
+    /// profile.
+    func test_reattaching_a_name_writes_no_profile() {
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one"),
+                                     segment("SPEAKER_01", 2, "two")],
+                          snapshotEntries: [("SPEAKER_00", [1, 0, 0, 0], 1),
+                                            ("SPEAKER_01", [0, 1, 0, 0], 1)])
+
+        w.store.reattachSpeakerName("Carol", toSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_00"], "Carol", "the label is written")
+        XCTAssertTrue(w.profiles.profiles.isEmpty,
+                      "…and no `onSpeakerNamed` fired: naming through the ordinary setter "
+                      + "would have created Carol from this recording's observation")
+    }
+
+    /// It reaches disk. A name that survives only in memory comes back as
+    /// "Speaker A" on the next launch, with the contribution it accounts for
+    /// still in the profile — the same stranding, one relaunch later.
+    func test_a_reattached_name_is_persisted() throws {
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one")])
+
+        w.store.reattachSpeakerName("Carol", toSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+
+        let onDisk = String(decoding: try Data(contentsOf: w.store.storeURL), as: UTF8.self)
+        XCTAssertTrue(onDisk.contains("Carol"), "recordings.json still has no Carol in it")
+    }
+
+    /// It never replaces a name. An id that already carries one carries it
+    /// because something else set it — the user typing while the pass ran,
+    /// most likely — and dropping that name here would fire no
+    /// `onSpeakerUnnamed`, stranding the contribution it stands for. A
+    /// replacement is a profile correction and belongs on `setSpeakerName`.
+    func test_reattaching_over_an_existing_name_is_refused() {
+        let voice: [Float] = [1, 0, 0, 0]
+        let w = makeWorld(segments: [segment("SPEAKER_00", 0, "one")],
+                          snapshotEntries: [("SPEAKER_00", voice, 1)])
+        w.store.setSpeakerName("Dana", forSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+        XCTAssertEqual(w.profiles.profile(named: "Dana")?.sampleCount, 1,
+                       "precondition: Dana's profile holds this recording's observation")
+
+        w.store.reattachSpeakerName("Carol", toSpeaker: "SPEAKER_00", recordingID: w.recordingID)
+
+        XCTAssertEqual(row(w).speakerNames["SPEAKER_00"], "Dana", "the user's label stands")
+        XCTAssertNil(w.profiles.profile(named: "Carol"))
+        XCTAssertEqual(w.profiles.profile(named: "Dana")?.sampleCount, 1,
+                       "and Dana keeps what she was given")
+    }
+
     // MARK: - Move one line
 
     func test_reassigning_moves_only_the_named_segment() {

--- a/MilaTests/TranscriptionServiceSpeakerCarryTests.swift
+++ b/MilaTests/TranscriptionServiceSpeakerCarryTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+import TranscriptionCore
+@testable import Mila
+
+/// Collects the two completion hooks in the order the service fires them. A
+/// class rather than captured `var`s, so both escaping closures write to one
+/// place.
+@MainActor
+private final class PassRecorder {
+    var events: [String] = []
+    var clearedID: UUID?
+    var clearedNames: [String: String]?
+    var namesOnTheCompletedRow: [String: String]?
+}
+
+/// The half of island-io/mila#260 that only a real pass can pin: a batch
+/// transcription clears the recording's `speakerNames` wholesale, and the
+/// names it drops have to be handed over **before** the completion hook —
+/// because `OfflineVoiceEmbedder.matchAfterPass`, wired to that hook, drops
+/// every observation those names were keyed to as its first act.
+///
+/// `OfflineVoiceEmbedderTests` supplies the pass output by hand, which means
+/// it cannot see the service capture the names as it clears them, or fire the
+/// two hooks in the wrong order. Those are exactly the ways this can fail
+/// silently — no crash, no error, just a profile contribution stranded again
+/// — so they are driven here through `enqueue`, a real store write and a real
+/// (stubbed-engine) pass.
+@MainActor
+final class TranscriptionServiceSpeakerCarryTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var store: RecordingStore!
+    private var manager: ModelManager!
+    private var stub: StubWhisperEngine!
+    private var service: TranscriptionService!
+    private var savedSelection: String?
+
+    private let suite = "TranscriptionServiceSpeakerCarryTests"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = TestSupport.makeTempRoot(label: suite)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+        store = RecordingStore(rootDirectory: tempRoot)
+        manager = ModelManager(modelsDirectory: tempRoot.appendingPathComponent("Models"))
+        savedSelection = UserDefaults.standard.string(forKey: "selectedModelName")
+        try TestSupport.installFakeModel(into: manager)
+
+        stub = StubWhisperEngine()
+        service = TranscriptionService(
+            store: store,
+            modelManager: manager,
+            diarizationSettings: DiarizationSettings(
+                defaults: .init(suiteName: "\(suite).diarization")!),
+            remoteSettings: TestSupport.isolatedRemoteSettings(label: suite),
+            engine: stub)
+    }
+
+    override func tearDown() async throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+        for name in ["\(suite).diarization", "\(suite).remote"] {
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+        if let savedSelection {
+            UserDefaults.standard.set(savedSelection, forKey: "selectedModelName")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "selectedModelName")
+        }
+        try await super.tearDown()
+    }
+
+    private func wireHooks(to recorder: PassRecorder) {
+        service.onPassClearedSpeakerNames = { recordingID, names in
+            recorder.events.append("cleared")
+            recorder.clearedID = recordingID
+            recorder.clearedNames = names
+        }
+        service.onTranscriptionCompleted = { rec, _ in
+            recorder.events.append("completed")
+            recorder.namesOnTheCompletedRow = rec.speakerNames
+        }
+    }
+
+    /// The pass re-keys every `SPEAKER_NN`, so it clears the names bound to
+    /// the old ids — and each of those names had folded an observation into a
+    /// voice profile. This is the only moment those pairs still exist: the
+    /// row handed to `onTranscriptionCompleted` has already lost them, which
+    /// the last assertion here pins directly.
+    func test_a_pass_hands_over_the_speaker_names_it_clears() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Named")
+        store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: fixture.recording.id)
+        store.setSpeakerName("Bob", forSpeaker: "SPEAKER_01", recordingID: fixture.recording.id)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 0.5, text: "hello")])
+
+        let recorder = PassRecorder()
+        wireHooks(to: recorder)
+
+        service.enqueue(try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id }))
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertTrue(stored.speakerNames.isEmpty,
+                      "precondition: a segment-producing pass still clears the names it re-keyed")
+        XCTAssertEqual(recorder.clearedID, fixture.recording.id)
+        XCTAssertEqual(recorder.clearedNames,
+                       ["SPEAKER_00": "Alice", "SPEAKER_01": "Bob"],
+                       "every pair the row lost, taken from the row that was actually written")
+        XCTAssertEqual(recorder.namesOnTheCompletedRow, [String: String](),
+                       "the completed row carries none of them — which is why they need their own hand-over")
+    }
+
+    /// The ordering the repair depends on. `matchAfterPass` runs off
+    /// `onTranscriptionCompleted` and invalidates the recording's
+    /// observations immediately, so a hand-over that arrived afterwards would
+    /// name contributions nothing can resolve any more. Swapping the two
+    /// lines in `announceCompletion` fails nothing else in the suite.
+    func test_the_cleared_names_arrive_before_the_completion_hook() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Ordered")
+        store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: fixture.recording.id)
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 0.5, text: "hello")])
+
+        let recorder = PassRecorder()
+        wireHooks(to: recorder)
+
+        service.enqueue(try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id }))
+        await service.waitForIdle()
+
+        XCTAssertEqual(recorder.events, ["cleared", "completed"])
+    }
+
+    /// A first transcription has nothing to hand over, and says so. The hook
+    /// still fires for every completed pass — `OfflineVoiceEmbedder` uses the
+    /// empty announcement to clear anything a previous pass left behind.
+    func test_a_pass_with_nothing_to_clear_still_reports_an_empty_map() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Fresh")
+        await stub.setDefaultCanned([TranscriptSegment(start: 0, end: 0.5, text: "hello")])
+
+        let recorder = PassRecorder()
+        wireHooks(to: recorder)
+
+        service.enqueue(fixture.recording)
+        await service.waitForIdle()
+
+        XCTAssertEqual(recorder.events, ["cleared", "completed"])
+        XCTAssertEqual(recorder.clearedNames, [String: String]())
+    }
+
+    /// The negative control on the capture: a pass that produced NO segments
+    /// re-keyed nothing, so it neither clears the user's speaker names nor
+    /// reports any. (It lands `.failed`, so neither hook fires at all.) A
+    /// capture taken outside the `enrichedSegments` check would report names
+    /// that are still on the row — inviting a correction for a change that
+    /// never happened.
+    func test_an_empty_pass_neither_clears_nor_reports_the_names() async throws {
+        let fixture = try TestRecordingFixture.make(in: store, title: "Silent")
+        store.setSpeakerName("Alice", forSpeaker: "SPEAKER_00", recordingID: fixture.recording.id)
+        await stub.setDefaultCanned([])
+
+        let recorder = PassRecorder()
+        wireHooks(to: recorder)
+
+        service.enqueue(try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id }))
+        await service.waitForIdle()
+
+        let stored = try XCTUnwrap(store.recordings.first { $0.id == fixture.recording.id })
+        XCTAssertEqual(stored.status, .failed)
+        XCTAssertEqual(stored.speakerNames, ["SPEAKER_00": "Alice"],
+                       "hand-typed names survive a pass that produced nothing")
+        XCTAssertEqual(recorder.events, [String](), "and nothing is announced about them")
+        XCTAssertNil(recorder.clearedNames)
+    }
+}


### PR DESCRIPTION
Closes #260

## What & why

The batch pass clears a recording's `speakerNames` wholesale — it re-keyed every `SPEAKER_NN`, so names bound to the old ids would label the wrong voice — and that clear fires no hook. Every name had folded an observation into a voice profile, so each contribution is left with **no label to un-name**: #237's correction can never reach it. `OfflineVoiceEmbedder.matchAfterPass` then re-embeds every speaker, matches them against the same profiles and names them again, folding a **second** observation of the same recording in beside the stranded one. Alice ends a re-transcribe at `sampleCount: 2` for one recording, one of which is unreachable forever.

**The fix repairs it from the naming side, not the retiring side.** A name the row carried *before* the pass, **whose observation is still held**, is not a new name. When the re-match resolves a speaker to one of them, the label is re-attached to the contribution the profile **already holds**:

- `TranscriptionService.announceCompletion` hands the cleared `[oldID: name]` map to the new `onPassClearedSpeakerNames` hook and *then* fires `onTranscriptionCompleted`. One function, because `matchAfterPass` (wired to the second) invalidates the observations the first one's pairs resolve through, as its first act.
- `OfflineVoiceEmbedder.notePassClearedSpeakerNames` resolves each name to the observation it folded in, while those are still keyed to the pre-pass ids. Several ids under one name are combined (weighted mean, summed count — the same equivalence `ObservedVoiceSnapshots.absorb` relies on), so one subtraction still reverses all of them.
- `matchAfterPass` claims each carried contribution **at most once**: the claiming id gets that observation written into its snapshot entry and its name written through `RecordingStore.reattachSpeakerName`, which fires no `onSpeakerNamed`. A second id matching the same profile is a genuinely new contribution and folds exactly as before.

Result: the profile stays at the weight the user actually taught it, and un-naming the restored speaker subtracts precisely what naming it added — the invariant #253/#237 exist for.

**Suppressing the fold and re-pointing the snapshot are one act, never one without the other.** A cleared name whose observation is *not* held takes the ordinary path and folds. That is `main`'s behaviour — the profile carries this recording twice and the older contribution is residue — and it is deliberate: half the correction is worse than none, because a snapshot describing an observation the profile never received makes the eventual un-name subtract a vector that was never added. Nor is it a corner case; `ObservedVoiceSnapshots` is in-memory only, so **every re-transcribe after a relaunch** arrives with the names (persisted on the row) and none of the observations. Without the evidence to do better, degrade to `main`. (Caught by Bugbot on the first head; see the review thread for what I verified and what changed.)

### What this deliberately does not do

**It never subtracts and it never deletes.** `update(_:retiringSpeakerNames:)` (#258) is not used on this path in either direction, and that is the whole reason #260 was filed separately rather than fixed there:

- *retire before the re-match* takes away the weight — and shifts the centroid — that the lookup resolves through, and deletes outright any profile whose only content came from this recording (`sampleCount: 1`, the ordinary state of one created through the on-demand path). "Name auto-restored, profile inflated" becomes "profile deleted, name lost, voice forgotten";
- *retire after* has nothing left to subtract: the snapshot was invalidated and refilled with the new pass's observations.

So the question the issue asked to decide explicitly — what happens when the old name does **not** come back from the re-match — is answered: **leave it as residue**, exactly as `main` does today. Retiring there would delete a profile on the evidence of a similarity score that came up short, not of a user saying "that isn't her", on a batch write nobody is watching. Residue is recoverable (delete the profile, let it re-learn); a deleted voice is not. `test_a_cleared_name_the_rematch_cannot_find_keeps_its_contribution` pins that choice so it is reviewable rather than incidental, and the reasoning is recorded on `matchAfterPass` and on `update(_:retiringSpeakerNames:)`.

The strongest thing I can say about the blast radius: **the production diff adds no call to `SpeakerProfileStore` at all** (the only mention is in a doc comment). It can do exactly three things — suppress an `updateProfile` *in the same act as* re-pointing the snapshot at the contribution that profile received, so the two can never disagree; re-point a snapshot entry, only ever to an observation from this recording that the named profile actually holds; and write a label onto an id that has none. A recording with no carried contribution takes a path identical to `main`.

### `matchAfterPass`'s `speakerNames.isEmpty` guard

Revisited, as the issue asks, and deliberately unchanged: the carry travels *beside* the row rather than on it, precisely so the pass can go on clearing names it re-keyed, so the guard still means "only auto-name a recording the pass left unlabelled". Noted at the method that a design which preserves names *on* the row must revisit both together.

### `RecordingStore.reattachSpeakerName`

Not a general quiet setter. It refuses an id that already carries a name (a replacement is a profile correction and belongs on `setSpeakerName`, which fires both hooks), so the only thing it can do is add a label where there was none. Its doc states the full precondition — the caller must have established *both* that the profile carries this recording's contribution under that name and that the snapshot points at that same contribution — and that a caller which cannot do both must use `setSpeakerName`. One caller.

## How it was tested

**Nothing was compiled or run locally: there is no Swift toolchain and no Mac in this environment. CI is the only compiler here.** The diff was re-read adversarially, every assertion's arithmetic worked through by hand, and every constructor/API used in the new tests copied from an existing call site.

The tests are split so that neither half simulates what the other pins — the lesson from #254, where simulating the store write is what hid the missing notify.

**`MilaTests/TranscriptionServiceSpeakerCarryTests.swift` (new)** drives a **real pass** (`enqueue` + `StubWhisperEngine` + `waitForIdle` + a real store write):

- the cleared pairs are handed over, taken from the row that was actually written, and the completed row carries none of them — which is why they need their own hand-over;
- they arrive **before** the completion hook (swapping the two lines in `announceCompletion` fails nothing else in the suite, and the failure in production is silent);
- a pass with nothing to clear still reports an empty map;
- a pass that produced no segments neither clears the names nor reports any — the negative control on taking the capture inside the `enrichedSegments` check.

**`MilaTests/OfflineVoiceEmbedderTests.swift`** now wires the `onSpeakerUnnamed` half of `MilaApp.init` verbatim as well, so every claim about a contribution being reversible is checked *by reversing it*, and drives the post-whisper sequence through the production `announceCompletion` rather than an order the test picked:

- **the headline, discriminating in three directions.** Alice arrives at 3 samples from earlier recordings and this recording takes her to 4. `main` → 5 after the re-transcribe, and un-naming leaves 4 stranded. Suppress the second fold but leave the *fresh* observation in the snapshot → 4, but the un-name subtracts an embedding the profile never received and her centroid lands on `[1.03, -0.13, 0, 0]` instead of back on `[1, 0, 0, 0]`. This fix → 4, and the un-name returns her to exactly her pre-recording weight **and** centroid;
- **a cleared name with no held observation folds instead** — the post-relaunch state (`heldRecordingCount == 0` asserted as a precondition), which is the ordinary path after any restart. The profile must end inflated-but-reconcilable, and un-naming must return the centroid exactly where the pass found it rather than to the drifted `[1.03, -0.13, 0, 0]` at one sample fewer. Fails against the pre-fix head in both directions;
- a cleared name the re-match cannot find keeps its contribution and **is not deleted** (the destructive fix #260 rejects);
- a pass with no cleared names still folds what it learns (the negative control — suppressing unconditionally would silently stop voice recognition improving);
- only one new speaker claims a carried contribution: treat the claim as membership rather than a claim and both re-attach, leaving the profile at 4 with two snapshot entries pointing at one observation, so un-naming both lands on 2;
- two ids that shared a name carry **one combined** contribution — carrying only one (or none) leaves her at 4 after the un-name instead of 3;
- a carry left behind by another recording is not applied here (backed by a real observation of a different voice, so it still fails if the recording-id guard is removed).

**`MilaTests/SpeakerCorrectionActionsTests.swift`** covers the new store primitive: re-attaching writes no profile (naming through the ordinary setter *would* have created one from the snapshot), the name reaches disk, and re-attaching over an existing name is refused with both profiles untouched.

## Checklist

- [ ] Builds locally (`make build`) and tests pass (`make test`) — **not possible in this environment; relying on CI**
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [x] User-facing change is noted in the README changelog (if applicable) — n/a, a data-integrity fix with no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PewyUzivK9LuGMezKJM2vN