### PR TITLE
feat(recording): add batch-only transcription mode

### DIFF
--- a/Mila/Actions/PostRecordingCoordinator.swift
+++ b/Mila/Actions/PostRecordingCoordinator.swift
@@ -159,6 +159,13 @@ final class PostRecordingCoordinator: ObservableObject {
         armAutoSuggestTitle(for: recording)
     }
 
+    /// Run the background auto-suggest title without opening the rename
+    /// sheet. Used when batch-only mode is on: the recording saves
+    /// immediately but the LLM title still upgrades it in the background.
+    func autoSuggestOnly(for recording: Recording) {
+        armAutoSuggestTitle(for: recording)
+    }
+
     // MARK: - Background auto-suggest title
 
     /// Kick off background title suggestion for a freshly-added recording.

--- a/Mila/Actions/QuickActionsController.swift
+++ b/Mila/Actions/QuickActionsController.swift
@@ -64,6 +64,10 @@ final class QuickActionsController: ObservableObject {
     /// new app and the user has to re-grant access.
     @Published var microphonePermissionMissing = false
 
+    /// Set by `stopRecording` in batch-only mode to navigate the sidebar
+    /// to the saved recording and bring Mila to the front.
+    @Published var revealRecordingID: UUID?
+
     /// Mila folder the *next* recording is filed into (nil = All Transcriptions).
     /// Always defaults to All Transcriptions on launch — the choice is
     /// per-session only and deliberately NOT persisted across launches, so a
@@ -145,6 +149,9 @@ final class QuickActionsController: ObservableObject {
     /// transcript — but only once that stored transcript is final. See the
     /// ordering note in `stopRecording` at `store.add`.
     var liveSidecarWriter: LiveTranscriptSidecarWriter?
+    /// When `batchOnly` is on, the live pipeline is skipped entirely and
+    /// the rename sheet is not shown after stop.
+    var postRecordingSettings: PostRecordingSettings?
 
     /// True only while `stopRecording` is running its inline LIVE-PIPELINE
     /// drain — the short, bounded window where it flushes the transcriber
@@ -855,8 +862,14 @@ final class QuickActionsController: ObservableObject {
                 wasOnBattery: !SleepGuard.isOnACPower()
             )
         }
-        if sleepReason == nil {
+        let batchOnly = postRecordingSettings?.batchOnly == true
+        if sleepReason == nil && !batchOnly {
             postRecording.present(recording, titleWasUserProvided: titleWasUserProvided)
+        } else if batchOnly {
+            if !titleWasUserProvided {
+                postRecording.autoSuggestOnly(for: recording)
+            }
+            revealRecordingID = recording.id
         }
 
         // ---- INLINE LIVE-PIPELINE DRAIN: finalize whatever was still

--- a/Mila/App/MilaApp.swift
+++ b/Mila/App/MilaApp.swift
@@ -343,6 +343,7 @@ struct MilaApp: App {
     @StateObject private var diarizationSettings: DiarizationSettings
     @StateObject private var remoteTranscriptionSettings: RemoteTranscriptionSettings
     @StateObject private var meetingDetectionSettings: MeetingDetectionSettings
+    @StateObject private var postRecordingSettings: PostRecordingSettings
     @StateObject private var meetingDetector: MeetingDetector
     @StateObject private var meetingPrompt: MeetingPromptCoordinator
     @StateObject private var liveAISettings: LiveAISettings
@@ -889,6 +890,8 @@ struct MilaApp: App {
         // the user throws the recording away.
         coordinator.obsidianExporter = obsidian
         actions.liveSidecarWriter = sidecarWriter
+        let postRecSettings = PostRecordingSettings()
+        actions.postRecordingSettings = postRecSettings
         let meetingSettings = MeetingDetectionSettings()
         let detector = MeetingDetector()
         let promptCoordinator = MeetingPromptCoordinator(
@@ -919,6 +922,7 @@ struct MilaApp: App {
         _inputLevelMonitor = StateObject(wrappedValue: inputMonitor)
         _llmSettings = StateObject(wrappedValue: llm)
         _postRecording = StateObject(wrappedValue: coordinator)
+        _postRecordingSettings = StateObject(wrappedValue: postRecSettings)
         _meetingDetectionSettings = StateObject(wrappedValue: meetingSettings)
         _meetingDetector = StateObject(wrappedValue: detector)
         _meetingPrompt = StateObject(wrappedValue: promptCoordinator)
@@ -1024,6 +1028,7 @@ struct MilaApp: App {
                 .environmentObject(inputLevelMonitor.meter)
                 .environmentObject(llmSettings)
                 .environmentObject(postRecording)
+                .environmentObject(postRecordingSettings)
                 .environmentObject(diarizationSettings)
                 .environmentObject(remoteTranscriptionSettings)
                 .environmentObject(liveAISettings)
@@ -1131,6 +1136,7 @@ struct MilaApp: App {
                 .environmentObject(diarizationSettings)
                 .environmentObject(remoteTranscriptionSettings)
                 .environmentObject(meetingDetectionSettings)
+                .environmentObject(postRecordingSettings)
                 .environmentObject(liveAISettings)
                 .environmentObject(voiceMemosSettings)
                 .environmentObject(voiceMemosImporter)
@@ -1606,6 +1612,7 @@ struct MilaApp: App {
         let diarSettings = diarizationSettings
         let langSettings = languageSettings
         let sessionRef = session
+        let postRecSettings = postRecordingSettings
         // `actions` captured weakly so the .idle handler can read
         // its `isFinalizingRecording` flag to decide whether the
         // drain belongs here (sleep/lock/quit path) or to
@@ -1660,9 +1667,10 @@ struct MilaApp: App {
                 // `start()`, so it cannot be fooled that way.
                 if wiredCaptureEpoch == sessionRef.captureEpoch { break }
                 wiredCaptureEpoch = sessionRef.captureEpoch
-                guard aiSettings.isLiveAIAvailable else {
-                    // Hardware below the Live AI bar AND no override
-                    // flipped. Recording still runs via RecordingSession;
+                guard aiSettings.isLiveAIAvailable, !postRecSettings.batchOnly else {
+                    // Hardware below the Live AI bar, no override
+                    // flipped, OR batch-only mode is on. Recording
+                    // still runs via RecordingSession;
                     // QuickActionsController enqueues a post-record
                     // transcribe on stop. We just skip the live
                     // pipeline setup.

--- a/Mila/Models/PostRecordingSettings.swift
+++ b/Mila/Models/PostRecordingSettings.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Controls whether recordings use live transcription or batch-only mode.
+///
+/// When `batchOnly` is ON:
+///   * Audio is captured normally but the live pipeline (LiveTranscriber,
+///     LiveSpeakerDiarizer, LiveAI) is not started.
+///   * On stop, the recording saves immediately without the rename sheet,
+///     auto-titled from the meeting app name or the date.
+///   * Transcription, diarization, and summary run in the background via
+///     the existing batch queue.
+///
+/// Default is OFF — preserving the current live transcription behavior.
+@MainActor
+final class PostRecordingSettings: ObservableObject {
+    @Published var batchOnly: Bool {
+        didSet { defaults.set(batchOnly, forKey: Keys.batchOnly) }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.batchOnly = defaults.bool(forKey: Keys.batchOnly)
+    }
+
+    deinit {}
+
+    private enum Keys {
+        static let batchOnly = "postRecording.batchOnly"
+    }
+}

--- a/Mila/Views/ContentView.swift
+++ b/Mila/Views/ContentView.swift
@@ -217,6 +217,13 @@ struct ContentView: View {
             // flicker.
             NotificationCenter.default.post(name: .milaSidebarVisibilityDidChange, object: nil)
         }
+        .onChange(of: actions.revealRecordingID) { _, id in
+            guard let id else { return }
+            selection = .recording(id)
+            actions.revealRecordingID = nil
+            // Bring Mila to the front so the user sees the recording.
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 
     /// True while the detail pane is showing the "Recently Deleted" list —

--- a/Mila/Views/LiveAIRecordingView.swift
+++ b/Mila/Views/LiveAIRecordingView.swift
@@ -26,6 +26,7 @@ struct LiveAIRecordingView: View {
     @EnvironmentObject private var languageSettings: RecordingLanguageSettings
     @EnvironmentObject private var liveAISettings: LiveAISettings
     @EnvironmentObject private var llmSettings: LLMSettings
+    @EnvironmentObject private var postRecordingSettings: PostRecordingSettings
 
     /// Whether the per-meeting notes editor is open. Collapsed by
     /// default so the pane still leads with the AI's output; the toggle
@@ -40,11 +41,18 @@ struct LiveAIRecordingView: View {
         VStack(spacing: 0) {
             header
             Divider().opacity(0.4)
-            // Action items pane is rendered only when Live AI is on +
-            // a CLI is configured. When AI is off the live transcript
-            // takes the whole detail pane so the user still sees what
-            // Mila is hearing in real time.
-            if aiActive {
+            if postRecordingSettings.batchOnly {
+                // Batch-only mode: no live transcription, just capture.
+                Spacer()
+                Text("Transcript will appear after recording")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else if aiActive {
+                // Action items pane is rendered only when Live AI is on +
+                // a CLI is configured. When AI is off the live transcript
+                // takes the whole detail pane so the user still sees what
+                // Mila is hearing in real time.
                 VSplitView {
                     actionItemsPane
                         .frame(minHeight: 140)

--- a/Mila/Views/SettingsView.swift
+++ b/Mila/Views/SettingsView.swift
@@ -2692,6 +2692,7 @@ private struct VoiceRecognitionSection: View {
 /// hunting through UserDefaults.
 private struct MeetingsSettingsTab: View {
     @EnvironmentObject private var settings: MeetingDetectionSettings
+    @EnvironmentObject private var postRecordingSettings: PostRecordingSettings
 
     var body: some View {
         ScrollView {
@@ -2711,6 +2712,21 @@ private struct MeetingsSettingsTab: View {
                 .controlSize(.regular)
                 // Meetings' per-section probe for `DetailLayoutUITests`.
                 .accessibilityIdentifier("meetings.enable.toggle")
+
+                Divider()
+
+                Toggle(isOn: $postRecordingSettings.batchOnly) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Batch transcription only")
+                            .font(.body)
+                        Text("Record audio without live transcription. After recording stops, transcription, speaker identification, and AI summary run in the background. Saves recordings automatically without the rename window.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .toggleStyle(.switch)
+                .controlSize(.regular)
 
                 Divider()
 

--- a/MilaTests/PostRecordingSettingsTests.swift
+++ b/MilaTests/PostRecordingSettingsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Mila
+
+@MainActor
+final class PostRecordingSettingsTests: XCTestCase {
+
+    private func freshDefaults() -> UserDefaults {
+        let suite = "PostRecordingSettingsTests.\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    func test_batchOnly_defaults_to_off() {
+        let s = PostRecordingSettings(defaults: freshDefaults())
+        XCTAssertFalse(s.batchOnly, "Batch-only should default OFF so users get live transcription")
+    }
+
+    func test_batchOnly_persists_across_reinit() throws {
+        let defaults = freshDefaults()
+        do {
+            let s = PostRecordingSettings(defaults: defaults)
+            s.batchOnly = true
+        }
+        let reloaded = PostRecordingSettings(defaults: defaults)
+        XCTAssertTrue(reloaded.batchOnly, "Batch-only should survive a relaunch")
+    }
+
+    func test_batchOnly_toggle_off_persists() throws {
+        let defaults = freshDefaults()
+        do {
+            let s = PostRecordingSettings(defaults: defaults)
+            s.batchOnly = true
+            s.batchOnly = false
+        }
+        let reloaded = PostRecordingSettings(defaults: defaults)
+        XCTAssertFalse(reloaded.batchOnly, "Turning batch-only off should persist")
+    }
+}


### PR DESCRIPTION
Closes #288

## Summary

- Adds a "Batch transcription only" toggle in Settings > Meetings
- When on: skips the live pipeline (~1GB memory saved), shows placeholder during recording, skips rename sheet on stop
- Auto-titles from meeting app name or date; LLM title suggestion still runs in background
- Brings Mila to the front with the recording selected on stop
- Batch transcription, diarization, and summary run via the existing queue

Default OFF — preserves current live transcription behavior.

## Test plan

- [ ] Enable "Batch transcription only" in Settings > Meetings
- [ ] Start recording — verify no live transcript, just "Transcript will appear after recording"
- [ ] Stop — verify no rename sheet, Mila comes to front with recording selected
- [ ] Wait for batch transcription — verify transcript + speakers appear
- [ ] Verify LLM title suggestion updates the name in background (if configured)
- [ ] Disable toggle — verify live transcription works as before
- [ ] PostRecordingSettingsTests pass (default OFF, persistence round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stop-recording and live-pipeline wiring; default-off limits blast radius, but wrong gating could skip live transcription or post-stop UX unexpectedly.
> 
> **Overview**
> Adds an optional **batch-only recording mode** (Settings → Meetings: **Batch transcription only**), persisted via new `PostRecordingSettings` and **off by default**.
> 
> When enabled, **live transcription / diarization / Live AI are not started** during capture; the recording UI shows a placeholder instead of a live transcript. On stop, the app **skips the rename sheet**, keeps the auto-generated title (or a pre-entered meeting name), still runs **background LLM title suggestion** via `autoSuggestOnly`, and **selects the new recording in the sidebar** while bringing Mila to the front. Transcription, diarization, and summary continue through the **existing batch queue** unchanged.
> 
> Unit tests cover default-off behavior and UserDefaults persistence for the toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af43b12a5a9726e1882feb58480be301e59f513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->