### PR TITLE
fix(recording): stop re-evaluating the App scene on every audio buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ New app-wide settings (like `DiarizationSettings`) must be:
 2. Injected via `.environmentObject()` on both the main window and the Settings scene
 3. Accepted in tests via a custom `UserDefaults` suite (not `.standard`) to avoid polluting state
 
+**An App-level `@StateObject` must not carry a high-frequency `@Published`.** A `@StateObject` subscribes its owner to `objectWillChange`, and the owner here is `MilaApp` — so every publish re-evaluates the App `body` and re-diffs every scene (window root view, sidebar outline view, `.commands` → main menu), ~10–20 ms each, whatever the body reads. `RecordingSession`'s per-audio-buffer `micLevel`/`systemLevel` and 5 Hz `elapsed` did exactly that and pinned the main thread at 60–75% for whole recordings (#280). Anything that changes at audio or timer cadence goes on its own small `ObservableObject` (`RecordingMeters`, `InputLevelMeter`) that is injected separately and observed only by the leaf view that displays it; the parent keeps read-only passthroughs for one-shot readers. `RecordingSessionMetersTests` counts `objectWillChange` on both objects to pin the split — a round-trip test cannot, because the values read the same whichever object publishes them.
+
 ### Python Subprocess Integration
 When calling Python ML pipelines from Swift via `Process`:
 - Use inline Python scripts via `-c` argument (not bundled .py files) for the main pipeline -- this avoids path-resolution issues with app bundles

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -954,10 +954,14 @@ struct MilaApp: App {
                 .environmentObject(dictation)
                 .environmentObject(actions)
                 .environmentObject(session)
+                // The session's live readouts ride on their own object so a
+                // per-buffer meter tick never re-publishes `session` (#280).
+                .environmentObject(session.meters)
                 .environmentObject(hotkeySettings)
                 .environmentObject(languageSettings)
                 .environmentObject(audioInputSettings)
                 .environmentObject(inputLevelMonitor)
+                .environmentObject(inputLevelMonitor.meter)
                 .environmentObject(llmSettings)
                 .environmentObject(postRecording)
                 .environmentObject(diarizationSettings)
@@ -1061,6 +1065,7 @@ struct MilaApp: App {
                 .environmentObject(transcription)
                 .environmentObject(audioInputSettings)
                 .environmentObject(inputLevelMonitor)
+                .environmentObject(inputLevelMonitor.meter)
                 .environmentObject(actions)
                 .environmentObject(llmSettings)
                 .environmentObject(diarizationSettings)

--- a/Mila/Audio/InputLevelMonitor.swift
+++ b/Mila/Audio/InputLevelMonitor.swift
@@ -18,7 +18,15 @@ import Combine
 ///     `restart()`; switching the device on a running engine is fragile.
 @MainActor
 final class InputLevelMonitor: ObservableObject {
-    @Published private(set) var level: Float = 0
+    /// The level itself lives on its own `ObservableObject` — see
+    /// `RecordingMeters` for the reasoning. This monitor is a `@StateObject`
+    /// on `MilaApp`, and the tap publishes ~47 times a second while the
+    /// Settings → Audio meter is open; as a `@Published` property here each
+    /// tick re-evaluated the App `body` and re-diffed every scene. The
+    /// `LevelMeterView` observes `meter`; the passthrough is for one-shot
+    /// reads and does not subscribe.
+    let meter = InputLevelMeter()
+    var level: Float { meter.level }
     @Published private(set) var isRunning = false
 
     /// kAudioDevicePropertyDeviceUID of the input we should monitor, or nil to
@@ -52,7 +60,7 @@ final class InputLevelMonitor: ObservableObject {
                 // its teardown lands — its queued updates must not repaint
                 // the meter after stop() zeroed it.
                 guard let self, self.generation == myGeneration else { return }
-                self.level = lvl
+                self.meter.level = lvl
             }
         }
         let built: AVAudioEngine? = await Task.detached(priority: .utility) {
@@ -76,7 +84,7 @@ final class InputLevelMonitor: ObservableObject {
             }
         }.value
         guard let built else {
-            if generation == myGeneration { self.level = 0 }
+            if generation == myGeneration { self.meter.level = 0 }
             return
         }
         guard generation == myGeneration, engine == nil else {
@@ -95,7 +103,7 @@ final class InputLevelMonitor: ObservableObject {
         let toTeardown = engine
         engine = nil
         isRunning = false
-        level = 0
+        meter.level = 0
         guard let toTeardown else { return }
         await Self.teardown(toTeardown)
     }
@@ -114,4 +122,12 @@ final class InputLevelMonitor: ObservableObject {
         await stop()
         await start()
     }
+}
+
+/// The 0…1 input level published by `InputLevelMonitor`, on its own object so
+/// only the meter view re-renders per tap buffer. Written by the monitor
+/// alone (`fileprivate(set)`).
+@MainActor
+final class InputLevelMeter: ObservableObject {
+    @Published fileprivate(set) var level: Float = 0
 }

--- a/Mila/Audio/RecordingSession.swift
+++ b/Mila/Audio/RecordingSession.swift
@@ -12,9 +12,30 @@ private let recLog = Logger(subsystem: "io.island.whisper.IslandWhisper", catego
 final class RecordingSession: ObservableObject {
     enum State { case idle, recording, paused, stopping }
     @Published private(set) var state: State = .idle
-    @Published private(set) var elapsed: TimeInterval = 0
-    @Published private(set) var micLevel: Float = 0
-    @Published private(set) var systemLevel: Float = 0
+
+    /// The live readouts — elapsed clock and the two level meters — on their
+    /// own `ObservableObject`, deliberately NOT `@Published` here.
+    ///
+    /// They change at audio-buffer cadence: `micLevel` per mic tap buffer
+    /// (~12 Hz), `systemLevel` per ScreenCaptureKit buffer (up to ~50 Hz),
+    /// `elapsed` at 5 Hz. When they were `@Published` on this object every
+    /// one of those ticks re-published `RecordingSession` — and this object
+    /// is a `@StateObject` on `MilaApp`, so each publish re-evaluated the
+    /// App's `body` and re-diffed the whole scene: the window root view, the
+    /// sidebar outline view, even the main menu. A `sample` of a recording
+    /// put 81% of main-thread time inside that SwiftUI update, i.e. 60–75%
+    /// CPU for the recording alone, on the remote backend with nothing local
+    /// to transcribe (#280).
+    ///
+    /// Views that show the clock or a meter observe `meters` directly (it is
+    /// injected as its own environment object). The passthroughs below keep
+    /// the synchronous readers — the silence watchdog, `stopRecording`'s
+    /// duration snapshot, the tests — working unchanged; reading them does
+    /// not subscribe to anything.
+    let meters = RecordingMeters()
+    var elapsed: TimeInterval { meters.elapsed }
+    var micLevel: Float { meters.micLevel }
+    var systemLevel: Float { meters.systemLevel }
 
     let mic = MicrophoneRecorder()
     let system = SystemAudioRecorder()
@@ -203,8 +224,8 @@ final class RecordingSession: ObservableObject {
         timerTask = Task { @MainActor [weak self] in
             while let self, self.state == .recording || self.state == .paused {
                 if self.state == .recording, let start = self.startTime {
-                    self.elapsed = Self.elapsed(now: Date(), startTime: start,
-                                                totalPaused: self.totalPaused)
+                    self.meters.elapsed = Self.elapsed(now: Date(), startTime: start,
+                                                       totalPaused: self.totalPaused)
                 }
                 try? await Task.sleep(nanoseconds: 200_000_000)
             }
@@ -259,8 +280,8 @@ final class RecordingSession: ObservableObject {
         // The meters are driven from `consumeMic` / `consumeSystem`, which
         // stop running now — without this they'd sit frozen at their last
         // pre-pause reading and read as "still listening".
-        micLevel = 0
-        systemLevel = 0
+        meters.micLevel = 0
+        meters.systemLevel = 0
         recLog.log("pause: source=\(self.source.rawValue, privacy: .public) elapsed=\(self.elapsed, privacy: .public)")
     }
 
@@ -336,7 +357,7 @@ final class RecordingSession: ObservableObject {
         startTime = nil
         pausedAt = nil
         totalPaused = 0
-        elapsed = 0
+        meters.elapsed = 0
         isFakeForTesting = false
         state = .idle
         return url
@@ -358,7 +379,7 @@ final class RecordingSession: ObservableObject {
         startTime = nil
         pausedAt = nil
         totalPaused = 0
-        elapsed = 0
+        meters.elapsed = 0
         isFakeForTesting = false
         pendingSystem.removeAll(keepingCapacity: false)
         state = .idle
@@ -366,7 +387,10 @@ final class RecordingSession: ObservableObject {
 
     // MARK: - Mixing
 
-    private func consumeMic(_ buffer: AVAudioPCMBuffer) async {
+    /// Internal rather than private so `RecordingSessionMetersTests` can push
+    /// buffers through the REAL mic path of a fake session and count who
+    /// publishes; nothing in the app calls it from outside this file.
+    func consumeMic(_ buffer: AVAudioPCMBuffer) async {
         // Paused: discard the buffer entirely so nothing reaches the WAV or
         // the live transcriber. The engine keeps running; we just drop its
         // output until `resume()`.
@@ -377,7 +401,7 @@ final class RecordingSession: ObservableObject {
         // cost a suspension point — one a `pause()` could land inside, which
         // would leave the meter lit at a live-looking level for the rest of
         // the pause with nothing still running to clear it.
-        micLevel = AudioMeter.level(from: buffer)
+        meters.micLevel = AudioMeter.level(from: buffer)
         if source == .microphone {
             // Mic-only: the live feed and the saved file are both just the
             // mic, so drive the live transcriber here and write directly.
@@ -405,7 +429,7 @@ final class RecordingSession: ObservableObject {
         guard state == .recording else { return }
         let samples = AudioConvert.samples(from: buffer)
         // Direct assignment for the same reason as `consumeMic` — see there.
-        systemLevel = AudioMeter.level(from: buffer)
+        meters.systemLevel = AudioMeter.level(from: buffer)
         if source == .systemAudio {
             // No mic to clock against — system audio IS the recording.
             // write() drives the live feed for `.systemAudio`.
@@ -527,4 +551,25 @@ final class RecordingSession: ObservableObject {
             onLive(samples[0..<samples.count])
         }
     }
+}
+
+/// The high-frequency readouts of a `RecordingSession`: the elapsed clock and
+/// the mic / system level meters.
+///
+/// A separate object so that the session itself only publishes on state
+/// transitions. Anything that wants the live numbers observes THIS object —
+/// and it should be a small leaf view (`RecordingElapsedLabel`,
+/// `RecordingChip`), because whatever observes it re-renders at audio-buffer
+/// cadence. Nothing at the `App` level may hold it as a `@StateObject`; see
+/// `RecordingSession.meters` for the storm that caused.
+///
+/// Only `RecordingSession` writes these (`fileprivate(set)`): the values are
+/// derived from its capture pipeline and its state machine, and letting a
+/// view or controller poke them would decouple the meter from the audio it
+/// claims to describe.
+@MainActor
+final class RecordingMeters: ObservableObject {
+    @Published fileprivate(set) var elapsed: TimeInterval = 0
+    @Published fileprivate(set) var micLevel: Float = 0
+    @Published fileprivate(set) var systemLevel: Float = 0
 }

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -485,6 +485,10 @@ private struct LanguagePickerToolbarItem: View {
 private struct RecordingChip: View {
     @EnvironmentObject private var actions: QuickActionsController
     @EnvironmentObject private var session: RecordingSession
+    /// The clock comes from `meters`, not `session`: the session publishes
+    /// only on state transitions now, and this chip is a leaf, so it is the
+    /// right place to absorb the 5 Hz elapsed ticks.
+    @EnvironmentObject private var meters: RecordingMeters
 
     var body: some View {
         // One read of the paused state for the whole chip — the dot, the
@@ -495,7 +499,7 @@ private struct RecordingChip: View {
             Circle()
                 .fill(paused ? Color.orange : Color.red)
                 .frame(width: 8, height: 8)
-            Text(formatDuration(session.elapsed))
+            Text(formatDuration(meters.elapsed))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(paused ? .orange : .primary)
             // `RecordingPauseButton` applies its own `.buttonStyle(.plain)`

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -12,12 +12,14 @@ import TranscriptionCore
 /// vs. transcript volumes can drag the divider to fit their preference.
 struct LiveAIRecordingView: View {
     @EnvironmentObject private var actions: QuickActionsController
-    // NOTE: `session` is deliberately NOT observed here. RecordingSession
-    // is a fat ObservableObject that also @Publishes micLevel/systemLevel
-    // at ~50 Hz; holding it here re-evaluated this whole body (including
-    // the growing transcript ForEach) on every mic-level tick. The
-    // elapsed clock now lives in the `RecordingElapsedLabel` leaf so only
-    // that tiny Text re-renders at audio cadence — not the transcript.
+    // NOTE: neither `session` nor `RecordingMeters` is observed here. The
+    // meters publish elapsed / micLevel / systemLevel at audio-buffer
+    // cadence; holding them here re-evaluated this whole body (including
+    // the growing transcript ForEach) on every tick. The elapsed clock
+    // lives in the `RecordingElapsedLabel` leaf so only that tiny Text
+    // re-renders at audio cadence — not the transcript. (The same storm at
+    // the App level — `RecordingSession` is a `@StateObject` on `MilaApp` —
+    // is why the readouts moved onto `RecordingMeters` at all; see #280.)
     @EnvironmentObject private var transcriber: LiveTranscriber
     @EnvironmentObject private var diarizer: LiveSpeakerDiarizer
     @EnvironmentObject private var aiSession: LiveAISession
@@ -727,17 +729,19 @@ private struct ActionItemRow: View {
     }
 }
 
-/// Leaf that owns the only dependency on `RecordingSession`, so the
-/// session's high-frequency @Published updates (elapsed at 5 Hz,
-/// micLevel/systemLevel at ~50 Hz) re-render ONLY this small Text rather
-/// than the whole `LiveAIRecordingView` body (which holds the growing
-/// transcript). The mm:ss display rounds to whole seconds, so the extra
-/// audio-cadence updates here are cheap and invisible.
+/// Leaf that owns the only dependency on `RecordingMeters`, so the meters'
+/// high-frequency @Published updates (elapsed at 5 Hz, micLevel/systemLevel
+/// at up to ~50 Hz) re-render ONLY this small Text rather than the whole
+/// `LiveAIRecordingView` body (which holds the growing transcript). The
+/// mm:ss display rounds to whole seconds, so the extra audio-cadence updates
+/// here are cheap and invisible. `session` is still observed for the paused
+/// state, which changes only on user action.
 private struct RecordingElapsedLabel: View {
     @EnvironmentObject private var session: RecordingSession
+    @EnvironmentObject private var meters: RecordingMeters
 
     var body: some View {
-        let t = Int(session.elapsed.rounded())
+        let t = Int(meters.elapsed.rounded())
         let clock = String(format: "%02d:%02d", t / 60, t % 60)
         // Show "Paused" alongside the (frozen) clock so the user gets clear
         // feedback that capture is suspended. This leaf already observes the

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -323,6 +323,18 @@ private struct SettingsWindowTitle: NSViewRepresentable {
 
 // MARK: - Audio
 
+/// Leaf that owns the only dependency on `InputLevelMeter`, so the ~47 Hz
+/// level ticks re-render this bar alone rather than the whole Audio tab.
+private struct LiveInputLevelMeter: View {
+    @EnvironmentObject private var inputLevel: InputLevelMeter
+    let isLive: Bool
+
+    var body: some View {
+        LevelMeterView(level: inputLevel.level, isLive: isLive)
+            .frame(maxWidth: 360)
+    }
+}
+
 private struct AudioSettingsTab: View {
     @EnvironmentObject private var settings: AudioInputSettings
     @EnvironmentObject private var monitor: InputLevelMonitor
@@ -393,9 +405,9 @@ private struct AudioSettingsTab: View {
                         // have no input device.
                         .accessibilityIdentifier("audio.meter.status")
                 }
-                LevelMeterView(level: monitor.level,
-                               isLive: monitor.isRunning && !actions.isRecording)
-                    .frame(maxWidth: 360)
+                // The ~47 Hz level is observed by the leaf below, not by
+                // this tab — see `InputLevelMonitor.meter`.
+                LiveInputLevelMeter(isLive: monitor.isRunning && !actions.isRecording)
             }
 
             Divider().padding(.vertical, 4)

--- a/MilaTests/RecordingSessionMetersTests.swift
+++ b/MilaTests/RecordingSessionMetersTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import AVFoundation
+import Combine
+@testable import Mila
+
+/// Pins the split between `RecordingSession` and `RecordingMeters` (#280).
+///
+/// `RecordingSession` is a `@StateObject` on `MilaApp`, so every one of its
+/// `objectWillChange` emissions re-evaluates the App `body` and re-diffs the
+/// whole scene — window root view, sidebar outline view, main menu. While the
+/// elapsed clock and the level meters were `@Published` on the session, that
+/// happened at audio-buffer cadence and cost 60–75% of a core for the whole
+/// recording. The readouts now live on `session.meters`, which only small
+/// leaf views observe.
+///
+/// A round-trip test cannot catch a regression here: the values are still
+/// readable through the passthroughs whichever object publishes them. What has
+/// to be asserted is WHO emits — so these tests count `objectWillChange` on
+/// both objects while the timer ticks.
+@MainActor
+final class RecordingSessionMetersTests: XCTestCase {
+
+    /// Counts `objectWillChange` emissions until cancelled.
+    private final class EmissionCounter {
+        private(set) var count = 0
+        private var cancellable: AnyCancellable?
+        init<O: ObservableObject>(_ object: O) {
+            cancellable = object.objectWillChange.sink { [weak self] _ in
+                self?.count += 1
+            }
+        }
+    }
+
+    /// The elapsed clock ticks (200 ms timer) must publish on `meters` and
+    /// leave the session silent: nothing about the session's *state* changed.
+    func test_elapsed_ticks_publish_on_meters_not_on_the_session() async throws {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meters-ticks-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        // Subscribe AFTER start so the `.idle → .recording` transition is not
+        // counted against the session.
+        let sessionEmissions = EmissionCounter(session)
+        let meterEmissions = EmissionCounter(session.meters)
+
+        try await Task.sleep(nanoseconds: 700_000_000)
+
+        XCTAssertGreaterThanOrEqual(meterEmissions.count, 2,
+                                    "the 200 ms elapsed timer should have ticked on `meters`")
+        XCTAssertEqual(sessionEmissions.count, 0,
+                       "an elapsed tick must not re-publish the session — that re-evaluates the App body")
+        XCTAssertGreaterThan(session.elapsed, 0,
+                             "the passthrough still reads the live clock")
+
+        _ = await session.stop()
+    }
+
+    /// The audio path itself: every mic buffer updates `micLevel`, which used
+    /// to re-publish the session once per buffer (~12 Hz mic-only, ~50 Hz with
+    /// system audio) for the whole recording. Drive the real `consumeMic` on a
+    /// fake session — `write()` no-ops without an `AVAudioFile` — and count.
+    func test_mic_buffers_publish_on_meters_not_on_the_session() async throws {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meters-buffers-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        let sessionEmissions = EmissionCounter(session)
+        let meterEmissions = EmissionCounter(session.meters)
+
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let frames: AVAudioFrameCount = 1_365   // one mic tap buffer's worth at 16 kHz
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        buffer.frameLength = frames
+        let channel = try XCTUnwrap(buffer.floatChannelData?[0])
+        for i in 0..<Int(frames) {
+            channel[i] = 0.25 * sinf(Float(i) * 2 * .pi * 440 / 16_000)
+        }
+
+        let bufferCount = 120   // ~10 s of mic audio
+        for _ in 0..<bufferCount {
+            await session.consumeMic(buffer)
+        }
+
+        XCTAssertGreaterThan(session.micLevel, 0, "the meter saw the signal")
+        XCTAssertGreaterThanOrEqual(meterEmissions.count, bufferCount,
+                                    "each buffer updates the meter object")
+        XCTAssertEqual(sessionEmissions.count, 0,
+                       "a mic buffer must never re-publish the session — with the session a "
+                       + "@StateObject on MilaApp, that was one App-body re-evaluation per buffer")
+
+        _ = await session.stop()
+    }
+
+    /// State transitions are the session's to publish — and only the
+    /// session's. A pause zeroes the meters (that is a `meters` emission) and
+    /// flips `state` (a session emission); neither must leak into the other.
+    func test_state_transitions_publish_on_the_session() async {
+        let session = RecordingSession()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meters-state-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: url)
+        let sessionEmissions = EmissionCounter(session)
+
+        await session.pause()
+        XCTAssertEqual(session.state, .paused)
+        XCTAssertGreaterThanOrEqual(sessionEmissions.count, 1,
+                                    "a state transition is exactly what the session should publish")
+        XCTAssertEqual(session.micLevel, 0)
+        XCTAssertEqual(session.systemLevel, 0)
+
+        session.resume()
+        _ = await session.stop()
+        XCTAssertEqual(session.state, .idle)
+        XCTAssertEqual(session.elapsed, 0, accuracy: 0.001,
+                       "stop resets the clock through the meters object")
+    }
+
+    /// The readouts are one object for the life of the session, so a view
+    /// that captured `session.meters` at record-start keeps observing the
+    /// right thing across pause / resume / stop / the next recording.
+    func test_meters_identity_is_stable_across_recordings() async {
+        let session = RecordingSession()
+        let meters = session.meters
+        let first = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meters-identity-1-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: first)
+        _ = await session.stop()
+        let second = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meters-identity-2-\(UUID().uuidString).wav")
+        await session.startFakeForTesting(outputURL: second)
+        XCTAssertTrue(session.meters === meters)
+        _ = await session.stop()
+    }
+}


### PR DESCRIPTION
Closes #280

## What & why

A recording pinned Mila's main thread at **60–75% CPU for its whole duration**, on the remote backend with nothing local to transcribe (a user's diagnostic report on 1.9.3-beta.4, then reproduced live on 1.9.3). A `sample` of the recording process put ~81% of main-thread time inside SwiftUI's view-graph update, and the stacks underneath were the **App scene** being re-diffed: `AppGraph.sceneList` / `AppKitWindowController.updateRootView`, the sidebar's `OutlineListCoordinator`, and `AppDelegate.makeMainMenu` — with `MilaApp.body.getter` in them.

`RecordingSession` is a `@StateObject` on `MilaApp`. A `@StateObject` subscribes its owner to `objectWillChange`, so every publish re-evaluates `MilaApp.body` and re-diffs every scene, ~10–20 ms each, although the App body reads none of the session's properties. And the session published at audio-buffer cadence: `micLevel` per mic tap buffer (~12 Hz), `systemLevel` per ScreenCaptureKit buffer (up to ~50 Hz in meeting mode), `elapsed` at 5 Hz. `InputLevelMonitor.level` (~47 Hz while Settings → Audio is open) had the same shape.

`LiveAIRecordingView` already guarded against this one level down ("`session` is deliberately NOT observed here …", the `RecordingElapsedLabel` leaf) — the App-level `@StateObject` is upstream of every view and was never isolated.

**The change:** the high-frequency readouts move onto their own small `ObservableObject`s that only the leaf views displaying them observe.

- `RecordingSession.meters: RecordingMeters` — `elapsed`, `micLevel`, `systemLevel`; injected as its own environment object; observed only by `RecordingElapsedLabel` and `RecordingChip`. The session keeps read-only passthroughs, so synchronous readers (the silence watchdog, `stopRecording`'s duration snapshot, existing tests) are unchanged. `RecordingSession` now publishes only on state transitions. Setters are `fileprivate(set)` — the session alone writes them.
- `InputLevelMonitor.meter: InputLevelMeter` — observed by a new `LiveInputLevelMeter` leaf in the Audio settings tab instead of the whole tab.
- `RecordingSessionMetersTests` counts `objectWillChange` on both objects while the elapsed timer ticks. That is the tripwire this needs: a round-trip test cannot catch the regression because the values read identically whichever object publishes them.
- `CLAUDE.md` records the rule under *Environment Objects*.

Not in this PR (same investigation, filed separately or noted in #280): the diagnostic report omitting `transcription.`/`remote.`/`liveAI.` keys (#281); Live AI retrying a missing `claude` binary every 20 s with no back-off; the `HeroRecordButton` `repeatForever` pulse (~6% on its own, same class as the fixed `ThinkingIndicator`).

## How it was tested

- `make project` + `xcodebuild build-for-testing` (app and both test bundles compile). The unit tests were **not run locally on purpose**: `MilaTests` is app-hosted and would launch a second Mila while the reporter's own Mila was mid-recording — CI runs them.
- Diagnosis evidence: `sample Mila` during a live remote-backend meeting recording (81% of main-thread samples under `NSHostingView.beginTransaction`; `top` at 61–75%); the user's diagnostic report log (71-min remote recording, no local transcription, every LLM tick failing fast, diarizer daemon healthy) to rule out the pipeline itself.
- Verifying the fix on a machine: start a recording on the remote backend and watch `top -pid $(pgrep -x Mila)` — expect low single digits instead of 60–75%; the Home/Live AI clock still advances and the pause chip still zeroes the meters.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — build verified locally; tests left to CI, see above
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — changelog entries are written per release; this goes into the next `RELEASE_NOTES/` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recording UI state wiring and SwiftUI observation boundaries; behavior should be unchanged for readers using passthroughs, but incorrect observation in a parent view could still reintroduce perf regressions.
> 
> **Overview**
> Fixes **#280**, where recordings pinned the main thread at **60–75% CPU** because `RecordingSession` is a `@StateObject` on `MilaApp`: every `@Published` tick on that object re-ran `MilaApp.body` and re-diffed the whole scene even though the App never reads those values.
> 
> **High-frequency readouts move off the app-level session/monitor objects** onto small dedicated `ObservableObject`s that only leaf views observe:
> 
> - **`RecordingMeters`** (`elapsed`, `micLevel`, `systemLevel`) — owned by `RecordingSession`, injected as `session.meters`; `RecordingChip` and `RecordingElapsedLabel` observe it. `RecordingSession` now publishes only on **state** transitions; synchronous callers still use passthrough properties (`session.elapsed`, etc.) without subscribing.
> - **`InputLevelMeter`** — same pattern for Settings → Audio VU (~47 Hz); new **`LiveInputLevelMeter`** leaf so the whole Audio tab does not re-render.
> 
> `MilaApp` adds `.environmentObject(session.meters)` and `.environmentObject(inputLevelMonitor.meter)` on the main window and Settings. **`RecordingSessionMetersTests`** asserts `objectWillChange` counts (timer and mic buffers must hit `meters`, not `session`). **`CLAUDE.md`** documents the rule: no high-frequency `@Published` on App-level `@StateObject`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deeb3aa2ee5e681921885272ebc4eee9dbfca969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->