### PR TITLE
test(ci): count App-scene re-evaluations during a recording so a per-buffer @StateObject publish fails the build

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -78,6 +78,14 @@ jobs:
             -resolvePackageDependencies
 
       - name: Run unit tests
+        env:
+          # Opts in MilaTests/AppSceneChurnTests: it drives the HOST APP's real
+          # recording controller for ~12 s of fixture audio and asserts a
+          # publish budget per App-level object (the #280 class of bug — a
+          # @StateObject on MilaApp publishing per audio buffer). CI-only
+          # because on a developer's machine the same run would boot their
+          # diarization runtime and fire their configured LLM.
+          MILA_APP_CHURN_E2E: "1"
         run: |
           set -o pipefail
           # `-retry-tests-on-failure -test-iterations 3`: the subprocess-spawning

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -84,8 +84,14 @@ jobs:
           # publish budget per App-level object (the #280 class of bug — a
           # @StateObject on MilaApp publishing per audio buffer). CI-only
           # because on a developer's machine the same run would boot their
-          # diarization runtime and fire their configured LLM.
+          # diarization runtime and fire their configured LLM. Set in both
+          # forms: xcodebuild forwards `TEST_RUNNER_`-prefixed vars into the
+          # test process with the prefix stripped, and the plain form is what
+          # the audio-loopback job relies on for the same bundle — the step
+          # after the run checks the test actually PASSED rather than skipped,
+          # so a delivery regression cannot hide behind a green job.
           MILA_APP_CHURN_E2E: "1"
+          TEST_RUNNER_MILA_APP_CHURN_E2E: "1"
         run: |
           set -o pipefail
           # `-retry-tests-on-failure -test-iterations 3`: the subprocess-spawning
@@ -120,6 +126,32 @@ jobs:
             -default-test-execution-time-allowance 240 \
             -maximum-test-execution-time-allowance 480 \
             test 2>&1 | tee build/unit-tests.log | tail -200
+
+      # The App-scene churn budget (#283) is gated on an env var, and a gated
+      # test that XCTSkips leaves the job green — which is exactly how a
+      # per-buffer @StateObject publish (#280) would ship again. Require the
+      # test to have PASSED, and surface its one-line report (per-object
+      # publish counts + main-thread CPU fraction) so the budgets can be read
+      # against a real runner without downloading the log.
+      - name: Verify the App-scene churn test ran
+        run: |
+          log=build/unit-tests.log
+          line=$(grep -E "^Test Case '-\[MilaTests\.AppSceneChurnTests test_live_recording_stays_within_the_app_scene_publish_budget\]' (passed|failed|skipped)" "$log" | tail -1 || true)
+          report=$(grep -E "^AppSceneChurn: " "$log" | tail -1 || true)
+          echo "result: ${line:-<not found>}"
+          echo "report: ${report:-<none>}"
+          {
+            echo "### App-scene churn budget (#283)"
+            echo
+            echo '```'
+            echo "${line:-test case line not found in log}"
+            echo "${report:-no AppSceneChurn: report line}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          case "$line" in
+            *"' passed"*) ;;
+            *) echo "::error::AppSceneChurnTests did not pass (skipped or missing) — is MILA_APP_CHURN_E2E reaching the test host?"; exit 1 ;;
+          esac
 
       # Issue #208: with `-retry-tests-on-failure`, a green job can sit on top
       # of a pile of failed executions — one run logged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ These patches live in `SpeakerDiarizer.swift`'s inline diarize script. If upgrad
 
 - `TranscriptionService` now requires a `diarizationSettings:` parameter. In tests, always pass `DiarizationSettings(defaults: .init(suiteName: "TestClassName.diarization")!)` to isolate from user defaults.
 - Run tests with `make test` or via Xcode. Package tests: `make package-test` (TranscriptionCore + MilaKit).
