### PR TITLE
fix(diagnostics): export every Mila settings namespace, with credentials redacted and prompts as lengths

### DIFF
--- a/Mila/Actions/DiagnosticReporter.swift
+++ b/Mila/Actions/DiagnosticReporter.swift
@@ -19,8 +19,9 @@ import OSLog
 ///   - `recordings.json`         — metadata (titles, durations, statuses)
 ///                                  but NOT transcript text or audio
 ///   - `folders.json`            — folder list (already metadata-only)
-///   - `settings.json`           — UserDefaults keys under "diarization.",
-///                                 "audio.", "llm.", "hotkeys.", etc.
+///   - `settings.json`           — every Mila-namespaced UserDefaults key
+///                                 (`exportedSettingsPrefixes`); credentials
+///                                 redacted, prompt text as lengths only
 ///   - `diarization-health.txt`  — the last health-check result
 ///   - `crash-reports/`          — the 5 most recent .ips files matching
 ///                                 Mila / IslandWhisper / IvritWhisper
@@ -29,6 +30,8 @@ import OSLog
 /// Things deliberately **NOT** included:
 ///   - Audio files (too big + sensitive)
 ///   - Transcript sidecar `.txt` files (sensitive)
+///   - The text of the user's AI prompts (only their length — people paste
+///     meeting agendas into them)
 ///   - LLM CLI executables, model weights, etc.
 @MainActor
 enum DiagnosticReporter {
@@ -99,7 +102,7 @@ enum DiagnosticReporter {
           logs/process.log       Recent OSLog entries from this run
           recordings.json        Recording metadata (no audio, no transcripts)
           folders.json           User-created folder list
-          settings.json          App preferences (no auth tokens)
+          settings.json          App preferences (no auth tokens; prompt text as lengths)
           diarization-health.txt Speaker-detection pipeline status
           crash-reports/         Up to 5 most recent .ips files
 
@@ -107,7 +110,8 @@ enum DiagnosticReporter {
           - Audio files (.wav)
           - Transcript text (.txt sidecars)
           - LLM CLI executables or output
-          - HuggingFace / cloud auth tokens
+          - HuggingFace / cloud auth tokens, API keys
+          - The text of your AI prompts (only their length)
 
         Send this zip to whoever is helping you diagnose the issue.
         """
@@ -188,31 +192,72 @@ enum DiagnosticReporter {
     }
 
     private static func writeSettings(at dir: URL) throws {
-        // Whitelist of UserDefaults key prefixes we know are Mila-owned.
-        // Avoids leaking unrelated app or system defaults into the zip.
-        // "recording." covers `recording.language` — the key the language
-        // picker actually persists (RecordingLanguageSettings). The old
-        // entry here was "recordingLanguage", which matches no real key,
-        // so the one setting most language-related support reports need
-        // was silently missing from settings.json.
-        let prefixes = ["diarization.", "audio.", "llm.", "hotkeys.",
-                        "home.", "rename.", "recording.", "selectedModelName"]
-        let defaults = UserDefaults.standard.dictionaryRepresentation()
+        let scoped = scopedSettings(from: UserDefaults.standard.dictionaryRepresentation())
+        let data = try JSONSerialization.data(withJSONObject: scoped,
+                                              options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: dir.appendingPathComponent("settings.json"))
+    }
+
+    /// UserDefaults key prefixes exported to `settings.json` — every
+    /// namespace Mila writes, so a support bundle answers "which backend,
+    /// which Live AI mode, which toggles" on its own. It used to be eight
+    /// prefixes, and the omissions were the ones support needs most: a
+    /// "100% CPU although remote transcription is on" report (#281) carried
+    /// `selectedModelName` (a local model — misleading) but neither
+    /// `transcription.backend` nor `liveAI.backgroundMode`, which decides
+    /// whether the user was even looking at the live pane. The allowlist is
+    /// against *unrelated* defaults (Apple's, other apps') leaking into the
+    /// zip, not against Mila's own settings; what is sensitive in Mila's
+    /// settings is handled per value in `scopedSettings`.
+    ///
+    /// `speakers.` matches only `speakers.voiceRecognition.enabled` —
+    /// `speakers.known.*` are accessibility identifiers, not defaults keys.
+    /// `coreml.` is `coreml.compiled.<model>`, written by the whisper engine.
+    static let exportedSettingsPrefixes: [String] = [
+        "audio.", "audioInput.", "bundle.", "claudeSetup.", "coreml.",
+        "diarization.", "downloads.", "home.", "hotkeys.", "liveAI.", "llm.",
+        "mcp.", "meetingDetection.", "model.", "obsidian.", "recording.",
+        "recordings.", "remote.", "rename.", "speakers.", "storage.",
+        "transcription.", "updates.", "voiceMemos.", "whatsNew.",
+        "selectedModelName"
+    ]
+
+    /// The `settings.json` payload for a defaults dictionary. Pure, so the
+    /// tests can feed it a synthetic dictionary instead of the real
+    /// `UserDefaults.standard`.
+    ///
+    /// Per-value rules, in order:
+    ///   - anything credential-shaped by key name (`token`, `secret`,
+    ///     `apikey`, `password`) is `<redacted>` — the remote bearer token and
+    ///     the OpenAI key live in the Keychain anyway, but a future key that
+    ///     did not would still be covered;
+    ///   - any `…prompt…` key is reported as `<N chars>`: prompts are
+    ///     user-authored text, and people paste meeting agendas into them
+    ///     (that is how "the summary mentions last week's call" reports
+    ///     usually resolve). The length still shows whether one is set and
+    ///     whether it is the default's size;
+    ///   - `obsidian.writtenIndex` maps recording ids to vault paths derived
+    ///     from recording titles — reported as an entry count;
+    ///   - everything else goes through `sanitizedValue` (Data, i.e.
+    ///     security-scoped bookmarks, becomes a byte count).
+    static func scopedSettings(from defaults: [String: Any]) -> [String: Any] {
         var scoped: [String: Any] = [:]
         for (key, value) in defaults {
-            guard prefixes.contains(where: { key.hasPrefix($0) }) else { continue }
-            // Don't leak anything that looks like a secret. There aren't
-            // supposed to be any, but a future change might add one.
-            if key.lowercased().contains("token") || key.lowercased().contains("secret")
-                || key.lowercased().contains("apikey") || key.lowercased().contains("password") {
+            guard exportedSettingsPrefixes.contains(where: { key.hasPrefix($0) }) else { continue }
+            let lower = key.lowercased()
+            if lower.contains("token") || lower.contains("secret")
+                || lower.contains("apikey") || lower.contains("password") {
                 scoped[key] = "<redacted>"
+            } else if lower.contains("prompt"), let text = value as? String {
+                scoped[key] = "<\(text.count) chars>"
+            } else if key == "obsidian.writtenIndex" {
+                let count = (value as? [String: Any])?.count ?? (value as? [Any])?.count ?? 0
+                scoped[key] = "<\(count) entries>"
             } else {
                 scoped[key] = sanitizedValue(value)
             }
         }
-        let data = try JSONSerialization.data(withJSONObject: scoped,
-                                              options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: dir.appendingPathComponent("settings.json"))
+        return scoped
     }
 
     /// JSON only encodes specific types — translate the catch-alls we get

--- a/MilaTests/DiagnosticReporterTests.swift
+++ b/MilaTests/DiagnosticReporterTests.swift
@@ -90,6 +90,97 @@ final class DiagnosticReporterTests: XCTestCase {
         XCTAssertEqual(body, "STUB_HEALTH_OUTPUT_42")
     }
 
+    // MARK: - settings.json scoping (#281)
+
+    /// The report's `settings.json` has to say which backend and which Live
+    /// AI mode the user is in without a follow-up email — a CPU report whose
+    /// remote backend had to be inferred from log lines is what #281 was.
+    /// Every Mila namespace is exported; unrelated defaults are not.
+    func test_scopedSettings_exports_every_mila_namespace_and_drops_the_rest() throws {
+        let defaults: [String: Any] = [
+            "transcription.backend": "remote",
+            "remote.endpoint": "https://asr.example.internal/v1",
+            "remote.model": "ivrit-ai/whisper-large-v3-turbo-ct2",
+            "liveAI.enabled": true,
+            "liveAI.backgroundMode": true,
+            "meetingDetection.enabled": true,
+            "voiceMemos.folderBookmark": Data([1, 2, 3]),
+            "mcp.enabled": false,
+            "updates.betaChannel": true,
+            "audioInput.adaptiveGainEnabled": true,
+            "coreml.compiled.openai-whisper-large-v3-turbo": true,
+            "speakers.voiceRecognition.enabled": false,
+            "model.declinedNames": ["ivrit-ai-whisper-large-v3"],
+            "selectedModelName": "openai-whisper-large-v3-turbo",
+            // Not Mila's — must not leak into the zip.
+            "NSNavLastRootDirectory": "~/Desktop",
+            "com.apple.trackpad.scaling": 1.5,
+            "AppleLanguages": ["en"],
+        ]
+        let scoped = DiagnosticReporter.scopedSettings(from: defaults)
+
+        XCTAssertEqual(scoped["transcription.backend"] as? String, "remote")
+        XCTAssertEqual(scoped["remote.endpoint"] as? String, "https://asr.example.internal/v1")
+        XCTAssertEqual(scoped["remote.model"] as? String, "ivrit-ai/whisper-large-v3-turbo-ct2")
+        XCTAssertEqual(scoped["liveAI.backgroundMode"] as? Bool, true)
+        XCTAssertEqual(scoped["meetingDetection.enabled"] as? Bool, true)
+        XCTAssertEqual(scoped["voiceMemos.folderBookmark"] as? String, "<3 bytes>",
+                       "security-scoped bookmarks are opaque Data — a byte count is all the report needs")
+        XCTAssertEqual(scoped["mcp.enabled"] as? Bool, false)
+        XCTAssertEqual(scoped["updates.betaChannel"] as? Bool, true)
+        XCTAssertEqual(scoped["audioInput.adaptiveGainEnabled"] as? Bool, true)
+        XCTAssertEqual(scoped["coreml.compiled.openai-whisper-large-v3-turbo"] as? Bool, true)
+        XCTAssertEqual(scoped["speakers.voiceRecognition.enabled"] as? Bool, false)
+        XCTAssertEqual(scoped["model.declinedNames"] as? [String], ["ivrit-ai-whisper-large-v3"])
+        XCTAssertEqual(scoped["selectedModelName"] as? String, "openai-whisper-large-v3-turbo")
+
+        XCTAssertNil(scoped["NSNavLastRootDirectory"])
+        XCTAssertNil(scoped["com.apple.trackpad.scaling"])
+        XCTAssertNil(scoped["AppleLanguages"])
+        XCTAssertEqual(scoped.count, 14, "exactly the Mila keys, nothing else")
+
+        // What comes out must be what `writeSettings` can serialise.
+        XCTAssertNoThrow(try JSONSerialization.data(withJSONObject: scoped, options: [.sortedKeys]))
+    }
+
+    /// Widening the allowlist to every Mila namespace pulls in keys that
+    /// carry credentials and user-authored text. Credentials are redacted
+    /// by key name; prompts are reported as a length — people paste meeting
+    /// agendas into them; the Obsidian written-index is a count, because its
+    /// vault paths are derived from recording titles.
+    func test_scopedSettings_redacts_credentials_and_reports_prompts_as_lengths() throws {
+        let agenda = "Q3 planning: budget cuts in the Berlin office, layoffs to be discussed Thursday"
+        let defaults: [String: Any] = [
+            "remote.apiKey": "sk-live-abc123",
+            "llm.openai.apiKey": "sk-proj-xyz",
+            "claudeSetup.oauthToken": "oat-secret",
+            "liveAI.prompt": agenda,
+            "liveAI.summaryPrompt": "Summarise the meeting.",
+            "llm.action.prompt": agenda,
+            "llm.name.prompt": "",
+            "obsidian.writtenIndex": ["id-1": "Meetings/Berlin layoffs.md", "id-2": "Notes/x.md"],
+            "llm.tool": "claude",
+        ]
+        let scoped = DiagnosticReporter.scopedSettings(from: defaults)
+
+        for key in ["remote.apiKey", "llm.openai.apiKey", "claudeSetup.oauthToken"] {
+            XCTAssertEqual(scoped[key] as? String, "<redacted>", key)
+        }
+        XCTAssertEqual(scoped["liveAI.prompt"] as? String, "<\(agenda.count) chars>")
+        XCTAssertEqual(scoped["llm.action.prompt"] as? String, "<\(agenda.count) chars>")
+        XCTAssertEqual(scoped["liveAI.summaryPrompt"] as? String, "<22 chars>")
+        XCTAssertEqual(scoped["llm.name.prompt"] as? String, "<0 chars>",
+                       "an empty prompt is still worth knowing about — as a length")
+        XCTAssertEqual(scoped["obsidian.writtenIndex"] as? String, "<2 entries>")
+        XCTAssertEqual(scoped["llm.tool"] as? String, "claude", "plain settings pass through")
+
+        let json = String(decoding: try JSONSerialization.data(withJSONObject: scoped, options: [.sortedKeys]),
+                          as: UTF8.self)
+        XCTAssertFalse(json.contains("Berlin"), "prompt text and vault paths must not reach the zip")
+        XCTAssertFalse(json.contains("sk-live"), "credentials must not reach the zip")
+        XCTAssertFalse(json.contains("oat-secret"))
+    }
+
     // MARK: - Test helpers
 
     /// Extract `zip` into a fresh temp directory and return its URL.


### PR DESCRIPTION
Closes #281

## What & why

`settings.json` in the diagnostic report exported eight key prefixes. The "100% CPU although remote transcription is on" report (#280) carried `selectedModelName` — a local model, actively misleading — but neither `transcription.backend` nor `liveAI.backgroundMode`, which decides whether the user was even looking at the live pane. Both had to be inferred from log lines.

The allowlist now covers **every namespace Mila writes** (`DiagnosticReporter.exportedSettingsPrefixes`): `transcription.`, `remote.`, `liveAI.`, `meetingDetection.`, `voiceMemos.`, `mcp.`, `obsidian.`, `updates.`, `storage.`, `claudeSetup.`, `audioInput.`, `coreml.`, `model.`, `speakers.`, `recordings.`, `bundle.`, `downloads.`, `whatsNew.` on top of the existing ones. The allowlist's job is keeping *unrelated* defaults (Apple's, other apps') out of the zip; what is sensitive inside Mila's own settings is handled per value:

- credential-shaped keys (`token`, `secret`, `apikey`, `password`) → `<redacted>` (the remote bearer token and the OpenAI key live in the Keychain anyway; `claudeSetup.oauthToken` is covered by name);
- any `…prompt…` key → `<N chars>`. This is a deliberate change for `llm.action.prompt` / `llm.name.prompt`, which were exported verbatim: prompts are user-authored text and people paste meeting agendas into them. The length still shows whether one is set and whether it is default-sized;
- `obsidian.writtenIndex` → `<N entries>` (its vault paths derive from recording titles);
- everything else through the existing `sanitizedValue` (security-scoped bookmarks → byte count).

`scopedSettings(from:)` is now a pure function over a dictionary so it can be tested without touching `UserDefaults.standard`; two tests pin the export set, the exclusions, the redactions and the prompt/index summaries, and check the JSON never contains the seeded prompt text or key material. The manifest and the header comment say what changed for the recipient.

## How it was tested

- `xcodebuild build-for-testing` (app + test bundles compile); `DiagnosticReporterTests` runs in `unit-and-ui-tests` on this PR.
- Not run locally by hand — `MilaTests` is app-hosted and the maintainer's own Mila was in use.

## Checklist

- [x] Builds locally (`make build`) and tests pass (`make test`) — compile verified; tests run in CI
- [x] No secrets, credentials, tokens, or internal infrastructure references added
- [x] Follows the conventions in `CLAUDE.md`
- [ ] User-facing change is noted in the README changelog (if applicable) — goes into the next `RELEASE_NOTES/` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect opt-in diagnostic zip contents only, with added redaction for prompts and credentials rather than broader data exposure.
> 
> **Overview**
> **Diagnostic `settings.json` now includes every Mila UserDefaults namespace** via `exportedSettingsPrefixes` (e.g. `transcription.`, `remote.`, `liveAI.`), so support bundles show backend and Live AI mode without inferring from logs (#281). Unrelated system/app defaults stay excluded.
> 
> **Export logic is centralized in testable `scopedSettings(from:)`** with stricter per-key handling: credential-shaped keys → `<redacted>`, any `…prompt…` string → `<N chars>` (no longer full prompt text), `obsidian.writtenIndex` → entry count; other values still pass through `sanitizedValue`. The manifest and file header document what is and is not included.
> 
> **Two unit tests** lock the allowlist, redactions, and that serialized JSON never contains prompt or secret substrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276cbd159a04ee459ad24c105ea2ce7c0d812ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->