+- `AppSceneChurnTests` (CI-only, `MILA_APP_CHURN_E2E=1`) pumps 12 s of fixture audio through the HOST app's real `RecordingSession` and asserts a publish budget per App-level `@StateObject`, via `AppSceneChurnProbe` (DEBUG-only: counts `MilaApp.body` evaluations and registers every App-level object by name). It exists because the #280 class of regression — one object publishing per audio buffer, the App scene re-diffing each time — is invisible in logs and only shows up in Activity Monitor. Keep it count-based: publish counts are deterministic on a loaded runner, a CPU threshold is not (the CPU fraction is asserted only as a wide backstop). Adding a new App-level `@StateObject` needs no change here — `MilaApp.init` registers them by pattern.
 
 ## Release Process
 - **Release notes are REQUIRED, first.** Every release must add

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -411,6 +411,13 @@ final class QuickActionsController: ObservableObject {
     /// teardown: it drains and stops the live transcriber, diarizer and Live
     /// AI session itself, so nothing is left running against a recording that
     /// no longer exists.
+    ///
+    /// Returns only once that teardown has run: `cancelAll()` merely publishes
+    /// `.idle`, and the `$state` observer then `await`s `transcribeNow()` and
+    /// the diarizer drain on the same main-actor objects. Returning earlier
+    /// would hand the next test a transcriber still mid-tick. The observer's
+    /// last act is clearing `session.onLiveSamples`, so that is what is
+    /// waited for (bounded — the observer is not installed in every host).
     func discardFakeRecordingForTesting() async {
         guard case .recording = activeJob else { return }
         silenceWatchTask?.cancel()
@@ -419,6 +426,9 @@ final class QuickActionsController: ObservableObject {
         remoteProbeTask = nil
         await session.cancelAll()
         activeJob = .none
+        for _ in 0..<200 where session.onLiveSamples != nil {   // ≤ 10 s
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
     }
 
     private func startRecording(withSystemAudio: Bool) async {

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -400,6 +400,27 @@ final class QuickActionsController: ObservableObject {
         activeJob = .recording(withSystemAudio: false)
     }
 
+    /// Test seam, the pair of `startFakeRecordingForTesting`: end the fake
+    /// recording WITHOUT the finalize tail — no saved `Recording`, no rename
+    /// sheet, no batch transcription, summary or transcode. For tests that
+    /// only need the live pipeline to have been running (`AppSceneChurnTests`
+    /// drives the host app's real controller and must leave its store alone).
+    ///
+    /// `session.cancelAll()` takes the session straight to `.idle`, which
+    /// `wireLiveAIPipeline` already treats as the sleep / lock / quit
+    /// teardown: it drains and stops the live transcriber, diarizer and Live
+    /// AI session itself, so nothing is left running against a recording that
+    /// no longer exists.
+    func discardFakeRecordingForTesting() async {
+        guard case .recording = activeJob else { return }
+        silenceWatchTask?.cancel()
+        silenceWatchTask = nil
+        remoteProbeTask?.cancel()
+        remoteProbeTask = nil
+        await session.cancelAll()
+        activeJob = .none
+    }
+
     private func startRecording(withSystemAudio: Bool) async {
         // Controller-side counterpart to HomeView's
         // `.disabled(... transcription.isPreparingModel)`. The button

--- a/Mila/App/AppSceneChurnProbe.swift
+++ b/Mila/App/AppSceneChurnProbe.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Combine
+
+/// Test-only instrumentation for how often the App scene re-evaluates, and
+/// which App-level object made it do so.
+///
+/// Every `@StateObject` on `MilaApp` subscribes the App `body` to that
+/// object's `objectWillChange`; a publish re-evaluates the body and re-diffs
+/// every scene (window root view, sidebar outline view, main menu) at
+/// ~10–20 ms a time. A single object publishing at audio-buffer cadence is
+/// therefore a whole core for as long as it keeps publishing — which is how a
+/// recording pinned the main thread at 60–75% for its full duration (#280),
+/// and why `RecordingMeters` / `InputLevelMeter` exist. Nothing in the
+/// pipeline logs "the App body ran", so the regression is invisible until a
+/// user opens Activity Monitor.
+///
+/// This probe makes it countable. `MilaApp.body` bumps `bodyEvaluations` on
+/// each evaluation, and `MilaApp.init` registers every App-level object by
+/// property name with a type-erased `objectWillChange`. `AppSceneChurnTests`
+/// runs a fake recording in the app-hosted test bundle and asserts a publish
+/// budget per object — a count, not a timing, so it holds on a loaded CI
+/// runner — and names the object that blew it.
+///
+/// Compiled into release builds as an empty shell: the counter and the
+/// registry only exist under `DEBUG`, and `noteBodyEvaluation()` is a no-op
+/// there. Referencing it from `body` unconditionally keeps the App source
+/// free of `#if` inside a result builder.
+@MainActor
+final class AppSceneChurnProbe {
+    static let shared = AppSceneChurnProbe()
+
+    /// One App-level object as seen by the test: its `MilaApp` property name
+    /// and a publisher that fires whenever it is about to publish.
+    struct Registered {
+        let name: String
+        let willChange: AnyPublisher<Void, Never>
+
+        /// Erases `object.objectWillChange` while its concrete type is still
+        /// known — at the `MilaApp.init` call site — so the registry never
+        /// has to open an `any ObservableObject` (which Swift 5.10 refuses:
+        /// the protocol's publisher is an associated type).
+        static func of<O: ObservableObject>(_ name: String, _ object: O) -> Registered {
+            Registered(name: name,
+                       willChange: object.objectWillChange
+                           .map { _ in () }
+                           .eraseToAnyPublisher())
+        }
+    }
+
+    /// Number of `MilaApp.body` evaluations so far in this process.
+    private(set) var bodyEvaluations = 0
+    /// Every App-level `@StateObject`, in registration order.
+    private(set) var appLevelObjects: [Registered] = []
+    /// The two objects a churn test drives directly. Weak: the App owns them.
+    private(set) weak var session: RecordingSession?
+    private(set) weak var actions: QuickActionsController?
+
+    private init() {}
+
+    /// Called from `MilaApp.body`. A no-op outside `DEBUG`.
+    static func noteBodyEvaluation() {
+        #if DEBUG
+        shared.bodyEvaluations += 1
+        #endif
+    }
+
+    /// Called once from `MilaApp.init` with every App-level object. A no-op
+    /// outside `DEBUG` so release builds keep no extra references.
+    func registerAppLevelObjects(session: RecordingSession,
+                                 actions: QuickActionsController,
+                                 _ objects: [Registered]) {
+        #if DEBUG
+        self.session = session
+        self.actions = actions
+        appLevelObjects = objects
+        #endif
+    }
+}

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -942,9 +942,60 @@ struct MilaApp: App {
                                                       liveTranscriber: dictationTrans)
         dictationController.storageSettings = storage
         _dictation = StateObject(wrappedValue: dictationController)
+
+        #if DEBUG
+        // Hand every App-level object to the churn probe by property name,
+        // so `AppSceneChurnTests` can say WHICH object re-evaluated this App
+        // body too often. `SpeakerDirectory` and `UpdaterViewModel` are built
+        // inline above and are not listed; neither publishes during a
+        // recording.
+        AppSceneChurnProbe.shared.registerAppLevelObjects(
+            session: session,
+            actions: actions,
+            [
+                .of("voiceRecognitionSettings", voiceSettings),
+                .of("speakerProfileStore", profileStoreRef),
+                .of("store", store),
+                .of("storageSettings", storage),
+                .of("modelManager", mgr),
+                .of("transcription", svc),
+                .of("diarizationSettings", diarSettings),
+                .of("remoteTranscriptionSettings", remoteSettings),
+                .of("session", session),
+                .of("actions", actions),
+                .of("hotkeySettings", hotkeys),
+                .of("languageSettings", langSettings),
+                .of("audioInputSettings", audioSettings),
+                .of("inputLevelMonitor", inputMonitor),
+                .of("llmSettings", llm),
+                .of("postRecording", coordinator),
+                .of("meetingDetectionSettings", meetingSettings),
+                .of("meetingDetector", detector),
+                .of("meetingPrompt", promptCoordinator),
+                .of("liveAISettings", liveAI),
+                .of("liveTranscriber", liveTrans),
+                .of("liveSpeakerDiarizer", liveDiar),
+                .of("liveAISession", liveSession),
+                .of("recordingSummarizer", summarizer),
+                .of("obsidianVaultSettings", obsidianSettings),
+                .of("mcpAccessSettings", mcpAccess),
+                .of("claudeSetupSettings", claudeSetup),
+                .of("obsidianExporter", obsidian),
+                .of("voiceMemosSettings", vmSettings),
+                .of("voiceMemosImporter", vmImporter),
+                .of("configImporter", configImporter),
+                .of("liveSidecarWriter", sidecarWriter),
+                .of("dictation", dictationController)
+            ])
+        #endif
     }
 
     var body: some Scene {
+        // Counts this evaluation for `AppSceneChurnTests` (DEBUG only; a
+        // no-op call in release). Every `@StateObject` above re-evaluates
+        // this body when it publishes, and each evaluation re-diffs every
+        // scene below — see `AppSceneChurnProbe` for why that is counted.
+        let _ = AppSceneChurnProbe.noteBodyEvaluation()
         WindowGroup("Mila") {
             ContentView()
                 .environmentObject(store)

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -454,9 +454,18 @@ struct MilaApp: App {
         // untouched in real launches. Centralising the bypass here is
         // simpler and less error-prone than sprinkling
         // `CommandLine.arguments` checks at every gate.
+        //
+        // App-hosted unit tests (`MilaTests`, TEST_HOST = Mila.app) get the
+        // same override: `AppSceneChurnTests` drives this App's real
+        // recording pipeline, and `wireLiveAIPipeline`'s `.recording` branch
+        // gates on `isLiveAIAvailable` — on a runner that reports as an Air
+        // the pipeline would silently not wire and the test would skip. The
+        // app process of an XCUITest run does not load `XCTestCase`, so UI
+        // tests are unaffected by this clause; they keep the arg-based one.
         let uiTestForcesLiveAI =
             CommandLine.arguments.contains("--ui-test-rtl-live-hebrew")
             || CommandLine.arguments.contains(where: { $0.hasPrefix("--ui-test-inject-fixture-wav=") })
+            || NSClassFromString("XCTestCase") != nil
         let liveAICapabilities: SystemCapabilities = uiTestForcesLiveAI
             ? SystemCapabilities(
                 modelIdentifier: SystemCapabilities.live.modelIdentifier,

--- a/MilaTests/AppSceneChurnTests.swift
+++ b/MilaTests/AppSceneChurnTests.swift
@@ -90,7 +90,12 @@ final class AppSceneChurnTests: XCTestCase {
             if session.onLiveSamples != nil { wired = true; break }
             try await Task.sleep(nanoseconds: 50_000_000)
         }
-        XCTAssertTrue(wired, "the live pipeline never wired up to the fake recording")
+        // A skip, not a failure: `wireLiveAIPipeline` gates on
+        // `isLiveAIAvailable`, which `MilaApp.init` forces true under XCTest
+        // hosting — if that override ever regresses, the CI step that checks
+        // this test PASSED (not skipped) is what goes red, with this reason.
+        try XCTSkipUnless(wired, "the live pipeline never wired up to the fake recording "
+                          + "(isLiveAIAvailable false in the test host?) — nothing to budget")
         // Let the start-up publishes (state, activeJob, transcriber start)
         // drain before counting: the budget is for the steady state.
         try await Task.sleep(nanoseconds: 500_000_000)

--- a/MilaTests/AppSceneChurnTests.swift
+++ b/MilaTests/AppSceneChurnTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+import AVFoundation
+import Combine
+@testable import Mila
+
+/// Publish budget for the App scene during a live recording (#283).
+///
+/// `MilaApp` holds ~35 `@StateObject`s; each one that publishes re-evaluates
+/// the App `body` and re-diffs every scene. A recording once did that per
+/// audio buffer — `RecordingSession.micLevel` at ~12 Hz — and pinned the main
+/// thread at 60–75% for the whole recording (#280). Nothing in the pipeline
+/// logs "the App body ran", so this test counts it.
+///
+/// **Why counts, not CPU.** A CPU threshold on a shared CI runner is a coin
+/// toss: the same work reads 8% on an idle runner and 30% on a loaded one.
+/// Publish counts are sample-driven — the same fixture through the same
+/// pipeline publishes the same number of times whatever the machine is doing
+/// — and they name the object that blew the budget, which a CPU number never
+/// can. The main-thread CPU fraction is still asserted, but as a coarse
+/// backstop with a wide margin (the bug read 60–75%; the fix reads single
+/// digits), and the failure message points at the counts.
+///
+/// **Why app-hosted and CI-only.** The App scene under test is the real one:
+/// `MilaTests` runs inside `Mila.app`, and `AppSceneChurnProbe` hands the test
+/// the App's own `RecordingSession` / `QuickActionsController`. Driving them
+/// on a developer's machine would boot their diarization runtime and fire
+/// their configured LLM for the duration, so the test is gated on
+/// `MILA_APP_CHURN_E2E=1`, which only the `unit-and-ui-tests` job sets.
+@MainActor
+final class AppSceneChurnTests: XCTestCase {
+    private static let gate = "MILA_APP_CHURN_E2E"
+
+    /// Seconds of fixture audio pumped, at real time — real time so a 5 Hz
+    /// timer regression shows up as 5 publishes a second, not as the handful
+    /// a fast pump would let through.
+    private static let pumpSeconds: TimeInterval = 12
+
+    /// Publishes any single App-level object may make per second of
+    /// recording. Utterance-driven objects (`LiveTranscriber` flips
+    /// `isTranscribing` twice per utterance and appends a segment) sit near
+    /// 1/s on this fixture; the bug signature starts at 12/s (one per mic
+    /// buffer) and a timer regression at 5/s.
+    private static let publishBudgetPerSecond = 4.0
+
+    /// Main-thread CPU fraction during the pump: the coarse backstop.
+    private static let mainThreadCPUBudget = 0.5
+
+    /// One mic tap buffer at 16 kHz — `MicrophoneRecorder` taps 4096 frames at
+    /// 48 kHz, which `RecordingSession` sees as ~1365 samples every ~85 ms.
+    private static let framesPerBuffer = 1_365
+    private static let bufferIntervalNanos: UInt64 = 85_000_000
+
+    /// Counts `objectWillChange` emissions per registered object.
+    private final class PublishCounter {
+        private(set) var counts: [String: Int] = [:]
+        private var subscriptions = Set<AnyCancellable>()
+        init(_ objects: [AppSceneChurnProbe.Registered]) {
+            for entry in objects {
+                entry.willChange
+                    .sink { [weak self] _ in self?.counts[entry.name, default: 0] += 1 }
+                    .store(in: &subscriptions)
+            }
+        }
+        func stop() { subscriptions.removeAll() }
+    }
+
+    func test_live_recording_stays_within_the_app_scene_publish_budget() async throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment[Self.gate] == "1",
+                          "Set \(Self.gate)=1 to run — drives the host app's real recording controller (CI only).")
+        let probe = AppSceneChurnProbe.shared
+        guard let session = probe.session, let actions = probe.actions,
+              !probe.appLevelObjects.isEmpty else {
+            throw XCTSkip("App-level objects are not registered — needs the app-hosted DEBUG test host")
+        }
+        try XCTSkipIf(actions.isRecording, "the host app is already recording")
+
+        let fixture = try Self.loadFixture()
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("app-churn-\(UUID().uuidString).wav")
+        await actions.startFakeRecordingForTesting(outputURL: outputURL)
+        XCTAssertTrue(actions.isRecording, "startFakeRecordingForTesting did not start a recording")
+        addTeardownBlock { @MainActor in
+            await actions.discardFakeRecordingForTesting()
+        }
+
+        // `wireLiveAIPipeline` installs `onLiveSamples` when it sees
+        // `.recording`; the live pipeline is not running until it has.
+        var wired = false
+        for _ in 0..<60 {
+            if session.onLiveSamples != nil { wired = true; break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertTrue(wired, "the live pipeline never wired up to the fake recording")
+        // Let the start-up publishes (state, activeJob, transcriber start)
+        // drain before counting: the budget is for the steady state.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let counter = PublishCounter(probe.appLevelObjects)
+        let bodyBefore = probe.bodyEvaluations
+        let cpuBefore = Self.mainThreadCPUSeconds()
+        let wallBefore = Date()
+
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let totalBuffers = Int(Self.pumpSeconds * 16_000) / Self.framesPerBuffer
+        var offset = 0
+        for _ in 0..<totalBuffers {
+            let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format,
+                                                        frameCapacity: AVAudioFrameCount(Self.framesPerBuffer)))
+            buffer.frameLength = AVAudioFrameCount(Self.framesPerBuffer)
+            let channel = try XCTUnwrap(buffer.floatChannelData?[0])
+            for i in 0..<Self.framesPerBuffer {
+                channel[i] = fixture[(offset + i) % fixture.count]
+            }
+            offset += Self.framesPerBuffer
+            // The real mic path: meters, live feed, VAD, transcriber — but
+            // `write()` no-ops on a fake session, so nothing hits disk.
+            await session.consumeMic(buffer)
+            try await Task.sleep(nanoseconds: Self.bufferIntervalNanos)
+        }
+
+        let wall = Date().timeIntervalSince(wallBefore)
+        let cpu = Self.mainThreadCPUSeconds() - cpuBefore
+        counter.stop()
+        let bodyDelta = probe.bodyEvaluations - bodyBefore
+        let counts = counter.counts
+
+        let report = counts.sorted { $0.value > $1.value }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ", ")
+        print("AppSceneChurn: \(String(format: "%.1f", wall))s pumped, MilaApp.body evaluated \(bodyDelta)×, "
+              + "main-thread CPU \(String(format: "%.2f", cpu))s (\(String(format: "%.0f", 100 * cpu / wall))%), "
+              + "publishes: \(report.isEmpty ? "none" : report)")
+
+        // Primary: no App-level object publishes at buffer or timer cadence.
+        let budget = Int(Self.publishBudgetPerSecond * Self.pumpSeconds)
+        for (name, count) in counts where count > budget {
+            XCTFail("`\(name)` published \(count) times during \(Int(Self.pumpSeconds))s of recording "
+                    + "(budget \(budget)). It is a @StateObject on MilaApp, so each publish re-evaluated the "
+                    + "App body and re-diffed every scene — move the high-frequency value onto its own "
+                    + "ObservableObject, as RecordingMeters does (#280).")
+        }
+        XCTAssertEqual(counts["session"] ?? 0, 0,
+                       "RecordingSession publishes only on state transitions; nothing changed state mid-pump")
+        XCTAssertLessThanOrEqual(bodyDelta, budget,
+                                 "MilaApp.body evaluated \(bodyDelta) times in \(Int(Self.pumpSeconds))s of "
+                                 + "recording (budget \(budget)); publishes: \(report)")
+
+        // Backstop: the whole point of the budget is main-thread time.
+        XCTAssertLessThan(cpu / wall, Self.mainThreadCPUBudget,
+                          "main thread spent \(String(format: "%.0f", 100 * cpu / wall))% of the recording busy "
+                          + "(bug: 60–75%, fixed: single digits) — the publish counts above say who: \(report)")
+
+        await actions.discardFakeRecordingForTesting()
+        XCTAssertFalse(actions.isRecording, "discardFakeRecordingForTesting must leave the controller idle")
+    }
+
+    // MARK: - Helpers
+
+    /// `Packages/TranscriptionCore/Fixtures/en_meeting_notes.wav`: 5.7 s of
+    /// real English speech, Float32 mono 16 kHz — looped by the pump. Real
+    /// speech (not a tone) so the VAD emits utterances and the transcriber
+    /// runs its per-utterance publishes, which the budget has to leave room
+    /// for. Resolved from `#filePath` like `RemoteTranscriptionE2ETests`.
+    private static func loadFixture() throws -> [Float] {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // MilaTests/
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("Packages/TranscriptionCore/Fixtures/en_meeting_notes.wav")
+        let file = try AVAudioFile(forReading: url)
+        let frames = AVAudioFrameCount(file.length)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frames))
+        try file.read(into: buffer)
+        XCTAssertEqual(file.processingFormat.sampleRate, 16_000, "fixture is expected at 16 kHz")
+        let channel = try XCTUnwrap(buffer.floatChannelData?[0])
+        let samples = Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+        XCTAssertGreaterThan(samples.count, 16_000, "fixture suspiciously short")
+        return samples
+    }
+
+    /// CPU seconds consumed by the calling thread. The test is `@MainActor`,
+    /// so this is the main thread — where SwiftUI does its updates.
+    private static func mainThreadCPUSeconds() -> TimeInterval {
+        var ts = timespec()
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts)
+        return TimeInterval(ts.tv_sec) + TimeInterval(ts.tv_nsec) / 1_000_000_000
+    }
+}


### PR DESCRIPTION
Closes #283

## What & why

#280 shipped through every existing check: a `@StateObject` on `MilaApp` published once per audio buffer, the App scene re-diffed at ~12–50 Hz, and a recording pinned the main thread at 60–75% for its whole duration. Nothing in the pipeline logs "the App body ran", unit tests exercise objects in isolation (where a publish is free), and the UI E2Es assert content, not cost. This adds a CI check for that class of regression — and keeps it **count-based**, because a CPU-percentage threshold on a shared macOS runner is a coin toss.

- **`AppSceneChurnProbe`** (`Mila/App/`, DEBUG-only — an empty shell in release): `MilaApp.body` bumps a counter on every evaluation; `MilaApp.init` registers every App-level `@StateObject` by property name with a type-erased `objectWillChange`. New App-level objects only need a line in that list.
- **`AppSceneChurnTests`** (app-hosted `MilaTests`, gated on `MILA_APP_CHURN_E2E=1`): starts a fake recording on the host app's *real* `QuickActionsController`, pumps 12 s of `en_meeting_notes.wav` through the real `RecordingSession.consumeMic` path at real time (so a 5 Hz timer regression reads as 60 publishes, not 5), then asserts:
  1. no App-level object published more than 4× per second of recording — the failure names it;
  2. `RecordingSession` published 0 times mid-pump (state transitions only);
  3. `MilaApp.body` evaluated within the same budget;
  4. main-thread CPU fraction < 50% as a backstop only (bug: 60–75%; fix: single digits), with the message pointing at the counts.
- **`QuickActionsController.discardFakeRecordingForTesting()`**: ends the fake recording through `session.cancelAll()` — the teardown `wireLiveAIPipeline` already runs for sleep/lock/quit — so the test writes nothing to the host's store and shows no rename sheet.
- **CI-only on purpose.** The host app is the developer's real one: on a dev machine the same run would boot their diarization runtime and fire their configured LLM for 12 s. `unit-and-ui-tests` sets the gate; `make test` skips it.

## How it was tested

- `make project` + `xcodebuild build-for-testing`: app and both test bundles compile (the probe's registry is built from the init-time locals, so a missing name fails the build).
- The test itself was **not run locally** (it is CI-gated for the reason above; and running app-hosted tests here would launch a second Mila while the reporter's own was recording). It runs in this PR's `unit-and-ui-tests` job — please read that job's log for the `AppSceneChurn:` line, which prints the per-object counts and the measured CPU fraction so the budgets can be judged against a real runner.
- Expected on `main` with #282: `session=0`, body evaluations in the low tens for 12 s, CPU fraction well under 0.5. Expected on the pre-#282 tree: `session≈140` and the test fails naming `session`.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — compile verified; the new test is CI-gated and runs in this PR's checks
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — not user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and DEBUG-only instrumentation plus CI enforcement; production behavior changes only the XCTest-hosted Live AI capability override so app-hosted tests can wire the live pipeline.
> 
> **Overview**
> Adds a **CI-only regression guard** for the #280 class of bug: an App-level `@StateObject` publishing on every audio buffer, forcing `MilaApp.body` to re-diff the whole scene at mic cadence.
> 
> **`AppSceneChurnProbe`** (DEBUG-only shell in release) counts `MilaApp.body` evaluations and registers each App-level `@StateObject` by name with type-erased `objectWillChange`. **`AppSceneChurnTests`** runs inside the real app host when `MILA_APP_CHURN_E2E=1`: fake recording via `QuickActionsController`, 12 s of real-time fixture audio through `RecordingSession.consumeMic`, then asserts per-object publish counts (≤4/s), zero mid-pump `session` publishes, body-eval budget, and a loose main-thread CPU backstop. **`discardFakeRecordingForTesting()`** tears down via `cancelAll()` without saving or finalizing.
> 
> **`MilaApp`** registers probe targets in DEBUG, calls `noteBodyEvaluation()` from `body`, and treats XCTest-hosted runs like UI tests for the Live AI hardware gate so the live pipeline wires on Air-class CI runners.
> 
> **GitHub Actions** sets both `MILA_APP_CHURN_E2E` and `TEST_RUNNER_*`, then **fails the job** if the churn test did not **pass** (so an env-gated `XCTSkip` cannot green-wash), and posts the `AppSceneChurn:` report to the step summary. **`CLAUDE.md`** documents the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb4d5a5ddcaae089e06c1528d264e81b3fc2a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->